### PR TITLE
perf: precompute sort keys and share color nodes

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -302,7 +302,8 @@ let adjust_pseudo class_name (prio, suborder) =
 let collect_order_map tw_classes =
   let m = Hashtbl.create 256 in
   let rec collect = function
-    | Utility.Base b -> Hashtbl.replace m (Utility.class_of_base b) (Utility.order b)
+    | Utility.Base b ->
+        Hashtbl.replace m (Utility.class_of_base b) (Utility.order b)
     | Utility.Modified (_, t) -> collect t
     | Utility.Group us -> List.iter collect us
   in
@@ -377,6 +378,7 @@ let add_index triples =
       Buffer.clear buf;
       Css.Selector.to_buffer buf sel;
       let selector_str = Buffer.contents buf in
+      let media_key, nested_media_key = Sort.media_sort_keys typ nested in
       ({
          index = i;
          rule_type = typ;
@@ -396,6 +398,8 @@ let add_index triples =
            (match base_class with
            | Some s -> Sort.normalize_for_sort s
            | None -> "");
+         media_key;
+         nested_media_key;
        }
         : Sort.indexed_rule))
     triples

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -392,6 +392,10 @@ let add_index triples =
          not_order;
          variant_order = Rule.compute_variant_order base_class sel;
          variant_key = Sort.variant_sort_key base_class nested;
+         normalized_base_class =
+           (match base_class with
+           | Some s -> Sort.normalize_for_sort s
+           | None -> "");
        }
         : Sort.indexed_rule))
     triples

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1006,11 +1006,45 @@ let oklch_node_of color shade =
   Css.oklch oklch.l oklch.c oklch.h
 
 (* The palette ([Red], [Blue], ...) is a fixed set of (colour, shade) pairs and
-   its oklch nodes are immutable, so build each one once and share it across
-   every utility and variant that uses the colour instead of reconstructing an
-   identical node per use. Keyed only on the constant palette constructors;
-   [Rgb]/[Theme_named] carry open-ended payloads and build fresh. *)
-let palette_nodes : (color * int, Css.color) Hashtbl.t = Hashtbl.create 256
+   its oklch nodes are immutable, so materialise each node once and share it
+   across every utility and variant that uses the colour, instead of
+   reconstructing an identical node per use. Built once on first use; only the
+   constant palette constructors are keyed here, [Rgb]/[Theme_named] carry
+   open-ended payloads and build fresh. *)
+let palette_nodes =
+  lazy
+    (let table = Hashtbl.create 256 in
+     List.iter
+       (fun (color, palette) ->
+         List.iter
+           (fun (shade, o) ->
+             Hashtbl.replace table (color, shade) (Css.oklch o.l o.c o.h))
+           palette)
+       [
+         (Gray, Tailwind.gray);
+         (Slate, Tailwind.slate);
+         (Zinc, Tailwind.zinc);
+         (Neutral, Tailwind.neutral);
+         (Stone, Tailwind.stone);
+         (Red, Tailwind.red);
+         (Orange, Tailwind.orange);
+         (Amber, Tailwind.amber);
+         (Yellow, Tailwind.yellow);
+         (Lime, Tailwind.lime);
+         (Green, Tailwind.green);
+         (Emerald, Tailwind.emerald);
+         (Teal, Tailwind.teal);
+         (Cyan, Tailwind.cyan);
+         (Sky, Tailwind.sky);
+         (Blue, Tailwind.blue);
+         (Indigo, Tailwind.indigo);
+         (Violet, Tailwind.violet);
+         (Purple, Tailwind.purple);
+         (Fuchsia, Tailwind.fuchsia);
+         (Pink, Tailwind.pink);
+         (Rose, Tailwind.rose);
+       ];
+     table)
 
 (* Convert color to CSS color value *)
 let to_css color shade =
@@ -1031,13 +1065,9 @@ let to_css color shade =
   | Css c -> c
   | Rgb _ | Theme_named _ -> oklch_node_of color shade
   | _ -> (
-      let key = (color, shade) in
-      match Hashtbl.find_opt palette_nodes key with
+      match Hashtbl.find_opt (Lazy.force palette_nodes) (color, shade) with
       | Some node -> node
-      | None ->
-          let node = oklch_node_of color shade in
-          Hashtbl.add palette_nodes key node;
-          node)
+      | None -> oklch_node_of color shade)
 
 let named_color_name = function
   | Black -> "black"

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1001,6 +1001,17 @@ let to_oklch_css color shade =
       | Some value -> value
       | None -> "oklch(0% 0 0)" (* Fallback *))
 
