### PR TITLE
typography: inline leading-none instead of minting a token

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -887,7 +887,19 @@ module Typography_early = struct
     style ~property_rules
       [ theme_decl; channel_decl; line_height (Css.Var theme_ref) ]
 
-  let leading_none () = leading_with_theme_var leading_none_var (Num 1.0)
+  let leading_none () =
+    match Var.theme_value "leading-none" with
+    | Some _ -> leading_with_theme_var leading_none_var (Num 1.0)
+    | None ->
+        (* Tailwind v4.3 ships no --leading-none token, so inline the literal
+           rather than minting a var. *)
+        let value : line_height = Num 1.0 in
+        let channel_decl, _ = Var.binding leading_var value in
+        let property_rules =
+          Var.property_rule leading_var |> Option.to_list |> Css.concat
+        in
+        style ~property_rules [ channel_decl; line_height value ]
+
   let leading_tight = leading_with_theme_var leading_tight_var (Num 1.25)
   let leading_snug = leading_with_theme_var leading_snug_var (Num 1.375)
   let leading_normal = leading_with_theme_var leading_normal_var (Num 1.5)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -284,10 +284,26 @@ let test_numeric_leading_spacing () =
     "leading-6 uses calc(var(--spacing)*6)" true
     (Astring.String.is_infix ~affix:"calc(var(--spacing)*6)" css)
 
+(* leading-none has no v4.3 theme token, so it inlines line-height: 1 rather
+   than minting a --leading-none var. *)
+let test_leading_none_inline () =
+  let css =
+    match Tw.of_string "leading-none" with
+    | Ok u -> Tw.to_css [ u ] |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.fail "could not parse leading-none"
+  in
+  Alcotest.(check bool)
+    "leading-none inlines line-height:1" true
+    (Astring.String.is_infix ~affix:"line-height:1" css);
+  Alcotest.(check bool)
+    "leading-none mints no --leading-none token" false
+    (Astring.String.is_infix ~affix:"--leading-none" css)
+
 let tests =
   [
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;
+    test_case "leading-none inline" `Quick test_leading_none_inline;
     test_case "font family" `Quick test_font_family;
     test_case "font size" `Quick test_font_size;
     test_case "font weight" `Quick test_font_weight;


### PR DESCRIPTION
Tailwind v4.3.1 ships no `--leading-none` theme token (unlike `--leading-tight`..`--leading-loose`), so `leading-none` inlines `line-height: 1`. tw instead emitted `var(--leading-none)` plus an invented `--leading-none` declaration. It now inlines the literal by default while still honoring an explicit `--leading-none` theme override. Verified with `--diff`; regression test added.