### PR TITLE
typography: honor --text-N--line-height theme overrides

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -776,19 +776,30 @@ module Typography_early = struct
         line_height (Var leading_with_fallback);
       ]
 
-  let text_xs = text_size_utility text_xs_var text_xs_lh_var 0.75 (Rem 1.0)
-  let text_sm = text_size_utility text_sm_var text_sm_lh_var 0.875 (Rem 1.25)
-  let text_base = text_size_utility text_base_var text_base_lh_var 1.0 (Rem 1.5)
-  let text_lg = text_size_utility text_lg_var text_lg_lh_var 1.125 (Rem 1.75)
-  let text_xl = text_size_utility text_xl_var text_xl_lh_var 1.25 (Rem 1.75)
-  let text_2xl = text_size_utility text_2xl_var text_2xl_lh_var 1.5 (Rem 2.0)
-  let text_3xl = text_size_utility text_3xl_var text_3xl_lh_var 1.875 (Rem 2.25)
-  let text_4xl = text_size_utility text_4xl_var text_4xl_lh_var 2.25 (Rem 2.5)
-  let text_5xl = text_size_utility text_5xl_var text_5xl_lh_var 3.0 (Num 1.0)
-  let text_6xl = text_size_utility text_6xl_var text_6xl_lh_var 3.75 (Num 1.0)
-  let text_7xl = text_size_utility text_7xl_var text_7xl_lh_var 4.5 (Num 1.0)
-  let text_8xl = text_size_utility text_8xl_var text_8xl_lh_var 6.0 (Num 1.0)
-  let text_9xl = text_size_utility text_9xl_var text_9xl_lh_var 8.0 (Num 1.0)
+  let text_xs () = text_size_utility text_xs_var text_xs_lh_var 0.75 (Rem 1.0)
+  let text_sm () = text_size_utility text_sm_var text_sm_lh_var 0.875 (Rem 1.25)
+
+  let text_base () =
+    text_size_utility text_base_var text_base_lh_var 1.0 (Rem 1.5)
+
+  let text_lg () = text_size_utility text_lg_var text_lg_lh_var 1.125 (Rem 1.75)
+  let text_xl () = text_size_utility text_xl_var text_xl_lh_var 1.25 (Rem 1.75)
+  let text_2xl () = text_size_utility text_2xl_var text_2xl_lh_var 1.5 (Rem 2.0)
+
+  let text_3xl () =
+    text_size_utility text_3xl_var text_3xl_lh_var 1.875 (Rem 2.25)
+
+  let text_4xl () =
+    text_size_utility text_4xl_var text_4xl_lh_var 2.25 (Rem 2.5)
+
+  let text_5xl () = text_size_utility text_5xl_var text_5xl_lh_var 3.0 (Num 1.0)
+
+  let text_6xl () =
+    text_size_utility text_6xl_var text_6xl_lh_var 3.75 (Num 1.0)
+
+  let text_7xl () = text_size_utility text_7xl_var text_7xl_lh_var 4.5 (Num 1.0)
+  let text_8xl () = text_size_utility text_8xl_var text_8xl_lh_var 6.0 (Num 1.0)
+  let text_9xl () = text_size_utility text_9xl_var text_9xl_lh_var 8.0 (Num 1.0)
 
   (* Font weight utilities set --tw-font-weight for animation but use theme var
      directly *)
@@ -1069,19 +1080,19 @@ module Typography_early = struct
   let bracket_font_size_style raw = style (bracket_font_size_decls raw)
 
   let to_style = function
-    | Text_xs -> text_xs
-    | Text_sm -> text_sm
-    | Text_base -> text_base
-    | Text_lg -> text_lg
-    | Text_xl -> text_xl
-    | Text_2xl -> text_2xl
-    | Text_3xl -> text_3xl
-    | Text_4xl -> text_4xl
-    | Text_5xl -> text_5xl
-    | Text_6xl -> text_6xl
-    | Text_7xl -> text_7xl
-    | Text_8xl -> text_8xl
-    | Text_9xl -> text_9xl
+    | Text_xs -> text_xs ()
+    | Text_sm -> text_sm ()
+    | Text_base -> text_base ()
+    | Text_lg -> text_lg ()
+    | Text_xl -> text_xl ()
+    | Text_2xl -> text_2xl ()
+    | Text_3xl -> text_3xl ()
+    | Text_4xl -> text_4xl ()
+    | Text_5xl -> text_5xl ()
+    | Text_6xl -> text_6xl ()
+    | Text_7xl -> text_7xl ()
+    | Text_8xl -> text_8xl ()
+    | Text_9xl -> text_9xl ()
     | Font_thin -> font_thin
     | Font_extralight -> font_extralight
     | Font_light -> font_light

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -308,11 +308,27 @@ let test_leading_none_inline () =
     "leading-none mints no --leading-none token" false
     (Astring.String.is_infix ~affix:"--leading-none" css)
 
