### PR TITLE
merlint: resolve all reported issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,96 @@
-# tw -- Type-safe Tailwind CSS v4 in OCaml
+# tw — Type-safe Tailwind CSS v4 in OCaml
 
-`tw` is a type-safe OCaml implementation of [Tailwind CSS v4](https://tailwindcss.com/).
-It compiles to CSS through a strongly-typed variable system that mirrors
-Tailwind's pipeline, producing **byte-for-byte identical output**.
+`tw` is an OCaml implementation of [Tailwind CSS v4](https://tailwindcss.com/).
+You assemble utilities as ordinary OCaml values and compile them to CSS through
+the same typed variable-and-layer pipeline Tailwind uses, producing
+byte-for-byte identical output. Unknown utilities are caught at compile time,
+and nothing depends on Node.js, PostCSS, or the Tailwind CLI at run time.
 
 ```ocaml
 open Tw
 
-let card = [
-  flex; flex_col; gap 4; p 6;
-  bg white; rounded_lg; shadow_sm;
-  border; border_color ~shade:200 gray;
-  hover [ shadow_md ];
-  dark [ bg ~shade:800 gray; text ~shade:100 gray ];
-]
+(* A set of utilities is a value of type [Tw.t list]. *)
+let card =
+  [
+    flex; flex_col; gap 4; p 6;
+    bg white; rounded_lg; shadow_sm;
+    border; border_color ~shade:200 gray;
+    hover [ shadow_md ];
+    dark [ bg ~shade:800 gray; text ~shade:100 gray ];
+  ]
 ```
 
 ## Features
 
-- **Tailwind v4 parity**: 765 upstream utility tests, 140 variant tests pass
-  against real Tailwind CSS output
-- **Full plugin support**: `@tailwindcss/typography` (prose) and
-  `@tailwindcss/forms` fully implemented
-- **Type-safe API**: Invalid classes caught at compile time
-- **String parsing**: `Tw.str "flex p-4 bg-blue-500"` for dynamic class lists
-- **OCaml 4.14+**: Builds on OCaml 4.14 through 5.4
-- **Pure OCaml**: No JavaScript, PostCSS, or Node.js required
-- **86k lines** of OCaml
+- **Tailwind v4 parity** — output is checked byte-for-byte against the real
+  Tailwind CSS CLI across the upstream utility and variant test suites.
+- **Both official plugins** — `@tailwindcss/typography` (`prose`) and
+  `@tailwindcss/forms` are fully implemented.
+- **Type-safe** — utilities are typed constructors, so invalid combinations are
+  compile errors rather than silent no-ops.
+- **String parsing** — `Tw.str "flex p-4 bg-blue-500"` turns class strings into
+  typed utilities for dynamic class lists.
+- **Pure OCaml** — no JavaScript toolchain required; the library also compiles
+  to JavaScript with js_of_ocaml.
 
 ## Installation
 
+Requires OCaml `>= 5.2`.
+
+<!-- $MDX skip -->
 ```bash
-opam pin add tw.dev https://github.com/samoht/tw.git
 opam install tw
 ```
 
-## Quick Start
+## Usage
 
-### Typed API
+### Typed utilities
 
 ```ocaml
 open Tw
 
-(* Spacing: integers are multiplied by 0.25rem *)
+(* Spacing scales: the integer is multiplied by 0.25rem, so [p 4] is 1rem. *)
 let layout = [ flex; items_center; gap 4; p 6; mx_auto; max_w_4xl ]
 
-(* Colors: default shade is 500, use ~shade for others *)
-let colors = [ bg blue; text white; border_color ~shade:300 gray ]
+(* Colors default to shade 500; [~shade] picks another, [~opacity] adds alpha. *)
+let colors = [ bg blue; text white; border_color ~shade:300 gray; bg ~opacity:50 white ]
 
-(* Opacity modifier *)
-let faded = [ bg ~opacity:50 white; border_color ~opacity:5 white ]
+(* Variants nest as functions: responsive breakpoints, state, and dark mode. *)
+let responsive =
+  [ p 4; md [ p 8 ]; lg [ p 12 ]; bg blue; hover [ bg ~shade:600 blue ]; dark [ text ~shade:300 gray ] ]
 
-(* Responsive and state modifiers *)
-let responsive = [
-  p 4; md [ p 8 ]; lg [ p 12 ];
-  bg blue; hover [ bg ~shade:600 blue ];
-  text white; dark [ text ~shade:300 gray ];
-]
-
-(* Typography plugin *)
-let article = [ prose; prose_lg; max_w_4xl; mx_auto ]
-
-(* Prose element variants *)
-let styled_prose = [
-  prose;
-  prose_headings [ text ~shade:600 blue ];
-  prose_a [ text blue ];
-  prose_code [ bg ~shade:100 gray ];
-  prose_pre [ bg ~shade:800 gray ];
-]
-
-(* Generate CSS *)
-let css = Build.to_css ~base:true ~minify:true ~optimize:true layout
+(* The typography plugin, including per-element variants. *)
+let article =
+  [ prose; prose_lg; mx_auto; prose_headings [ text ~shade:600 blue ]; prose_code [ bg ~shade:100 gray ] ]
 ```
 
-### String API
+### Rendering to CSS
 
 ```ocaml
-(* Parse class strings -- raises Invalid_argument on unknown classes *)
+open Tw
+
+(* [to_classes] returns the value for an HTML [class] attribute. *)
+let class_attr = to_classes [ flex; p 4; bg blue ]
+
+(* [to_css] builds a stylesheet; [Css.to_string] renders it to text. *)
+let stylesheet = to_css [ flex; p 4; bg blue; hover [ bg ~shade:600 blue ] ]
+let css = Css.to_string ~minify:true stylesheet
+```
+
+### Parsing class strings
+
+```ocaml
+(* [Tw.str] parses a class string into utilities (raises on unknown classes). *)
 let styles = Tw.str "flex items-center gap-4 p-6 bg-white rounded-lg shadow-sm"
 
-(* Single class parsing *)
-let ok = Tw.of_string "hover:bg-blue-600"  (* Ok t *)
-let err = Tw.of_string "invalid-class"     (* Error (`Msg "...") *)
+(* [Tw.of_string] parses a single class and returns a result. *)
+let parsed = Tw.of_string "hover:bg-blue-600" (* Ok _ *)
+let rejected = Tw.of_string "not-a-class" (* Error (`Msg _) *)
 ```
 
 ### CLI
 
+<!-- $MDX skip -->
 ```bash
 # Generate CSS for specific classes
 tw -s "flex p-4 bg-blue-500 hover:bg-blue-600"
@@ -96,14 +100,6 @@ tw src/ > styles.css
 
 # Compare with real Tailwind CSS
 tw -s "prose mb-4 dark:text-gray-300" --diff
-
-# Generate with Tailwind for comparison
-tw -s "flex p-4" --tailwind
-
-# Options
-tw --minify --optimize --base src/
-tw --variables -s "p-4"        # CSS variables mode (default for files)
-tw --inline -s "p-4"           # Inline values (default for -s)
 ```
 
 ## Supported Utilities
@@ -147,16 +143,12 @@ All Tailwind CSS v4 core utilities and both official plugins:
 The `--diff` and `--tailwind` CLI modes require the `tailwindcss` standalone
 binary for comparison testing:
 
+<!-- $MDX skip -->
 ```bash
 # macOS (Apple Silicon)
 curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-arm64
 chmod +x tailwindcss-macos-arm64
 sudo mv tailwindcss-macos-arm64 /usr/local/bin/tailwindcss
-
-# macOS (Intel)
-curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-x64
-chmod +x tailwindcss-macos-x64
-sudo mv tailwindcss-macos-x64 /usr/local/bin/tailwindcss
 
 # Linux (x64)
 curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
@@ -166,21 +158,15 @@ sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
 
 ### Building
 
+<!-- $MDX skip -->
 ```bash
-# Build (both OCaml 5.4 and 4.14)
-dune build
+dune build         # build the library and CLI
+dune runtest       # run all tests, including README examples
 
-# Run all tests
-dune runtest
-
-# Run specific test suites
-dune exec test/upstream/test.exe     # Tailwind parity tests
-dune exec test/test.exe              # main tests
-
-# Compare single utility with Tailwind
+# Compare a single utility with Tailwind
 dune exec -- tw -s "bg-blue-500 hover:bg-blue-600" --diff
 ```
 
 ## License
 
-ISC
+ISC — see [LICENSE.md](LICENSE.md).

--- a/dune
+++ b/dune
@@ -1,0 +1,8 @@
+(env
+ (dev
+  (flags
+   (:standard %{dune-warnings}))))
+
+(mdx
+ (files README.md)
+ (libraries tw cascade))

--- a/dune-project
+++ b/dune-project
@@ -1,8 +1,10 @@
-(lang dune 3.0)
+(lang dune 3.21)
 
 (using mdx 0.2)
 
 (name tw)
+
+(implicit_transitive_deps false)
 
 (generate_opam_files true)
 

--- a/examples/index.ml
+++ b/examples/index.ml
@@ -15,78 +15,35 @@ let example_card ~title ~path ~height =
         [];
     ]
 
+(* Each example: title, iframe path, one-line blurb, and embed height. *)
+let examples =
+  [
+    ("Landing", "landing/", "Marketing page with gradients and CTA", 700);
+    ("Dashboard", "dashboard/", "Responsive admin layout", 800);
+    ("Prose", "prose/", "Typography for articles", 1200);
+    ("Forms", "forms/", "Input states and validation", 600);
+    ("Colors", "colors/", "Full palette and alpha variants", 900);
+    ("Layout", "layout/", "Flexbox and Grid patterns", 1800);
+    ("Modifiers", "modifiers/", "State, group, peer, and ARIA", 1600);
+    ("Animations", "animations/", "Keyframes and transitions", 1500);
+    ("Accessibility", "accessibility/", "Contrast, motion, focus", 1400);
+  ]
+
+let nav_link (title, path, blurb, _) =
+  li [ a ~at:[ At.href path ] [ txt (title ^ " — " ^ blurb) ] ]
+
 let content =
   [
     h1 [ txt "Examples Manual" ];
     p
       ~tw:Tw.[ prose_lead ]
       [ txt "Explore focused, feature-based examples. Each is embedded below." ];
-    ul
-      [
-        li
-          [
-            a
-              ~at:[ At.href "landing/" ]
-              [ txt "Landing — Marketing page with gradients and CTA" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "dashboard/" ]
-              [ txt "Dashboard — Responsive admin layout" ];
-          ];
-        li
-          [
-            a ~at:[ At.href "prose/" ] [ txt "Prose — Typography for articles" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "forms/" ]
-              [ txt "Forms — Input states and validation" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "colors/" ]
-              [ txt "Colors — Full palette and alpha variants" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "layout/" ]
-              [ txt "Layout — Flexbox and Grid patterns" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "modifiers/" ]
-              [ txt "Modifiers — State, group, peer, and ARIA" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "animations/" ]
-              [ txt "Animations — Keyframes and transitions" ];
-          ];
-        li
-          [
-            a
-              ~at:[ At.href "accessibility/" ]
-              [ txt "Accessibility — Contrast, motion, focus" ];
-          ];
-      ];
+    ul (List.map nav_link examples);
     hr ();
-    example_card ~title:"Landing" ~path:"landing/" ~height:700;
-    example_card ~title:"Dashboard" ~path:"dashboard/" ~height:800;
-    example_card ~title:"Prose" ~path:"prose/" ~height:1200;
-    example_card ~title:"Forms" ~path:"forms/" ~height:600;
-    example_card ~title:"Colors" ~path:"colors/" ~height:900;
-    example_card ~title:"Layout" ~path:"layout/" ~height:1800;
-    example_card ~title:"Modifiers" ~path:"modifiers/" ~height:1600;
-    example_card ~title:"Animations" ~path:"animations/" ~height:1500;
-    example_card ~title:"Accessibility" ~path:"accessibility/" ~height:1400;
   ]
+  @ List.map
+      (fun (title, path, _, height) -> example_card ~title ~path ~height)
+      examples
 
 let page_view =
   page ~title:"Examples Manual" ~tw_css:"manual.css" []

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -394,15 +394,23 @@ let rule_sets_from_selector_props all_rules =
   if Sort.debug_compare_enabled () then
     List.iter
       (fun (r : Sort.indexed_rule) ->
-        Fmt.epr "SORTED: vo=%d base=%s type=%s nested=%d@." r.variant_order
-          (match r.base_class with Some s -> s | None -> "<none>")
-          (match r.rule_type with
-          | `Regular -> "R"
-          | `Media m -> "M:" ^ Css.Media.to_string m
-          | `Container _ -> "C"
-          | `Starting -> "S"
-          | `Supports _ -> "U")
-          (List.length r.nested))
+        prerr_endline
+          (Pp.str
+             [
+               "SORTED: vo=";
+               Pp.int r.variant_order;
+               " base=";
+               (match r.base_class with Some s -> s | None -> "<none>");
+               " type=";
+               (match r.rule_type with
+               | `Regular -> "R"
+               | `Media m -> "M:" ^ Css.Media.to_string m
+               | `Container _ -> "C"
+               | `Starting -> "S"
+               | `Supports _ -> "U");
+               " nested=";
+               Pp.int (List.length r.nested);
+             ]))
       sorted;
   sorted |> List.map indexed_rule_to_statement
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -273,19 +273,11 @@ let hex_to_rgb hex =
   with Invalid_argument _ | Failure _ -> None
 
 let rgb_to_hex rgb =
-  let to_hex_byte n =
-    let hex = "0123456789abcdef" in
-    String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
-  in
-  "#" ^ to_hex_byte rgb.r ^ to_hex_byte rgb.g ^ to_hex_byte rgb.b
+  "#" ^ Pp.hex_byte rgb.r ^ Pp.hex_byte rgb.g ^ Pp.hex_byte rgb.b
 
 (** Add alpha to a hex color string. Returns #RRGGBBAA format. The opacity is a
     percentage (0-100). *)
 let hex_with_alpha hex_str opacity_percent =
-  let to_hex_byte n =
-    let hex = "0123456789abcdef" in
-    String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
-  in
   (* Parse hex color *)
   let hex_clean =
     if String.length hex_str > 0 && hex_str.[0] = '#' then
@@ -295,7 +287,7 @@ let hex_with_alpha hex_str opacity_percent =
   (* Convert opacity percentage to 8-bit alpha value, with rounding *)
   let alpha = int_of_float ((opacity_percent /. 100.0 *. 255.0) +. 0.5) in
   let alpha_clamped = max 0 (min 255 alpha) in
-  let full = hex_clean ^ to_hex_byte alpha_clamped in
+  let full = hex_clean ^ Pp.hex_byte alpha_clamped in
   (* Shorten #RRGGBBAA → #RGBA when each pair is identical *)
   let len = String.length full in
   let shortened =

--- a/lib/dom/dune
+++ b/lib/dom/dune
@@ -1,7 +1,7 @@
 (library
  (name tw_dom)
  (public_name tw.dom)
- (libraries tw brr)
+ (libraries tw brr cascade)
  (optional))
 
 (mdx

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (public_name tw)
  (name tw)
- (libraries cascade fmt))
+ (libraries cascade))
 
 (mdx
  (files tw.mli prose.mli utility.mli var.mli)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -8,11 +8,12 @@ let set_scheme scheme = current_scheme := scheme
 module Handler = struct
   open Style
 
+  (* Capture the project Pp helpers before [open Css] shadows Pp with Css.Pp. *)
   let pp_float = Pp.float
+  let pp_str = Pp.str
+  let hex_byte = Pp.hex_byte
 
   open Css
-
-  let hex_byte n = Printf.sprintf "%02x" n
 
   let rgba_hex_string r g b a =
     let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
@@ -310,7 +311,8 @@ module Handler = struct
     | None -> make_color_var (Parse.extract_var_name v)
 
   let relative_oklab_from_var v percent =
-    Css.parse_color (Fmt.str "oklab(from %s l a b / %s%%)" v (pp_float percent))
+    Css.parse_color
+      (pp_str [ "oklab(from "; v; " l a b / "; pp_float percent; "%)" ])
 
   let box_shadow_composition v_shadow =
     let v_inset = Var.reference inset_shadow_var in

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -9,6 +9,11 @@ module Css = Cascade.Css
 
 module Handler = struct
   open Style
+
+  (* Capture project Pp helpers before [open Css] shadows Pp with Css.Pp. *)
+  let pp_str = Pp.str
+  let pp_int = Pp.int
+
   open Css
 
   type t =
@@ -83,7 +88,8 @@ module Handler = struct
   let basis_spacing n =
     let spacing_decl, _ = Var.binding Theme.spacing_var Theme.spacing_base in
     let cursor =
-      Cascade.Cursor.of_string (Fmt.str "calc(var(--spacing) * %d)" n)
+      Cascade.Cursor.of_string
+        (pp_str [ "calc(var(--spacing) * "; pp_int n; ")" ])
     in
     let value =
       match
@@ -91,7 +97,8 @@ module Handler = struct
       with
       | Ok v -> v
       | Error _ ->
-          invalid_arg (Fmt.str "basis-%d: failed to parse spacing calc" n)
+          invalid_arg
+            (pp_str [ "basis-"; pp_int n; ": failed to parse spacing calc" ])
     in
     style [ spacing_decl; flex_basis value ]
 

--- a/lib/html/dune
+++ b/lib/html/dune
@@ -1,4 +1,4 @@
 (library
  (name tw_html)
  (public_name tw.html)
- (libraries tw))
+ (libraries tw cascade))

--- a/lib/html/tw_html.mli
+++ b/lib/html/tw_html.mli
@@ -22,7 +22,7 @@ module At : sig
   (** {1 Global attributes} *)
 
   val title : string -> attr
-  (** [title "My Title"] creates a [title] attribute. *)
+  (** [title s] creates a {!val-title} attribute. *)
 
   val lang : string -> attr
   (** [lang "en"] creates a [lang] attribute. *)
@@ -141,7 +141,7 @@ module At : sig
   (** [sizes "..."] creates a [sizes] attribute for responsive images. *)
 
   val title' : string -> attr
-  (** [title' "My Page"] creates a [title] attribute for elements. *)
+  (** [title' s] creates a {!val-title} attribute for elements. *)
 
   (** {1 Additional attributes} *)
 
@@ -174,7 +174,7 @@ module At : sig
   (** [to_pair at] returns the attribute as a (name, value) pair. *)
 
   val of_pair : string * string -> attr
-  (** [of_pair (n, v)] creates an attribute from a (name, value) pair. *)
+  (** [of_pair (n,v)] creates an attribute from a (name, value) pair. *)
 
   (** {2 Additional HTML5 attributes} *)
 
@@ -241,61 +241,61 @@ module At : sig
   (** {2 SVG Attributes} *)
 
   val fill_rule : [ `evenodd ] -> attr
-  (** [fill_rule `evenodd] sets the fill rule *)
+  (** [fill_rule `evenodd] sets the fill rule. *)
 
   val clip_rule : [ `evenodd ] -> attr
-  (** [clip_rule `evenodd] sets the clipping rule *)
+  (** [clip_rule `evenodd] sets the clipping rule. *)
 
   val cx : int -> attr
-  (** [cx n] sets the center x coordinate *)
+  (** [cx n] sets the center x coordinate. *)
 
   val cy : int -> attr
-  (** [cy n] sets the center y coordinate *)
+  (** [cy n] sets the center y coordinate. *)
 
   val r : int -> attr
-  (** [r n] sets the radius *)
+  (** [r n] sets the radius. *)
 
   val view_box : string -> attr
-  (** [view_box "0 0 20 20"] sets the viewBox *)
+  (** [view_box s] sets the viewBox. *)
 
   val fill : string -> attr
-  (** [fill "currentColor"] sets the fill color *)
+  (** [fill "currentColor"] sets the fill color. *)
 
   val stroke : string -> attr
-  (** [stroke "currentColor"] sets the stroke color *)
+  (** [stroke "currentColor"] sets the stroke color. *)
 
   val stroke_width : string -> attr
-  (** [stroke_width "2"] sets the stroke width *)
+  (** [stroke_width "2"] sets the stroke width. *)
 
   val stroke_linecap : string -> attr
-  (** [stroke_linecap "round"] sets the stroke line cap *)
+  (** [stroke_linecap "round"] sets the stroke line cap. *)
 
   val stroke_linejoin : string -> attr
-  (** [stroke_linejoin "round"] sets the stroke line join *)
+  (** [stroke_linejoin "round"] sets the stroke line join. *)
 
   val x : string -> attr
-  (** [x "10"] sets the x coordinate *)
+  (** [x "10"] sets the x coordinate. *)
 
   val y : string -> attr
-  (** [y "10"] sets the y coordinate *)
+  (** [y "10"] sets the y coordinate. *)
 
   val rx : string -> attr
-  (** [rx "5"] sets the x radius for rounded rectangles *)
+  (** [rx "5"] sets the x radius for rounded rectangles. *)
 
   val d : string -> attr
-  (** [d "M10 10 L20 20"] sets the path data *)
+  (** [d s] sets the path data. *)
 
   val x1 : string -> attr
-  (** [x1 "0"] sets the first x coordinate *)
+  (** [x1 "0"] sets the first x coordinate. *)
 
   val y1 : string -> attr
-  (** [y1 "0"] sets the first y coordinate *)
+  (** [y1 "0"] sets the first y coordinate. *)
 
   val x2 : string -> attr
-  (** [x2 "20"] sets the second x coordinate *)
+  (** [x2 "20"] sets the second x coordinate. *)
 
   val y2 : string -> attr
-  (** [y2 "20"] sets the second y coordinate *)
+  (** [y2 "20"] sets the second y coordinate. *)
 end
 
 (** {1 Text helpers} *)
@@ -413,7 +413,7 @@ module Livereload : sig
 
   val script : t
   (** [script] is the JavaScript code for livereload functionality. Only
-      included when [enabled] is true. *)
+      included when {!val-enabled} is true. *)
 end
 
 (** {1 HTML Elements} *)

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -693,7 +693,7 @@ val is_aria_shorthand : string -> bool
 
 val not_variant_order : modifier -> int
 (** [not_variant_order m] returns the cascade sort key for a [not-*] inner
-    modifier. Matches the ordering of [variant_order_of_prefix] for the
+    modifier. Matches the ordering of {!val-variant_order_of_prefix} for the
     corresponding pseudo-class/media prefix. *)
 
 val variant_order_of_prefix : string -> int
@@ -704,6 +704,6 @@ val variant_order_of_prefix : string -> int
 
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as
-    [variant_order_of_prefix] for the corresponding CSS media condition. Used to
-    derive the cascade position of rules whose ordering comes from a nested
-    media query rather than from the class-name prefix alone. *)
+    {!val-variant_order_of_prefix} for the corresponding CSS media condition.
+    Used to derive the cascade position of rules whose ordering comes from a
+    nested media query rather than from the class-name prefix alone. *)

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -74,6 +74,8 @@ val regular :
   ?not_order:int ->
   unit ->
   t
+(** [regular ~selector ~props ()] constructs a plain (non-media,
+    non-conditional) rule. *)
 
 val media_query :
   condition:Css.Media.t ->
@@ -84,8 +86,8 @@ val media_query :
   ?not_order:int ->
   unit ->
   t
-(** [media_query ~condition ~selector ~props ()] constructs a [Media_query] rule
-    wrapped in [@media condition]. *)
+(** [media_query ~condition ~selector ~props ()] constructs a
+    {!constructor-Media_query} rule wrapped in [@media condition]. *)
 
 val container_query :
   condition:Css.Container.t ->
@@ -95,7 +97,7 @@ val container_query :
   unit ->
   t
 (** [container_query ~condition ~selector ~props ()] constructs a
-    [Container_query] rule wrapped in [@container condition]. *)
+    {!constructor-Container_query} rule wrapped in [@container condition]. *)
 
 val starting_style :
   selector:Css.Selector.t ->
@@ -103,8 +105,8 @@ val starting_style :
   ?base_class:string ->
   unit ->
   t
-(** [starting_style ~selector ~props ()] constructs a [Starting_style] rule
-    wrapped in [@starting-style]. *)
+(** [starting_style ~selector ~props ()] constructs a
+    {!constructor-Starting_style} rule wrapped in [@starting-style]. *)
 
 val supports_query :
   condition:Css.Supports.t ->
@@ -116,7 +118,7 @@ val supports_query :
   unit ->
   t
 (** [supports_query ~condition ~selector ~props ()] constructs a
-    [Supports_query] rule wrapped in [@supports condition]. *)
+    {!constructor-Supports_query} rule wrapped in [@supports condition]. *)
 
 val pp : t -> string
 (** [pp r] returns a short human-readable description of [r], e.g.
@@ -136,10 +138,11 @@ type by_type = {
 *)
 
 val classify_by_type : t list -> by_type
-(** [classify_by_type rules] partitions [rules] by variant into a [by_type]
-    record. Each group preserves the original order of its elements. *)
+(** [classify_by_type rules] partitions [rules] by variant into a
+    {!type-by_type} record. Each group preserves the original order of its
+    elements. *)
 
 val is_hover_rule : t -> bool
-(** [is_hover_rule r] is [true] iff [r] is a [Regular] rule with
+(** [is_hover_rule r] is [true] iff [r] is a {!constructor-Regular} rule with
     [has_hover = true]. Used by {!Build} to gate hover utilities under
     [@media (hover:hover)]. *)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -57,6 +57,11 @@ let bool = string_of_bool
 (** Format int *)
 let int = string_of_int
 
+(** Format a byte (0-255) as two lowercase hex digits *)
+let hex_byte n =
+  let hex = "0123456789abcdef" in
+  String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
+
 (** Format float nicely without trailing dots *)
 let float f =
   let s = string_of_float f in

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -59,6 +59,10 @@ val bool : bool -> string
 val int : int -> string
 (** [int n] formats an integer. *)
 
+val hex_byte : int -> string
+(** [hex_byte n] formats a byte [n] (0-255) as two lowercase hexadecimal digits,
+    e.g. [hex_byte 255 = "ff"]. *)
+
 val float : float -> string
 (** [float f] formats a float without trailing dots. *)
 

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -211,152 +211,62 @@ type prose_theme = {
   invert_td_borders : Css.declaration * Css.color Css.var;
 }
 
-(* Default prose theme - created once and shared across all utilities *)
+(* Default prose theme - created once and shared across all utilities. Each
+   field is the (declaration, reference) pair returned by [Var.binding], so the
+   theme is a plain record literal. *)
 let default_prose_theme : prose_theme =
-  let body_d, body_v =
-    Var.binding prose_body_var (Css.oklch 37.3 0.034 259.733)
-  in
-  let headings_d, headings_v =
-    Var.binding prose_headings_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let lead_d, lead_v =
-    Var.binding prose_lead_var (Css.oklch 44.6 0.030 256.802)
-  in
-  let links_d, links_v =
-    Var.binding prose_links_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let bold_d, bold_v =
-    Var.binding prose_bold_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let counters_d, counters_v =
-    Var.binding prose_counters_var (Css.oklch 55.1 0.027 264.364)
-  in
-  let bullets_d, bullets_v =
-    Var.binding prose_bullets_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let hr_d, hr_v = Var.binding prose_hr_var (Css.oklch 92.8 0.006 264.531) in
-  let quotes_d, quotes_v =
-    Var.binding prose_quotes_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let quote_borders_d, quote_borders_v =
-    Var.binding prose_quote_borders_var (Css.oklch 92.8 0.006 264.531)
-  in
-  let captions_d, captions_v =
-    Var.binding prose_captions_var (Css.oklch 55.1 0.027 264.364)
-  in
-  let kbd_d, kbd_v = Var.binding prose_kbd_var (Css.oklch 21.0 0.034 264.665) in
-  let kbd_shadows_d, kbd_shadows_v =
-    Var.binding prose_kbd_shadows_var
-      (Css.oklaba 21.0 (-0.00316127) (-0.0338527) 0.1)
-  in
-  let code_d, code_v =
-    Var.binding prose_code_var (Css.oklch 21.0 0.034 264.665)
-  in
-  let pre_code_d, pre_code_v =
-    Var.binding prose_pre_code_var (Css.oklch 92.8 0.006 264.531)
-  in
-  let pre_bg_d, pre_bg_v =
-    Var.binding prose_pre_bg_var (Css.oklch 27.8 0.033 256.848)
-  in
-  let th_borders_d, th_borders_v =
-    Var.binding prose_th_borders_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let td_borders_d, td_borders_v =
-    Var.binding prose_td_borders_var (Css.oklch 92.8 0.006 264.531)
-  in
-  (* Invert variants *)
-  let invert_body_d, invert_body_v =
-    Var.binding prose_invert_body_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let invert_headings_d, invert_headings_v =
-    Var.binding prose_invert_headings_var (Css.hex "fff")
-  in
-  let invert_lead_d, invert_lead_v =
-    Var.binding prose_invert_lead_var (Css.oklch 70.7 0.022 261.325)
-  in
-  let invert_links_d, invert_links_v =
-    Var.binding prose_invert_links_var (Css.hex "fff")
-  in
-  let invert_bold_d, invert_bold_v =
-    Var.binding prose_invert_bold_var (Css.hex "fff")
-  in
-  let invert_counters_d, invert_counters_v =
-    Var.binding prose_invert_counters_var (Css.oklch 70.7 0.022 261.325)
-  in
-  let invert_bullets_d, invert_bullets_v =
-    Var.binding prose_invert_bullets_var (Css.oklch 44.6 0.030 256.802)
-  in
-  let invert_hr_d, invert_hr_v =
-    Var.binding prose_invert_hr_var (Css.oklch 37.3 0.034 259.733)
-  in
-  let invert_quotes_d, invert_quotes_v =
-    Var.binding prose_invert_quotes_var (Css.oklch 96.7 0.003 264.542)
-  in
-  let invert_quote_borders_d, invert_quote_borders_v =
-    Var.binding prose_invert_quote_borders_var (Css.oklch 37.3 0.034 259.733)
-  in
-  let invert_captions_d, invert_captions_v =
-    Var.binding prose_invert_captions_var (Css.oklch 70.7 0.022 261.325)
-  in
-  let invert_kbd_d, invert_kbd_v =
-    Var.binding prose_invert_kbd_var (Css.hex "fff")
-  in
-  let invert_kbd_shadows_d, invert_kbd_shadows_v =
-    Var.binding prose_invert_kbd_shadows_var (Css.hex "#ffffff1a")
-  in
-  let invert_code_d, invert_code_v =
-    Var.binding prose_invert_code_var (Css.hex "fff")
-  in
-  let invert_pre_code_d, invert_pre_code_v =
-    Var.binding prose_invert_pre_code_var (Css.oklch 87.2 0.010 258.338)
-  in
-  let invert_pre_bg_d, invert_pre_bg_v =
-    Var.binding prose_invert_pre_bg_var (Css.hex "00000080")
-  in
-  let invert_th_borders_d, invert_th_borders_v =
-    Var.binding prose_invert_th_borders_var (Css.oklch 44.6 0.030 256.802)
-  in
-  let invert_td_borders_d, invert_td_borders_v =
-    Var.binding prose_invert_td_borders_var (Css.oklch 37.3 0.034 259.733)
-  in
   {
-    body = (body_d, body_v);
-    headings = (headings_d, headings_v);
-    lead = (lead_d, lead_v);
-    links = (links_d, links_v);
-    bold = (bold_d, bold_v);
-    counters = (counters_d, counters_v);
-    bullets = (bullets_d, bullets_v);
-    hr = (hr_d, hr_v);
-    quotes = (quotes_d, quotes_v);
-    quote_borders = (quote_borders_d, quote_borders_v);
-    captions = (captions_d, captions_v);
-    kbd = (kbd_d, kbd_v);
-    kbd_shadows = (kbd_shadows_d, kbd_shadows_v);
-    code = (code_d, code_v);
-    pre_code = (pre_code_d, pre_code_v);
-    pre_bg = (pre_bg_d, pre_bg_v);
-    th_borders = (th_borders_d, th_borders_v);
-    td_borders = (td_borders_d, td_borders_v);
+    body = Var.binding prose_body_var (Css.oklch 37.3 0.034 259.733);
+    headings = Var.binding prose_headings_var (Css.oklch 21.0 0.034 264.665);
+    lead = Var.binding prose_lead_var (Css.oklch 44.6 0.030 256.802);
+    links = Var.binding prose_links_var (Css.oklch 21.0 0.034 264.665);
+    bold = Var.binding prose_bold_var (Css.oklch 21.0 0.034 264.665);
+    counters = Var.binding prose_counters_var (Css.oklch 55.1 0.027 264.364);
+    bullets = Var.binding prose_bullets_var (Css.oklch 87.2 0.010 258.338);
+    hr = Var.binding prose_hr_var (Css.oklch 92.8 0.006 264.531);
+    quotes = Var.binding prose_quotes_var (Css.oklch 21.0 0.034 264.665);
+    quote_borders =
+      Var.binding prose_quote_borders_var (Css.oklch 92.8 0.006 264.531);
+    captions = Var.binding prose_captions_var (Css.oklch 55.1 0.027 264.364);
+    kbd = Var.binding prose_kbd_var (Css.oklch 21.0 0.034 264.665);
+    kbd_shadows =
+      Var.binding prose_kbd_shadows_var
+        (Css.oklaba 21.0 (-0.00316127) (-0.0338527) 0.1);
+    code = Var.binding prose_code_var (Css.oklch 21.0 0.034 264.665);
+    pre_code = Var.binding prose_pre_code_var (Css.oklch 92.8 0.006 264.531);
+    pre_bg = Var.binding prose_pre_bg_var (Css.oklch 27.8 0.033 256.848);
+    th_borders = Var.binding prose_th_borders_var (Css.oklch 87.2 0.010 258.338);
+    td_borders = Var.binding prose_td_borders_var (Css.oklch 92.8 0.006 264.531);
     (* Invert variants *)
-    invert_body = (invert_body_d, invert_body_v);
-    invert_headings = (invert_headings_d, invert_headings_v);
-    invert_lead = (invert_lead_d, invert_lead_v);
-    invert_links = (invert_links_d, invert_links_v);
-    invert_bold = (invert_bold_d, invert_bold_v);
-    invert_counters = (invert_counters_d, invert_counters_v);
-    invert_bullets = (invert_bullets_d, invert_bullets_v);
-    invert_hr = (invert_hr_d, invert_hr_v);
-    invert_quotes = (invert_quotes_d, invert_quotes_v);
-    invert_quote_borders = (invert_quote_borders_d, invert_quote_borders_v);
-    invert_captions = (invert_captions_d, invert_captions_v);
-    invert_kbd = (invert_kbd_d, invert_kbd_v);
-    invert_kbd_shadows = (invert_kbd_shadows_d, invert_kbd_shadows_v);
-    invert_code = (invert_code_d, invert_code_v);
-    invert_pre_code = (invert_pre_code_d, invert_pre_code_v);
-    invert_pre_bg = (invert_pre_bg_d, invert_pre_bg_v);
-    invert_th_borders = (invert_th_borders_d, invert_th_borders_v);
-    invert_td_borders = (invert_td_borders_d, invert_td_borders_v);
+    invert_body =
+      Var.binding prose_invert_body_var (Css.oklch 87.2 0.010 258.338);
+    invert_headings = Var.binding prose_invert_headings_var (Css.hex "fff");
+    invert_lead =
+      Var.binding prose_invert_lead_var (Css.oklch 70.7 0.022 261.325);
+    invert_links = Var.binding prose_invert_links_var (Css.hex "fff");
+    invert_bold = Var.binding prose_invert_bold_var (Css.hex "fff");
+    invert_counters =
+      Var.binding prose_invert_counters_var (Css.oklch 70.7 0.022 261.325);
+    invert_bullets =
+      Var.binding prose_invert_bullets_var (Css.oklch 44.6 0.030 256.802);
+    invert_hr = Var.binding prose_invert_hr_var (Css.oklch 37.3 0.034 259.733);
+    invert_quotes =
+      Var.binding prose_invert_quotes_var (Css.oklch 96.7 0.003 264.542);
+    invert_quote_borders =
+      Var.binding prose_invert_quote_borders_var (Css.oklch 37.3 0.034 259.733);
+    invert_captions =
+      Var.binding prose_invert_captions_var (Css.oklch 70.7 0.022 261.325);
+    invert_kbd = Var.binding prose_invert_kbd_var (Css.hex "fff");
+    invert_kbd_shadows =
+      Var.binding prose_invert_kbd_shadows_var (Css.hex "#ffffff1a");
+    invert_code = Var.binding prose_invert_code_var (Css.hex "fff");
+    invert_pre_code =
+      Var.binding prose_invert_pre_code_var (Css.oklch 87.2 0.010 258.338);
+    invert_pre_bg = Var.binding prose_invert_pre_bg_var (Css.hex "00000080");
+    invert_th_borders =
+      Var.binding prose_invert_th_borders_var (Css.oklch 44.6 0.030 256.802);
+    invert_td_borders =
+      Var.binding prose_invert_td_borders_var (Css.oklch 37.3 0.034 259.733);
   }
 
 (** Access theme record variables *)

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -109,7 +109,7 @@ module Handler = struct
 
   let hex_string_of (c : Css.color) : string =
     let fmt r g b a =
-      let h2 n = Printf.sprintf "%02x" n in
+      let h2 = Pp.hex_byte in
       "#" ^ h2 r ^ h2 g ^ h2 b ^ if a = 255 then "" else h2 a
     in
     match c with
@@ -253,7 +253,4 @@ module Handler = struct
     | _ -> Error (`Msg "Not a scrollbar utility")
 end
 
-open Handler
-
 let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)

--- a/lib/scrollbar.mli
+++ b/lib/scrollbar.mli
@@ -1,0 +1,7 @@
+(** Scrollbar utilities: [scrollbar-width], [scrollbar-gutter],
+    [scrollbar-thumb], and [scrollbar-track].
+
+    Constructed by parsing class names (e.g. [scrollbar-thin],
+    [scrollbar-thumb-red-500]); there is no typed DSL constructor. *)
+
+module Handler : Utility.Handler

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -51,8 +51,9 @@ val classify_selector : Css.Selector.t -> selector_kind
 (** {1 Sorting} *)
 
 val compare_indexed_rules : indexed_rule -> indexed_rule -> int
-(** [compare_indexed_rules r1 r2] is the total order over [indexed_rule] values
-    that produces Tailwind v4 cascade order when used with [List.sort]. *)
+(** [compare_indexed_rules r1 r2] is the total order over {!type-indexed_rule}
+    values that produces Tailwind v4 cascade order when used with [List.sort].
+*)
 
 (** {1 Debug} *)
 

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -111,7 +111,7 @@ module Handler = struct
   (* Extract a hex string (with leading #) from a Css.color, for oklab
      conversion *)
   let extract_hex_string css_color =
-    let hex_byte n = Printf.sprintf "%02x" n in
+    let hex_byte = Pp.hex_byte in
     let rgba_hex r g b a =
       let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
       if a = 255 then rgb else rgb ^ hex_byte a

--- a/lib/tab.mli
+++ b/lib/tab.mli
@@ -1,0 +1,8 @@
+(** tab-size utilities. *)
+
+open Utility
+
+val tab : int -> t
+(** [tab n] sets [tab-size] to [n]. *)
+
+module Handler : Utility.Handler

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -2,8 +2,9 @@
 
 module Css = Cascade.Css
 
-(* Capture Pp.float before open Css shadows it *)
+(* Capture project Pp helpers before open Css shadows Pp with Css.Pp. *)
 let pp_float = Pp.float
+let pp_str = Pp.str
 
 module Handler = struct
   open Style
@@ -74,7 +75,8 @@ module Handler = struct
     | None -> make_color_var (Parse.extract_var_name v)
 
   let relative_oklab_from_var v percent =
-    Css.parse_color (Fmt.str "oklab(from %s l a b / %s%%)" v (pp_float percent))
+    Css.parse_color
+      (pp_str [ "oklab(from "; v; " l a b / "; pp_float percent; "%)" ])
 
   (* ============ Parse arbitrary shadow ============ *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -56,6 +56,10 @@
       conventions
     - Colors, spacing, and sizes use consistent scales throughout *)
 
+(* Bind tw's own [Cursor] and [Rule] modules before [open Cascade] shadows the
+   bare names with [Cascade.Cursor] / [Cascade.Rule]. *)
+module Cursor = Cursor
+module Rule = Rule
 open Cascade
 
 (** {1 Core Types}
@@ -65,8 +69,9 @@ type t
 (** The abstract type representing a single CSS style utility. *)
 
 type color = Color.color
-(** Abstract type for colors. Use color constructors like [red], [blue], etc.
-    Colors can have shades from 50 (lightest) to 900 (darkest). *)
+(** Abstract type for colors. Use color constructors like {!val-red},
+    {!val-blue}, etc. Colors can have shades from 50 (lightest) to 900
+    (darkest). *)
 
 (** {1:tailwind_colors Tailwind colors}
 
@@ -271,7 +276,7 @@ val table : t
 
 val hidden : t
 (** [hidden] completely hides the element; no space is reserved and screen
-    readers skip it. Use [sr_only] to hide visually but keep accessible. *)
+    readers skip it. Use {!val-sr_only} to hide visually but keep accessible. *)
 
 (** {2 Float}
     @see <https://tailwindcss.com/docs/float> Float *)
@@ -447,8 +452,8 @@ val absolute : t
     ]} *)
 
 val fixed : t
-(** [fixed] is like [absolute] but relative to the viewport; it stays in place
-    when scrolling. *)
+(** [fixed] is like {!val-absolute} but relative to the viewport; it stays in
+    place when scrolling. *)
 
 val sticky : t
 (** [sticky] scrolls normally until it reaches a viewport edge, then sticks.
@@ -577,7 +582,7 @@ val flex : t
     ]} *)
 
 val inline_flex : t
