### PR TITLE
forms: emit the plugin base layer behind an explicit opt-in

### DIFF
--- a/examples/forms/main.ml
+++ b/examples/forms/main.ml
@@ -115,7 +115,7 @@ let contact_form =
     ]
 
 let page_view =
-  page ~title:"Forms Demo" ~tw_css:"forms.css" []
+  page ~forms:true ~title:"Forms Demo" ~tw_css:"forms.css" []
     [
       div
         ~tw:Tw.[ min_h_screen; bg ~shade:100 gray; py 12 ]

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1050,17 +1050,6 @@ let flatten_property_rules property_rules_lists =
   property_rules_lists |> List.concat_map Css.statements
 
 (* Build individual CSS layers *)
-(* Detect if forms utilities are used - triggers including forms base layer *)
-let has_forms_utilities tw_classes =
-  let rec check_utility = function
-    | Utility.Base u ->
-        let name = Utility.name_of_base u in
-        name = "forms" || name = "forms_select"
-    | Utility.Modified (_, u) -> check_utility u
-    | Utility.Group us -> List.exists check_utility us
-  in
-  List.exists check_utility tw_classes
-
 (* Detect if before/after pseudo-elements are used - triggers content var
    property rule *)
 let has_pseudo_elements tw_classes =
@@ -1192,11 +1181,12 @@ let layers ~layers ~include_base ?forms ~selector_props tw_classes statements =
     collect_all_property_rules vars_from_utilities set_var_names
       explicit_property_rules
   in
-  (* Use explicit forms flag if provided, otherwise auto-detect from
-     utilities *)
-  let forms_base =
-    match forms with Some f -> f | None -> has_forms_utilities tw_classes
-  in
+  (* The forms base layer is the plugin's [base] strategy: a global reset of
+     native form controls. It is opt-in only ([~forms:true]), mirroring
+     Tailwind's [\@plugin '@tailwindcss/forms']. The [.form-*] class-strategy
+     utilities emit their own per-class styles when used, independent of this
+     flag, so utility presence must not auto-enable the global base. *)
+  let forms_base = match forms with Some f -> f | None -> false in
   let individual =
     individual_layers ~layers ~include_base ~forms_base first_usage_order
       selector_props all_property_statements statements

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -883,7 +883,7 @@ let file_input_base () =
         border_color Inherit;
         font_size Unset;
         line_height Inherit;
-        border_width (Px 0.);
+        border_width Zero;
         border_radius (radius Zero);
         padding [ Px 0. ];
       ];
@@ -908,16 +908,14 @@ let file_input_base () =
       ];
   ]
 
-(* Tailwind v4's [\@tailwindcss/forms] plugin defaults to [strategy: 'class'] -
-   the plugin only emits styles for elements bearing one of the [.form-*]
-   utility classes, not for global [input/select/textarea] selectors. The
-   per-class styling is emitted directly by the [.form-*] utility handlers
-   above, so this base stylesheet stays empty. *)
+(* Tailwind v4's [\@tailwindcss/forms] plugin defaults to the [base] strategy:
+   it resets native form controls globally ([input]/[select]/[textarea]/...),
+   not only elements bearing a [.form-*] class. Those global resets are the
+   forms base layer, emitted whenever the forms plugin is active. The rule order
+   below mirrors the plugin's own output. *)
 
 (** Complete base layer stylesheet for forms plugin *)
 let base_stylesheet () =
-  let _ = text_inputs_base in
-  let _ = select_base in
-  let _ = checkbox_radio_base in
-  let _ = file_input_base in
-  Css.v []
+  Css.v
+    (text_inputs_base () @ select_base () @ checkbox_radio_base ()
+   @ file_input_base ())

--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -404,7 +404,7 @@ let line ?at ?tw children = el_with_tw "line" ?at ?tw children
 (* Type for page generation result *)
 type page = { html : string; css : Tw.Css.t; tw_css : string }
 
-let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css head_content
+let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css ?forms head_content
     body_content =
   (* Build HTML tree with placeholder for CSS link *)
   let meta_charset = meta ~at:[ At.charset charset ] () in
@@ -423,14 +423,16 @@ let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css head_content
   (* Add styles from head content *)
   let all_tw = all_tw @ List.concat_map to_tw head_content in
 
-  (* Detect if forms plugin base styles are needed. Check body and head content
-     for form elements (input, select, textarea). *)
-  let forms_in_body = has_forms body_element in
-  let forms_in_head = List.exists has_forms head_content in
-  let need_forms = forms_in_body || forms_in_head in
-
-  (* Generate CSS and compute MD5 hash for cache busting *)
-  let css_stylesheet = Tw.to_css ~forms:need_forms all_tw in
+  (* The forms plugin base layer follows Tailwind's [\@plugin] model: it is
+     emitted only when the plugin is explicitly enabled ([~forms:true]), since a
+     page merely containing form controls does not opt into the plugin. When
+     [forms] is unset, [Tw.to_css] auto-detects from forms utility usage, the
+     same way prose styling is driven by the [prose] utility. *)
+  let css_stylesheet =
+    match forms with
+    | Some forms -> Tw.to_css ~forms all_tw
+    | None -> Tw.to_css all_tw
+  in
   let css_string = Tw.Css.to_string ~minify:true css_stylesheet in
 
   (* Compute MD5 hash of the CSS content for cache busting *)
@@ -461,8 +463,8 @@ let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css head_content
 
 (* Page generation with CSS - use renamed parameters to avoid shadowing *)
 let page ?(lang = "en") ?(meta = []) ?title ?(charset = "utf-8")
-    ?(tw_css = "tw.css") head_content body_content =
-  page_impl ~lang ~meta_list:meta ?title_text:title ~charset ~tw_css
+    ?(tw_css = "tw.css") ?forms head_content body_content =
+  page_impl ~lang ~meta_list:meta ?title_text:title ~charset ~tw_css ?forms
     head_content body_content
 
 (* Page accessor functions *)

--- a/lib/html/tw_html.mli
+++ b/lib/html/tw_html.mli
@@ -375,11 +375,12 @@ val page :
   ?title:string ->
   ?charset:string ->
   ?tw_css:string ->
+  ?forms:bool ->
   t list ->
   t list ->
   page
-(** [page ?lang ?meta ?title ?charset ?tw_css head body] generates a complete
-    HTML page and its corresponding CSS.
+(** [page ?lang ?meta ?title ?charset ?tw_css ?forms head body] generates a
+    complete HTML page and its corresponding CSS.
 
     - [lang] defaults to ["en"]
     - [charset] defaults to ["utf-8"]
@@ -387,6 +388,9 @@ val page :
     - [title] is the page title
     - [tw_css] defaults to ["tw.css"] - the filename for the CSS, automatically
       included as a [<link>] tag in HTML head
+    - [forms] explicitly enables the [\@tailwindcss/forms] plugin base layer,
+      mirroring Tailwind's [\@plugin] opt-in. When omitted, the forms base is
+      auto-detected from forms utility usage (like prose styling).
     - [head] is additional content for the head section
     - [body] is the body content
 


### PR DESCRIPTION
The `@tailwindcss/forms` plugin defaults to the base strategy, a global reset of native form controls. tw never emitted it (`Forms.base_stylesheet` was an empty placeholder), so the forms example diverged from Tailwind by 44%. It now matches byte-for-byte.

The base layer is gated on an explicit `?forms` opt-in on `Tw_html.page`, mirroring Tailwind's `@plugin` directive: a page merely containing form controls no longer auto-enables the global reset, and the `.form-*` class-strategy utilities are unaffected. Stacked on #10.