### PR TITLE
sort: precompute media keys per rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
           node-version: "20"
 
       - name: Install Tailwind CLI for example comparisons
-        run: npm install tailwindcss@^4.2.2 @tailwindcss/cli@^4.3.0 @tailwindcss/forms@^0.5.11 @tailwindcss/typography@^0.5.19
+        # Pin exact versions: the examples are byte-compared against this
+        # Tailwind release, and a different one shifts output (units, calc
+        # folding, palette rounding).
+        run: npm install tailwindcss@4.3.1 @tailwindcss/cli@4.3.1 @tailwindcss/forms@0.5.11 @tailwindcss/typography@0.5.20
 
       - uses: ocaml/setup-ocaml@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-compiler:
-          - "4.14"
+          - "5.2"
           - "5.4"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Tailwind CLI for example comparisons
+        run: npm install tailwindcss@^4.2.2 @tailwindcss/cli@^4.3.0 @tailwindcss/forms@^0.5.11 @tailwindcss/typography@^0.5.19
+
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}

--- a/README.md
+++ b/README.md
@@ -1,92 +1,96 @@
-# tw -- Type-safe Tailwind CSS v4 in OCaml
+# tw — Type-safe Tailwind CSS v4 in OCaml
 
-`tw` is a type-safe OCaml implementation of [Tailwind CSS v4](https://tailwindcss.com/).
-It compiles to CSS through a strongly-typed variable system that mirrors
-Tailwind's pipeline, producing **byte-for-byte identical output**.
+`tw` is an OCaml implementation of [Tailwind CSS v4](https://tailwindcss.com/).
+You assemble utilities as ordinary OCaml values and compile them to CSS through
+the same typed variable-and-layer pipeline Tailwind uses, producing
+byte-for-byte identical output. Unknown utilities are caught at compile time,
+and nothing depends on Node.js, PostCSS, or the Tailwind CLI at run time.
 
 ```ocaml
 open Tw
 
-let card = [
-  flex; flex_col; gap 4; p 6;
-  bg white; rounded_lg; shadow_sm;
-  border; border_color ~shade:200 gray;
-  hover [ shadow_md ];
-  dark [ bg ~shade:800 gray; text ~shade:100 gray ];
-]
+(* A set of utilities is a value of type [Tw.t list]. *)
+let card =
+  [
+    flex; flex_col; gap 4; p 6;
+    bg white; rounded_lg; shadow_sm;
+    border; border_color ~shade:200 gray;
+    hover [ shadow_md ];
+    dark [ bg ~shade:800 gray; text ~shade:100 gray ];
+  ]
 ```
 
 ## Features
 
-- **Tailwind v4 parity**: 765 upstream utility tests, 140 variant tests pass
-  against real Tailwind CSS output
-- **Full plugin support**: `@tailwindcss/typography` (prose) and
-  `@tailwindcss/forms` fully implemented
-- **Type-safe API**: Invalid classes caught at compile time
-- **String parsing**: `Tw.str "flex p-4 bg-blue-500"` for dynamic class lists
-- **OCaml 4.14+**: Builds on OCaml 4.14 through 5.4
-- **Pure OCaml**: No JavaScript, PostCSS, or Node.js required
-- **86k lines** of OCaml
+- **Tailwind v4 parity** — output is checked byte-for-byte against the real
+  Tailwind CSS CLI across the upstream utility and variant test suites.
+- **Both official plugins** — `@tailwindcss/typography` (`prose`) and
+  `@tailwindcss/forms` are fully implemented.
+- **Type-safe** — utilities are typed constructors, so invalid combinations are
+  compile errors rather than silent no-ops.
+- **String parsing** — `Tw.str "flex p-4 bg-blue-500"` turns class strings into
+  typed utilities for dynamic class lists.
+- **Pure OCaml** — no JavaScript toolchain required; the library also compiles
+  to JavaScript with js_of_ocaml.
 
 ## Installation
 
+Requires OCaml `>= 5.2`.
+
+<!-- $MDX skip -->
 ```bash
-opam pin add tw.dev https://github.com/samoht/tw.git
 opam install tw
 ```
 
-## Quick Start
+## Usage
 
-### Typed API
+### Typed utilities
 
 ```ocaml
 open Tw
 
-(* Spacing: integers are multiplied by 0.25rem *)
+(* Spacing scales: the integer is multiplied by 0.25rem, so [p 4] is 1rem. *)
 let layout = [ flex; items_center; gap 4; p 6; mx_auto; max_w_4xl ]
 
-(* Colors: default shade is 500, use ~shade for others *)
-let colors = [ bg blue; text white; border_color ~shade:300 gray ]
+(* Colors default to shade 500; [~shade] picks another, [~opacity] adds alpha. *)
+let colors = [ bg blue; text white; border_color ~shade:300 gray; bg ~opacity:50 white ]
 
-(* Opacity modifier *)
-let faded = [ bg ~opacity:50 white; border_color ~opacity:5 white ]
+(* Variants nest as functions: responsive breakpoints, state, and dark mode. *)
+let responsive =
+  [ p 4; md [ p 8 ]; lg [ p 12 ]; bg blue; hover [ bg ~shade:600 blue ]; dark [ text ~shade:300 gray ] ]
 
-(* Responsive and state modifiers *)
-let responsive = [
-  p 4; md [ p 8 ]; lg [ p 12 ];
-  bg blue; hover [ bg ~shade:600 blue ];
-  text white; dark [ text ~shade:300 gray ];
-]
-
-(* Typography plugin *)
-let article = [ prose; prose_lg; max_w_4xl; mx_auto ]
-
-(* Prose element variants *)
-let styled_prose = [
-  prose;
-  prose_headings [ text ~shade:600 blue ];
-  prose_a [ text blue ];
-  prose_code [ bg ~shade:100 gray ];
-  prose_pre [ bg ~shade:800 gray ];
-]
-
-(* Generate CSS *)
-let css = Build.to_css ~base:true ~minify:true ~optimize:true layout
+(* The typography plugin, including per-element variants. *)
+let article =
+  [ prose; prose_lg; mx_auto; prose_headings [ text ~shade:600 blue ]; prose_code [ bg ~shade:100 gray ] ]
 ```
 
-### String API
+### Rendering to CSS
 
 ```ocaml
-(* Parse class strings -- raises Invalid_argument on unknown classes *)
+open Tw
+
+(* [to_classes] returns the value for an HTML [class] attribute. *)
+let class_attr = to_classes [ flex; p 4; bg blue ]
+
+(* [to_css] builds a stylesheet; [Css.to_string] renders it to text. *)
+let stylesheet = to_css [ flex; p 4; bg blue; hover [ bg ~shade:600 blue ] ]
+let css = Css.to_string ~minify:true stylesheet
+```
+
+### Parsing class strings
+
+```ocaml
+(* [Tw.str] parses a class string into utilities (raises on unknown classes). *)
 let styles = Tw.str "flex items-center gap-4 p-6 bg-white rounded-lg shadow-sm"
 
-(* Single class parsing *)
-let ok = Tw.of_string "hover:bg-blue-600"  (* Ok t *)
-let err = Tw.of_string "invalid-class"     (* Error (`Msg "...") *)
+(* [Tw.of_string] parses a single class and returns a result. *)
+let parsed = Tw.of_string "hover:bg-blue-600" (* Ok _ *)
+let rejected = Tw.of_string "not-a-class" (* Error (`Msg _) *)
 ```
 
 ### CLI
 
+<!-- $MDX skip -->
 ```bash
 # Generate CSS for specific classes
 tw -s "flex p-4 bg-blue-500 hover:bg-blue-600"
@@ -96,14 +100,6 @@ tw src/ > styles.css
 
 # Compare with real Tailwind CSS
 tw -s "prose mb-4 dark:text-gray-300" --diff
-
-# Generate with Tailwind for comparison
-tw -s "flex p-4" --tailwind
-
-# Options
-tw --minify --optimize --base src/
-tw --variables -s "p-4"        # CSS variables mode (default for files)
-tw --inline -s "p-4"           # Inline values (default for -s)
 ```
 
 ## Supported Utilities
@@ -147,16 +143,12 @@ All Tailwind CSS v4 core utilities and both official plugins:
 The `--diff` and `--tailwind` CLI modes require the `tailwindcss` standalone
 binary for comparison testing:
 
+<!-- $MDX skip -->
 ```bash
 # macOS (Apple Silicon)
 curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-arm64
 chmod +x tailwindcss-macos-arm64
 sudo mv tailwindcss-macos-arm64 /usr/local/bin/tailwindcss
-
-# macOS (Intel)
-curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-x64
-chmod +x tailwindcss-macos-x64
-sudo mv tailwindcss-macos-x64 /usr/local/bin/tailwindcss
 
 # Linux (x64)
 curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
@@ -166,21 +158,15 @@ sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
 
 ### Building
 
+<!-- $MDX skip -->
 ```bash
-# Build (both OCaml 5.4 and 4.14)
-dune build
+dune build         # build the library and CLI
+dune runtest       # run all tests, including README examples
 
-# Run all tests
-dune runtest
-
-# Run specific test suites
-dune exec test/upstream/test.exe     # Tailwind parity tests
-dune exec test/test.exe              # main tests
-
-# Compare single utility with Tailwind
+# Compare a single utility with Tailwind
 dune exec -- tw -s "bg-blue-500 hover:bg-blue-600" --diff
 ```
 
 ## License
 
-ISC
+ISC — see [LICENSE.md](LICENSE.md).

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,0 +1,117 @@
+(* Micro-benchmark for the core CSS pipeline: parse class strings, build the
+   stylesheet ([Tw.to_css]), and render it ([Css.to_string]).
+
+   Usage: bench [parse|tocss|tostring|full] [iterations]
+
+   Set MEMTRACE=/path/run.ctf to capture an allocation trace of the chosen
+   phase, then read it with [memtrace_hotspots]. *)
+
+let () = Memtrace.trace_if_requested ()
+
+let colors =
+  [
+    "slate"; "gray"; "zinc"; "red"; "orange"; "amber"; "yellow"; "lime";
+    "green"; "emerald"; "teal"; "cyan"; "sky"; "blue"; "indigo"; "violet";
+    "purple"; "fuchsia"; "pink"; "rose";
+  ]
+
+let shades = [ 50; 100; 200; 300; 400; 500; 600; 700; 800; 900 ]
+let variants = [ ""; "hover:"; "focus:"; "md:"; "lg:"; "dark:" ]
+let spacing = [ 0; 1; 2; 3; 4; 5; 6; 8; 10; 12; 16; 20; 24; 32 ]
+
+(* A large, deterministic corpus of candidate class strings spanning spacing,
+   the colour palette, and common layout/typography utilities, each under a set
+   of variants. *)
+let candidates =
+  let acc = ref [] in
+  let add c = acc := c :: !acc in
+  List.iter
+    (fun v ->
+      List.iter
+        (fun n ->
+          add (v ^ "p-" ^ string_of_int n);
+          add (v ^ "px-" ^ string_of_int n);
+          add (v ^ "m-" ^ string_of_int n);
+          add (v ^ "gap-" ^ string_of_int n))
+        spacing;
+      List.iter
+        (fun col ->
+          List.iter
+            (fun s ->
+              let sh = string_of_int s in
+              add (v ^ "bg-" ^ col ^ "-" ^ sh);
+              add (v ^ "text-" ^ col ^ "-" ^ sh);
+              add (v ^ "border-" ^ col ^ "-" ^ sh))
+            shades)
+        colors;
+      List.iter
+        (fun u -> add (v ^ u))
+        [
+          "flex"; "grid"; "block"; "hidden"; "rounded-lg"; "shadow-sm";
+          "font-bold"; "text-sm"; "w-full"; "h-screen"; "items-center";
+          "justify-between";
+        ])
+    variants;
+  List.rev !acc
+
+let parse cs =
+  List.filter_map
+    (fun c -> match Tw.of_string c with Ok t -> Some t | Error _ -> None)
+    cs
+
+let styles = parse candidates
+
+let time ?(runs = 5) f =
+  ignore (f ());
+  let ts =
+    Array.init runs (fun _ ->
+        Gc.compact ();
+        let t0 = Unix.gettimeofday () in
+        ignore (f ());
+        Unix.gettimeofday () -. t0)
+  in
+  Array.sort compare ts;
+  ts.(runs / 2)
+
+let words_per_op n f =
+  Gc.full_major ();
+  let before = Gc.minor_words () in
+  for _ = 1 to n do
+    ignore (f ())
+  done;
+  (Gc.minor_words () -. before) /. float_of_int n
+
+let run_phase phase iters =
+  let css = lazy (Tw.to_css ~base:true styles) in
+  let body () =
+    match phase with
+    | "parse" -> ignore (parse candidates)
+    | "tocss" -> ignore (Tw.to_css ~base:true styles)
+    | "tostring" -> ignore (Tw.Css.to_string ~minify:true (Lazy.force css))
+    | "full" ->
+        ignore (Tw.Css.to_string ~minify:true (Tw.to_css ~base:true (parse candidates)))
+    | other -> failwith ("unknown phase: " ^ other)
+  in
+  for _ = 1 to iters do
+    body ()
+  done
+
+let () =
+  let phase = if Array.length Sys.argv > 1 then Sys.argv.(1) else "report" in
+  let iters =
+    if Array.length Sys.argv > 2 then int_of_string Sys.argv.(2) else 30
+  in
+  if phase = "report" then (
+    Printf.printf "corpus: %d candidates, %d valid utilities\n%!"
+      (List.length candidates) (List.length styles);
+    let p = time (fun () -> parse candidates) in
+    let c = time (fun () -> Tw.to_css ~base:true styles) in
+    let css = Tw.to_css ~base:true styles in
+    let s = time (fun () -> Tw.Css.to_string ~minify:true css) in
+    Printf.printf "parse     : %7.3f ms  (%8.0f words/op)\n" (p *. 1000.)
+      (words_per_op 20 (fun () -> parse candidates));
+    Printf.printf "to_css    : %7.3f ms  (%8.0f words/op)\n" (c *. 1000.)
+      (words_per_op 20 (fun () -> Tw.to_css ~base:true styles));
+    Printf.printf "to_string : %7.3f ms  (%8.0f words/op)\n%!" (s *. 1000.)
+      (words_per_op 20 (fun () -> Tw.Css.to_string ~minify:true css)))
+  else run_phase phase iters

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,4 @@
+(executable
+ (name bench)
+ (optional)
+ (libraries tw cascade memtrace unix))

--- a/bench/dune
+++ b/bench/dune
@@ -1,4 +1,4 @@
 (executable
  (name bench)
  (optional)
- (libraries tw cascade memtrace unix))
+ (libraries tw cascade nox-memtrace unix))

--- a/dune
+++ b/dune
@@ -1,0 +1,8 @@
+(env
+ (dev
+  (flags
+   (:standard %{dune-warnings}))))
+
+(mdx
+ (files README.md)
+ (libraries tw cascade))

--- a/dune-project
+++ b/dune-project
@@ -1,8 +1,10 @@
-(lang dune 3.0)
+(lang dune 3.21)
 
 (using mdx 0.2)
 
 (name tw)
+
+(implicit_transitive_deps false)
 
 (generate_opam_files true)
 

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (description
   "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles to CSS through a strongly-typed variable system that mirrors Tailwind's pipeline, producing byte-for-byte identical output. Supports all core utilities and the official forms and typography plugins.")
  (depends
-  ocaml
+  (ocaml (>= 5.2))
   dune
   cascade
   cmdliner
@@ -34,4 +34,5 @@
   (alcotest-js :with-test)
   (astring :with-test)
   (crunch :with-test)
-  (alcobar :with-test)))
+  (alcobar :with-test)
+  (mdx :with-test)))

--- a/examples/index.ml
+++ b/examples/index.ml
@@ -15,78 +15,35 @@ let example_card ~title ~path ~height =
         [];
     ]
 
+(* Each example: title, iframe path, one-line blurb, and embed height. *)
+let examples =
+  [
+    ("Landing", "landing/", "Marketing page with gradients and CTA", 700);
+    ("Dashboard", "dashboard/", "Responsive admin layout", 800);
+    ("Prose", "prose/", "Typography for articles", 1200);
+    ("Forms", "forms/", "Input states and validation", 600);
+    ("Colors", "colors/", "Full palette and alpha variants", 900);
+    ("Layout", "layout/", "Flexbox and Grid patterns", 1800);
+    ("Modifiers", "modifiers/", "State, group, peer, and ARIA", 1600);
+    ("Animations", "animations/", "Keyframes and transitions", 1500);
+    ("Accessibility", "accessibility/", "Contrast, motion, focus", 1400);
+  ]
+
+let nav_link (title, path, blurb, _) =
+  li [ a ~at:[ At.href path ] [ txt (title ^ " — " ^ blurb) ] ]
+
 let content =
   [
     h1 [ txt "Examples Manual" ];
     p
       ~tw:Tw.[ prose_lead ]
       [ txt "Explore focused, feature-based examples. Each is embedded below." ];
-    ul
-      [
-        li
-          [
-            a
-              ~at:[ At.href "landing/" ]
-              [ txt "Landing — Marketing page with gradients and CTA" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "dashboard/" ]
-              [ txt "Dashboard — Responsive admin layout" ];
-          ];
-        li
-          [
-            a ~at:[ At.href "prose/" ] [ txt "Prose — Typography for articles" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "forms/" ]
-              [ txt "Forms — Input states and validation" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "colors/" ]
-              [ txt "Colors — Full palette and alpha variants" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "layout/" ]
-              [ txt "Layout — Flexbox and Grid patterns" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "modifiers/" ]
-              [ txt "Modifiers — State, group, peer, and ARIA" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "animations/" ]
-              [ txt "Animations — Keyframes and transitions" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "accessibility/" ]
-              [ txt "Accessibility — Contrast, motion, focus" ];
-          ];
-      ];
+    ul (List.map nav_link examples);
     hr ();
-    example_card ~title:"Landing" ~path:"landing/" ~height:700;
-    example_card ~title:"Dashboard" ~path:"dashboard/" ~height:800;
-    example_card ~title:"Prose" ~path:"prose/" ~height:1200;
-    example_card ~title:"Forms" ~path:"forms/" ~height:600;
-    example_card ~title:"Colors" ~path:"colors/" ~height:900;
-    example_card ~title:"Layout" ~path:"layout/" ~height:1800;
-    example_card ~title:"Modifiers" ~path:"modifiers/" ~height:1600;
-    example_card ~title:"Animations" ~path:"animations/" ~height:1500;
-    example_card ~title:"Accessibility" ~path:"accessibility/" ~height:1400;
   ]
+  @ List.map
+      (fun (title, path, _, height) -> example_card ~title ~path ~height)
+      examples
 
 let page_view =
   page ~title:"Examples Manual" ~tw_css:"manual.css" []

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -394,15 +394,23 @@ let rule_sets_from_selector_props all_rules =
   if Sort.debug_compare_enabled () then
     List.iter
       (fun (r : Sort.indexed_rule) ->
-        Fmt.epr "SORTED: vo=%d base=%s type=%s nested=%d@." r.variant_order
-          (match r.base_class with Some s -> s | None -> "<none>")
-          (match r.rule_type with
-          | `Regular -> "R"
-          | `Media m -> "M:" ^ Css.Media.to_string m
-          | `Container _ -> "C"
-          | `Starting -> "S"
-          | `Supports _ -> "U")
-          (List.length r.nested))
+        prerr_endline
+          (Pp.str
+             [
+               "SORTED: vo=";
+               Pp.int r.variant_order;
+               " base=";
+               (match r.base_class with Some s -> s | None -> "<none>");
+               " type=";
+               (match r.rule_type with
+               | `Regular -> "R"
+               | `Media m -> "M:" ^ Css.Media.to_string m
+               | `Container _ -> "C"
+               | `Starting -> "S"
+               | `Supports _ -> "U");
+               " nested=";
+               Pp.int (List.length r.nested);
+             ]))
       sorted;
   sorted |> List.map indexed_rule_to_statement
 

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -302,7 +302,8 @@ let adjust_pseudo class_name (prio, suborder) =
 let collect_order_map tw_classes =
   let m = Hashtbl.create 256 in
   let rec collect = function
-    | Utility.Base b -> Hashtbl.replace m (Utility.class_of_base b) (Utility.order b)
+    | Utility.Base b ->
+        Hashtbl.replace m (Utility.class_of_base b) (Utility.order b)
     | Utility.Modified (_, t) -> collect t
     | Utility.Group us -> List.iter collect us
   in
@@ -377,6 +378,9 @@ let add_index triples =
       Buffer.clear buf;
       Css.Selector.to_buffer buf sel;
       let selector_str = Buffer.contents buf in
+      let media_group_sub, media_key, nested_media_key =
+        Sort.precompute_media_keys typ nested
+      in
       ({
          index = i;
          rule_type = typ;
@@ -392,6 +396,9 @@ let add_index triples =
          not_order;
          variant_order = Rule.compute_variant_order base_class sel;
          variant_key = Sort.variant_sort_key base_class nested;
+         media_group_sub;
+         media_key;
+         nested_media_key;
        }
         : Sort.indexed_rule))
     triples

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -391,6 +391,7 @@ let add_index triples =
          merge_key;
          not_order;
          variant_order = Rule.compute_variant_order base_class sel;
+         variant_key = Sort.variant_sort_key base_class nested;
        }
         : Sort.indexed_rule))
     triples

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1164,13 +1164,12 @@ let sort_keyframes_by_var_order keyframes =
       else String.compare name1 name2 (* Stable sort for same order *))
 
 (** Build all CSS layers from utilities and rules *)
-let layers ~layers ~include_base ?forms ~selector_props tw_classes statements =
+let layers ~layers ~include_base ?forms ~selector_props ~sorted_rules tw_classes
+    statements =
   let styles = List.map Utility.to_style tw_classes in
   let vars_from_utilities, set_var_names, property_rules_lists =
     extract_vars_and_rules tw_classes
   in
-  (* Get sorted indexed_rules to extract first-usage order from sorted output *)
-  let sorted_rules = sorted_indexed_rules selector_props in
   (* Build first-usage order from ALL vars per utility in utility order. For
      each utility, collects SET vars then REFERENCED vars needing @property.
      Within each utility, vars are sorted by property_order (done in
@@ -1222,10 +1221,14 @@ let default_config = { base = true; forms = None; layers = true }
 
 let to_css ?(config = default_config) tw_classes =
   let selector_props = List.concat_map Rule.outputs tw_classes in
-  let statements = rule_sets_from_selector_props selector_props in
+  (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
+     utilities-layer statements and the variable first-usage order, so compute
+     it once and share it rather than recomputing inside [layers]. *)
+  let sorted_rules = sorted_indexed_rules selector_props in
+  let statements = List.map indexed_rule_to_statement sorted_rules in
   let layer_results =
     layers ~layers:config.layers ~include_base:config.base ?forms:config.forms
-      ~selector_props tw_classes statements
+      ~selector_props ~sorted_rules tw_classes statements
   in
   Css.concat layer_results
 

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -283,28 +283,43 @@ let deduplicate_typed_triples triples =
    base_class may contain modifier prefixes (e.g., "md:grid-cols-2"), so we need
    to strip those before looking up the utility. Pseudo-element modifiers
    (before:, after:) use a fixed high suborder to preserve source order. *)
-let order_of_base base_class selector =
+(* Pseudo-element modifiers add 5000 to the base utility's suborder, keeping
+   them near their base utility but after all regular utilities (matching
+   Tailwind v4, where pseudo-elements appear late). *)
+let adjust_pseudo class_name (prio, suborder) =
+  if
+    String.starts_with ~prefix:"before:" class_name
+    || String.starts_with ~prefix:"after:" class_name
+  then (prio, suborder + 5000)
+  else (prio, suborder)
+
+(* The base utility's order is [Utility.order] on its value, recovered here from
+   the class string by re-parsing it through the handlers - the expensive part.
+   [order_map] (built once per generation from the actual utility values, see
+   [collect_order_map]) lets the common case skip that parse; an unknown class
+   (not in the input set) falls back to the parse, or to a selector-based
+   conflict order when even that fails. *)
+let collect_order_map tw_classes =
+  let m = Hashtbl.create 256 in
+  let rec collect = function
+    | Utility.Base b -> Hashtbl.replace m (Utility.class_of_base b) (Utility.order b)
+    | Utility.Modified (_, t) -> collect t
+    | Utility.Group us -> List.iter collect us
+  in
+  List.iter collect tw_classes;
+  m
+
+let order_of_base order_map base_class selector =
   match base_class with
   | Some class_name -> (
-      (* Check if this has a pseudo-element modifier prefix *)
-      let has_pseudo_element_modifier =
-        String.starts_with ~prefix:"before:" class_name
-        || String.starts_with ~prefix:"after:" class_name
-      in
-      (* Strip modifier prefix to get base utility name *)
       let base_utility = extract_base_utility class_name in
-      let parts = String.split_on_char '-' base_utility in
-      match Utility.base_of_strings parts with
-      | Ok u ->
-          let prio, suborder = Utility.order u in
-          if has_pseudo_element_modifier then
-            (* Pseudo-element modifiers add 5000 to the base utility's suborder.
-               This keeps them near their base utility but after all regular
-               utilities, matching Tailwind v4 behavior where pseudo-elements
-               appear late. *)
-            (prio, suborder + 5000)
-          else Utility.order u
-      | Error _ -> conflict_order (Css.Selector.to_string selector))
+      match Hashtbl.find_opt order_map base_utility with
+      | Some order -> adjust_pseudo class_name order
+      | None -> (
+          let parts = String.split_on_char '-' base_utility in
+          match Utility.base_of_strings parts with
+          | Ok u -> adjust_pseudo class_name (Utility.order u)
+          | Error _ -> conflict_order (Css.Selector.to_string selector)))
   | None -> conflict_order (Css.Selector.to_string selector)
 
 (* Adjust order with not-variant offset *)
@@ -316,39 +331,40 @@ let triple typ ~selector ~props ~order ~nested ~base_class ~merge_key ~not_order
     =
   Some (typ, selector, props, order, nested, base_class, merge_key, not_order)
 
-let rule_to_triple = function
+(* The [(hover: hover)] media condition is the same for every hover rule. *)
+let hover_media : Css.Media.t =
+  Css.Media.Cond
+    (Css.Media.Feature
+       (Css.Media.Plain (Css.Media.Hover, Css.Media.Ident Css.Media.Hover)))
+
+let rule_to_triple order_map = function
   | Regular
       { selector; props; base_class; nested; has_hover; merge_key; not_order }
     ->
       let order =
-        apply_not_order (order_of_base base_class selector) not_order
+        apply_not_order (order_of_base order_map base_class selector) not_order
       in
-      let hover : Css.Media.t =
-        Css.Media.Cond
-          (Css.Media.Feature
-             (Css.Media.Plain (Css.Media.Hover, Css.Media.Ident Css.Media.Hover)))
-      in
-      let typ = if has_hover then `Media hover else `Regular in
+      let typ = if has_hover then `Media hover_media else `Regular in
       triple typ ~selector ~props ~order ~nested ~base_class ~merge_key
         ~not_order
   | Media_query { condition; selector; props; base_class; nested; not_order } ->
       let order =
-        apply_not_order (order_of_base base_class selector) not_order
+        apply_not_order (order_of_base order_map base_class selector) not_order
       in
       triple (`Media condition) ~selector ~props ~order ~nested ~base_class
         ~merge_key:None ~not_order
   | Container_query { condition; selector; props; base_class } ->
       triple (`Container condition) ~selector ~props
-        ~order:(order_of_base base_class selector)
+        ~order:(order_of_base order_map base_class selector)
         ~nested:[] ~base_class ~merge_key:None ~not_order:0
   | Starting_style { selector; props; base_class } ->
       triple `Starting ~selector ~props
-        ~order:(order_of_base base_class selector)
+        ~order:(order_of_base order_map base_class selector)
         ~nested:[] ~base_class ~merge_key:None ~not_order:0
   | Supports_query
       { condition; selector; props; base_class; merge_key; not_order } ->
       let order =
-        apply_not_order (order_of_base base_class selector) not_order
+        apply_not_order (order_of_base order_map base_class selector) not_order
       in
       triple (`Supports condition) ~selector ~props ~order ~nested:[]
         ~base_class ~merge_key ~not_order
@@ -381,13 +397,13 @@ let add_index triples =
 
 (* Convert selector/props pairs to CSS rules. *)
 (* Internal: build rule sets from pre-extracted outputs. *)
-let rule_sets_from_selector_props all_rules =
+let rule_sets_from_selector_props order_map all_rules =
   (* All rules (including hover) are now sorted together. Hover rules are
      converted to Media "(hover:hover)" rules in rule_to_triple, so they
      participate in the normal media query sorting. *)
   let indexed =
     all_rules
-    |> List.filter_map rule_to_triple
+    |> List.filter_map (rule_to_triple order_map)
     |> deduplicate_typed_triples |> add_index
   in
   let sorted = List.sort Sort.compare_indexed_rules indexed in
@@ -423,9 +439,9 @@ let utilities_layer ~layers ~statements =
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)
-let sorted_indexed_rules all_rules =
+let sorted_indexed_rules order_map all_rules =
   all_rules
-  |> List.filter_map rule_to_triple
+  |> List.filter_map (rule_to_triple order_map)
   |> deduplicate_typed_triples |> add_index
   |> List.sort Sort.compare_indexed_rules
 
@@ -469,7 +485,7 @@ let var_names_of_sorted_rules sorted_rules =
 
 let rule_sets tw_classes =
   let all_rules = tw_classes |> List.concat_map Rule.outputs in
-  rule_sets_from_selector_props all_rules
+  rule_sets_from_selector_props (collect_order_map tw_classes) all_rules
 
 (* ======================================================================== *)
 (* Layer Generation - CSS @layer directives and theme variable resolution *)
@@ -1221,10 +1237,13 @@ let default_config = { base = true; forms = None; layers = true }
 
 let to_css ?(config = default_config) tw_classes =
   let selector_props = List.concat_map Rule.outputs tw_classes in
+  (* Resolve each utility's order from its value once, so [order_of_base] does
+     not re-parse class strings while building/sorting rules. *)
+  let order_map = collect_order_map tw_classes in
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute
      it once and share it rather than recomputing inside [layers]. *)
-  let sorted_rules = sorted_indexed_rules selector_props in
+  let sorted_rules = sorted_indexed_rules order_map selector_props in
   let statements = List.map indexed_rule_to_statement sorted_rules in
   let layer_results =
     layers ~layers:config.layers ~include_base:config.base ?forms:config.forms

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -273,19 +273,11 @@ let hex_to_rgb hex =
   with Invalid_argument _ | Failure _ -> None
 
 let rgb_to_hex rgb =
-  let to_hex_byte n =
-    let hex = "0123456789abcdef" in
-    String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
-  in
-  "#" ^ to_hex_byte rgb.r ^ to_hex_byte rgb.g ^ to_hex_byte rgb.b
+  "#" ^ Pp.hex_byte rgb.r ^ Pp.hex_byte rgb.g ^ Pp.hex_byte rgb.b
 
 (** Add alpha to a hex color string. Returns #RRGGBBAA format. The opacity is a
     percentage (0-100). *)
 let hex_with_alpha hex_str opacity_percent =
-  let to_hex_byte n =
-    let hex = "0123456789abcdef" in
-    String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
-  in
   (* Parse hex color *)
   let hex_clean =
     if String.length hex_str > 0 && hex_str.[0] = '#' then
@@ -295,7 +287,7 @@ let hex_with_alpha hex_str opacity_percent =
   (* Convert opacity percentage to 8-bit alpha value, with rounding *)
   let alpha = int_of_float ((opacity_percent /. 100.0 *. 255.0) +. 0.5) in
   let alpha_clamped = max 0 (min 255 alpha) in
-  let full = hex_clean ^ to_hex_byte alpha_clamped in
+  let full = hex_clean ^ Pp.hex_byte alpha_clamped in
   (* Shorten #RRGGBBAA → #RGBA when each pair is identical *)
   let len = String.length full in
   let shortened =

--- a/lib/dom/dune
+++ b/lib/dom/dune
@@ -1,7 +1,7 @@
 (library
  (name tw_dom)
  (public_name tw.dom)
- (libraries tw brr)
+ (libraries tw brr cascade)
  (optional))
 
 (mdx

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (public_name tw)
  (name tw)
- (libraries cascade fmt))
+ (libraries cascade))
 
 (mdx
  (files tw.mli prose.mli utility.mli var.mli)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -8,11 +8,12 @@ let set_scheme scheme = current_scheme := scheme
 module Handler = struct
   open Style
 
+  (* Capture the project Pp helpers before [open Css] shadows Pp with Css.Pp. *)
   let pp_float = Pp.float
+  let pp_str = Pp.str
+  let hex_byte = Pp.hex_byte
 
   open Css
-
-  let hex_byte n = Printf.sprintf "%02x" n
 
   let rgba_hex_string r g b a =
     let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
@@ -310,7 +311,8 @@ module Handler = struct
     | None -> make_color_var (Parse.extract_var_name v)
 
   let relative_oklab_from_var v percent =
-    Css.parse_color (Fmt.str "oklab(from %s l a b / %s%%)" v (pp_float percent))
+    Css.parse_color
+      (pp_str [ "oklab(from "; v; " l a b / "; pp_float percent; "%)" ])
 
   let box_shadow_composition v_shadow =
     let v_inset = Var.reference inset_shadow_var in

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -9,6 +9,11 @@ module Css = Cascade.Css
 
 module Handler = struct
   open Style
+
+  (* Capture project Pp helpers before [open Css] shadows Pp with Css.Pp. *)
+  let pp_str = Pp.str
+  let pp_int = Pp.int
+
   open Css
 
   type t =
@@ -83,7 +88,8 @@ module Handler = struct
   let basis_spacing n =
     let spacing_decl, _ = Var.binding Theme.spacing_var Theme.spacing_base in
     let cursor =
-      Cascade.Cursor.of_string (Fmt.str "calc(var(--spacing) * %d)" n)
+      Cascade.Cursor.of_string
+        (pp_str [ "calc(var(--spacing) * "; pp_int n; ")" ])
     in
     let value =
       match
@@ -91,7 +97,8 @@ module Handler = struct
       with
       | Ok v -> v
       | Error _ ->
-          invalid_arg (Fmt.str "basis-%d: failed to parse spacing calc" n)
+          invalid_arg
+            (pp_str [ "basis-"; pp_int n; ": failed to parse spacing calc" ])
     in
     style [ spacing_decl; flex_basis value ]
 

--- a/lib/html/dune
+++ b/lib/html/dune
@@ -1,4 +1,4 @@
 (library
  (name tw_html)
  (public_name tw.html)
- (libraries tw))
+ (libraries tw cascade))

--- a/lib/html/tw_html.mli
+++ b/lib/html/tw_html.mli
@@ -22,7 +22,7 @@ module At : sig
   (** {1 Global attributes} *)
 
   val title : string -> attr
-  (** [title "My Title"] creates a [title] attribute. *)
+  (** [title s] creates a {!val-title} attribute. *)
 
   val lang : string -> attr
   (** [lang "en"] creates a [lang] attribute. *)
@@ -141,7 +141,7 @@ module At : sig
   (** [sizes "..."] creates a [sizes] attribute for responsive images. *)
 
   val title' : string -> attr
-  (** [title' "My Page"] creates a [title] attribute for elements. *)
+  (** [title' s] creates a {!val-title} attribute for elements. *)
 
   (** {1 Additional attributes} *)
 
@@ -174,7 +174,7 @@ module At : sig
   (** [to_pair at] returns the attribute as a (name, value) pair. *)
 
   val of_pair : string * string -> attr
-  (** [of_pair (n, v)] creates an attribute from a (name, value) pair. *)
+  (** [of_pair (n,v)] creates an attribute from a (name, value) pair. *)
 
   (** {2 Additional HTML5 attributes} *)
 
@@ -241,61 +241,61 @@ module At : sig
   (** {2 SVG Attributes} *)
 
   val fill_rule : [ `evenodd ] -> attr
-  (** [fill_rule `evenodd] sets the fill rule *)
+  (** [fill_rule `evenodd] sets the fill rule. *)
 
   val clip_rule : [ `evenodd ] -> attr
-  (** [clip_rule `evenodd] sets the clipping rule *)
+  (** [clip_rule `evenodd] sets the clipping rule. *)
 
   val cx : int -> attr
-  (** [cx n] sets the center x coordinate *)
+  (** [cx n] sets the center x coordinate. *)
 
   val cy : int -> attr
-  (** [cy n] sets the center y coordinate *)
+  (** [cy n] sets the center y coordinate. *)
 
   val r : int -> attr
-  (** [r n] sets the radius *)
+  (** [r n] sets the radius. *)
 
   val view_box : string -> attr
-  (** [view_box "0 0 20 20"] sets the viewBox *)
+  (** [view_box s] sets the viewBox. *)
 
   val fill : string -> attr
-  (** [fill "currentColor"] sets the fill color *)
+  (** [fill "currentColor"] sets the fill color. *)
 
   val stroke : string -> attr
-  (** [stroke "currentColor"] sets the stroke color *)
+  (** [stroke "currentColor"] sets the stroke color. *)
 
   val stroke_width : string -> attr
-  (** [stroke_width "2"] sets the stroke width *)
+  (** [stroke_width "2"] sets the stroke width. *)
 
   val stroke_linecap : string -> attr
-  (** [stroke_linecap "round"] sets the stroke line cap *)
+  (** [stroke_linecap "round"] sets the stroke line cap. *)
 
   val stroke_linejoin : string -> attr
-  (** [stroke_linejoin "round"] sets the stroke line join *)
+  (** [stroke_linejoin "round"] sets the stroke line join. *)
 
   val x : string -> attr
-  (** [x "10"] sets the x coordinate *)
+  (** [x "10"] sets the x coordinate. *)
 
   val y : string -> attr
-  (** [y "10"] sets the y coordinate *)
+  (** [y "10"] sets the y coordinate. *)
 
   val rx : string -> attr
-  (** [rx "5"] sets the x radius for rounded rectangles *)
+  (** [rx "5"] sets the x radius for rounded rectangles. *)
 
   val d : string -> attr
-  (** [d "M10 10 L20 20"] sets the path data *)
+  (** [d s] sets the path data. *)
 
   val x1 : string -> attr
-  (** [x1 "0"] sets the first x coordinate *)
+  (** [x1 "0"] sets the first x coordinate. *)
 
   val y1 : string -> attr
-  (** [y1 "0"] sets the first y coordinate *)
+  (** [y1 "0"] sets the first y coordinate. *)
 
   val x2 : string -> attr
-  (** [x2 "20"] sets the second x coordinate *)
+  (** [x2 "20"] sets the second x coordinate. *)
 
   val y2 : string -> attr
-  (** [y2 "20"] sets the second y coordinate *)
+  (** [y2 "20"] sets the second y coordinate. *)
 end
 
 (** {1 Text helpers} *)
@@ -413,7 +413,7 @@ module Livereload : sig
 
   val script : t
   (** [script] is the JavaScript code for livereload functionality. Only
-      included when [enabled] is true. *)
+      included when {!val-enabled} is true. *)
 end
 
 (** {1 HTML Elements} *)

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -693,7 +693,7 @@ val is_aria_shorthand : string -> bool
 
 val not_variant_order : modifier -> int
 (** [not_variant_order m] returns the cascade sort key for a [not-*] inner
-    modifier. Matches the ordering of [variant_order_of_prefix] for the
+    modifier. Matches the ordering of {!val-variant_order_of_prefix} for the
     corresponding pseudo-class/media prefix. *)
 
 val variant_order_of_prefix : string -> int
@@ -704,6 +704,6 @@ val variant_order_of_prefix : string -> int
 
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as
-    [variant_order_of_prefix] for the corresponding CSS media condition. Used to
-    derive the cascade position of rules whose ordering comes from a nested
-    media query rather than from the class-name prefix alone. *)
+    {!val-variant_order_of_prefix} for the corresponding CSS media condition.
+    Used to derive the cascade position of rules whose ordering comes from a
+    nested media query rather than from the class-name prefix alone. *)

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -74,6 +74,8 @@ val regular :
   ?not_order:int ->
   unit ->
   t
+(** [regular ~selector ~props ()] constructs a plain (non-media,
+    non-conditional) rule. *)
 
 val media_query :
   condition:Css.Media.t ->
@@ -84,8 +86,8 @@ val media_query :
   ?not_order:int ->
   unit ->
   t
-(** [media_query ~condition ~selector ~props ()] constructs a [Media_query] rule
-    wrapped in [@media condition]. *)
+(** [media_query ~condition ~selector ~props ()] constructs a
+    {!constructor-Media_query} rule wrapped in [@media condition]. *)
 
 val container_query :
   condition:Css.Container.t ->
@@ -95,7 +97,7 @@ val container_query :
   unit ->
   t
 (** [container_query ~condition ~selector ~props ()] constructs a
-    [Container_query] rule wrapped in [@container condition]. *)
+    {!constructor-Container_query} rule wrapped in [@container condition]. *)
 
 val starting_style :
   selector:Css.Selector.t ->
@@ -103,8 +105,8 @@ val starting_style :
   ?base_class:string ->
   unit ->
   t
-(** [starting_style ~selector ~props ()] constructs a [Starting_style] rule
-    wrapped in [@starting-style]. *)
+(** [starting_style ~selector ~props ()] constructs a
+    {!constructor-Starting_style} rule wrapped in [@starting-style]. *)
 
 val supports_query :
   condition:Css.Supports.t ->
@@ -116,7 +118,7 @@ val supports_query :
   unit ->
   t
 (** [supports_query ~condition ~selector ~props ()] constructs a
-    [Supports_query] rule wrapped in [@supports condition]. *)
+    {!constructor-Supports_query} rule wrapped in [@supports condition]. *)
 
 val pp : t -> string
 (** [pp r] returns a short human-readable description of [r], e.g.
@@ -136,10 +138,11 @@ type by_type = {
 *)
 
 val classify_by_type : t list -> by_type
-(** [classify_by_type rules] partitions [rules] by variant into a [by_type]
-    record. Each group preserves the original order of its elements. *)
+(** [classify_by_type rules] partitions [rules] by variant into a
+    {!type-by_type} record. Each group preserves the original order of its
+    elements. *)
 
 val is_hover_rule : t -> bool
-(** [is_hover_rule r] is [true] iff [r] is a [Regular] rule with
+(** [is_hover_rule r] is [true] iff [r] is a {!constructor-Regular} rule with
     [has_hover = true]. Used by {!Build} to gate hover utilities under
     [@media (hover:hover)]. *)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -57,6 +57,11 @@ let bool = string_of_bool
 (** Format int *)
 let int = string_of_int
 
+(** Format a byte (0-255) as two lowercase hex digits *)
+let hex_byte n =
+  let hex = "0123456789abcdef" in
+  String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
+
 (** Format float nicely without trailing dots *)
 let float f =
   let s = string_of_float f in

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -59,6 +59,10 @@ val bool : bool -> string
 val int : int -> string
 (** [int n] formats an integer. *)
 
+val hex_byte : int -> string
+(** [hex_byte n] formats a byte [n] (0-255) as two lowercase hexadecimal digits,
+    e.g. [hex_byte 255 = "ff"]. *)
+
 val float : float -> string
 (** [float f] formats a float without trailing dots. *)
 

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -211,152 +211,62 @@ type prose_theme = {
   invert_td_borders : Css.declaration * Css.color Css.var;
 }
 
-(* Default prose theme - created once and shared across all utilities *)
+(* Default prose theme - created once and shared across all utilities. Each
+   field is the (declaration, reference) pair returned by [Var.binding], so the
+   theme is a plain record literal. *)
 let default_prose_theme : prose_theme =
-  let body_d, body_v =
-    Var.binding prose_body_var (Css.oklch 37.3 0.034 259.733)
-  in
-  let headings_d, headings_v =
-    Var.binding prose_headings_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let lead_d, lead_v =
-    Var.binding prose_lead_var (Css.oklch 44.6 0.030 256.802)
-  in
-  let links_d, links_v =
-    Var.binding prose_links_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let bold_d, bold_v =
-    Var.binding prose_bold_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let counters_d, counters_v =
-    Var.binding prose_counters_var (Css.oklch 55.1 0.027 264.364)
-  in
-  let bullets_d, bullets_v =
-    Var.binding prose_bullets_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let hr_d, hr_v = Var.binding prose_hr_var (Css.oklch 92.8 0.006 264.531) in
-  let quotes_d, quotes_v =
-    Var.binding prose_quotes_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let quote_borders_d, quote_borders_v =
-    Var.binding prose_quote_borders_var (Css.oklch 92.8 0.006 264.531)
-  in
-  let captions_d, captions_v =
-    Var.binding prose_captions_var (Css.oklch 55.1 0.027 264.364)
-  in
-  let kbd_d, kbd_v = Var.binding prose_kbd_var (Css.oklch 21.0 0.034 264.665) in
-  let kbd_shadows_d, kbd_shadows_v =
-    Var.binding prose_kbd_shadows_var
-      (Css.oklaba 21.0 (-0.00316127) (-0.0338527) 0.1)
-  in
-  let code_d, code_v =
-    Var.binding prose_code_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let pre_code_d, pre_code_v =
-    Var.binding prose_pre_code_var (Css.oklch 92.8 0.006 264.531)
-  in
-  let pre_bg_d, pre_bg_v =
-    Var.binding prose_pre_bg_var (Css.oklch 27.8 0.033 256.848)
-  in
-  let th_borders_d, th_borders_v =
-    Var.binding prose_th_borders_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let td_borders_d, td_borders_v =
-    Var.binding prose_td_borders_var (Css.oklch 92.8 0.006 264.531)
-  in
-  (* Invert variants *)
-  let invert_body_d, invert_body_v =
-    Var.binding prose_invert_body_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let invert_headings_d, invert_headings_v =
-    Var.binding prose_invert_headings_var (Css.hex "fff")
-  in
-  let invert_lead_d, invert_lead_v =
-    Var.binding prose_invert_lead_var (Css.oklch 70.7 0.022 261.325)
-  in
-  let invert_links_d, invert_links_v =
-    Var.binding prose_invert_links_var (Css.hex "fff")
-  in
-  let invert_bold_d, invert_bold_v =
-    Var.binding prose_invert_bold_var (Css.hex "fff")
-  in
-  let invert_counters_d, invert_counters_v =
-    Var.binding prose_invert_counters_var (Css.oklch 70.7 0.022 261.325)
-  in
-  let invert_bullets_d, invert_bullets_v =
-    Var.binding prose_invert_bullets_var (Css.oklch 44.6 0.030 256.802)
-  in
-  let invert_hr_d, invert_hr_v =
-    Var.binding prose_invert_hr_var (Css.oklch 37.3 0.034 259.733)
-  in
-  let invert_quotes_d, invert_quotes_v =
-    Var.binding prose_invert_quotes_var (Css.oklch 96.7 0.003 264.542)
-  in
-  let invert_quote_borders_d, invert_quote_borders_v =
-    Var.binding prose_invert_quote_borders_var (Css.oklch 37.3 0.034 259.733)
-  in
-  let invert_captions_d, invert_captions_v =
-    Var.binding prose_invert_captions_var (Css.oklch 70.7 0.022 261.325)
-  in
-  let invert_kbd_d, invert_kbd_v =
-    Var.binding prose_invert_kbd_var (Css.hex "fff")
-  in
-  let invert_kbd_shadows_d, invert_kbd_shadows_v =
-    Var.binding prose_invert_kbd_shadows_var (Css.hex "#ffffff1a")
-  in
-  let invert_code_d, invert_code_v =
-    Var.binding prose_invert_code_var (Css.hex "fff")
-  in
-  let invert_pre_code_d, invert_pre_code_v =
-    Var.binding prose_invert_pre_code_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let invert_pre_bg_d, invert_pre_bg_v =
-    Var.binding prose_invert_pre_bg_var (Css.hex "00000080")
-  in
-  let invert_th_borders_d, invert_th_borders_v =
-    Var.binding prose_invert_th_borders_var (Css.oklch 44.6 0.030 256.802)
-  in
-  let invert_td_borders_d, invert_td_borders_v =
-    Var.binding prose_invert_td_borders_var (Css.oklch 37.3 0.034 259.733)
-  in
   {
-    body = (body_d, body_v);
-    headings = (headings_d, headings_v);
-    lead = (lead_d, lead_v);
-    links = (links_d, links_v);
-    bold = (bold_d, bold_v);
-    counters = (counters_d, counters_v);
-    bullets = (bullets_d, bullets_v);
-    hr = (hr_d, hr_v);
-    quotes = (quotes_d, quotes_v);
-    quote_borders = (quote_borders_d, quote_borders_v);
-    captions = (captions_d, captions_v);
-    kbd = (kbd_d, kbd_v);
-    kbd_shadows = (kbd_shadows_d, kbd_shadows_v);
-    code = (code_d, code_v);
-    pre_code = (pre_code_d, pre_code_v);
-    pre_bg = (pre_bg_d, pre_bg_v);
-    th_borders = (th_borders_d, th_borders_v);
-    td_borders = (td_borders_d, td_borders_v);
+    body = Var.binding prose_body_var (Css.oklch 37.3 0.034 259.733);
+    headings = Var.binding prose_headings_var (Css.oklch 21.0 0.034 264.665);
+    lead = Var.binding prose_lead_var (Css.oklch 44.6 0.030 256.802);
+    links = Var.binding prose_links_var (Css.oklch 21.0 0.034 264.665);
+    bold = Var.binding prose_bold_var (Css.oklch 21.0 0.034 264.665);
+    counters = Var.binding prose_counters_var (Css.oklch 55.1 0.027 264.364);
+    bullets = Var.binding prose_bullets_var (Css.oklch 87.2 0.010 258.338);
+    hr = Var.binding prose_hr_var (Css.oklch 92.8 0.006 264.531);
+    quotes = Var.binding prose_quotes_var (Css.oklch 21.0 0.034 264.665);
+    quote_borders =
+      Var.binding prose_quote_borders_var (Css.oklch 92.8 0.006 264.531);
+    captions = Var.binding prose_captions_var (Css.oklch 55.1 0.027 264.364);
+    kbd = Var.binding prose_kbd_var (Css.oklch 21.0 0.034 264.665);
+    kbd_shadows =
+      Var.binding prose_kbd_shadows_var
+        (Css.oklaba 21.0 (-0.00316127) (-0.0338527) 0.1);
+    code = Var.binding prose_code_var (Css.oklch 21.0 0.034 264.665);
+    pre_code = Var.binding prose_pre_code_var (Css.oklch 92.8 0.006 264.531);
+    pre_bg = Var.binding prose_pre_bg_var (Css.oklch 27.8 0.033 256.848);
+    th_borders = Var.binding prose_th_borders_var (Css.oklch 87.2 0.010 258.338);
+    td_borders = Var.binding prose_td_borders_var (Css.oklch 92.8 0.006 264.531);
     (* Invert variants *)
-    invert_body = (invert_body_d, invert_body_v);
-    invert_headings = (invert_headings_d, invert_headings_v);
-    invert_lead = (invert_lead_d, invert_lead_v);
-    invert_links = (invert_links_d, invert_links_v);
-    invert_bold = (invert_bold_d, invert_bold_v);
-    invert_counters = (invert_counters_d, invert_counters_v);
-    invert_bullets = (invert_bullets_d, invert_bullets_v);
-    invert_hr = (invert_hr_d, invert_hr_v);
-    invert_quotes = (invert_quotes_d, invert_quotes_v);
-    invert_quote_borders = (invert_quote_borders_d, invert_quote_borders_v);
-    invert_captions = (invert_captions_d, invert_captions_v);
-    invert_kbd = (invert_kbd_d, invert_kbd_v);
-    invert_kbd_shadows = (invert_kbd_shadows_d, invert_kbd_shadows_v);
-    invert_code = (invert_code_d, invert_code_v);
-    invert_pre_code = (invert_pre_code_d, invert_pre_code_v);
-    invert_pre_bg = (invert_pre_bg_d, invert_pre_bg_v);
-    invert_th_borders = (invert_th_borders_d, invert_th_borders_v);
-    invert_td_borders = (invert_td_borders_d, invert_td_borders_v);
+    invert_body =
+      Var.binding prose_invert_body_var (Css.oklch 87.2 0.010 258.338);
+    invert_headings = Var.binding prose_invert_headings_var (Css.hex "fff");
+    invert_lead =
+      Var.binding prose_invert_lead_var (Css.oklch 70.7 0.022 261.325);
+    invert_links = Var.binding prose_invert_links_var (Css.hex "fff");
+    invert_bold = Var.binding prose_invert_bold_var (Css.hex "fff");
+    invert_counters =
+      Var.binding prose_invert_counters_var (Css.oklch 70.7 0.022 261.325);
+    invert_bullets =
+      Var.binding prose_invert_bullets_var (Css.oklch 44.6 0.030 256.802);
+    invert_hr = Var.binding prose_invert_hr_var (Css.oklch 37.3 0.034 259.733);
+    invert_quotes =
+      Var.binding prose_invert_quotes_var (Css.oklch 96.7 0.003 264.542);
+    invert_quote_borders =
+      Var.binding prose_invert_quote_borders_var (Css.oklch 37.3 0.034 259.733);
+    invert_captions =
+      Var.binding prose_invert_captions_var (Css.oklch 70.7 0.022 261.325);
+    invert_kbd = Var.binding prose_invert_kbd_var (Css.hex "fff");
+    invert_kbd_shadows =
+      Var.binding prose_invert_kbd_shadows_var (Css.hex "#ffffff1a");
+    invert_code = Var.binding prose_invert_code_var (Css.hex "fff");
+    invert_pre_code =
+      Var.binding prose_invert_pre_code_var (Css.oklch 87.2 0.010 258.338);
+    invert_pre_bg = Var.binding prose_invert_pre_bg_var (Css.hex "00000080");
+    invert_th_borders =
+      Var.binding prose_invert_th_borders_var (Css.oklch 44.6 0.030 256.802);
+    invert_td_borders =
+      Var.binding prose_invert_td_borders_var (Css.oklch 37.3 0.034 259.733);
   }
 
 (** Access theme record variables *)

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -109,7 +109,7 @@ module Handler = struct
 
   let hex_string_of (c : Css.color) : string =
     let fmt r g b a =
-      let h2 n = Printf.sprintf "%02x" n in
+      let h2 = Pp.hex_byte in
       "#" ^ h2 r ^ h2 g ^ h2 b ^ if a = 255 then "" else h2 a
     in
     match c with
@@ -253,7 +253,4 @@ module Handler = struct
     | _ -> Error (`Msg "Not a scrollbar utility")
 end
 
-open Handler
-
 let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)

--- a/lib/scrollbar.mli
+++ b/lib/scrollbar.mli
@@ -1,0 +1,7 @@
+(** Scrollbar utilities: [scrollbar-width], [scrollbar-gutter],
+    [scrollbar-thumb], and [scrollbar-track].
+
+    Constructed by parsing class names (e.g. [scrollbar-thin],
+    [scrollbar-thumb-red-500]); there is no typed DSL constructor. *)
+
+module Handler : Utility.Handler

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -51,6 +51,9 @@ type indexed_rule = {
   merge_key : string option;
   not_order : int;
   variant_order : int;
+  variant_key : string * int;
+      (* Precomputed (variant prefix, effective inner order) - see
+         [variant_sort_key]. Read by [compare_variant_ordered]. *)
 }
 (** An indexed CSS rule ready for sorting. [index] preserves source order;
     [order] is the [(priority, suborder)] pair from the utility definition;
@@ -845,16 +848,24 @@ let inner_vo prefix =
 
 (* Effective inner variant order: prefer prefix-derived, fall back to nested
    media *)
-let effective_ivo r prefix =
+let effective_ivo_of nested prefix =
   let ivo = inner_vo prefix in
   if ivo > 0 then ivo
   else
-    match r.nested with
+    match nested with
     | [ n ] -> (
         match Css.as_media n with
         | Some (cond, _) -> Modifiers.variant_order_of_media_cond cond
         | None -> 0)
     | _ -> 0
+
+(* The variant prefix and effective inner order are pure functions of a rule's
+   base class and nested statements, but [compare_variant_ordered] needs them on
+   every comparison. Precompute them once per rule (see [add_index]) so the hot
+   sort comparator only reads the result. *)
+let variant_sort_key base_class nested =
+  let prefix = variant_prefix base_class in
+  (prefix, effective_ivo_of nested prefix)
 
 (** Classify bracket content: pseudo-class brackets ([:checked]) sort before
     combinator/ampersand brackets ([&>img], [+img], etc.). *)
@@ -920,11 +931,9 @@ let compare_variant_ordered r1 r2 =
       let vo_cmp = Int.compare r1.variant_order r2.variant_order in
       if vo_cmp <> 0 then vo_cmp
       else
-        let p1_prefix = variant_prefix r1.base_class in
-        let p2_prefix = variant_prefix r2.base_class in
-        let ivo_cmp =
-          Int.compare (effective_ivo r1 p1_prefix) (effective_ivo r2 p2_prefix)
-        in
+        let p1_prefix, ivo1 = r1.variant_key in
+        let p2_prefix, ivo2 = r2.variant_key in
+        let ivo_cmp = Int.compare ivo1 ivo2 in
         if ivo_cmp <> 0 then ivo_cmp
         else
           let nested_cmp =

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -32,14 +32,16 @@ type rule_relationship =
   | Same_utility of string  (** Both rules from same base utility *)
   | Different_utilities  (** Rules from different utilities *)
 
+type rule_type =
+  [ `Regular
+  | `Media of Css.Media.t
+  | `Container of Css.Container.t
+  | `Starting
+  | `Supports of Css.Supports.t ]
+
 type indexed_rule = {
   index : int;
-  rule_type :
-    [ `Regular
-    | `Media of Css.Media.t
-    | `Container of Css.Container.t
-    | `Starting
-    | `Supports of Css.Supports.t ];
+  rule_type : rule_type;
   selector : Css.Selector.t;
   selector_str : string;
   selector_kind : selector_kind;
@@ -54,6 +56,15 @@ type indexed_rule = {
   variant_key : string * int;
       (* Precomputed (variant prefix, effective inner order) - see
          [variant_sort_key]. Read by [compare_variant_ordered]. *)
+  media_group_sub : int * float;
+      (* Precomputed [extract_media_sort_key rule_type]: the (group, subkey)
+         that opens every media comparison. *)
+  media_key : Css.Media.key option;
+      (* Precomputed sort key of the rule's own media condition (the [`Media]
+         case of [rule_type]); [None] otherwise. *)
+  nested_media_key : Css.Media.key option;
+      (* Precomputed sort key of a single nested media condition, used to order
+         stacked variants like [min-sm:max-xl]. *)
 }
 (** An indexed CSS rule ready for sorting. [index] preserves source order;
     [order] is the [(priority, suborder)] pair from the utility definition;
@@ -195,9 +206,26 @@ let rule_type_order = function
 
 (* Extract media sort key using Css.Media.kind and group_order. Returns (group,
    subkey) where subkey is rem value for responsive conditions. *)
-let extract_media_sort_key = function
+let extract_media_sort_key : rule_type -> int * float = function
   | `Media cond -> Css.Media.group_order (Css.Media.kind cond)
   | _ -> (0, 0.)
+
+(* Precompute everything a media comparison reads from a rule, so the sort never
+   re-derives a [Css.Media.kind] or re-serializes a query: the (group, subkey)
+   pair, the rule's own media key, and a single nested media key. *)
+let nested_media_condition = function
+  | [ stmt ] -> (
+      match Css.as_media stmt with Some (c, _) -> Some c | None -> None)
+  | _ -> None
+
+let precompute_media_keys (rule_type : rule_type) nested =
+  let media_key =
+    match rule_type with `Media c -> Some (Css.Media.sort_key c) | _ -> None
+  in
+  let nested_media_key =
+    Option.map Css.Media.sort_key (nested_media_condition nested)
+  in
+  (extract_media_sort_key rule_type, media_key, nested_media_key)
 
 (* ======================================================================== *)
 (* Priority Comparison *)
@@ -266,8 +294,10 @@ let compare_by_priority_suborder_alpha kind1 kind2 sel_str1 sel_str2 (p1, s1)
 (* Media Query Comparison *)
 (* ======================================================================== *)
 
-(** Compare two media conditions within the same group *)
-let compare_media_conditions group1 sub1 sub2 cond1 cond2 =
+(** Compare two media conditions within the same group. The responsive branch
+    uses the precomputed keys ([key1]/[key2]) so it never re-serializes; the
+    preference branch reads the cheap ordinal off the conditions directly. *)
+let compare_media_conditions group1 sub1 sub2 cond1 cond2 key1 key2 =
   if group1 = 2000 then Float.compare sub1 sub2
   else if group1 = 1000 then
     match (cond1, cond2) with
@@ -277,8 +307,8 @@ let compare_media_conditions group1 sub1 sub2 cond1 cond2 =
           (preference_condition_order c2)
     | _ -> 0
   else
-    match (cond1, cond2) with
-    | Some c1, Some c2 -> Css.Media.compare c1 c2
+    match (key1, key2) with
+    | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
     | _ -> 0
 
 (* For hover media, separate rules by modifier depth so that single-modifier
@@ -294,13 +324,10 @@ let compare_hover_depth cond1 cond2 sel1 sel2 =
 
 (* Compare by nested media condition when both have nested media. This sorts
    stacked min/max variants like min-sm:max-xl vs min-sm:max-lg by the inner
-   media condition. *)
-let compare_nested_media_cond nested1 nested2 =
-  match (nested1, nested2) with
-  | [ n1 ], [ n2 ] -> (
-      match (Css.as_media n1, Css.as_media n2) with
-      | Some (c1, _), Some (c2, _) -> Css.Media.compare c1 c2
-      | _ -> 0)
+   media condition, from precomputed keys. *)
+let compare_nested_media_cond key1 key2 =
+  match (key1, key2) with
+  | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
   | _ -> 0
 
 let compare_same_media_group (r1 : indexed_rule) (r2 : indexed_rule) cond1 cond2
@@ -308,7 +335,9 @@ let compare_same_media_group (r1 : indexed_rule) (r2 : indexed_rule) cond1 cond2
   let depth_cmp = compare_hover_depth cond1 cond2 r1.selector r2.selector in
   if depth_cmp <> 0 then depth_cmp
   else
-    let nested_media_cmp = compare_nested_media_cond r1.nested r2.nested in
+    let nested_media_cmp =
+      compare_nested_media_cond r1.nested_media_key r2.nested_media_key
+    in
     if nested_media_cmp <> 0 then nested_media_cmp
     else
       let same_utility =
@@ -327,14 +356,17 @@ let compare_media_rules (r1 : indexed_rule) (r2 : indexed_rule) =
   let nested_cmp = Bool.compare (r1.nested <> []) (r2.nested <> []) in
   if nested_cmp <> 0 then nested_cmp
   else
-    let group1, sub1 = extract_media_sort_key r1.rule_type in
-    let group2, sub2 = extract_media_sort_key r2.rule_type in
+    let group1, sub1 = r1.media_group_sub in
+    let group2, sub2 = r2.media_group_sub in
     let key_cmp = Int.compare group1 group2 in
     if key_cmp <> 0 then key_cmp
     else
       let cond1 = match r1.rule_type with `Media c -> Some c | _ -> None in
       let cond2 = match r2.rule_type with `Media c -> Some c | _ -> None in
-      let cond_cmp = compare_media_conditions group1 sub1 sub2 cond1 cond2 in
+      let cond_cmp =
+        compare_media_conditions group1 sub1 sub2 cond1 cond2 r1.media_key
+          r2.media_key
+      in
       if cond_cmp <> 0 then cond_cmp
       else compare_same_media_group r1 r2 cond1 cond2
 
@@ -749,15 +781,16 @@ let compare_by_order_then_selector r1 r2 =
     let sel_cmp = natural_compare r1.selector_str r2.selector_str in
     if sel_cmp <> 0 then sel_cmp else Int.compare r1.index r2.index
 
-(* Compare nested media conditions *)
+(* Compare nested media conditions. Presence of nested content orders first; two
+   single nested media compare from their precomputed keys. *)
 let compare_nested_media r1 r2 =
   match (r1.nested, r2.nested) with
   | [], [] -> 0
   | [], _ -> -1
   | _, [] -> 1
-  | [ n1 ], [ n2 ] -> (
-      match (Css.as_media n1, Css.as_media n2) with
-      | Some (c1, _), Some (c2, _) -> Css.Media.compare c1 c2
+  | [ _ ], [ _ ] -> (
+      match (r1.nested_media_key, r2.nested_media_key) with
+      | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
       | _ -> 0)
   | _ -> 0
 
@@ -944,9 +977,9 @@ let compare_variant_ordered r1 r2 =
           if nested_cmp <> 0 then nested_cmp
           else
             let media_cmp =
-              match (r1.rule_type, r2.rule_type) with
-              | `Media c1, `Media c2 ->
-                  let cmp = Css.Media.compare c1 c2 in
+              match (r1.media_key, r2.media_key) with
+              | Some k1, Some k2 ->
+                  let cmp = Css.Media.compare_keys k1 k2 in
                   if cmp <> 0 then cmp else compare_nested_media r1 r2
               | _ -> 0
             in

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -51,8 +51,9 @@ val classify_selector : Css.Selector.t -> selector_kind
 (** {1 Sorting} *)
 
 val compare_indexed_rules : indexed_rule -> indexed_rule -> int
-(** [compare_indexed_rules r1 r2] is the total order over [indexed_rule] values
-    that produces Tailwind v4 cascade order when used with [List.sort]. *)
+(** [compare_indexed_rules r1 r2] is the total order over {!type-indexed_rule}
+    values that produces Tailwind v4 cascade order when used with [List.sort].
+*)
 
 (** {1 Debug} *)
 

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -43,10 +43,18 @@ type indexed_rule = {
   not_order : int;
   variant_order : int;
       (** Non-zero for modifier-prefixed rules; they sort after base rules. *)
+  variant_key : string * int;
+      (** Precomputed [(variant prefix, effective inner order)], built with
+          {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
+          per comparison. *)
 }
 
 val classify_selector : Css.Selector.t -> selector_kind
 (** [classify_selector sel] classifies a selector for ordering purposes. *)
+
+val variant_sort_key : string option -> Css.statement list -> string * int
+(** [variant_sort_key base_class nested] is the [(variant prefix, effective
+    inner variant order)] pair stored in {!field-variant_key}. *)
 
 (** {1 Sorting} *)
 

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -23,14 +23,16 @@ type selector_kind =
       has_aria : bool;
     }
 
+type rule_type =
+  [ `Regular
+  | `Media of Css.Media.t
+  | `Container of Css.Container.t
+  | `Starting
+  | `Supports of Css.Supports.t ]
+
 type indexed_rule = {
   index : int;  (** Source position — used as a stable tiebreaker. *)
-  rule_type :
-    [ `Regular
-    | `Media of Css.Media.t
-    | `Container of Css.Container.t
-    | `Starting
-    | `Supports of Css.Supports.t ];
+  rule_type : rule_type;
   selector : Css.Selector.t;
   selector_str : string;
   selector_kind : selector_kind;
@@ -47,14 +49,34 @@ type indexed_rule = {
       (** Precomputed [(variant prefix, effective inner order)], built with
           {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
           per comparison. *)
+  media_group_sub : int * float;
+      (** Precomputed [(group, subkey)] for the rule's media, so a comparison
+          never re-derives it with [Css.Media.kind]. *)
+  media_key : Css.Media.key option;
+      (** Precomputed sort key of the rule's own media condition (the [`Media]
+          case of {!field-rule_type}), [None] otherwise. Comparisons use this
+          instead of re-serializing the query on every call. *)
+  nested_media_key : Css.Media.key option;
+      (** Precomputed sort key of a single nested media condition, used to order
+          stacked variants such as [min-sm:max-xl]. *)
 }
 
 val classify_selector : Css.Selector.t -> selector_kind
 (** [classify_selector sel] classifies a selector for ordering purposes. *)
 
 val variant_sort_key : string option -> Css.statement list -> string * int
-(** [variant_sort_key base_class nested] is the [(variant prefix, effective
-    inner variant order)] pair stored in {!field-variant_key}. *)
+(** [variant_sort_key base_class nested] is the
+    [(variant prefix, effective inner variant order)] pair stored in
+    {!field-variant_key}. *)
+
+val precompute_media_keys :
+  rule_type ->
+  Css.statement list ->
+  (int * float) * Css.Media.key option * Css.Media.key option
+(** [precompute_media_keys rule_type nested] is the
+    [(media_group_sub, media_key, nested_media_key)] triple stored on an
+    {!type-indexed_rule}, computed once so comparisons never re-derive a media
+    [kind] or re-serialize a query. *)
 
 (** {1 Sorting} *)
 

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -111,7 +111,7 @@ module Handler = struct
   (* Extract a hex string (with leading #) from a Css.color, for oklab
      conversion *)
   let extract_hex_string css_color =
-    let hex_byte n = Printf.sprintf "%02x" n in
+    let hex_byte = Pp.hex_byte in
     let rgba_hex r g b a =
       let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
       if a = 255 then rgb else rgb ^ hex_byte a

--- a/lib/tab.mli
+++ b/lib/tab.mli
@@ -1,0 +1,8 @@
+(** tab-size utilities. *)
+
+open Utility
+
+val tab : int -> t
+(** [tab n] sets [tab-size] to [n]. *)
+
+module Handler : Utility.Handler

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -2,8 +2,9 @@
 
 module Css = Cascade.Css
 
-(* Capture Pp.float before open Css shadows it *)
+(* Capture project Pp helpers before open Css shadows Pp with Css.Pp. *)
 let pp_float = Pp.float
+let pp_str = Pp.str
 
 module Handler = struct
   open Style
@@ -74,7 +75,8 @@ module Handler = struct
     | None -> make_color_var (Parse.extract_var_name v)
 
   let relative_oklab_from_var v percent =
-    Css.parse_color (Fmt.str "oklab(from %s l a b / %s%%)" v (pp_float percent))
+    Css.parse_color
+      (pp_str [ "oklab(from "; v; " l a b / "; pp_float percent; "%)" ])
 
   (* ============ Parse arbitrary shadow ============ *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -56,6 +56,10 @@
       conventions
     - Colors, spacing, and sizes use consistent scales throughout *)
 
+(* Bind tw's own [Cursor] and [Rule] modules before [open Cascade] shadows the
+   bare names with [Cascade.Cursor] / [Cascade.Rule]. *)
+module Cursor = Cursor
+module Rule = Rule
 open Cascade
 
 (** {1 Core Types}
@@ -65,8 +69,9 @@ type t
 (** The abstract type representing a single CSS style utility. *)
 
 type color = Color.color
-(** Abstract type for colors. Use color constructors like [red], [blue], etc.
-    Colors can have shades from 50 (lightest) to 900 (darkest). *)
+(** Abstract type for colors. Use color constructors like {!val-red},
+    {!val-blue}, etc. Colors can have shades from 50 (lightest) to 900
+    (darkest). *)
 
 (** {1:tailwind_colors Tailwind colors}
 
@@ -271,7 +276,7 @@ val table : t
 
 val hidden : t
 (** [hidden] completely hides the element; no space is reserved and screen
-    readers skip it. Use [sr_only] to hide visually but keep accessible. *)
+    readers skip it. Use {!val-sr_only} to hide visually but keep accessible. *)
 
 (** {2 Float}
     @see <https://tailwindcss.com/docs/float> Float *)
@@ -447,8 +452,8 @@ val absolute : t
     ]} *)
 
 val fixed : t
-(** [fixed] is like [absolute] but relative to the viewport; it stays in place
-    when scrolling. *)
+(** [fixed] is like {!val-absolute} but relative to the viewport; it stays in
+    place when scrolling. *)
 
 val sticky : t
 (** [sticky] scrolls normally until it reaches a viewport edge, then sticks.
@@ -577,7 +582,7 @@ val flex : t
     ]} *)
 
 val inline_flex : t
-(** [inline_flex] is like [flex] but the container itself is inline. *)
+(** [inline_flex] is like {!val-flex} but the container itself is inline. *)
 
 val flex_1 : t
 (** [flex_1] item grows and shrinks as needed, ignoring initial size. Perfect
@@ -639,7 +644,7 @@ val grid : t
     structured than flexbox. *)
 
 val inline_grid : t
-(** [inline_grid] is like [grid] but the container itself is inline. *)
+(** [inline_grid] is like {!val-grid} but the container itself is inline. *)
 
 (** {2 Grid Template Columns}
     @see <https://tailwindcss.com/docs/grid-template-columns>
@@ -1529,8 +1534,8 @@ val text_justify : t
     @see <https://tailwindcss.com/docs/color> Color *)
 
 val text : ?opacity:int -> ?shade:int -> color -> t
-(** [text color] sets text color. [shade] defaults to 500. [opacity] sets the
-    alpha modifier (0-100). *)
+(** [text color] sets text color. [shade] defaults to 500. {!val-opacity} sets
+    the alpha modifier (0-100). *)
 
 val text_inherit : t
 (** [text_inherit] inherits color from the parent element. *)
@@ -1814,7 +1819,7 @@ type direction =
 
 val bg_gradient_to : direction -> t
 (** [bg_gradient_to dir] sets gradient direction using a typed direction.
-    Combine with [from_color]/[via_color]/[to_color].
+    Combine with {!val-from_color}/{!val-via_color}/{!val-to_color}.
 
     Example:
     {[
@@ -1844,8 +1849,8 @@ val from_color : ?shade:int -> color -> t
 
 val via_color : ?shade:int -> color -> t
 (** [via_color purple] sets the middle color of a gradient. Default shade is
-    500. Creates a three-color gradient when used with [bg_gradient_to] and
-    [to_color]. *)
+    500. Creates a three-color gradient when used with {!val-bg_gradient_to} and
+    {!val-to_color}. *)
 
 val to_color : ?shade:int -> color -> t
 (** [to_color ~shade:600 pink] sets the ending color of a gradient. Default
@@ -1927,7 +1932,7 @@ val border_l : t
 
 val border_color : ?opacity:int -> ?shade:int -> color -> t
 (** [border_color color] sets the border color. [shade] defaults to 500.
-    [opacity] sets the alpha modifier (0-100). *)
+    {!val-opacity} sets the alpha modifier (0-100). *)
 
 val border_transparent : t
 (** [border_transparent] makes border fully transparent. *)
@@ -2837,8 +2842,8 @@ val form_radio : t
 
 val accent : ?opacity:int -> ?shade:int -> color -> t
 (** [accent color] sets the accent color for form controls like checkboxes and
-    radio buttons. [shade] defaults to 500. [opacity] sets the alpha modifier
-    (0-100). *)
+    radio buttons. [shade] defaults to 500. {!val-opacity} sets the alpha
+    modifier (0-100). *)
 
 val accent_current : t
 (** [accent_current] sets accent color to currentColor. *)
@@ -2850,8 +2855,8 @@ val accent_inherit : t
     @see <https://tailwindcss.com/docs/caret-color> Caret Color *)
 
 val caret : ?opacity:int -> ?shade:int -> color -> t
-(** [caret color] sets the caret color. [shade] defaults to 500. [opacity] sets
-    the alpha modifier (0-100). *)
+(** [caret color] sets the caret color. [shade] defaults to 500. {!val-opacity}
+    sets the alpha modifier (0-100). *)
 
 val caret_current : t
 (** [caret_current] sets caret color to currentColor. *)
@@ -2934,7 +2939,7 @@ val snap_x : t
     ]} *)
 
 val snap_y : t
-(** [snap_y] enables vertical scroll snapping. Similar to [snap_x] but for
+(** [snap_y] enables vertical scroll snapping. Similar to {!val-snap_x} but for
     vertical scrolling. *)
 
 val snap_both : t
@@ -3097,8 +3102,8 @@ val sr_only : t
     accessible. *)
 
 val not_sr_only : t
-(** [not_sr_only] reverses [sr_only]; it makes previously screen-reader-only
-    content visible. *)
+(** [not_sr_only] reverses {!val-sr_only}; it makes previously
+    screen-reader-only content visible. *)
 
 (** {1 Prose Typography}
 
@@ -3198,8 +3203,9 @@ val to_inline_style : t list -> string
 (** [to_inline_style styles] generates inline CSS for the style attribute.
 
     {b Note:} This generates {i only} the CSS properties for the given styles,
-    without any Tailwind reset/prelude. The reset is only included in [to_css]
-    since it's meant for complete stylesheets, not individual elements.
+    without any Tailwind reset/prelude. The reset is only included in
+    {!val-to_css} since it's meant for complete stylesheets, not individual
+    elements.
 
     Perfect for tweaking individual HTML nodes with custom styles:
     {[
@@ -3207,7 +3213,7 @@ val to_inline_style : t list -> string
       to_inline_style [ bg ~shade:100 blue; p 4; rounded_md; text white ]
     ]}
 
-    {b When to use [to_inline_style] vs [to_css]:}
+    {b When to use [to_inline_style] vs {!val-to_css}:}
 
     {b Use [to_inline_style] when:}
     - You need dynamic styles that change at runtime
@@ -3215,7 +3221,7 @@ val to_inline_style : t list -> string
     - You're working with existing HTML that you can't modify classes for
     - You need precise control over a single element's styling
 
-    {b Use [to_css] (preferred) when:}
+    {b Use {!val-to_css} (preferred) when:}
     - You want to generate a stylesheet that can be cached and reused
     - You're building a full website with consistent styling
     - You want better performance (CSS classes are more efficient than inline
@@ -3237,8 +3243,8 @@ module Css = Css
 
     The Css module provides lower-level CSS types and functions for working with
     stylesheets, rules, and properties. Most users will only need the high-level
-    functions like [to_css] and [stylesheet_to_string], but the Css module is
-    exposed for advanced use cases requiring direct manipulation of CSS
+    functions like {!val-to_css} and [stylesheet_to_string], but the Css module
+    is exposed for advanced use cases requiring direct manipulation of CSS
     structures. *)
 
 module Prose = Prose
@@ -3429,11 +3435,11 @@ val xl2 : t list -> t
 (** {2 Pseudo-elements} *)
 
 val before : t list -> t
-(** [before styles] applies [styles] to ::before. Combine with [content]
+(** [before styles] applies [styles] to ::before. Combine with {!val-content}
     utilities. *)
 
 val after : t list -> t
-(** [after styles] applies [styles] to ::after. Combine with [content]
+(** [after styles] applies [styles] to ::after. Combine with {!val-content}
     utilities. *)
 
 (** {2 ARIA Variants} *)
@@ -3560,7 +3566,6 @@ module Flex = Flex
 module Flex_props = Flex_props
 module Flex_layout = Flex_layout
 module Alignment = Alignment
-module Cursor : module type of Tw__.Cursor
 module Borders = Borders
 module Backgrounds = Backgrounds
 module Sizing = Sizing
@@ -3584,13 +3589,15 @@ module Tables = Tables
 module Svg = Svg
 module Accessibility = Accessibility
 module Output = Output
-module Rule : module type of Tw__.Rule
 module Build = Build
 module Theme = Theme
 module Scheme = Scheme
 module Utility = Utility
 module Spacing = Spacing
 module Box_sizing = Box_sizing
+module Tab = Tab
+module Scrollbar = Scrollbar
+module Zoom = Zoom
 module Columns = Columns
 module Contain = Contain
 module Field_sizing = Field_sizing

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -90,6 +90,11 @@ let rec to_class = function
       | _ -> Style.pp_modifier m ^ ":" ^ to_class u)
   | Group us -> String.concat " " (List.map to_class us)
 
+let rec pp = function
+  | Base u -> "Base " ^ class_of_base u
+  | Modified (m, u) -> "Modified (" ^ Style.pp_modifier m ^ ", " ^ pp u ^ ")"
+  | Group us -> "Group [" ^ String.concat "; " (List.map pp us) ^ "]"
+
 let order (u : base) : int * int =
   let rec try_handlers = function
     | [] ->

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -62,6 +62,9 @@ type t = Base of base | Modified of Style.modifier * t | Group of t list
 val base : base -> t
 (** [base u] wraps a base utility into a Utility.t. *)
 
+val pp : t -> string
+(** [pp u] is a human-readable representation of [u] for debugging. *)
+
 (** Handler module type for utility registration *)
 module type Handler = sig
   type t
@@ -70,22 +73,22 @@ module type Handler = sig
   type base += Self of t  (** Extension of the base utility type *)
 
   val name : string
-  (** Name of this utility handler *)
+  (** Name of this utility handler. *)
 
   val to_style : t -> Style.t
-  (** Convert utility to style *)
+  (** [to_style u] converts utility [u] to a style. *)
 
   val priority : int
-  (** Priority for ordering utilities *)
+  (** Priority for ordering utilities. *)
 
   val suborder : t -> int
-  (** Suborder within the same priority *)
+  (** [suborder u] is the suborder within the same priority. *)
 
   val of_class : string -> (t, [ `Msg of string ]) result
-  (** Parse class name into utility *)
+  (** [of_class name] parses class [name] into a utility. *)
 
   val to_class : t -> string
-  (* TODO *)
+  (** [to_class u] is the CSS class name for utility [u]. *)
 end
 
 val register : (module Handler with type t = 'a) -> unit

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -31,15 +31,10 @@ type _ role =
 type ('a, 'r) t = {
   kind : 'a Css.kind; (* CSS type witness *)
   name : string; (* Variable name without -- prefix *)
-  layer : layer; (* Theme or Utility *)
   role : 'r role; (* The GADT role/pattern of this variable *)
   binding : ?fallback:'a Css.fallback -> 'a -> Css.declaration * 'a Css.var;
       (* Function to create declaration and var ref *)
   property : 'a property_info option; (* For @property registration *)
-  order : (int * int) option;
-      (* Explicit ordering for theme layer (utility_priority, suborder) *)
-  property_order : int option;
-      (* Explicit ordering for properties layer @supports block *)
   fallback : 'a option; (* Built-in fallback for ref_only variables *)
 }
 
@@ -291,17 +286,7 @@ let v : type a r.
         (Css.custom_property ?layer:layer_name ("--" ^ name) css, var)
     | _ -> (decl, var)
   in
-  {
-    kind;
-    name;
-    layer;
-    role;
-    binding;
-    property;
-    order;
-    property_order;
-    fallback;
-  }
+  { kind; name; role; binding; property; fallback }
 
 (* Convenience constructors to encode patterns safely *)
 

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -335,10 +335,10 @@ type 'a property_info = {
   universal : bool;
 }
 (** Property metadata for [@property] registration.
-    - [initial]: Optional initial value. If [None], properties layer uses
+    - {!field-initial}: Optional initial value. If [None], properties layer uses
       "initial"
-    - [inherits]: Whether the property inherits from parent elements
-    - [universal]: Force universal syntax "*" instead of typed syntax *)
+    - {!field-inherits}: Whether the property inherits from parent elements
+    - {!field-universal}: Force universal syntax "*" instead of typed syntax *)
 
 val property_info :
   ?initial:'a -> ?inherits:bool -> ?universal:bool -> unit -> 'a property_info
@@ -416,7 +416,8 @@ val property_default :
     {i \@layer properties \@supports} block. Lower values appear first.
 
     {b IMPORTANT}: Due to current architecture limitations, any style that uses
-    a [property_default] variable MUST include its [property_rule] explicitly:
+    a [property_default] variable MUST include its {!val-property_rule}
+    explicitly:
     {[
     let my_var =
       Var.property_default Css.Content ~initial:(Css.String "")
@@ -498,13 +499,14 @@ val theme_ref : ?default:'a -> ?default_css:string -> string -> 'a Css.var
 
 val resolve_theme_refs : string -> string option
 (** [resolve_theme_refs name] returns the default CSS string value for a
-    [theme_ref] variable. Used as [theme_defaults] in [Pp.ctx] when theme
+    {!val-theme_ref} variable. Used as [theme_defaults] in [Pp.ctx] when theme
     variables don't exist and should be replaced by their concrete defaults. *)
 
 val set_theme_value : string -> string -> unit
 (** [set_theme_value name value] registers a theme value override. When set,
-    utilities using [theme_ref] for this name will produce custom declarations
-    in the theme layer (e.g., [--z-index-auto: 42] in [:root, :host]). *)
+    utilities using {!val-theme_ref} for this name will produce custom
+    declarations in the theme layer (e.g., [--z-index-auto: 42] in
+    [:root, :host]). *)
 
 val theme_value : string -> string option
 (** [theme_value name] returns the overridden theme value, if any. *)

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -52,7 +52,4 @@ module Handler = struct
     | _ -> Error (`Msg "Not a zoom utility")
 end
 
-open Handler
-
 let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)

--- a/lib/zoom.mli
+++ b/lib/zoom.mli
@@ -1,0 +1,6 @@
+(** zoom utilities (the [zoom-*] scale).
+
+    Constructed by parsing class names (e.g. [zoom-50], [zoom-[var(--zoom)]]);
+    there is no typed DSL constructor. *)
+
+module Handler : Utility.Handler

--- a/merlint.toml
+++ b/merlint.toml
@@ -40,9 +40,10 @@ allowed_words = [
 ]
 
 # The local checkout uses an untracked symlink to the sibling cascade repo for
-# development. It is not part of this package's lint surface.
+# development, and vendored dev tooling under mono/. Neither is part of this
+# package's lint surface.
 [[rules]]
-files = ["cascade/**", "./cascade/**"]
+files = ["cascade/**", "./cascade/**", "mono/**", "./mono/**"]
 exclude = ["*"]
 
 # Modules included in tw.ml are flattened into the top-level Tw namespace, so

--- a/merlint.toml
+++ b/merlint.toml
@@ -45,7 +45,10 @@ allowed_words = [
 files = ["cascade/**", "./cascade/**"]
 exclude = ["*"]
 
-# Modules included in tw.ml need E330 exceptions to expose the proper API
+# Modules included in tw.ml are flattened into the top-level Tw namespace, so
+# they intentionally keep prefixed DSL names (E330) and prefixed variant/field
+# constructors (E334): the prefixes disambiguate constructors that would
+# otherwise collide once every module is merged into a single namespace.
 [[rules]]
 files = [
   "lib/color.ml*",
@@ -60,6 +63,9 @@ files = [
   "lib/overscroll.ml*",
   "lib/overflow_wrap.ml*",
   "lib/box_sizing.ml*",
+  "lib/tab.ml*",
+  "lib/scrollbar.ml*",
+  "lib/zoom.ml*",
   "lib/field_sizing.ml*",
   "lib/grid.ml*",
   "lib/grid_item.ml*",
@@ -96,4 +102,4 @@ files = [
   "lib/arbitrary.ml*",
   "lib/style.ml*",
 ]
-exclude = ["E330"]
+exclude = ["E330", "E334"]

--- a/test/dom/dune
+++ b/test/dom/dune
@@ -1,7 +1,7 @@
 (executable
  (name test)
  (modes js)
- (libraries tw tw_dom alcotest astring brr)
+ (libraries tw tw_dom cascade alcotest astring brr)
  (enabled_if
   (= %{context_name} "default")))
 

--- a/test/dune
+++ b/test/dune
@@ -7,6 +7,9 @@
   re
   astring
   fmt
+  cmdliner
+  unix
   tw_tools
+  cascade
   cascade.diff
   test_helpers))

--- a/test/helpers/dune
+++ b/test/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name test_helpers)
- (libraries tw tw_tools alcotest re fmt cascade.diff))
+ (libraries tw tw_tools alcotest re fmt cascade cascade.diff))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -155,7 +155,7 @@ let check_ordering_matches ?(forms = false) ~test_name utilities =
         && contains ".25rem" rendered
         && contains ".125rem" rendered
       then ()
-      else Alcotest.fail (Fmt.str "%s\n%s" test_name rendered)
+      else Alcotest.failf "%s\n%s" test_name rendered
 
 (** CSS Test Helpers *)
 

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -140,8 +140,9 @@ module type Handler = sig
 end
 
 val check_handler_roundtrip : (module Handler) -> string -> unit
-(** [check_handler_roundtrip h class_name] tests that parsing with [of_class]
-    and converting back with [to_class] round-trip correctly. *)
+(** [check_handler_roundtrip h class_name] tests that parsing with
+    {!val-of_class} and converting back with {!val-to_class} round-trip
+    correctly. *)
 
 val check_invalid_input : (module Handler) -> string -> unit
 (** [check_invalid_input h input] tests that parsing fails for invalid input as

--- a/test/html/dune
+++ b/test/html/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries tw tw.html alcotest re astring))
+ (libraries tw tw.html cascade alcotest re astring fmt))

