### PR TITLE
html: add inline CSS delivery for pages

### DIFF
--- a/examples/accessibility/main.ml
+++ b/examples/accessibility/main.ml
@@ -430,7 +430,7 @@ let page_intro =
     ]
 
 let page_view =
-  page ~title:"Accessibility Demo" ~tw_css:"accessibility.css" []
+  page ~title:"Accessibility Demo" ~tw_css:(Link "accessibility.css") []
     [
       page_header;
       main
@@ -457,7 +457,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/animations/main.ml
+++ b/examples/animations/main.ml
@@ -562,7 +562,7 @@ let page_intro =
     ]
 
 let page_view =
-  page ~title:"Animations Demo" ~tw_css:"animations.css" []
+  page ~title:"Animations Demo" ~tw_css:(Link "animations.css") []
     [
       page_header;
       main
@@ -590,7 +590,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/colors/main.ml
+++ b/examples/colors/main.ml
@@ -45,7 +45,7 @@ let text_on_bg_examples =
     ]
 
 let page_view =
-  page ~title:"Colors Demo" ~tw_css:"colors.css" []
+  page ~title:"Colors Demo" ~tw_css:(Link "colors.css") []
     [
       div
         ~tw:Tw.[ max_w_6xl; mx_auto; p 8; flex; flex_col; gap 6 ]
@@ -78,7 +78,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/dashboard/main.ml
+++ b/examples/dashboard/main.ml
@@ -694,7 +694,7 @@ let content =
     ]
 
 let page_view =
-  page ~title:"Analytics Dashboard" ~tw_css:"dashboard.css"
+  page ~title:"Analytics Dashboard" ~tw_css:(Link "dashboard.css")
     ~meta:
       [
         ( "description",
@@ -711,7 +711,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/forms/main.ml
+++ b/examples/forms/main.ml
@@ -115,7 +115,7 @@ let contact_form =
     ]
 
 let page_view =
-  page ~forms:true ~title:"Forms Demo" ~tw_css:"forms.css" []
+  page ~forms:true ~title:"Forms Demo" ~tw_css:(Link "forms.css") []
     [
       div
         ~tw:Tw.[ min_h_screen; bg ~shade:100 gray; py 12 ]
@@ -136,7 +136,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/index.ml
+++ b/examples/index.ml
@@ -46,7 +46,7 @@ let content =
       examples
 
 let page_view =
-  page ~title:"Examples Manual" ~tw_css:"manual.css" []
+  page ~title:"Examples Manual" ~tw_css:(Link "manual.css") []
     [ div ~tw:Tw.[ prose; max_w_4xl; mx_auto; p 8 ] content ]
 
 let () =
@@ -56,7 +56,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/landing/main.ml
+++ b/examples/landing/main.ml
@@ -219,7 +219,7 @@ let main =
           "A landing page demonstrating Tw CSS generation with OCaml" );
         ("viewport", "width=device-width, initial-scale=1.0");
       ]
-    ~tw_css:"landing.css"
+    ~tw_css:(Link "landing.css")
     (* Head content *)
     [ meta ~at:[ At.name "author"; At.content "tw.html" ] () ]
     (* Body content *)
@@ -258,8 +258,11 @@ let () =
   close_out oc_html;
 
   (* Write CSS file *)
-  let oc_css = open_out css_filename in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_filename;
 
   ()

--- a/examples/layout/main.ml
+++ b/examples/layout/main.ml
@@ -560,7 +560,7 @@ let page_intro =
     ]
 
 let page_view =
-  page ~title:"Layout Demo" ~tw_css:"layout.css" []
+  page ~title:"Layout Demo" ~tw_css:(Link "layout.css") []
     [
       page_header;
       main
@@ -591,7 +591,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/modifiers/main.ml
+++ b/examples/modifiers/main.ml
@@ -768,7 +768,7 @@ let page_intro =
     ]
 
 let page_view =
-  page ~title:"Modifiers Demo" ~tw_css:"modifiers.css" []
+  page ~title:"Modifiers Demo" ~tw_css:(Link "modifiers.css") []
     [
       page_header;
       main
@@ -796,7 +796,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_str;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_str;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_str;
+      close_out oc_css)
+    css_file;
   ()