-(** [inline_flex] is like [flex] but the container itself is inline. *)
+(** [inline_flex] is like {!val-flex} but the container itself is inline. *)
 
 val flex_1 : t
 (** [flex_1] item grows and shrinks as needed, ignoring initial size. Perfect
@@ -639,7 +644,7 @@ val grid : t
     structured than flexbox. *)
 
 val inline_grid : t
-(** [inline_grid] is like [grid] but the container itself is inline. *)
+(** [inline_grid] is like {!val-grid} but the container itself is inline. *)
 
 (** {2 Grid Template Columns}
     @see <https://tailwindcss.com/docs/grid-template-columns>
@@ -1529,8 +1534,8 @@ val text_justify : t
     @see <https://tailwindcss.com/docs/color> Color *)
 
 val text : ?opacity:int -> ?shade:int -> color -> t
-(** [text color] sets text color. [shade] defaults to 500. [opacity] sets the
-    alpha modifier (0-100). *)
+(** [text color] sets text color. [shade] defaults to 500. {!val-opacity} sets
+    the alpha modifier (0-100). *)
 
 val text_inherit : t
 (** [text_inherit] inherits color from the parent element. *)
@@ -1814,7 +1819,7 @@ type direction =
 
 val bg_gradient_to : direction -> t
 (** [bg_gradient_to dir] sets gradient direction using a typed direction.
-    Combine with [from_color]/[via_color]/[to_color].
+    Combine with {!val-from_color}/{!val-via_color}/{!val-to_color}.
 
     Example:
     {[
@@ -1844,8 +1849,8 @@ val from_color : ?shade:int -> color -> t
 
 val via_color : ?shade:int -> color -> t
 (** [via_color purple] sets the middle color of a gradient. Default shade is
-    500. Creates a three-color gradient when used with [bg_gradient_to] and
-    [to_color]. *)
+    500. Creates a three-color gradient when used with {!val-bg_gradient_to} and
+    {!val-to_color}. *)
 
 val to_color : ?shade:int -> color -> t
 (** [to_color ~shade:600 pink] sets the ending color of a gradient. Default
@@ -1927,7 +1932,7 @@ val border_l : t
 
 val border_color : ?opacity:int -> ?shade:int -> color -> t
 (** [border_color color] sets the border color. [shade] defaults to 500.
-    [opacity] sets the alpha modifier (0-100). *)
+    {!val-opacity} sets the alpha modifier (0-100). *)
 
 val border_transparent : t
 (** [border_transparent] makes border fully transparent. *)
@@ -2837,8 +2842,8 @@ val form_radio : t
 
 val accent : ?opacity:int -> ?shade:int -> color -> t
 (** [accent color] sets the accent color for form controls like checkboxes and
-    radio buttons. [shade] defaults to 500. [opacity] sets the alpha modifier
-    (0-100). *)
+    radio buttons. [shade] defaults to 500. {!val-opacity} sets the alpha
+    modifier (0-100). *)
 
 val accent_current : t
 (** [accent_current] sets accent color to currentColor. *)
@@ -2850,8 +2855,8 @@ val accent_inherit : t
     @see <https://tailwindcss.com/docs/caret-color> Caret Color *)
 
 val caret : ?opacity:int -> ?shade:int -> color -> t
-(** [caret color] sets the caret color. [shade] defaults to 500. [opacity] sets
-    the alpha modifier (0-100). *)
+(** [caret color] sets the caret color. [shade] defaults to 500. {!val-opacity}
+    sets the alpha modifier (0-100). *)
 
 val caret_current : t
 (** [caret_current] sets caret color to currentColor. *)
@@ -2934,7 +2939,7 @@ val snap_x : t
     ]} *)
 
 val snap_y : t
