### PR TITLE
variants: support container style-query custom variants

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -168,6 +168,38 @@ let try_custom_variant s =
   in
   List.find_map (fun (name, cv) -> resolve name cv) !custom_variants
 
+(** Registry for [@custom-variant]s whose body is a container query (e.g.
+    [@custom-variant has-a { @container style(--a) { @slot } }]). Kept separate
+    from {!custom_variants} because the condition is structural
+    ([Css.Container.t]) so the [not-] prefix can negate it soundly. *)
+let container_variants : (string * Css.Container.t) list ref = ref []
+
+let register_container_variants vs = container_variants := vs
+let clear_container_variants () = container_variants := []
+
+(* Negate a container condition, cancelling double-negation and pushing through
+   a named container: [not (not C)] = [C]; [name (C)] -> [name (not C)]. *)
+let rec negate_container (c : Css.Container.t) : Css.Container.t =
+  match c with
+  | Css.Container.Not x -> x
+  | Css.Container.Named (name, x) ->
+      Css.Container.Named (name, negate_container x)
+  | x -> Css.Container.Not x
+
+(* Parse [has-a] (registered) or [not-has-a] (negated) against the
+   container-variant registry, yielding a [Container_style] modifier. *)
+let try_container_variant s =
+  let lookup name = List.assoc_opt name !container_variants in
+  match lookup s with
+  | Some cond -> Some (Container_style (s, cond))
+  | None ->
+      if String.length s > 4 && String.sub s 0 4 = "not-" then
+        let inner = String.sub s 4 (String.length s - 4) in
+        Option.map
+          (fun cond -> Container_style (s, negate_container cond))
+          (lookup inner)
+      else None
+
 (** Helper: direction selector (ltr/rtl) *)
 let dir_selector dir cls =
   let open Css.Selector in
@@ -1145,6 +1177,7 @@ let rec pp_modifier = function
       "group-peer-" ^ pp_modifier inner ^ "/" ^ name
   | Arbitrary_selector content -> "[" ^ content ^ "]"
   | Custom_variant (token, _) -> token
+  | Container_style (token, _) -> token
   | Prose_element name -> "prose-" ^ name
 
 (* Find matching closing bracket, handling nested brackets *)
@@ -1914,6 +1947,9 @@ let parse_modifier s : modifier option =
       (fun () -> try_in_modifier s);
       (fun () -> try_not_in_modifier s);
       (fun () -> try_group_peer_not s);
+      (* Before [try_not_modifier]: a container variant handles its own [not-]
+         (negating the structural condition), not the generic [Not] wrapper. *)
+      (fun () -> try_container_variant s);
       (fun () -> try_not_modifier s);
       (fun () -> try_bare_data_aria s);
       (fun () -> try_prose_element s);

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -42,6 +42,14 @@ val register_custom_variants : (string * custom_variant) list -> unit
 val clear_custom_variants : unit -> unit
 (** [clear_custom_variants ()] clears the custom variant registry. *)
 
+val register_container_variants : (string * Css.Container.t) list -> unit
+(** [register_container_variants vs] sets the [@custom-variant]s whose body is a
+    container query (e.g. [has-a] -> [@container style(--a)]). The [not-] prefix
+    on these negates the condition structurally. *)
+
+val clear_container_variants : unit -> unit
+(** [clear_container_variants ()] clears the container-variant registry. *)
+
 (** {1 State Variants} *)
 
 val hover : t list -> t

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1492,6 +1492,17 @@ let modifier_to_rule ?(inner_has_hover = false) modifier base_class selector
       arbitrary_selector_rule content base_class props
   | Style.Custom_variant (token, template) ->
       custom_variant_rule token template base_class props
+  | Style.Container_style (token, condition) ->
+      (* A [@custom-variant] whose body is a container query: wrap the utility
+         in [@container <condition>], like [container_rule] but with a
+         structural condition supplied by the variant. *)
+      let modified_class = token ^ ":" ^ base_class in
+      let new_selector =
+        Rules_selector.replace_class_in_selector ~old_class:base_class
+          ~new_class:modified_class selector
+      in
+      container_query ~condition ~selector:new_selector ~props
+        ~base_class:modified_class ()
   (* Prose element variants — descendant selector with element filter *)
   | Style.Prose_element name ->
       let modified_class = "prose-" ^ name ^ ":" ^ base_class in

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -226,6 +226,11 @@ type modifier =
           the class-name token (e.g. [is-data-foo]); second is the resolved
           selector template with the value substituted (e.g.
           [&:is([data-foo])]), where [&] is the element's own class. *)