--- a/examples/prose/main.ml
+++ b/examples/prose/main.ml
@@ -180,7 +180,7 @@ let page_content =
   ]
 
 let doc =
-  page ~title:"Prose Typography Demo" ~tw_css:"prose.css" []
+  page ~title:"Prose Typography Demo" ~tw_css:(Link "prose.css") []
     [
       div
         ~tw:
@@ -206,7 +206,10 @@ let () =
   let oc_html = open_out "index.html" in
   output_string oc_html html_out;
   close_out oc_html;
-  let oc_css = open_out css_file in
-  output_string oc_css css_out;
-  close_out oc_css;
+  Option.iter
+    (fun file ->
+      let oc_css = open_out file in
+      output_string oc_css css_out;
+      close_out oc_css)
+    css_file;
   ()

--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -330,6 +330,20 @@ let img ?at ?tw () = void_el "img" ?at ?tw ()
 let meta ?at ?tw () = void_el "meta" ?at ?tw ()
 let link ?at ?tw () = void_el "link" ?at ?tw ()
 
+(* The <style> element holds raw CSS. Its content is emitted unescaped because
+   <style> is a raw-text element: escaping would turn selectors such as [ol>li]
+   into [ol&gt;li] and corrupt the stylesheet. *)
+let style ?at ?(tw = []) css =
+  let atts = Option.value ~default:[] at in
+  let tw_from_at, raw_classes, other_atts = extract_class_attrs atts in
+  let all_tw = tw @ tw_from_at in
+  let atts_with_tw = class_atts all_tw raw_classes other_atts in
+  {
+    el = El.v ~at:atts_with_tw "style" [ El.unsafe_raw css ];
+    tw = all_tw;
+    forms = false;
+  }
+
 (* Void is now an alias for empty *)
 let void = empty
 
@@ -401,8 +415,12 @@ let rect ?at ?tw children = el_with_tw "rect" ?at ?tw children
 let path ?at ?tw children = el_with_tw "path" ?at ?tw children
 let line ?at ?tw children = el_with_tw "line" ?at ?tw children
 
+(* CSS delivery strategy: link to an external stylesheet (with cache busting) or
+   inline the stylesheet directly into the document. *)
+type tw_css = Link of string | Inline
+
 (* Type for page generation result *)
-type page = { html : string; css : Tw.Css.t; tw_css : string }
+type page = { html : string; css : Tw.Css.t; tw_css : tw_css }
 
 let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css ?forms head_content
     body_content =
@@ -435,25 +453,25 @@ let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css ?forms head_content
   in
   let css_string = Tw.Css.to_string ~minify:true css_stylesheet in
 
-  (* Compute MD5 hash of the CSS content for cache busting *)
-  let css_hash =
-    let digest = Digest.string css_string in
-    (* Convert first 8 bytes of MD5 to hex string *)
-    let hex = Digest.to_hex digest in
-    String.sub hex 0 8
-  in
-
-  (* Add cache busting query parameter to CSS URL *)
-  let css_url_with_hash = String.concat "" [ tw_css; "?v="; css_hash ] in
-
-  (* Build final HTML with cache-busted CSS link *)
-  let css_link =
-    link ~at:[ At.rel "stylesheet"; At.href css_url_with_hash ] ()
+  (* Build the head CSS node: a cache-busted <link> for an external stylesheet,
+     or an inline <style> when the stylesheet is embedded in the document. *)
+  let css_head =
+    match tw_css with
+    | Inline -> style css_string
+    | Link file ->
+        (* Compute MD5 hash of the CSS content for cache busting *)
+        let css_hash =
+          let digest = Digest.string css_string in
+          (* Use the first 8 hex chars of the MD5 digest *)
+          String.sub (Digest.to_hex digest) 0 8
+        in
+        let css_url_with_hash = String.concat "" [ file; "?v="; css_hash ] in
+        link ~at:[ At.rel "stylesheet"; At.href css_url_with_hash ] ()
   in
   let head_children =
     meta_tags
     @ (match title_text with Some t -> [ title [ txt t ] ] | None -> [])
-    @ [ css_link ] @ head_content
+    @ [ css_head ] @ head_content
   in
   let html_tree =
     root ~at:[ At.lang lang ] [ head head_children; body_element ]
@@ -463,13 +481,17 @@ let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css ?forms head_content
 
 (* Page generation with CSS - use renamed parameters to avoid shadowing *)
 let page ?(lang = "en") ?(meta = []) ?title ?(charset = "utf-8")
-    ?(tw_css = "tw.css") ?forms head_content body_content =
+    ?(tw_css = Link "tw.css") ?forms head_content body_content =
   page_impl ~lang ~meta_list:meta ?title_text:title ~charset ~tw_css ?forms
     head_content body_content
 
 (* Page accessor functions *)
 let html page = page.html
-let css page = (page.tw_css, page.css)
+
+let css page =
+  match page.tw_css with
+  | Link file -> (Some file, page.css)
+  | Inline -> (None, page.css)
 
 (* Pretty printing *)
 let pp t =

--- a/lib/html/tw_html.mli
+++ b/lib/html/tw_html.mli
@@ -357,6 +357,14 @@ val has_forms : t -> bool
 
 (** {1 Page generation} *)
 
+(** How a {!page} delivers its generated CSS. *)
+type tw_css =
+  | Link of string
+      (** Write the CSS to this file and reference it with a cache-busted
+          [<link>] tag. *)
+  | Inline
+      (** Embed the CSS directly in the document inside a [<style>] tag. *)
+
 type page
 (** Complete HTML page with integrated CSS.
 
@@ -374,7 +382,7 @@ val page :
   ?meta:(string * string) list ->
   ?title:string ->
   ?charset:string ->
-  ?tw_css:string ->
+  ?tw_css:tw_css ->
   ?forms:bool ->
   t list ->
   t list ->
@@ -386,23 +394,26 @@ val page :
     - [charset] defaults to ["utf-8"]
     - [meta] is a list of [(name, content)] pairs for meta tags
     - [title] is the page title
-    - [tw_css] defaults to ["tw.css"] - the filename for the CSS, automatically
-      included as a [<link>] tag in HTML head
+    - [tw_css] controls how the CSS is delivered (see {!type:tw_css}). Defaults
+      to [Link "tw.css"], which references the CSS through a cache-busted
+      [<link>] tag in the HTML head. Use [Inline] to embed the CSS in the
+      document and avoid an extra HTTP request.
     - [forms] explicitly enables the [\@tailwindcss/forms] plugin base layer,
       mirroring Tailwind's [\@plugin] opt-in. When omitted, the forms base is
       auto-detected from forms utility usage (like prose styling).
     - [head] is additional content for the head section
     - [body] is the body content
 
-    The HTML automatically includes a [<link rel="stylesheet" href="{tw_css}">]
-    tag. Use {!html} to get the HTML string and {!css} to get the CSS filename
-    and stylesheet. *)
+    Use {!html} to get the HTML string and {!css} to get the CSS filename and
+    stylesheet. *)
 
 val html : page -> string
 (** [html page] extracts the HTML string from a page result. *)
 
