### PR TITLE
perf: cache color vars and record utility order cheaply

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -295,20 +295,10 @@ let adjust_pseudo class_name (prio, suborder) =
 
 (* The base utility's order is [Utility.order] on its value, recovered here from
    the class string by re-parsing it through the handlers - the expensive part.
-   [order_map] (built once per generation from the actual utility values, see
-   [collect_order_map]) lets the common case skip that parse; an unknown class
-   (not in the input set) falls back to the parse, or to a selector-based
-   conflict order when even that fails. *)
-let collect_order_map tw_classes =
-  let m = Hashtbl.create 256 in
-  let rec collect = function
-    | Utility.Base b ->
-        Hashtbl.replace m (Utility.class_of_base b) (Utility.order b)
-    | Utility.Modified (_, t) -> collect t
-    | Utility.Group us -> List.iter collect us
-  in
-  List.iter collect tw_classes;
-  m
+   [order_map] is populated by [Rule.outputs ~order_tbl] from the class strings
+   it already builds, so the common case is a lookup; an unknown class (not in
+   the input set) falls back to the parse, or to a selector-based conflict order
+   when even that fails. *)
 
 let order_of_base order_map base_class selector =
   match base_class with
@@ -493,8 +483,9 @@ let var_names_of_sorted_rules sorted_rules =
       sort_vars_by_property_order (set_vars @ ref_vars))
 
 let rule_sets tw_classes =
-  let all_rules = tw_classes |> List.concat_map Rule.outputs in
-  rule_sets_from_selector_props (collect_order_map tw_classes) all_rules
+  let order_tbl = Hashtbl.create 256 in
+  let all_rules = List.concat_map (Rule.outputs ~order_tbl) tw_classes in
+  rule_sets_from_selector_props order_tbl all_rules
 
 (* ======================================================================== *)
 (* Layer Generation - CSS @layer directives and theme variable resolution *)
@@ -1235,10 +1226,13 @@ type config = { base : bool; forms : bool option; layers : bool }
 let default_config = { base = true; forms = None; layers = true }
 
 let to_css ?(config = default_config) tw_classes =
-  let selector_props = List.concat_map Rule.outputs tw_classes in
-  (* Resolve each utility's order from its value once, so [order_of_base] does
-     not re-parse class strings while building/sorting rules. *)
-  let order_map = collect_order_map tw_classes in
+  (* [Rule.outputs ~order_tbl] records each base utility's order under the class
+     name it already builds, so [order_of_base] looks it up instead of re-parsing
+     the class string while building/sorting rules. *)
+  let order_map = Hashtbl.create 256 in
+  let selector_props =
+    List.concat_map (Rule.outputs ~order_tbl:order_map) tw_classes
+  in
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute
      it once and share it rather than recomputing inside [layers]. *)

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -288,8 +288,8 @@ let deduplicate_typed_triples triples =
    Tailwind v4, where pseudo-elements appear late). *)
 let adjust_pseudo class_name (prio, suborder) =
   if
-    String.starts_with ~prefix:"before:" class_name
-    || String.starts_with ~prefix:"after:" class_name
+    Parse.has_prefix ~prefix:"before:" class_name
+    || Parse.has_prefix ~prefix:"after:" class_name
   then (prio, suborder + 5000)
   else (prio, suborder)
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1318,35 +1318,45 @@ let theme_order_with_shade color_name shade =
   (var_priority, base_order + shade)
 
 (* Memoization table for color variables *)
-let color_var_cache : (string, Css.color Var.theme) Hashtbl.t =
+(* Keyed by [(color, shade)] (shade normalised to 0 for shadeless colours, which
+   ignore it) rather than the materialized name, so a cache hit skips building
+   the name string entirely - and within one generation bg/text/border share the
+   same colour, so hits happen even on a single cold run. *)
+let color_var_cache : (color * int, Css.color Var.theme) Hashtbl.t =
   Hashtbl.create 128
