### PR TITLE
typography: emit tracking-normal as 0em not 0

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2151,7 +2151,9 @@ module Typography_late = struct
       [ theme_decl; channel_decl; letter_spacing (Css.Var theme_ref) ]
 
   let tracking_normal () =
-    let theme_decl, theme_ref = Var.binding tracking_normal_var Zero in
+    (* Tailwind's default theme defines --tracking-normal as 0em, not a unitless
+       0, so keep the explicit em unit. *)
+    let theme_decl, theme_ref = Var.binding tracking_normal_var (Em 0.0) in
     let channel_decl, _ = Var.binding tracking_var (Css.Var theme_ref) in
     let property_rules =
       Var.property_rule tracking_var |> Option.to_list |> Css.concat

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -266,8 +266,15 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"typography suborder matches Tailwind" shuffled
 
+(* tracking-normal's token must keep the em unit (0em), not collapse to 0. *)
+let test_tracking_normal_unit () =
+  let css = Tw.to_css [ Tw.tracking_normal ] |> Tw.Css.pp ~minify:true in
+  Alcotest.check bool "tracking-normal token keeps em unit" true
+    (Astring.String.is_infix ~affix:"--tracking-normal:0em" css)
+
 let tests =
   [
+    test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "font family" `Quick test_font_family;
     test_case "font size" `Quick test_font_size;
     test_case "font weight" `Quick test_font_weight;


### PR DESCRIPTION
Tailwind's default theme defines `--tracking-normal: 0em`, but tw bound the token to a unitless `Zero` and emitted `--tracking-normal: 0`. Bind it to `Em 0.0` so the unit matches. Verified with `--diff`; upstream and main suites green.