--- a/test/test.ml
+++ b/test/test.ml
@@ -73,6 +73,9 @@ let () =
       Test_utility.suite;
       Test_spacing.suite;
       Test_box_sizing.suite;
+      Test_tab.suite;
+      Test_scrollbar.suite;
+      Test_zoom.suite;
       Test_columns.suite;
       Test_contain.suite;
       Test_divide.suite;

--- a/test/test_accessibility.mli
+++ b/test/test_accessibility.mli
@@ -1,2 +1,4 @@
+(** Tests for the accessibility module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_alignment.mli
+++ b/test/test_alignment.mli
@@ -1,2 +1,4 @@
+(** Tests for the alignment module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_animations.mli
+++ b/test/test_animations.mli
@@ -1,2 +1,4 @@
+(** Tests for the animations module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_backgrounds.mli
+++ b/test/test_backgrounds.mli
@@ -1,2 +1,4 @@
+(** Tests for the backgrounds module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_borders.mli
+++ b/test/test_borders.mli
@@ -1,2 +1,4 @@
+(** Tests for the borders module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_box_sizing.mli
+++ b/test/test_box_sizing.mli
@@ -1,2 +1,4 @@
+(** Tests for the box_sizing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_build.mli
+++ b/test/test_build.mli
@@ -1,2 +1,4 @@
+(** Tests for the build module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Build}. *)

--- a/test/test_clipping.ml
+++ b/test/test_clipping.ml
@@ -23,7 +23,7 @@ let test_clip_inset_shorthand () =
   let normalize input =
     let wrapped = ".x{" ^ input ^ "}" in
     match Css.of_string wrapped with
-    | Error _ -> Alcotest.fail (Fmt.str "Failed to parse: %s" input)
+    | Error _ -> Alcotest.failf "Failed to parse: %s" input
     | Ok { stylesheet; _ } ->
         let out =
           stylesheet

--- a/test/test_clipping.mli
+++ b/test/test_clipping.mli
@@ -1,2 +1,4 @@
+(** Tests for the clipping module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_columns.mli
+++ b/test/test_columns.mli
@@ -1,2 +1,4 @@
+(** Tests for the columns module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_containers.mli
+++ b/test/test_containers.mli
@@ -1,2 +1,4 @@
+(** Tests for the containers module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_cursor.mli
+++ b/test/test_cursor.mli
@@ -1,2 +1,4 @@
+(** Tests for the cursor module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_divide.mli
+++ b/test/test_divide.mli
@@ -1,2 +1,4 @@
+(** Tests for the divide module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_effects.mli
+++ b/test/test_effects.mli
@@ -1,2 +1,4 @@
+(** Tests for the effects module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_field_sizing.mli
+++ b/test/test_field_sizing.mli
@@ -1,2 +1,4 @@
+(** Tests for the field_sizing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_filters.mli
+++ b/test/test_filters.mli
@@ -1,2 +1,4 @@
+(** Tests for the filters module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_flex.mli
+++ b/test/test_flex.mli
@@ -1,2 +1,4 @@
+(** Tests for the flex module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_flex_layout.mli
+++ b/test/test_flex_layout.mli
@@ -1,2 +1,4 @@
+(** Tests for the flex_layout module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_flex_props.mli
+++ b/test/test_flex_props.mli
@@ -1,2 +1,4 @@
+(** Tests for the flex_props module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_forms.mli
+++ b/test/test_forms.mli
@@ -1,2 +1,4 @@
+(** Tests for the forms module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_gap.mli
+++ b/test/test_gap.mli
@@ -1,2 +1,4 @@
+(** Tests for the gap module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_grid.mli
+++ b/test/test_grid.mli
@@ -1,2 +1,4 @@
+(** Tests for the grid module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_grid_item.mli
+++ b/test/test_grid_item.mli
@@ -1,2 +1,4 @@
+(** Tests for the grid_item module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_grid_template.mli
+++ b/test/test_grid_template.mli
@@ -1,2 +1,4 @@
+(** Tests for the grid_template module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_interactivity.mli
+++ b/test/test_interactivity.mli
@@ -1,2 +1,4 @@
+(** Tests for the interactivity module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_layout.mli
+++ b/test/test_layout.mli
@@ -1,2 +1,4 @@
+(** Tests for the layout module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_margin.mli
+++ b/test/test_margin.mli
@@ -1,2 +1,4 @@
+(** Tests for the margin module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_mask_gradient.mli
+++ b/test/test_mask_gradient.mli
@@ -1,2 +1,4 @@
+(** Tests for the mask_gradient module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_masks.mli
+++ b/test/test_masks.mli
@@ -1,2 +1,4 @@
+(** Tests for the masks module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -53,9 +53,7 @@ let test_validate_no_nested_responsive () =
     try
       validate_no_nested_responsive [ sm [ md [ p 4 ] ] ];
       fail "Should have raised exception for nested responsive"
-    with
-    | Failure _ -> ()
-    | _ -> fail "Expected Failure with 'responsive' in message"
+    with Failure _ -> ()
   in
   test_nested_fail ();
 
@@ -65,9 +63,7 @@ let test_validate_no_nested_responsive () =
       let responsive_style = sm [ p 4 ] in
       validate_no_nested_responsive [ responsive_style ];
       fail "Should have rejected responsive style"
-    with
-    | Failure _ -> () (* Expected to fail *)
-    | _ -> fail "Expected Failure for responsive style"
+    with Failure _ -> () (* Expected to fail *)
   in
   test_already_responsive ()
 
@@ -76,9 +72,7 @@ let test_responsive_rejects name outer_fn inner_content =
   try
     let _ = outer_fn [ inner_content ] in
     Alcotest.failf "%s should reject nested responsive" name
-  with
-  | Failure _ -> () (* Expected to fail *)
-  | _ -> Alcotest.failf "Expected Failure about nested responsive"
+  with Failure _ -> () (* Expected to fail *)
 
 (* Test that responsive functions reject nested responsive *)
 let test_responsive_functions_reject_nesting () =

--- a/test/test_output.mli
+++ b/test/test_output.mli
@@ -1,2 +1,4 @@
+(** Tests for the output module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Output}. *)

--- a/test/test_overflow.mli
+++ b/test/test_overflow.mli
@@ -1,2 +1,4 @@
+(** Tests for the overflow module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_overflow_wrap.mli
+++ b/test/test_overflow_wrap.mli
@@ -1,2 +1,4 @@
+(** Tests for the overflow_wrap module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_overscroll.mli
+++ b/test/test_overscroll.mli
@@ -1,2 +1,4 @@
+(** Tests for the overscroll module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_padding.mli
+++ b/test/test_padding.mli
@@ -1,2 +1,4 @@
+(** Tests for the padding module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_parse.mli
+++ b/test/test_parse.mli
@@ -1,2 +1,4 @@
+(** Tests for the parse module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_position.mli
+++ b/test/test_position.mli
@@ -1,2 +1,4 @@
+(** Tests for the position module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_pp.ml
+++ b/test/test_pp.ml
@@ -1,5 +1,5 @@
 (* Tests for Pp module *)
-module Pp = Tw__Pp (* Access internal module *)
+module Pp = Tw__.Pp (* Access internal module *)
 
 let test_str () =
   let result = Pp.str [ "Hello"; " "; "World" ] in

--- a/test/test_preflight.mli
+++ b/test/test_preflight.mli
@@ -1,2 +1,4 @@
+(** Tests for the preflight module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_property.mli
+++ b/test/test_property.mli
@@ -1,2 +1,4 @@
+(** Tests for the property module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_rule.mli
+++ b/test/test_rule.mli
@@ -1,2 +1,4 @@
+(** Tests for the rule module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Rule}. *)

--- a/test/test_scheme.mli
+++ b/test/test_scheme.mli
@@ -1,2 +1,4 @@
+(** Tests for the scheme module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_scroll.mli
+++ b/test/test_scroll.mli
@@ -1,2 +1,4 @@
+(** Tests for the scroll module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_scrollbar.ml
+++ b/test/test_scrollbar.ml
@@ -1,0 +1,30 @@
+let check = Test_helpers.check_handler_roundtrip (module Tw.Scrollbar.Handler)
+
+let test_roundtrip () =
+  (* scrollbar-width *)
+  check "scrollbar-auto";
+  check "scrollbar-none";
+  check "scrollbar-thin";
+  (* scrollbar-gutter *)
+  check "scrollbar-gutter-auto";
+  check "scrollbar-gutter-stable";
+  check "scrollbar-gutter-both";
+  (* scrollbar-thumb / -track colours *)
+  check "scrollbar-thumb-red-500";
+  check "scrollbar-track-gray-200";
+  check "scrollbar-thumb-current";
+  check "scrollbar-thumb-transparent";
+  check "scrollbar-thumb-inherit";
+  check "scrollbar-thumb-[#ff0000]"
+
+let test_invalid () =
+  Test_helpers.check_invalid_input (module Tw.Scrollbar.Handler) "scrollbar";
+  Test_helpers.check_invalid_input (module Tw.Scrollbar.Handler) "scrollbar-foo";
+  Test_helpers.check_invalid_input
+    (module Tw.Scrollbar.Handler)
+    "scrollbar-gutter-foo"
+
+let tests =
+  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+
+let suite = ("scrollbar", tests)

--- a/test/test_scrollbar.mli
+++ b/test/test_scrollbar.mli
@@ -1,4 +1,4 @@
-(** Tests for the contain module. *)
+(** Tests for the scrollbar utilities. *)
 
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_sizing.mli
+++ b/test/test_sizing.mli
@@ -1,2 +1,4 @@
+(** Tests for the sizing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_sort.mli
+++ b/test/test_sort.mli
@@ -1,2 +1,4 @@
+(** Tests for the sort module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Sort}. *)

--- a/test/test_source_scan.mli
+++ b/test/test_source_scan.mli
@@ -1,2 +1,4 @@
+(** Tests for the source_scan module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_spacing.mli
+++ b/test/test_spacing.mli
@@ -1,2 +1,4 @@
+(** Tests for the spacing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_style.mli
+++ b/test/test_style.mli
@@ -1,2 +1,4 @@
+(** Tests for the style module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_svg.mli
+++ b/test/test_svg.mli
@@ -1,2 +1,4 @@
+(** Tests for the svg module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_tab.ml
+++ b/test/test_tab.ml
@@ -1,0 +1,17 @@
+let check = Test_helpers.check_handler_roundtrip (module Tw.Tab.Handler)
+
+let test_roundtrip () =
+  check "tab-2";
+  check "tab-8";
+  check "tab-[3]";
+  check "tab-[12px]"
+
+let test_invalid () =
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab";
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-2.5";
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-unknown"
+
+let tests =
+  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+
+let suite = ("tab", tests)

--- a/test/test_tab.mli
+++ b/test/test_tab.mli
@@ -1,4 +1,4 @@
-(** Tests for the contain module. *)
+(** Tests for the [tab-size] utilities. *)
 
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_tables.mli
+++ b/test/test_tables.mli
@@ -1,2 +1,4 @@
+(** Tests for the tables module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_text_shadow.mli
+++ b/test/test_text_shadow.mli
@@ -1,2 +1,4 @@
+(** Tests for the text_shadow module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_theme.mli
+++ b/test/test_theme.mli
@@ -1,2 +1,4 @@
+(** Tests for the theme module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_touch.mli
+++ b/test/test_touch.mli
@@ -1,2 +1,4 @@
+(** Tests for the touch module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_transforms.mli
+++ b/test/test_transforms.mli
@@ -1,2 +1,4 @@
+(** Tests for the transforms module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_transitions.mli
+++ b/test/test_transitions.mli
@@ -1,2 +1,4 @@
+(** Tests for the transitions module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_typography.mli
+++ b/test/test_typography.mli
@@ -1,2 +1,4 @@
+(** Tests for the typography module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_utility.mli
+++ b/test/test_utility.mli
@@ -1,2 +1,4 @@
+(** Tests for the utility module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_var.mli
+++ b/test/test_var.mli
@@ -1,2 +1,4 @@
+(** Tests for the var module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_zoom.ml
+++ b/test/test_zoom.ml
@@ -1,0 +1,16 @@
+let check = Test_helpers.check_handler_roundtrip (module Tw.Zoom.Handler)
+
+let test_roundtrip () =
+  check "zoom-50";
+  check "zoom-100";
+  check "zoom-[var(--zoom)]"
+
+let test_invalid () =
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom";
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-1.5";
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-unknown"
+
+let tests =
+  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+
+let suite = ("zoom", tests)

--- a/test/test_zoom.mli
+++ b/test/test_zoom.mli
@@ -1,4 +1,4 @@
-(** Tests for the contain module. *)
+(** Tests for the [zoom] utilities. *)
 
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/tw.opam
+++ b/tw.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/samoht/tw"
 bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
   "ocaml" {>= "5.2"}
-  "dune" {>= "3.0"}
+  "dune" {>= "3.21"}
   "cascade"
   "cmdliner"
   "fmt"
@@ -41,6 +41,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/samoht/tw.git"
+x-maintenance-intent: ["(latest)"]
 pin-depends: [
   [ "cascade.dev" "git+https://github.com/samoht/cascade.git#main" ]
 ]

--- a/tw.opam
+++ b/tw.opam
@@ -40,3 +40,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/samoht/tw.git"
+pin-depends: [
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#main" ]
+]

--- a/tw.opam
+++ b/tw.opam
@@ -9,7 +9,7 @@ license: "ISC"
 homepage: "https://github.com/samoht/tw"
 bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "5.2"}
   "dune" {>= "3.0"}
   "cascade"
   "cmdliner"
@@ -23,6 +23,7 @@ depends: [
   "astring" {with-test}
   "crunch" {with-test}
   "alcobar" {with-test}
+  "mdx" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/tw.opam.template
+++ b/tw.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#main" ]
+]


### PR DESCRIPTION
The cascade rule sort compared media conditions through `Css.Media.compare` on every comparison, which serialized the query and re-extracted its kind. Rules that share a breakpoint tie on every cheap key, so the hot sort reached that path O(n log n) times.

This precomputes the `(group, subkey)` and the media sort keys once per `indexed_rule` (alongside the existing `selector_str`) and compares with `Css.Media.compare_keys`, so no query is serialized inside a comparator. Ordering is unchanged (upstream parity stays green); the `tocss` benchmark drops from 4.93 GB to 3.44 GB total allocation (-30%). Depends on the cascade `Media.key` API (samoht/cascade#63). Stacked on #7.