-(** [snap_y] enables vertical scroll snapping. Similar to [snap_x] but for
+(** [snap_y] enables vertical scroll snapping. Similar to {!val-snap_x} but for
     vertical scrolling. *)
 
 val snap_both : t
@@ -3097,8 +3102,8 @@ val sr_only : t
     accessible. *)
 
 val not_sr_only : t
-(** [not_sr_only] reverses [sr_only]; it makes previously screen-reader-only
-    content visible. *)
+(** [not_sr_only] reverses {!val-sr_only}; it makes previously
+    screen-reader-only content visible. *)
 
 (** {1 Prose Typography}
 
@@ -3198,8 +3203,9 @@ val to_inline_style : t list -> string
 (** [to_inline_style styles] generates inline CSS for the style attribute.
 
     {b Note:} This generates {i only} the CSS properties for the given styles,
-    without any Tailwind reset/prelude. The reset is only included in [to_css]
-    since it's meant for complete stylesheets, not individual elements.
+    without any Tailwind reset/prelude. The reset is only included in
+    {!val-to_css} since it's meant for complete stylesheets, not individual
+    elements.
 
     Perfect for tweaking individual HTML nodes with custom styles:
     {[
@@ -3207,7 +3213,7 @@ val to_inline_style : t list -> string
       to_inline_style [ bg ~shade:100 blue; p 4; rounded_md; text white ]
     ]}
 
-    {b When to use [to_inline_style] vs [to_css]:}
+    {b When to use [to_inline_style] vs {!val-to_css}:}
 
     {b Use [to_inline_style] when:}
     - You need dynamic styles that change at runtime
@@ -3215,7 +3221,7 @@ val to_inline_style : t list -> string
     - You're working with existing HTML that you can't modify classes for
     - You need precise control over a single element's styling
 
-    {b Use [to_css] (preferred) when:}
+    {b Use {!val-to_css} (preferred) when:}
     - You want to generate a stylesheet that can be cached and reused
     - You're building a full website with consistent styling
     - You want better performance (CSS classes are more efficient than inline
@@ -3237,8 +3243,8 @@ module Css = Css
 
     The Css module provides lower-level CSS types and functions for working with
     stylesheets, rules, and properties. Most users will only need the high-level
-    functions like [to_css] and [stylesheet_to_string], but the Css module is
-    exposed for advanced use cases requiring direct manipulation of CSS
+    functions like {!val-to_css} and [stylesheet_to_string], but the Css module
+    is exposed for advanced use cases requiring direct manipulation of CSS
     structures. *)
 
 module Prose = Prose
@@ -3429,11 +3435,11 @@ val xl2 : t list -> t
 (** {2 Pseudo-elements} *)
 
 val before : t list -> t
-(** [before styles] applies [styles] to ::before. Combine with [content]
+(** [before styles] applies [styles] to ::before. Combine with {!val-content}
     utilities. *)
 
 val after : t list -> t
-(** [after styles] applies [styles] to ::after. Combine with [content]
+(** [after styles] applies [styles] to ::after. Combine with {!val-content}
     utilities. *)
 
 (** {2 ARIA Variants} *)
@@ -3560,7 +3566,6 @@ module Flex = Flex
 module Flex_props = Flex_props
 module Flex_layout = Flex_layout
 module Alignment = Alignment
-module Cursor : module type of Tw__.Cursor
 module Borders = Borders
 module Backgrounds = Backgrounds
 module Sizing = Sizing
@@ -3584,13 +3589,15 @@ module Tables = Tables
 module Svg = Svg
 module Accessibility = Accessibility
 module Output = Output
-module Rule : module type of Tw__.Rule
 module Build = Build
 module Theme = Theme
 module Scheme = Scheme
 module Utility = Utility
 module Spacing = Spacing
 module Box_sizing = Box_sizing
+module Tab = Tab
+module Scrollbar = Scrollbar
+module Zoom = Zoom
 module Columns = Columns
 module Contain = Contain
 module Field_sizing = Field_sizing

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -90,6 +90,11 @@ let rec to_class = function
       | _ -> Style.pp_modifier m ^ ":" ^ to_class u)
   | Group us -> String.concat " " (List.map to_class us)
 
+let rec pp = function
+  | Base u -> "Base " ^ class_of_base u
+  | Modified (m, u) -> "Modified (" ^ Style.pp_modifier m ^ ", " ^ pp u ^ ")"
+  | Group us -> "Group [" ^ String.concat "; " (List.map pp us) ^ "]"
+
 let order (u : base) : int * int =
   let rec try_handlers = function
     | [] ->

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -62,6 +62,9 @@ type t = Base of base | Modified of Style.modifier * t | Group of t list
 val base : base -> t
 (** [base u] wraps a base utility into a Utility.t. *)
 
+val pp : t -> string
+(** [pp u] is a human-readable representation of [u] for debugging. *)
+
 (** Handler module type for utility registration *)
 module type Handler = sig
   type t
@@ -70,22 +73,22 @@ module type Handler = sig
   type base += Self of t  (** Extension of the base utility type *)
 
   val name : string
-  (** Name of this utility handler *)
+  (** Name of this utility handler. *)
 
   val to_style : t -> Style.t
-  (** Convert utility to style *)
+  (** [to_style u] converts utility [u] to a style. *)
 
   val priority : int
-  (** Priority for ordering utilities *)
+  (** Priority for ordering utilities. *)
 
   val suborder : t -> int
-  (** Suborder within the same priority *)
+  (** [suborder u] is the suborder within the same priority. *)
 
   val of_class : string -> (t, [ `Msg of string ]) result
-  (** Parse class name into utility *)
+  (** [of_class name] parses class [name] into a utility. *)
 
   val to_class : t -> string
-  (* TODO *)
+  (** [to_class u] is the CSS class name for utility [u]. *)
 end
 
 val register : (module Handler with type t = 'a) -> unit

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -31,15 +31,10 @@ type _ role =
 type ('a, 'r) t = {
   kind : 'a Css.kind; (* CSS type witness *)
   name : string; (* Variable name without -- prefix *)
-  layer : layer; (* Theme or Utility *)
   role : 'r role; (* The GADT role/pattern of this variable *)
   binding : ?fallback:'a Css.fallback -> 'a -> Css.declaration * 'a Css.var;
       (* Function to create declaration and var ref *)
   property : 'a property_info option; (* For @property registration *)
-  order : (int * int) option;
-      (* Explicit ordering for theme layer (utility_priority, suborder) *)
-  property_order : int option;
-      (* Explicit ordering for properties layer @supports block *)
   fallback : 'a option; (* Built-in fallback for ref_only variables *)
 }
 
@@ -291,17 +286,7 @@ let v : type a r.
         (Css.custom_property ?layer:layer_name ("--" ^ name) css, var)
     | _ -> (decl, var)
   in
-  {
-    kind;
-    name;
-    layer;
-    role;
-    binding;
-    property;
-    order;
-    property_order;
-    fallback;
-  }
+  { kind; name; role; binding; property; fallback }
 
 (* Convenience constructors to encode patterns safely *)
 

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -335,10 +335,10 @@ type 'a property_info = {
   universal : bool;
 }
 (** Property metadata for [@property] registration.
-    - [initial]: Optional initial value. If [None], properties layer uses
+    - {!field-initial}: Optional initial value. If [None], properties layer uses
       "initial"
-    - [inherits]: Whether the property inherits from parent elements
-    - [universal]: Force universal syntax "*" instead of typed syntax *)
+    - {!field-inherits}: Whether the property inherits from parent elements
+    - {!field-universal}: Force universal syntax "*" instead of typed syntax *)
 
 val property_info :
   ?initial:'a -> ?inherits:bool -> ?universal:bool -> unit -> 'a property_info
@@ -416,7 +416,8 @@ val property_default :
     {i \@layer properties \@supports} block. Lower values appear first.
 
     {b IMPORTANT}: Due to current architecture limitations, any style that uses
-    a [property_default] variable MUST include its [property_rule] explicitly:
+    a [property_default] variable MUST include its {!val-property_rule}
+    explicitly:
     {[
     let my_var =
       Var.property_default Css.Content ~initial:(Css.String "")
@@ -498,13 +499,14 @@ val theme_ref : ?default:'a -> ?default_css:string -> string -> 'a Css.var
 
 val resolve_theme_refs : string -> string option
 (** [resolve_theme_refs name] returns the default CSS string value for a
-    [theme_ref] variable. Used as [theme_defaults] in [Pp.ctx] when theme
+    {!val-theme_ref} variable. Used as [theme_defaults] in [Pp.ctx] when theme
     variables don't exist and should be replaced by their concrete defaults. *)
 
 val set_theme_value : string -> string -> unit
 (** [set_theme_value name value] registers a theme value override. When set,
-    utilities using [theme_ref] for this name will produce custom declarations
-    in the theme layer (e.g., [--z-index-auto: 42] in [:root, :host]). *)
+    utilities using {!val-theme_ref} for this name will produce custom
+    declarations in the theme layer (e.g., [--z-index-auto: 42] in
+    [:root, :host]). *)
 
 val theme_value : string -> string option
 (** [theme_value name] returns the overridden theme value, if any. *)

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -52,7 +52,4 @@ module Handler = struct
     | _ -> Error (`Msg "Not a zoom utility")
 end
 
-open Handler
-
 let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)

--- a/lib/zoom.mli
+++ b/lib/zoom.mli
@@ -1,0 +1,6 @@
+(** zoom utilities (the [zoom-*] scale).
+
+    Constructed by parsing class names (e.g. [zoom-50], [zoom-[var(--zoom)]]);
+    there is no typed DSL constructor. *)
+
+module Handler : Utility.Handler

--- a/merlint.toml
+++ b/merlint.toml
@@ -40,9 +40,10 @@ allowed_words = [
 ]
 
 # The local checkout uses an untracked symlink to the sibling cascade repo for
-# development. It is not part of this package's lint surface.
+# development, and vendored dev tooling under mono/. Neither is part of this
+# package's lint surface.
 [[rules]]
-files = ["cascade/**", "./cascade/**"]
+files = ["cascade/**", "./cascade/**", "mono/**", "./mono/**"]
 exclude = ["*"]
 
 # Modules included in tw.ml are flattened into the top-level Tw namespace, so

--- a/merlint.toml
+++ b/merlint.toml
@@ -45,7 +45,10 @@ allowed_words = [
 files = ["cascade/**", "./cascade/**"]
 exclude = ["*"]
 
-# Modules included in tw.ml need E330 exceptions to expose the proper API
+# Modules included in tw.ml are flattened into the top-level Tw namespace, so
+# they intentionally keep prefixed DSL names (E330) and prefixed variant/field
+# constructors (E334): the prefixes disambiguate constructors that would
+# otherwise collide once every module is merged into a single namespace.
 [[rules]]
 files = [
   "lib/color.ml*",
@@ -60,6 +63,9 @@ files = [
   "lib/overscroll.ml*",
   "lib/overflow_wrap.ml*",
   "lib/box_sizing.ml*",
+  "lib/tab.ml*",
+  "lib/scrollbar.ml*",
+  "lib/zoom.ml*",
   "lib/field_sizing.ml*",
   "lib/grid.ml*",
   "lib/grid_item.ml*",
@@ -96,4 +102,4 @@ files = [
   "lib/arbitrary.ml*",
   "lib/style.ml*",
 ]
-exclude = ["E330"]
+exclude = ["E330", "E334"]

--- a/test/dom/dune
+++ b/test/dom/dune
@@ -1,7 +1,7 @@
 (executable
  (name test)
  (modes js)
- (libraries tw tw_dom alcotest astring brr)
+ (libraries tw tw_dom cascade alcotest astring brr)
  (enabled_if
   (= %{context_name} "default")))
 

--- a/test/dune
+++ b/test/dune
@@ -7,6 +7,9 @@
   re
   astring
   fmt
+  cmdliner
+  unix
   tw_tools
+  cascade
   cascade.diff
   test_helpers))

--- a/test/helpers/dune
+++ b/test/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name test_helpers)
- (libraries tw tw_tools alcotest re fmt cascade.diff))
+ (libraries tw tw_tools alcotest re fmt cascade cascade.diff))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -155,7 +155,7 @@ let check_ordering_matches ?(forms = false) ~test_name utilities =
         && contains ".25rem" rendered
         && contains ".125rem" rendered
       then ()
-      else Alcotest.fail (Fmt.str "%s\n%s" test_name rendered)
+      else Alcotest.failf "%s\n%s" test_name rendered
 
 (** CSS Test Helpers *)
 

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -140,8 +140,9 @@ module type Handler = sig
 end
 
 val check_handler_roundtrip : (module Handler) -> string -> unit
-(** [check_handler_roundtrip h class_name] tests that parsing with [of_class]
-    and converting back with [to_class] round-trip correctly. *)
+(** [check_handler_roundtrip h class_name] tests that parsing with
+    {!val-of_class} and converting back with {!val-to_class} round-trip
+    correctly. *)
 
 val check_invalid_input : (module Handler) -> string -> unit
 (** [check_invalid_input h input] tests that parsing fails for invalid input as

--- a/test/html/dune
+++ b/test/html/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries tw tw.html alcotest re astring))
+ (libraries tw tw.html cascade alcotest re astring fmt))

