### PR TITLE
cli: prune unused custom properties under --optimize

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -82,7 +82,12 @@ let render_css ~(opts : gen_opts) stylesheet =
     | Variables -> stylesheet
   in
   let stylesheet =
-    if opts.optimize then Tw.Css.optimize stylesheet else stylesheet
+    if opts.optimize then
+      (* The generated sheet is a closed author stylesheet, so prune theme
+         tokens nothing references -- e.g. --spacing once p-0 folds to 0, which
+         Tailwind also drops. *)
+      Tw.Css.optimize ~prune_unused_custom_props:true stylesheet
+    else stylesheet
   in
   Tw.Css.to_string ~minify:opts.minify stylesheet
 
@@ -96,7 +101,10 @@ let diff_single_class class_str ~(opts : gen_opts) =
     let styles = match tw_styles with [] -> [] | s -> s in
     let stylesheet = Tw.to_css ~base:true styles in
     let our_css = render_css ~opts stylesheet in
-    let diff = Css_compare.diff ~mode:`Canonical legacy_css our_css in
+    let diff =
+      Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+        legacy_css our_css
+    in
     match tw_styles with
     | [] when class_str = "" ->
         print_diff_result " (empty/base only)" diff;
@@ -178,7 +186,10 @@ let diff_files paths ~(opts : gen_opts) =
     let tw_styles = parse_known_candidates all_classes |> List.map snd in
     let stylesheet = Tw.to_css ~base:true tw_styles in
     let our_css = render_css ~opts stylesheet in
-    let diff = Css_compare.diff ~mode:`Canonical legacy_css our_css in
+    let diff =
+      Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+        legacy_css our_css
+    in
     print_diff_result "" diff;
     `Ok ()
   with e ->

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -706,8 +706,25 @@ let test_media_query_deduplication () =
   Alcotest.(check int)
     "preserves cascade with nested and top-level media" 2 count_768px
 
+(* p-0 folds to 0, so the unused --spacing token is pruned, matching
+   Tailwind. *)
+let check_spacing_zero_prune () =
+  let config = { Tw.Build.base = false; forms = None; layers = true } in
+  let css =
+    Tw.Build.to_css ~config [ p 0 ]
+    |> Css.optimize ~prune_unused_custom_props:true
+    |> Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "p-0 is padding:0" true
+    (Astring.String.is_infix ~affix:"padding:0" css);
+  Alcotest.(check bool)
+    "p-0 drops unused --spacing" false
+    (Astring.String.is_infix ~affix:"--spacing" css)
+
 let tests =
   [
+    test_case "spacing-0 prunes --spacing" `Quick check_spacing_zero_prune;
     test_case "theme layer - empty" `Quick check_theme_layer_empty;
     test_case "theme layer - with color" `Quick check_theme_layer_with_color;
     test_case "Tw.Build.conflict_order delegates to Utility.order" `Quick


### PR DESCRIPTION
Builds on #19. A fully optimized author stylesheet should drop theme tokens that nothing references, the way Tailwind's optimizer does: `p-0` folds to `padding: 0`, leaving `--spacing` unreferenced, yet tw still emitted it. `render_css`'s `--optimize` pass and the `--diff` comparison now prune unused custom properties, matching the upstream parity harness which already did. Regression test added.

Stacked on #19; the first commit is that PR.