+
+(* Property-scoped colour variables (text-color-*, accent-color-*, ...) keyed by
+   their full name, kept separate from the [(color, shade)] cache above. *)
+let property_color_var_cache : (string, Css.color Var.theme) Hashtbl.t =
+  Hashtbl.create 64
 
 (* Helper to create a color variable with memoization. Creates theme layer
    variables with deterministic ordering based on color and shade. *)
 let color_var color shade =
-  let base = pp color in
-  (* Escape brackets in variable names - CSS variable names can't have unescaped
-     []. Almost no colour name contains brackets, so keep a zero-allocation fast
-     path and only build a buffer when escaping is actually needed. *)
-  let escaped_base =
-    if String.contains base '[' || String.contains base ']' then (
-      let buf = Buffer.create (String.length base + 4) in
-      String.iter
-        (fun c ->
-          (match c with '[' | ']' -> Buffer.add_char buf '\\' | _ -> ());
-          Buffer.add_char buf c)
-        base;
-      Buffer.contents buf)
-    else base
-  in
-  let name =
-    if is_shadeless color then "color-" ^ escaped_base
-    else "color-" ^ escaped_base ^ "-" ^ string_of_int shade
-  in
-  (* Check if variable already exists in cache *)
-  match Hashtbl.find_opt color_var_cache name with
+  let shadeless = is_shadeless color in
+  let key = (color, if shadeless then 0 else shade) in
+  match Hashtbl.find_opt color_var_cache key with
   | Some var -> var
   | None ->
+      let base = pp color in
+      (* Escape brackets in variable names - CSS variable names can't have
+         unescaped []. Almost no colour name contains brackets, so keep a
+         zero-allocation fast path and only build a buffer when needed. *)
+      let escaped_base =
+        if String.contains base '[' || String.contains base ']' then (
+          let buf = Buffer.create (String.length base + 4) in
+          String.iter
+            (fun c ->
+              (match c with '[' | ']' -> Buffer.add_char buf '\\' | _ -> ());
+              Buffer.add_char buf c)
+            base;
+          Buffer.contents buf)
+        else base
+      in
+      let name =
+        if shadeless then "color-" ^ escaped_base
+        else Pp.str [ "color-"; escaped_base; "-"; string_of_int shade ]
+      in
       (* Create theme variable with deterministic theme layer order: - Base
          colors use theme_order(color_name) - Shaded colors use
          theme_order_with_shade(color_name, shade)
@@ -1355,11 +1365,11 @@ let color_var color shade =
          input, not by a fixed ordering. Our implementation uses a fixed
          ordering for determinism and consistency. *)
       let var_order =
-        if is_shadeless color then theme_order_with_shade base 0
+        if shadeless then theme_order_with_shade base 0
         else theme_order_with_shade base shade
       in
       let var = Var.theme Css.Color name ~order:var_order in
-      Hashtbl.add color_var_cache name var;
+      Hashtbl.add color_var_cache key var;
       var
 
 let color_to_string (c : color) : string =
@@ -1625,7 +1635,7 @@ module Handler = struct
     | Some _ -> (
         (* Property-scoped theme value exists, create scoped variable *)
         let name = prop_name in
-        match Hashtbl.find_opt color_var_cache name with
+        match Hashtbl.find_opt property_color_var_cache name with
         | Some var -> var
         | None ->
             let base = pp c in
@@ -1634,7 +1644,7 @@ module Handler = struct
               else theme_order_with_shade base shade
             in
             let var = Var.theme Css.Color name ~order:var_order in
-            Hashtbl.add color_var_cache name var;
+            Hashtbl.add property_color_var_cache name var;
             var)
     | None ->
         (* Fall back to generic --color-{name} *)

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2156,30 +2156,30 @@ let variant_order_of_prefix prefix =
   (* @starting-style: comes after all media queries including dark:hover *)
   | "starting" -> 95000
   | _ ->
-      if String.starts_with ~prefix:"group-" prefix then 500
-      else if String.starts_with ~prefix:"peer-" prefix then 600
-      else if String.starts_with ~prefix:"has-" prefix then 30600
-      else if String.starts_with ~prefix:"aria-" prefix then
+      if Parse.has_prefix ~prefix:"group-" prefix then 500
+      else if Parse.has_prefix ~prefix:"peer-" prefix then 600
+      else if Parse.has_prefix ~prefix:"has-" prefix then 30600
+      else if Parse.has_prefix ~prefix:"aria-" prefix then
         if String.length prefix > 5 && prefix.[5] <> '[' then 30700 else 30790