--- a/test/test.ml
+++ b/test/test.ml
@@ -73,6 +73,9 @@ let () =
       Test_utility.suite;
       Test_spacing.suite;
       Test_box_sizing.suite;
+      Test_tab.suite;
+      Test_scrollbar.suite;
+      Test_zoom.suite;
       Test_columns.suite;
       Test_contain.suite;
       Test_divide.suite;

--- a/test/test_accessibility.mli
+++ b/test/test_accessibility.mli
@@ -1,2 +1,4 @@
+(** Tests for the accessibility module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_alignment.mli
+++ b/test/test_alignment.mli
@@ -1,2 +1,4 @@
+(** Tests for the alignment module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_animations.mli
+++ b/test/test_animations.mli
@@ -1,2 +1,4 @@
+(** Tests for the animations module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_backgrounds.mli
+++ b/test/test_backgrounds.mli
@@ -1,2 +1,4 @@
+(** Tests for the backgrounds module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_borders.mli
+++ b/test/test_borders.mli
@@ -1,2 +1,4 @@
+(** Tests for the borders module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_box_sizing.mli
+++ b/test/test_box_sizing.mli
@@ -1,2 +1,4 @@
+(** Tests for the box_sizing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_build.mli
+++ b/test/test_build.mli
@@ -1,2 +1,4 @@
+(** Tests for the build module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Build}. *)

--- a/test/test_clipping.ml
+++ b/test/test_clipping.ml
@@ -23,7 +23,7 @@ let test_clip_inset_shorthand () =
   let normalize input =
     let wrapped = ".x{" ^ input ^ "}" in
     match Css.of_string wrapped with
-    | Error _ -> Alcotest.fail (Fmt.str "Failed to parse: %s" input)
+    | Error _ -> Alcotest.failf "Failed to parse: %s" input
     | Ok { stylesheet; _ } ->
         let out =
           stylesheet

--- a/test/test_clipping.mli
+++ b/test/test_clipping.mli
@@ -1,2 +1,4 @@
+(** Tests for the clipping module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_columns.mli
+++ b/test/test_columns.mli
@@ -1,2 +1,4 @@
+(** Tests for the columns module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_containers.mli
+++ b/test/test_containers.mli
@@ -1,2 +1,4 @@
+(** Tests for the containers module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_cursor.mli
+++ b/test/test_cursor.mli
@@ -1,2 +1,4 @@
+(** Tests for the cursor module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_divide.mli
+++ b/test/test_divide.mli
@@ -1,2 +1,4 @@
+(** Tests for the divide module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_effects.mli
+++ b/test/test_effects.mli
@@ -1,2 +1,4 @@
+(** Tests for the effects module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_field_sizing.mli
+++ b/test/test_field_sizing.mli
@@ -1,2 +1,4 @@
+(** Tests for the field_sizing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_filters.mli
+++ b/test/test_filters.mli
@@ -1,2 +1,4 @@
+(** Tests for the filters module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_flex.mli
+++ b/test/test_flex.mli
@@ -1,2 +1,4 @@
+(** Tests for the flex module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_flex_layout.mli
+++ b/test/test_flex_layout.mli
@@ -1,2 +1,4 @@
+(** Tests for the flex_layout module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_flex_props.mli
+++ b/test/test_flex_props.mli
@@ -1,2 +1,4 @@
+(** Tests for the flex_props module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_forms.mli
+++ b/test/test_forms.mli
@@ -1,2 +1,4 @@
+(** Tests for the forms module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_gap.mli
+++ b/test/test_gap.mli
@@ -1,2 +1,4 @@
+(** Tests for the gap module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_grid.mli
+++ b/test/test_grid.mli
@@ -1,2 +1,4 @@
+(** Tests for the grid module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_grid_item.mli
+++ b/test/test_grid_item.mli
@@ -1,2 +1,4 @@
+(** Tests for the grid_item module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_grid_template.mli
+++ b/test/test_grid_template.mli
@@ -1,2 +1,4 @@
+(** Tests for the grid_template module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_interactivity.mli
+++ b/test/test_interactivity.mli
@@ -1,2 +1,4 @@
+(** Tests for the interactivity module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_layout.mli
+++ b/test/test_layout.mli
@@ -1,2 +1,4 @@
+(** Tests for the layout module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_margin.mli
+++ b/test/test_margin.mli
@@ -1,2 +1,4 @@
+(** Tests for the margin module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_mask_gradient.mli
+++ b/test/test_mask_gradient.mli
@@ -1,2 +1,4 @@
+(** Tests for the mask_gradient module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_masks.mli
+++ b/test/test_masks.mli
@@ -1,2 +1,4 @@
+(** Tests for the masks module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -53,9 +53,7 @@ let test_validate_no_nested_responsive () =
     try
       validate_no_nested_responsive [ sm [ md [ p 4 ] ] ];
       fail "Should have raised exception for nested responsive"
-    with
-    | Failure _ -> ()
-    | _ -> fail "Expected Failure with 'responsive' in message"
+    with Failure _ -> ()
   in
   test_nested_fail ();
 
@@ -65,9 +63,7 @@ let test_validate_no_nested_responsive () =
       let responsive_style = sm [ p 4 ] in
       validate_no_nested_responsive [ responsive_style ];
       fail "Should have rejected responsive style"
-    with
-    | Failure _ -> () (* Expected to fail *)
-    | _ -> fail "Expected Failure for responsive style"
+    with Failure _ -> () (* Expected to fail *)
   in
   test_already_responsive ()
 
@@ -76,9 +72,7 @@ let test_responsive_rejects name outer_fn inner_content =
   try
     let _ = outer_fn [ inner_content ] in
     Alcotest.failf "%s should reject nested responsive" name
-  with
-  | Failure _ -> () (* Expected to fail *)
-  | _ -> Alcotest.failf "Expected Failure about nested responsive"
+  with Failure _ -> () (* Expected to fail *)
 
 (* Test that responsive functions reject nested responsive *)
 let test_responsive_functions_reject_nesting () =

--- a/test/test_output.mli
+++ b/test/test_output.mli
@@ -1,2 +1,4 @@
+(** Tests for the output module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Output}. *)

--- a/test/test_overflow.mli
+++ b/test/test_overflow.mli
@@ -1,2 +1,4 @@
+(** Tests for the overflow module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_overflow_wrap.mli
+++ b/test/test_overflow_wrap.mli
@@ -1,2 +1,4 @@
+(** Tests for the overflow_wrap module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_overscroll.mli
+++ b/test/test_overscroll.mli
@@ -1,2 +1,4 @@
+(** Tests for the overscroll module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_padding.mli
+++ b/test/test_padding.mli
@@ -1,2 +1,4 @@
+(** Tests for the padding module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_parse.mli
+++ b/test/test_parse.mli
@@ -1,2 +1,4 @@
+(** Tests for the parse module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_position.mli
+++ b/test/test_position.mli
@@ -1,2 +1,4 @@
+(** Tests for the position module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_pp.ml
+++ b/test/test_pp.ml
@@ -1,5 +1,5 @@
 (* Tests for Pp module *)
-module Pp = Tw__Pp (* Access internal module *)
+module Pp = Tw__.Pp (* Access internal module *)
 
 let test_str () =
   let result = Pp.str [ "Hello"; " "; "World" ] in

--- a/test/test_preflight.mli
+++ b/test/test_preflight.mli
@@ -1,2 +1,4 @@
+(** Tests for the preflight module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_property.mli
+++ b/test/test_property.mli
@@ -1,2 +1,4 @@
+(** Tests for the property module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_rule.mli
+++ b/test/test_rule.mli
@@ -1,2 +1,4 @@
+(** Tests for the rule module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Rule}. *)

--- a/test/test_scheme.mli
+++ b/test/test_scheme.mli
@@ -1,2 +1,4 @@
+(** Tests for the scheme module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_scroll.mli
+++ b/test/test_scroll.mli
@@ -1,2 +1,4 @@
+(** Tests for the scroll module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_scrollbar.ml
+++ b/test/test_scrollbar.ml
@@ -1,0 +1,30 @@
+let check = Test_helpers.check_handler_roundtrip (module Tw.Scrollbar.Handler)
+
+let test_roundtrip () =
+  (* scrollbar-width *)
+  check "scrollbar-auto";
+  check "scrollbar-none";
+  check "scrollbar-thin";
+  (* scrollbar-gutter *)
+  check "scrollbar-gutter-auto";
+  check "scrollbar-gutter-stable";
+  check "scrollbar-gutter-both";
+  (* scrollbar-thumb / -track colours *)
+  check "scrollbar-thumb-red-500";
+  check "scrollbar-track-gray-200";
+  check "scrollbar-thumb-current";
+  check "scrollbar-thumb-transparent";
+  check "scrollbar-thumb-inherit";
+  check "scrollbar-thumb-[#ff0000]"
+
+let test_invalid () =
+  Test_helpers.check_invalid_input (module Tw.Scrollbar.Handler) "scrollbar";
+  Test_helpers.check_invalid_input (module Tw.Scrollbar.Handler) "scrollbar-foo";
+  Test_helpers.check_invalid_input
+    (module Tw.Scrollbar.Handler)
+    "scrollbar-gutter-foo"
+
+let tests =
+  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+
+let suite = ("scrollbar", tests)

--- a/test/test_scrollbar.mli
+++ b/test/test_scrollbar.mli
@@ -1,4 +1,4 @@
-(** Tests for the contain module. *)
+(** Tests for the scrollbar utilities. *)
 
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_sizing.mli
+++ b/test/test_sizing.mli
@@ -1,2 +1,4 @@
+(** Tests for the sizing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_sort.mli
+++ b/test/test_sort.mli
@@ -1,2 +1,4 @@
+(** Tests for the sort module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite for {!Sort}. *)

--- a/test/test_source_scan.mli
+++ b/test/test_source_scan.mli
@@ -1,2 +1,4 @@
+(** Tests for the source_scan module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_spacing.mli
+++ b/test/test_spacing.mli
@@ -1,2 +1,4 @@
+(** Tests for the spacing module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_style.mli
+++ b/test/test_style.mli
@@ -1,2 +1,4 @@
+(** Tests for the style module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_svg.mli
+++ b/test/test_svg.mli
@@ -1,2 +1,4 @@
+(** Tests for the svg module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_tab.ml
+++ b/test/test_tab.ml
@@ -1,0 +1,17 @@
+let check = Test_helpers.check_handler_roundtrip (module Tw.Tab.Handler)
+
+let test_roundtrip () =
+  check "tab-2";
+  check "tab-8";
+  check "tab-[3]";
+  check "tab-[12px]"
+
+let test_invalid () =
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab";
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-2.5";
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-unknown"
+
+let tests =
+  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+
+let suite = ("tab", tests)

--- a/test/test_tab.mli
+++ b/test/test_tab.mli
@@ -1,4 +1,4 @@
-(** Tests for the contain module. *)
+(** Tests for the [tab-size] utilities. *)
 
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_tables.mli
+++ b/test/test_tables.mli
@@ -1,2 +1,4 @@
+(** Tests for the tables module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_text_shadow.mli
+++ b/test/test_text_shadow.mli
@@ -1,2 +1,4 @@
+(** Tests for the text_shadow module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_theme.mli
+++ b/test/test_theme.mli
@@ -1,2 +1,4 @@
+(** Tests for the theme module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_touch.mli
+++ b/test/test_touch.mli
@@ -1,2 +1,4 @@
+(** Tests for the touch module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_transforms.mli
+++ b/test/test_transforms.mli
@@ -1,2 +1,4 @@
+(** Tests for the transforms module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_transitions.mli
+++ b/test/test_transitions.mli
@@ -1,2 +1,4 @@
+(** Tests for the transitions module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_typography.mli
+++ b/test/test_typography.mli
@@ -1,2 +1,4 @@
+(** Tests for the typography module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_utility.mli
+++ b/test/test_utility.mli
@@ -1,2 +1,4 @@
+(** Tests for the utility module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/test/test_var.mli
+++ b/test/test_var.mli
@@ -1,2 +1,4 @@
+(** Tests for the var module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] test suite. *)

--- a/test/test_zoom.ml
+++ b/test/test_zoom.ml
@@ -1,0 +1,16 @@
+let check = Test_helpers.check_handler_roundtrip (module Tw.Zoom.Handler)
+
+let test_roundtrip () =
+  check "zoom-50";
+  check "zoom-100";
+  check "zoom-[var(--zoom)]"
+
+let test_invalid () =
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom";
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-1.5";
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-unknown"
+
+let tests =
+  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+
+let suite = ("zoom", tests)

--- a/test/test_zoom.mli
+++ b/test/test_zoom.mli
@@ -1,4 +1,4 @@
-(** Tests for the contain module. *)
+(** Tests for the [zoom] utilities. *)
 
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the test suite. *)

--- a/tw.opam
+++ b/tw.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/samoht/tw"
 bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
   "ocaml" {>= "5.2"}
-  "dune" {>= "3.0"}
+  "dune" {>= "3.21"}
   "cascade"
   "cmdliner"
   "fmt"
@@ -41,6 +41,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/samoht/tw.git"
+x-maintenance-intent: ["(latest)"]
 pin-depends: [
   [ "cascade.dev" "git+https://github.com/samoht/cascade.git#ad90d314c1e808b64b07fc0b532d14ea334bdc5c" ]
 ]


### PR DESCRIPTION
Resolve every issue reported by merlint and enable uniformly strict builds. Drops the Fmt dependency in favour of the in-house Pp module to keep the js_of_ocaml bundle small, enables dune-warnings and implicit_transitive_deps, and wires README.md into mdx, which surfaced stale API examples now rewritten against the public API.

Stacked on #7; CI inherits the pre-existing example parity failures tracked there.