-val css : page -> string * Tw.Css.t
-(** [css page] extracts the CSS filename and stylesheet from a page result. *)
+val css : page -> string option * Tw.Css.t
+(** [css page] extracts the CSS filename and stylesheet from a page result. The
+    filename is [Some file] when the page links to an external stylesheet
+    ([Link file]) and [None] when the CSS is inlined ([Inline]). *)
 
 (** {1 Livereload module}
 

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -171,7 +171,7 @@ let test_page_cache_busting () =
   let test_page =
     page ~title:"Test Page"
       ~meta:[ ("description", "Test page for cache busting") ]
-      ~tw_css:"styles.css" [ (* head content *) ]
+      ~tw_css:(Link "styles.css") [ (* head content *) ]
       [ div ~tw:Tw.[ p 4; bg white ] [ txt "Test content" ] ]
   in
 
@@ -183,7 +183,9 @@ let test_page_cache_busting () =
     (Astring.String.is_infix ~affix:"<link" html_content);
   check bool "CSS link has cache buster" true
     (Astring.String.is_infix ~affix:"styles.css?v=" html_content);
-  check string "CSS filename is correct" "styles.css" css_filename;
+  check
+    Alcotest.(option string)
+    "CSS filename is correct" (Some "styles.css") css_filename;
 
   (* Check that the hash is 8 characters (MD5 hash prefix) *)
   match Astring.String.find_sub ~sub:"styles.css?v=" html_content with
@@ -209,7 +211,7 @@ let test_page_cache_busting () =
 let test_page_cache_busting_consistency () =
   (* Test that same content produces same hash *)
   let create_test_page () =
-    page ~title:"Test" ~tw_css:"test.css" []
+    page ~title:"Test" ~tw_css:(Link "test.css") []
       [ div ~tw:Tw.[ p 4; m 2 ] [ txt "Content" ] ]
   in
 
@@ -236,13 +238,36 @@ let test_page_cache_busting_consistency () =
 
   (* Different content should produce different hash *)
   let page3 =
-    page ~title:"Test" ~tw_css:"test.css" []
+    page ~title:"Test" ~tw_css:(Link "test.css") []
       [ div ~tw:Tw.[ p 8; m 4 ] [ txt "Different" ] ]
   in
   let html3 = html page3 in
   let hash3 = extract_hash html3 in
 
   check bool "different content produces different hash" false (hash1 = hash3)
+
+let test_inline_css () =
+  let test_page =
+    page ~title:"Inline Style Test" ~tw_css:Inline []
+      [ div ~tw:Tw.[ p 4; bg white ] [ txt "Inline content" ] ]
+  in
+  let html_content = html test_page in
+  let css_filename, css_stylesheet = css test_page in
+
+  (* Inline pages have no external CSS file *)
+  check Alcotest.(option string) "no external CSS file" None css_filename;
+
+  (* The CSS is embedded in a <style> tag, not referenced via <link> *)
+  check bool "HTML contains style tag" true
+    (Astring.String.is_infix ~affix:"<style>" html_content);
+  check bool "HTML has no link tag" false
+    (Astring.String.is_infix ~affix:"<link" html_content);
+
+  (* The stylesheet is inlined verbatim: <style> is a raw-text element, so the
+     CSS must not be HTML-escaped (e.g. [>] must stay [>], not [&gt;]). *)
+  let expected_css = Tw.Css.to_string ~minify:true css_stylesheet in
+  check bool "stylesheet inlined verbatim (unescaped)" true
+    (Astring.String.is_infix ~affix:expected_css html_content)
 
 let test_exact_tailwind_match () =
   let page_content =
@@ -332,7 +357,9 @@ module.exports = {
 let test_exact_byte_match () =
   let page_content = div ~tw:Tw.[ p 4; bg blue; text white ] [ txt "Test" ] in
 
-  let generated_page = page ~title:"Test" ~tw_css:"" [] [ page_content ] in
+  let generated_page =
+    page ~title:"Test" ~tw_css:(Link "") [] [ page_content ]
+  in
   let html_output = html generated_page in
   let _css_filename, css_stylesheet = css generated_page in
   let our_css = Tw.Css.to_string ~minify:true css_stylesheet in
@@ -474,6 +501,7 @@ let suite =
       test_case "page cache busting" `Quick test_page_cache_busting;
       test_case "cache busting consistency" `Quick
         test_page_cache_busting_consistency;
+      test_case "inline css" `Quick test_inline_css;
       test_case "exact tailwind match" `Quick test_exact_tailwind_match;
       test_case "minified exact match" `Quick test_exact_byte_match;
     ] )


### PR DESCRIPTION
`Tw_html.page` could only deliver its generated CSS through an external `<link>`, so every page paid an extra request and could not be shipped as a single self-contained file. The `tw_css` argument now takes `Link of string` (the cache-busted link, still the default) or `Inline`, which embeds the stylesheet in a `<style>` tag; `css` correspondingly returns the filename as an option, `None` for inlined pages, rather than raising.

Backport of #2 by @Naora, whose branch had forked from a since-rewritten `main`. The inlined CSS is emitted unescaped because `<style>` is a raw-text element, and a test pins that the stylesheet is inlined verbatim.