-      else if String.starts_with ~prefix:"data-" prefix then
+      else if Parse.has_prefix ~prefix:"data-" prefix then
         if String.length prefix > 5 && prefix.[5] = '[' then 30810 else 30800
       else if
-        String.starts_with ~prefix:"supports-" prefix
-        || String.starts_with ~prefix:"supports" prefix
+        Parse.has_prefix ~prefix:"supports-" prefix
+        || Parse.has_prefix ~prefix:"supports" prefix
       then 40000
       else if prefix = "motion-safe" then 50000
       else if prefix = "motion-reduce" then 50100
       else if prefix = "contrast-more" then 50200
       else if prefix = "contrast-less" then 50300
-      else if String.starts_with ~prefix:"pointer-" prefix then 50400
-      else if String.starts_with ~prefix:"any-pointer-" prefix then 50500
+      else if Parse.has_prefix ~prefix:"pointer-" prefix then 50400
+      else if Parse.has_prefix ~prefix:"any-pointer-" prefix then 50500
       else if
         prefix = "sm" || prefix = "md" || prefix = "lg" || prefix = "xl"
         || prefix = "2xl"
-        || String.starts_with ~prefix:"min-" prefix
-        || String.starts_with ~prefix:"max-" prefix
+        || Parse.has_prefix ~prefix:"min-" prefix
+        || Parse.has_prefix ~prefix:"max-" prefix
       then 60000
