### PR TITLE
sizing: fix fractional spacing truncating to zero

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -204,8 +204,7 @@ module Handler = struct
       multiplying by 4, since --spacing is 0.25rem. Uses calc(var(--spacing) *
       n) for Tailwind v4 compatibility. *)
   let spacing_utility css_prop n =
-    let class_units = int_of_float (n *. 4.) in
-    let decl, spacing_value = Theme.spacing_calc class_units in
+    let decl, spacing_value = Theme.spacing_calc_float (n *. 4.) in
     style (decl :: [ css_prop spacing_value ])
 
   let w' size =
@@ -585,8 +584,7 @@ module Handler = struct
     | Size_max -> style [ width Max_content; height Max_content ]
     | Size_fit -> style [ width Fit_content; height Fit_content ]
     | Size_spacing n ->
-        let class_units = int_of_float (n *. 4.) in
-        let decl, spacing_value = Theme.spacing_calc class_units in
+        let decl, spacing_value = Theme.spacing_calc_float (n *. 4.) in
         style (decl :: [ width spacing_value; height spacing_value ])
     | Size_fraction f -> (
         match

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -169,8 +169,27 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"sizing suborder matches Tailwind" shuffled
 
+let css_of cls =
+  match Tw.of_string cls with
+  | Ok s -> Tw.to_css ~base:false [ s ] |> Css.to_string
+  | Error _ -> Alcotest.failf "could not parse %S" cls
+
+(* Fractional spacing steps must scale --spacing, not truncate to 0. *)
+let test_fractional_spacing () =
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " contains " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css_of cls))
+  in
+  has "h-0.5" "height: calc(var(--spacing) * .5)";
+  has "w-0.5" "width: calc(var(--spacing) * .5)";
+  has "size-0.5" "calc(var(--spacing) * .5)";
+  has "h-2.5" "height: calc(var(--spacing) * 2.5)"
+
 let tests =
   [
+    test_case "fractional spacing" `Quick test_fractional_spacing;
     test_case "widths" `Quick test_widths;
     test_case "heights" `Quick test_heights;
     test_case "min sizes" `Quick test_min_sizes;


### PR DESCRIPTION
`spacing_utility` and `Size_spacing` computed the multiplier with `int_of_float (n *. 4.)`, so every fractional sizing step collapsed: `h-0.5`/`w-0.5`/`size-0.5` emitted `calc(var(--spacing) * 0)` instead of `* .5`, and `h-1.5`/`w-2.5` truncated to `* 1`/`* 2`. Switch to `Theme.spacing_calc_float`, which keeps the fractional multiplier and still defers to the scheme for integer steps. Verified against v4.3.1 with `--diff` across the .5-step family.