+  | Container_style of string * Css.Container.t
+      (** [has-a:] — a [@custom-variant]-registered variant whose body is a
+          container query (e.g. [@container style(--a)]). First field is the
+          class-name token; second is the structural container condition (so the
+          [not-] prefix can negate it soundly, including double-negation). *)
   | Prose_element of string
       (** [prose-X:] — prose element variant, wraps utility in a descendant
           selector targeting specific HTML elements within prose content. E.g.
@@ -510,6 +515,7 @@ let rec pp_modifier = function
       "group-peer-" ^ pp_modifier inner ^ "/" ^ name
   | Arbitrary_selector content -> "[" ^ content ^ "]"
   | Custom_variant (token, _) -> token
+  | Container_style (token, _) -> token
   | Prose_element name -> "prose-" ^ name
 
 let rec pp = function

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -222,6 +222,10 @@ type modifier =
   | Custom_variant of string * string
       (** [is-data-foo:] — a [matchVariant]-registered variant: the class-name
           token and the resolved selector template ([&] is the own class). *)
+  | Container_style of string * Css.Container.t
+      (** [has-a:] — a [@custom-variant] whose body is a container query: the
+          class-name token and the structural container condition (so [not-]
+          can negate it soundly). *)
   | Prose_element of string
       (** [prose-X:] — prose element variant for targeting specific HTML
           elements within prose content *)

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -139,6 +139,24 @@ let parse_match_variants content =
     (Re.all re content);
   tbl
 
+(* Parse [@custom-variant <name> { @container <header> { @slot } }] blocks into
+   directive strings ["container <name> <header>"], e.g.
+   ["container has-c foo style(--c)"]. The runner registers these as structural
+   container-query variants. *)
+let parse_custom_variant_containers content =
+  let re =
+    Re.Pcre.regexp
+      {|@custom-variant\s+([A-Za-z0-9_-]+)\s*\{\s*@container\s+([^{\n]+?)\s*\{\s*@slot|}
+  in
+  let tbl = Hashtbl.create 4 in
+  List.iter
+    (fun m ->
+      let name = Re.Group.get m 1 in
+      let header = Re.Group.get m 2 |> String.trim in
+      Hashtbl.replace tbl name ("container " ^ name ^ " " ^ header))
+    (Re.all re content);
+  tbl
+
 type parse_state =
   | Outside
   | In_test of string
@@ -181,7 +199,11 @@ let parse_file filename =
   let current_classes = ref [] in
   let current_config = ref No_theme in
   let variant_defs = parse_match_variants content in
+  Hashtbl.iter
+    (fun k v -> Hashtbl.replace variant_defs k v)
+    (parse_custom_variant_containers content);
   let match_variant_use = Re.Pcre.regexp {|matchVariant\(\s*'([^']+)'|} in
+  let custom_variant_use = Re.Pcre.regexp {|@custom-variant\s+([A-Za-z0-9_-]+)|} in
   let current_variant_names = ref [] in
 
   let flush_test name expected =
@@ -220,6 +242,13 @@ let parse_file filename =
           (* Record any matchVariant plugin used by this test so the runner can
              register it before compiling. *)
           (match Re.exec_opt match_variant_use line with
+          | Some g ->
+              current_variant_names :=
+                Re.Group.get g 1 :: !current_variant_names
+          | None -> ());
+
+          (* Record [@custom-variant <name>] definitions used by this test. *)
+          (match Re.exec_opt custom_variant_use line with
           | Some g ->
               current_variant_names :=
                 Re.Group.get g 1 :: !current_variant_names

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -800,6 +800,7 @@ let run_test_case test () =
        "name <template> KEY=value ...", DEFAULT mapped to the default slot. *)
     let parse_variant_directive d =
       match String.split_on_char ' ' d with
+      | "container" :: _ -> None (* handled by parse_container_directive *)
       | name :: template :: pairs ->
           let values =
             List.filter_map
@@ -815,8 +816,30 @@ let run_test_case test () =
           Some (name, Tw.Modifiers.{ values; template })
       | _ -> None
     in
+    (* [@custom-variant <name> { @container <header> { @slot } }] directives,
+       extracted as "container <name> <header>". A leading plain identifier in
+       the header (not [not], not a function) is the container name. *)
+    let parse_container_directive d =
+      let container_of_header header =
+        match String.index_opt header ' ' with
+        | Some i ->
+            let first = String.sub header 0 i in
+            let rest = String.sub header (i + 1) (String.length header - i - 1) in
+            if first <> "not" && not (String.contains first '(') then
+              Css.Container.Named (first, Css.Container.of_string rest)
+            else Css.Container.of_string header
+        | None -> Css.Container.of_string header
+      in
+      match String.split_on_char ' ' d with
+      | "container" :: name :: (_ :: _ as rest) -> (
+          let header = String.concat " " rest in
+          try Some (name, container_of_header header) with _ -> None)
+      | _ -> None
+    in
     Tw.Modifiers.register_custom_variants
       (List.filter_map parse_variant_directive test.variants);
+    Tw.Modifiers.register_container_variants
+      (List.filter_map parse_container_directive test.variants);
     (* Register custom breakpoints before parsing classes *)
     let custom_bps = extract_custom_breakpoints test.classes test.expected in
     if custom_bps <> [] then (

--- a/test/upstream/variants.txt
+++ b/test/upstream/variants.txt
@@ -1648,6 +1648,10 @@ group-not-[:checked]/parent-name:flex group-not-[:checked]:flex group-not-checke
 <<<>>>
 # not
 @config run
+@variant container has-a style(--a)
+@variant container has-b not style(--b)
+@variant container has-c foo style(--c)
+@variant container has-d bar not style(--d)
 not-has-a:flex not-has-b:flex not-has-c:flex not-has-d:flex
 ---
 


### PR DESCRIPTION
Adds structural support for `@custom-variant` bodies that are container queries (v4.3.1), e.g. `@custom-variant has-a { @container style(--a) { @slot } }`.

A new `Container_style` modifier carries a `Css.Container.t` rather than a selector template, so the `not-` prefix negates the condition soundly — including double-negation (`not-has-b` of `@container not style(--b)` becomes `@container style(--b)`) and named containers. Fixes the upstream `not` container-style test.

Stacked on #12.