+let oklch_node_of color shade =
+  let oklch = to_oklch color shade in
+  Css.oklch oklch.l oklch.c oklch.h
+
+(* The palette ([Red], [Blue], ...) is a fixed set of (colour, shade) pairs and
+   its oklch nodes are immutable, so build each one once and share it across
+   every utility and variant that uses the colour instead of reconstructing an
+   identical node per use. Keyed only on the constant palette constructors;
+   [Rgb]/[Theme_named] carry open-ended payloads and build fresh. *)
+let palette_nodes : (color * int, Css.color) Hashtbl.t = Hashtbl.create 256
+
 (* Convert color to CSS color value *)
 let to_css color shade =
   match color with
@@ -1018,10 +1029,15 @@ let to_css color shade =
       Css.hex ("#" ^ shorten_hex_str hex_value)
   | Oklch oklch -> Css.oklch oklch.l oklch.c oklch.h
   | Css c -> c
-  | _ ->
-      (* For other colors, get OKLCH data directly *)
-      let oklch = to_oklch color shade in
-      Css.oklch oklch.l oklch.c oklch.h
+  | Rgb _ | Theme_named _ -> oklch_node_of color shade
+  | _ -> (
+      let key = (color, shade) in
+      match Hashtbl.find_opt palette_nodes key with
+      | Some node -> node
+      | None ->
+          let node = oklch_node_of color shade in
+          Hashtbl.add palette_nodes key node;
+          node)
 
 let named_color_name = function
   | Black -> "black"
@@ -1280,15 +1296,18 @@ let color_var_cache : (string, Css.color Var.theme) Hashtbl.t =
 let color_var color shade =
   let base = pp color in
   (* Escape brackets in variable names - CSS variable names can't have unescaped
-     [] *)
+     []. Almost no colour name contains brackets, so keep a zero-allocation fast
+     path and only build a buffer when escaping is actually needed. *)
   let escaped_base =
