### PR TITLE
typography: derive numeric leading from the spacing scale

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -895,11 +895,31 @@ module Typography_early = struct
   let leading_loose = leading_with_theme_var leading_loose_var (Num 2.0)
 
   let leading n =
-    let lh_value : line_height = Rem (float_of_int n *. 0.25) in
-    let theme_var =
-      Var.theme Css.Line_height ("leading-" ^ string_of_int n) ~order:(6, 53)
-    in
-    leading_with_theme_var theme_var lh_value
+    let name = "leading-" ^ string_of_int n in
+    match Var.theme_value name with
+    | Some _ ->
+        (* A theme overrides --leading-N: reference it like a named leading. *)
+        let theme_var = Var.theme Css.Line_height name ~order:(6, 53) in
+        leading_with_theme_var theme_var (Rem (float_of_int n *. 0.25))
+    | None ->
+        (* Tailwind v4.3 default: derive numeric leading from the spacing scale,
+           leading-1 -> var(--spacing), leading-N -> calc(var(--spacing) *
+           N). *)
+        let spacing_decl, _ =
+          Var.binding Theme.spacing_var Theme.spacing_base
+        in
+        let value : line_height =
+          if n = 1 then Css.Var (Var.theme_ref "spacing")
+          else
+            Css.Calc
+              (Css.Calc.mul (Css.Calc.var "spacing")
+                 (Css.Calc.float (float_of_int n)))
+        in
+        let channel_decl, _ = Var.binding leading_var value in
+        let property_rules =
+          Var.property_rule leading_var |> Option.to_list |> Css.concat
+        in
+        style ~property_rules [ spacing_decl; channel_decl; line_height value ]
 
   (* Lookup table for named text sizes: (name, size_var, default_rem) *)
   let text_size_data =

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -272,9 +272,22 @@ let test_tracking_normal_unit () =
   Alcotest.check bool "tracking-normal token keeps em unit" true
     (Astring.String.is_infix ~affix:"--tracking-normal:0em" css)
 
+(* Numeric leading derives from the spacing scale in v4.3.1 (not a --leading-N
+   theme token). *)
+let test_numeric_leading_spacing () =
+  let css =
+    match Tw.of_string "leading-6" with
+    | Ok u -> Tw.to_css [ u ] |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.fail "could not parse leading-6"
+  in
+  Alcotest.(check bool)
+    "leading-6 uses calc(var(--spacing)*6)" true
+    (Astring.String.is_infix ~affix:"calc(var(--spacing)*6)" css)
+
 let tests =
   [
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
+    test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;
     test_case "font family" `Quick test_font_family;
     test_case "font size" `Quick test_font_size;
     test_case "font weight" `Quick test_font_weight;


### PR DESCRIPTION
Tailwind v4.3.1 ships no `--leading-N` theme tokens for numeric line-height; it derives them from the spacing scale (`leading-1` -> `var(--spacing)`, `leading-N` -> `calc(var(--spacing) * N)`). tw instead minted a `--leading-N` token and referenced it, diverging from the real CLI for `leading-5`..`leading-10`. Numeric leading now derives from spacing by default while still honoring an explicit `--leading-N` theme override, so the upstream parity harness (which sets one as a fixture) stays green. Verified with `--diff`; regression test added.