### PR TITLE
opam: pin cascade from git for dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
           node-version: "20"
 
       - name: Install Tailwind CLI for example comparisons
-        run: npm install tailwindcss@^4.2.2 @tailwindcss/cli@^4.3.0 @tailwindcss/forms@^0.5.11 @tailwindcss/typography@^0.5.19
+        # Pin exact versions: the examples are byte-compared against this
+        # Tailwind release, and a different one shifts output (units, calc
+        # folding, palette rounding).
+        run: npm install tailwindcss@4.3.1 @tailwindcss/cli@4.3.1 @tailwindcss/forms@0.5.11 @tailwindcss/typography@0.5.20
 
       - uses: ocaml/setup-ocaml@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-compiler:
-          - "4.14"
+          - "5.2"
           - "5.4"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Tailwind CLI for example comparisons
+        run: npm install tailwindcss@^4.2.2 @tailwindcss/cli@^4.3.0 @tailwindcss/forms@^0.5.11 @tailwindcss/typography@^0.5.19
+
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (description
   "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles to CSS through a strongly-typed variable system that mirrors Tailwind's pipeline, producing byte-for-byte identical output. Supports all core utilities and the official forms and typography plugins.")
  (depends
-  ocaml
+  (ocaml (>= 5.2))
   dune
   cascade
   cmdliner
@@ -34,4 +34,5 @@
   (alcotest-js :with-test)
   (astring :with-test)
   (crunch :with-test)
-  (alcobar :with-test)))
+  (alcobar :with-test)
+  (mdx :with-test)))

--- a/tw.opam
+++ b/tw.opam
@@ -40,3 +40,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/samoht/tw.git"
+pin-depends: [
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#ad90d314c1e808b64b07fc0b532d14ea334bdc5c" ]
+]

--- a/tw.opam
+++ b/tw.opam
@@ -9,7 +9,7 @@ license: "ISC"
 homepage: "https://github.com/samoht/tw"
 bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "5.2"}
   "dune" {>= "3.0"}
   "cascade"
   "cmdliner"
@@ -23,6 +23,7 @@ depends: [
   "astring" {with-test}
   "crunch" {with-test}
   "alcobar" {with-test}
+  "mdx" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/tw.opam.template
+++ b/tw.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#ad90d314c1e808b64b07fc0b532d14ea334bdc5c" ]
+]


### PR DESCRIPTION
cascade is not published to opam, so `opam install` cannot resolve tw's dependencies. Pin it from git to a fixed reviewed revision (cascade ad90d314) so CI resolves deterministically rather than floating on cascade's main. This also raises the OCaml floor to 5.2 (cascade's minimum) and pins the Tailwind CLI the example comparisons are byte-compared against.

CI now resolves and builds; the remaining `dune runtest` failures are pre-existing tw-versus-tailwind parity gaps in the examples (calc folding, colour rounding, forms base) that are present on main and tracked separately.