-    let s = String.to_seq base |> List.of_seq in
-    let escaped =
-      List.concat_map
-        (function '[' -> [ '\\'; '[' ] | ']' -> [ '\\'; ']' ] | c -> [ c ])
-        s
-    in
-    String.of_seq (List.to_seq escaped)
+    if String.contains base '[' || String.contains base ']' then (
+      let buf = Buffer.create (String.length base + 4) in
+      String.iter
+        (fun c ->
+          (match c with '[' | ']' -> Buffer.add_char buf '\\' | _ -> ());
+          Buffer.add_char buf c)
+        base;
+      Buffer.contents buf)
+    else base
   in
   let name =
     if is_shadeless color then "color-" ^ escaped_base

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -56,7 +56,14 @@ type indexed_rule = {
          [variant_sort_key]. Read by [compare_variant_ordered]. *)
   normalized_base_class : string;
       (* Precomputed [normalize_for_sort base_class] ("" when no base class),
-         read by [compare_by_base_class] instead of re-mapping per comparison. *)
+         read by [compare_by_base_class] instead of re-mapping per
+         comparison. *)
+  media_key : Css.Media.key option;
+      (* Precomputed sort key of the rule's own media condition (the [`Media]
+         case of [rule_type]); [None] otherwise. Lets media comparisons use
+         [Css.Media.compare_keys] instead of re-serializing the query. *)
+  nested_media_key : Css.Media.key option;
+      (* Precomputed sort key of a single nested media condition. *)
 }
 (** An indexed CSS rule ready for sorting. [index] preserves source order;
     [order] is the [(priority, suborder)] pair from the utility definition;
@@ -202,6 +209,23 @@ let extract_media_sort_key = function
   | `Media cond -> Css.Media.group_order (Css.Media.kind cond)
   | _ -> (0, 0.)
 
+(* Precompute the sort keys for a rule's own and nested media conditions, so the
+   comparators use [Css.Media.compare_keys] (cheap) instead of re-serializing the
+   query on every comparison. See [media_key]/[nested_media_key]. *)
+let media_sort_keys rule_type nested =
+  let media_key =
+    match rule_type with `Media c -> Some (Css.Media.sort_key c) | _ -> None
+  in
+  let nested_media_key =
+    match nested with
+    | [ n ] -> (
+        match Css.as_media n with
+        | Some (c, _) -> Some (Css.Media.sort_key c)
+        | None -> None)
+    | _ -> None
+  in
+  (media_key, nested_media_key)
+
 (* ======================================================================== *)
 (* Priority Comparison *)
 (* ======================================================================== *)
@@ -270,7 +294,7 @@ let compare_by_priority_suborder_alpha kind1 kind2 sel_str1 sel_str2 (p1, s1)
 (* ======================================================================== *)
 
 (** Compare two media conditions within the same group *)
-let compare_media_conditions group1 sub1 sub2 cond1 cond2 =
+let compare_media_conditions group1 sub1 sub2 cond1 cond2 key1 key2 =
   if group1 = 2000 then Float.compare sub1 sub2
   else if group1 = 1000 then
     match (cond1, cond2) with
@@ -280,8 +304,8 @@ let compare_media_conditions group1 sub1 sub2 cond1 cond2 =
           (preference_condition_order c2)
     | _ -> 0
   else
-    match (cond1, cond2) with
-    | Some c1, Some c2 -> Css.Media.compare c1 c2
+    match (key1, key2) with
+    | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
     | _ -> 0
 
 (* For hover media, separate rules by modifier depth so that single-modifier
@@ -298,12 +322,9 @@ let compare_hover_depth cond1 cond2 sel1 sel2 =
 (* Compare by nested media condition when both have nested media. This sorts
    stacked min/max variants like min-sm:max-xl vs min-sm:max-lg by the inner
    media condition. *)
-let compare_nested_media_cond nested1 nested2 =
-  match (nested1, nested2) with
-  | [ n1 ], [ n2 ] -> (
-      match (Css.as_media n1, Css.as_media n2) with
-      | Some (c1, _), Some (c2, _) -> Css.Media.compare c1 c2
-      | _ -> 0)
+let compare_nested_media_cond nk1 nk2 =
+  match (nk1, nk2) with
+  | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
   | _ -> 0
 
 let compare_same_media_group (r1 : indexed_rule) (r2 : indexed_rule) cond1 cond2
@@ -311,7 +332,9 @@ let compare_same_media_group (r1 : indexed_rule) (r2 : indexed_rule) cond1 cond2
   let depth_cmp = compare_hover_depth cond1 cond2 r1.selector r2.selector in
   if depth_cmp <> 0 then depth_cmp
   else
-    let nested_media_cmp = compare_nested_media_cond r1.nested r2.nested in
+    let nested_media_cmp =
+      compare_nested_media_cond r1.nested_media_key r2.nested_media_key
+    in
     if nested_media_cmp <> 0 then nested_media_cmp
     else
       let same_utility =
@@ -337,7 +360,10 @@ let compare_media_rules (r1 : indexed_rule) (r2 : indexed_rule) =
     else
       let cond1 = match r1.rule_type with `Media c -> Some c | _ -> None in
       let cond2 = match r2.rule_type with `Media c -> Some c | _ -> None in
-      let cond_cmp = compare_media_conditions group1 sub1 sub2 cond1 cond2 in
+      let cond_cmp =
+        compare_media_conditions group1 sub1 sub2 cond1 cond2 r1.media_key
+          r2.media_key
+      in
       if cond_cmp <> 0 then cond_cmp
       else compare_same_media_group r1 r2 cond1 cond2
 
@@ -754,9 +780,9 @@ let compare_nested_media r1 r2 =
   | [], [] -> 0
   | [], _ -> -1
   | _, [] -> 1
-  | [ n1 ], [ n2 ] -> (
-      match (Css.as_media n1, Css.as_media n2) with
-      | Some (c1, _), Some (c2, _) -> Css.Media.compare c1 c2
+  | [ _ ], [ _ ] -> (
+      match (r1.nested_media_key, r2.nested_media_key) with
+      | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
       | _ -> 0)
   | _ -> 0
 
@@ -943,9 +969,9 @@ let compare_variant_ordered r1 r2 =
           if nested_cmp <> 0 then nested_cmp
           else
             let media_cmp =
-              match (r1.rule_type, r2.rule_type) with
-              | `Media c1, `Media c2 ->
-                  let cmp = Css.Media.compare c1 c2 in
+              match (r1.media_key, r2.media_key) with
+              | Some k1, Some k2 ->
+                  let cmp = Css.Media.compare_keys k1 k2 in
                   if cmp <> 0 then cmp else compare_nested_media r1 r2
               | _ -> 0
             in

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -54,6 +54,9 @@ type indexed_rule = {
   variant_key : string * int;
       (* Precomputed (variant prefix, effective inner order) - see
          [variant_sort_key]. Read by [compare_variant_ordered]. *)
+  normalized_base_class : string;
+      (* Precomputed [normalize_for_sort base_class] ("" when no base class),
+         read by [compare_by_base_class] instead of re-mapping per comparison. *)
 }
 (** An indexed CSS rule ready for sorting. [index] preserves source order;
     [order] is the [(priority, suborder)] pair from the utility definition;
@@ -710,15 +713,11 @@ let normalize_for_sort s =
       | '_' -> ' ' | '[' | ']' -> '~' | '/' -> '|' | ':' -> '!' | c -> c)
     s
 
-(* Compare by normalized base_class, then index *)
+(* Compare by normalized base_class (precomputed in [add_index]), then index *)
 let compare_by_base_class r1 r2 =
-  let bc1 =
-    match r1.base_class with Some s -> normalize_for_sort s | None -> ""
+  let class_cmp =
+    String.compare r1.normalized_base_class r2.normalized_base_class
   in
-  let bc2 =
-    match r2.base_class with Some s -> normalize_for_sort s | None -> ""
-  in
-  let class_cmp = String.compare bc1 bc2 in
   if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
 
 (* Sort key for supports modifier variants: named before bracket *)

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -48,8 +48,15 @@ type indexed_rule = {
           {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
           per comparison. *)
   normalized_base_class : string;
-      (** Precomputed [normalize_for_sort base_class] ([""] when there is no base
-          class), so [compare_indexed_rules] does not re-map it per comparison. *)
+      (** Precomputed [normalize_for_sort base_class] ([""] when there is no
+          base class), so [compare_indexed_rules] does not re-map it per
+          comparison. *)
+  media_key : Css.Media.key option;
+      (** Precomputed sort key of the rule's own media condition (the [`Media]
+          case of {!field-rule_type}), [None] otherwise. Comparisons use this
+          instead of re-serializing the query on every call. *)
+  nested_media_key : Css.Media.key option;
+      (** Precomputed sort key of a single nested media condition. *)
 }
 
 val classify_selector : Css.Selector.t -> selector_kind
@@ -60,8 +67,21 @@ val normalize_for_sort : string -> string
     Tailwind order. Stored per rule in {!field-normalized_base_class}. *)
 
 val variant_sort_key : string option -> Css.statement list -> string * int
-(** [variant_sort_key base_class nested] is the [(variant prefix, effective
-    inner variant order)] pair stored in {!field-variant_key}. *)
+(** [variant_sort_key base_class nested] is the
+    [(variant prefix, effective inner variant order)] pair stored in
+    {!field-variant_key}. *)
+
+val media_sort_keys :
+  [ `Regular
+  | `Media of Css.Media.t
+  | `Container of Css.Container.t
+  | `Starting
+  | `Supports of Css.Supports.t ] ->
+  Css.statement list ->
+  Css.Media.key option * Css.Media.key option
+(** [media_sort_keys rule_type nested] is the
+    [(media_key, nested_media_key)] pair stored on an {!type-indexed_rule},
+    computed once so comparisons never re-serialize a media query. *)
 
 (** {1 Sorting} *)
 

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -47,10 +47,17 @@ type indexed_rule = {
       (** Precomputed [(variant prefix, effective inner order)], built with
           {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
           per comparison. *)
+  normalized_base_class : string;
+      (** Precomputed [normalize_for_sort base_class] ([""] when there is no base
+          class), so [compare_indexed_rules] does not re-map it per comparison. *)
 }
 
 val classify_selector : Css.Selector.t -> selector_kind
 (** [classify_selector sel] classifies a selector for ordering purposes. *)
+
+val normalize_for_sort : string -> string
+(** [normalize_for_sort s] rewrites separator characters so base classes sort in
+    Tailwind order. Stored per rule in {!field-normalized_base_class}. *)
 
 val variant_sort_key : string option -> Css.statement list -> string * int
 (** [variant_sort_key base_class nested] is the [(variant prefix, effective


### PR DESCRIPTION
Second of three stacked allocation-reduction PRs. Stacked on #13.

Commit 151c0fce escapes var-name brackets without a seq round-trip; 670fd5e5 precomputes the normalized base class used by the tiebreaker; 9fc9cd41 shares palette oklch nodes instead of rebuilding them per use; 7af66133 precomputes media sort keys instead of re-serializing.