### PR TITLE
typography: accept any non-negative numeric leading

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -574,8 +574,8 @@ module Typography_early = struct
         if Parse.is_var inner then Ok (Leading_var inner)
         else Ok (Leading_bracket inner)
     | [ "leading"; n ] ->
-        Parse.int_bounded ~name:"leading" ~min:3 ~max:10 n >|= fun i ->
-        Leading i
+        (* Tailwind accepts any non-negative leading-N, derived from spacing. *)
+        Parse.int_pos ~name:"leading" n >|= fun i -> Leading i
     | [ "text"; part ] -> (
         match split_on_slash part with
         | Stdlib.Option.Some (base, lh_str) -> (
@@ -901,6 +901,14 @@ module Typography_early = struct
         (* A theme overrides --leading-N: reference it like a named leading. *)
         let theme_var = Var.theme Css.Line_height name ~order:(6, 53) in
         leading_with_theme_var theme_var (Rem (float_of_int n *. 0.25))
+    | None when n = 0 ->
+        (* leading-0 is a literal 0, not calc(var(--spacing) * 0). *)
+        let value : line_height = Num 0.0 in
+        let channel_decl, _ = Var.binding leading_var value in
+        let property_rules =
+          Var.property_rule leading_var |> Option.to_list |> Css.concat
+        in
+        style ~property_rules [ channel_decl; line_height value ]
     | None ->
         (* Tailwind v4.3 default: derive numeric leading from the spacing scale,
            leading-1 -> var(--spacing), leading-N -> calc(var(--spacing) *

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -76,6 +76,10 @@ let test_line_height () =
   List.iter
     (fun v -> check ("leading-" ^ v))
     [
+      "0";
+      "1";
+      "2";
+      "11";
       "3";
       "4";
       "5";
@@ -227,10 +231,6 @@ let of_string_invalid () =
   (* Invalid font weight *)
   fail_maybe [ "text"; "middle" ];
   (* Invalid text alignment *)
-  fail_maybe [ "leading"; "11" ];
-  (* Invalid line height *)
-  fail_maybe [ "leading"; "2" ];
-  (* Invalid line height *)
   fail_maybe [ "tracking"; "tightest" ];
   (* Invalid letter spacing *)
   fail_maybe [ "unknown" ]
@@ -275,14 +275,23 @@ let test_tracking_normal_unit () =
 (* Numeric leading derives from the spacing scale in v4.3.1 (not a --leading-N
    theme token). *)
 let test_numeric_leading_spacing () =
-  let css =
-    match Tw.of_string "leading-6" with
+  let css cls =
+    match Tw.of_string cls with
     | Ok u -> Tw.to_css [ u ] |> Tw.Css.to_string ~minify:true
-    | Error _ -> Alcotest.fail "could not parse leading-6"
+    | Error _ -> Alcotest.failf "could not parse %s" cls
   in
-  Alcotest.(check bool)
-    "leading-6 uses calc(var(--spacing)*6)" true
-    (Astring.String.is_infix ~affix:"calc(var(--spacing)*6)" css)
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " -> " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  (* Any non-negative N is accepted; N>=2 scales spacing, 1 is bare, 0 is 0. *)
+  has "leading-6" "calc(var(--spacing)*6)";
+  has "leading-2" "calc(var(--spacing)*2)";
+  has "leading-11" "calc(var(--spacing)*11)";
+  has "leading-1" "line-height:var(--spacing)";
+  has "leading-0" "line-height:0"
 
 let tests =
   [


### PR DESCRIPTION
Tailwind derives numeric line-height from the spacing scale for any non-negative `leading-N` (`leading-0` -> `0`, `leading-1` -> `var(--spacing)`, `leading-N` -> `calc(var(--spacing) * N)`), but tw's parser only accepted `leading-3`..`leading-10` and rejected the rest. The parser now uses `int_pos`, and `leading-0` inlines a bare `0`. Verified with `--diff` across 0/1/2/11/100; the negative-case test that asserted `leading-2`/`leading-11` invalid is removed and positive coverage added.