### PR TITLE
cli: run Css.optimize when --optimize is set

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -81,6 +81,9 @@ let render_css ~(opts : gen_opts) stylesheet =
     | Inline -> Tw.Css.inline_vars stylesheet
     | Variables -> stylesheet
   in
+  let stylesheet =
+    if opts.optimize then Tw.Css.optimize stylesheet else stylesheet
+  in
   Tw.Css.to_string ~minify:opts.minify stylesheet
 
 let diff_single_class class_str ~(opts : gen_opts) =


### PR DESCRIPTION
`render_css` applied `--minify` and variable inlining but never called `Css.optimize`, so the native backend's `--optimize` flag was a no-op: colour values stayed unfolded (`accent-[#0088cc]/50` emitted a 10-digit `oklab()` instead of `#0088cc80`) and rules were never merged. Only the `--tailwind` backend optimized. The fix runs the optimizer on the stylesheet.

No regression test is included: `render_css` is internal to the `tw` binary (no library surface), and the optimizer's folds (colour collapse, rule merge) are covered by cascade's own suite.