-      else if String.starts_with ~prefix:"prose-" prefix then
+      else if Parse.has_prefix ~prefix:"prose-" prefix then
         let name = String.sub prefix 6 (String.length prefix - 6) in
         prose_element_variant_order name
       else if String.length prefix > 0 && prefix.[0] = '[' then 100000

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -1,3 +1,13 @@
+(* [prefix_loop] is top-level so it captures nothing and allocates no closure -
+   unlike [String.starts_with]'s inner [aux], which allocates one per call in a
+   non-flambda build. Indices are kept in bounds by [has_prefix]. *)
+let rec prefix_loop prefix s i lp =
+  i = lp || (prefix.[i] = s.[i] && prefix_loop prefix s (i + 1) lp)
+
+let has_prefix ~prefix s =
+  let lp = String.length prefix in
+  lp <= String.length s && prefix_loop prefix s 0 lp
+
 let int_any s =
   match int_of_string_opt s with
   | Some n -> Ok n

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -5,6 +5,11 @@
     results. All functions return [result] with [`Msg] error messages instead of
     raising. *)
 
+val has_prefix : prefix:string -> string -> bool
+(** [has_prefix ~prefix s] is [true] when [s] starts with [prefix]. Like
+    [String.starts_with] but allocation-free (no per-call closure), for hot
+    prefix tests in ordering. *)
+
 val int_pos : name:string -> string -> (int, [> `Msg of string ]) result
 (** [int_pos ~name s] parses a non-negative integer from [s]. Returns [Ok n] if
     [s] is a decimal integer >= 0, otherwise [Error (`Msg msg)]. [name] is used

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1772,9 +1772,16 @@ let extract_style_with_rules ~sel ~class_name ?merge_key ~props rule_list =
   if !has_regular_rules then ordered_entries @ base_rule
   else base_rule @ ordered_entries
 
-let outputs util =
+let outputs ?order_tbl util =
   let rec extract_with_class class_name util_inner = function
     | Style.Style { props; rules; merge_key; pseudo_suffix; _ } -> (
+        (* Record the base utility's order under the class name we already built,
+           so the caller does not have to re-derive it from the string. *)
+        (match (order_tbl, util_inner) with
+        | Some tbl, Utility.Base b ->
+            if not (Hashtbl.mem tbl class_name) then
+              Hashtbl.add tbl class_name (Utility.order b)
+        | _ -> ());
         let sel =
           match pseudo_suffix with
           | None -> Css.Selector.Class class_name

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -29,12 +29,17 @@ val set_scheme : Scheme.t -> unit
 
 (** {1 Rule extraction} *)
 
-val outputs : Utility.t -> Output.t list
+val outputs :
+  ?order_tbl:(string, int * int) Hashtbl.t -> Utility.t -> Output.t list
 (** [outputs u] extracts the CSS rules for utility [u].
 
     Returns a list because a single utility can produce more than one rule — for
     example a container utility emits one plain rule plus one [@media] rule per
-    breakpoint. *)
+    breakpoint.
+
+    [?order_tbl], when given, is populated with [class name -> (priority,
+    suborder)] for each base utility encountered, reusing the class strings built
+    here so callers need not re-derive the order from the class name. *)
 
 (** {1 Modifier dispatch}
 

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -797,9 +797,9 @@ let variant_prefix = function
 (* Compute variant order for a modifier prefix, stripping group-/peer-
    wrappers *)
 let strip_group_peer_vo p =
-  if String.starts_with ~prefix:"group-" p then
+  if Parse.has_prefix ~prefix:"group-" p then
     Modifiers.variant_order_of_prefix (String.sub p 6 (String.length p - 6))
-  else if String.starts_with ~prefix:"peer-" p then
+  else if Parse.has_prefix ~prefix:"peer-" p then
     Modifiers.variant_order_of_prefix (String.sub p 5 (String.length p - 5))
   else Modifiers.variant_order_of_prefix p
 
@@ -853,8 +853,8 @@ let inner_vo prefix =
   | Some j ->
       let outer = String.sub prefix 0 j in
       if
-        String.starts_with ~prefix:"group-" outer
-        || String.starts_with ~prefix:"peer-" outer
+        Parse.has_prefix ~prefix:"group-" outer
+        || Parse.has_prefix ~prefix:"peer-" outer
       then
         let parts = split_on_colon_outside_brackets prefix in
         List.fold_left (fun acc p -> max acc (strip_group_peer_vo p)) 0 parts
@@ -863,10 +863,10 @@ let inner_vo prefix =
         let inner = String.sub prefix (j + 1) (String.length prefix - j - 1) in
         Modifiers.variant_order_of_prefix inner
   | None ->
-      if String.starts_with ~prefix:"group-" prefix then
+      if Parse.has_prefix ~prefix:"group-" prefix then
         Modifiers.variant_order_of_prefix
           (String.sub prefix 6 (String.length prefix - 6))
-      else if String.starts_with ~prefix:"peer-" prefix then
+      else if Parse.has_prefix ~prefix:"peer-" prefix then
         Modifiers.variant_order_of_prefix
           (String.sub prefix 5 (String.length prefix - 5))
       else 0
@@ -905,12 +905,12 @@ let bracket_content_key p =
 (** Check if a prefix is an aria-/data- attribute variant where underscores
     represent spaces. *)
 let is_attr_variant p =
-  String.starts_with ~prefix:"aria-[" p
-  || String.starts_with ~prefix:"data-[" p
-  || String.starts_with ~prefix:"group-aria-[" p
-  || String.starts_with ~prefix:"group-data-[" p
-  || String.starts_with ~prefix:"peer-aria-[" p
-  || String.starts_with ~prefix:"peer-data-[" p
+  Parse.has_prefix ~prefix:"aria-[" p
+  || Parse.has_prefix ~prefix:"data-[" p
+  || Parse.has_prefix ~prefix:"group-aria-[" p
+  || Parse.has_prefix ~prefix:"group-data-[" p
+  || Parse.has_prefix ~prefix:"peer-aria-[" p
+  || Parse.has_prefix ~prefix:"peer-data-[" p
 
 (** Compare two bracket-containing variant prefixes. Sorts by bracket content
     type (pseudo-class before combinator), then by normalized name for


### PR DESCRIPTION
Final of three stacked allocation-reduction PRs. Stacked on #14.

Commit 1c14fae4 keys the color-var cache by (color, shade); 092530a8 records utility order in Rule.outputs and drops collect_order_map; 3b82e489 adds an allocation-free has_prefix for hot prefix tests.