+(* A text size must honor a --text-N--line-height theme override at use time,
+   not bake in the spacing-derived default at module load. *)
+let test_text_line_height_override () =
+  Tw.Var.clear_theme_values ();
+  Tw.Var.set_theme_value "text-sm--line-height" "1.25rem";
+  let css =
+    match Tw.of_string "text-sm" with
+    | Ok u -> Tw.to_css [ u ] |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.fail "could not parse text-sm"
+  in
+  Tw.Var.clear_theme_values ();
+  Alcotest.(check bool)
+    "text-sm honors --text-sm--line-height override" true
+    (Astring.String.is_infix ~affix:"--text-sm--line-height:1.25rem" css)
+
 let tests =
   [
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;
     test_case "leading-none inline" `Quick test_leading_none_inline;
+    test_case "text line-height override" `Quick test_text_line_height_override;
     test_case "font family" `Quick test_font_family;
     test_case "font size" `Quick test_font_size;
     test_case "font weight" `Quick test_font_weight;

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -35,13 +35,14 @@ open Alcotest
    [is_allowed_canonicalization_diff], and it is pure fixture skew, not a tw
    bug. The hard-coded expectations in Tailwind's [*.test.ts] predate
    LightningCSS, so they carry the pre-optimise opacity hex ([#0088cc]/50 ->
-   [#0288cc80]) and an unresolved [--text-*--line-height] ([1.25rem]) where the
-   real v4.3.1 CLI -- and tw -- emit [#0088cc80] and [calc(1.25/.875)] (checked
-   with [tw -s ... --diff]). Set [TW_UPSTREAM_STRICT=1] to disable it and watch
-   for changes that close the gap. (A mask-angle calc allowance, an [@property
-   --spacing] hint and a prose selector-permutation allowance were all dropped
-   earlier, once tw emitted Tailwind's exact mask degrees and cascade gained
-   typed calc + the custom-property prune.) *)
+   [#0288cc80]) where the real v4.3.1 CLI -- and tw -- emit [#0088cc80] (checked
+   with [tw -s ... --diff]); only cascade rounding oklab to LightningCSS
+   precision retires it. Set [TW_UPSTREAM_STRICT=1] to disable it and watch for
+   changes that close the gap. (A [--text-*--line-height] allowance, a
+   mask-angle calc allowance, an [@property --spacing] hint and a prose
+   selector-permutation allowance were all dropped earlier, once tw honoured
+   theme line-height overrides, emitted Tailwind's exact mask degrees, and
+   cascade gained typed calc + the custom-property prune.) *)
 let strict = Sys.getenv_opt "TW_UPSTREAM_STRICT" <> None
 
 type theme_config =
@@ -492,10 +493,6 @@ let values_close expected actual =
 let is_allowed_canonicalization_diff diff =
   let allowed_custom_property = function
     | "--font-sans" | "--font-mono" -> true
-    | name
-      when String.starts_with ~prefix:"--text-" name
-           && String.ends_with ~suffix:"--line-height" name ->
-        true
     | name when String.starts_with ~prefix:"--tw-prose-" name -> true
     | _ -> false
   in


### PR DESCRIPTION
The text-size utilities (`text-xs`..`text-9xl`) were eager module-init values, so a custom `--text-N--line-height` set via `@theme` (after module load) was ignored and the spacing-derived default always won. They are now lazy functions, so `Var.binding` picks up a theme override at use time, matching Tailwind. The default (`calc(line-height / font-size)`) is unchanged.

This retires the now-dead `--text-*--line-height` arm of the upstream parity tolerance. The remaining colour arm is cascade-side oklab precision (the fixtures carry LightningCSS-rounded oklab; tw matches the live CLI), gated behind `TW_UPSTREAM_STRICT`. Verified with `--diff`; regression test covers the override.