### PR TITLE
test/upstream: allowlist exact stale fixture colours

### DIFF
--- a/test/tools/dune
+++ b/test/tools/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries alcotest tw_tools astring))
+ (libraries alcotest tw tw_tools cascade cascade.diff astring))

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -20,10 +20,45 @@ let test_generate_simple () =
     (* Skip if Tailwind not available *)
     check bool "test skipped (no tailwind)" true true
 
+(* The upstream runner keeps a tiny allowlist for the single arbitrary colour
+   ([#0088cc] at 25%/50%) that Tailwind's frozen [*.test.ts] fixtures store as
+   stale LightningCSS-rounded oklab ([#0288cc40]/[#0288cc80]) where tw and the
+   real v4 CLI emit the true [#0088cc40]/[#0088cc80]. That allowlist hardcodes
+   tw's "true" value, so pin it to the live CLI here: tw and the real
+   tailwindcss must agree (canonically) on these classes. If upstream ever
+   changes/fixes the rounding, this fails loudly instead of the allowlist
+   silently masking it. Skips when tailwindcss is unavailable. *)
+let test_arbitrary_color_opacity_matches_cli () =
+  let check_class cls =
+    try
+      let cli = generate ~minify:true ~optimize:true ~forms:true [ cls ] in
+      let tw =
+        match Tw.of_string cls with
+        | Ok u ->
+            Tw.to_css ~base:true [ u ]
+            |> Tw.Css.optimize ~prune_unused_custom_props:true
+            |> Tw.Css.to_string ~minify:true
+        | Error _ -> Alcotest.failf "tw could not parse %s" cls
+      in
+      let diff =
+        Cascade_diff.Css_compare.diff ~mode:`Canonical
+          ~prune_unused_custom_props:true cli tw
+      in
+      match diff.Cascade_diff.Css_compare.result with
+      | Cascade_diff.Css_compare.No_diff _ ->
+          check bool (cls ^ ": tw matches live Tailwind CLI") true true
+      | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
+    with Failure _ -> check bool "skipped (tailwindcss unavailable)" true true
+  in
+  check_class "accent-[#0088cc]/50";
+  check_class "accent-[#0088cc]/25"
+
 let tests =
   [
     test_case "check tailwindcss available" `Quick test_check_available;
     test_case "generate simple CSS" `Quick test_generate_simple;
+    test_case "arbitrary colour opacity matches live CLI" `Quick
+      test_arbitrary_color_opacity_matches_cli;
   ]
 
 let suite = ("tailwind_gen", tests)

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -422,32 +422,25 @@ let theme_config config expected =
 
 let canonical_stylesheet_css css = String.trim css
 
-(* Parse a [#rrggbb] / [#rrggbbaa] colour into its byte channels. *)
-let hex_channels s =
-  let s = String.trim s in
-  let len = String.length s in
-  if len >= 7 && s.[0] = '#' && (len = 7 || len = 9) then
-    let rec collect i acc =
-      if i >= len then Some (List.rev acc)
-      else
-        match int_of_string_opt ("0x" ^ String.sub s i 2) with
-        | Some v -> collect (i + 2) (v :: acc)
-        | None -> None
-    in
-    collect 1 []
-  else None
+(* The upstream fixtures store one opacity-modified arbitrary colour --
+   [#0088cc], at 25% and 50% -- as Tailwind's LightningCSS-rounded oklab, which
+   round-trips back to hex two units high in the red channel ([#0288cc40] /
+   [#0288cc80]). tw keeps full precision and emits the true [#0088cc40] /
+   [#0088cc80]. Those are the *only* fixture colours that skew, and they recur
+   across every colour utility (accent, bg, ring, gradient, shadow, ...), so
+   allow exactly those pairs. A fuzzy [abs (x - y) <= 2] per-channel threshold
+   would also cover them, but it would silently absorb a genuine colour
+   regression of a unit or two -- defeating the comparison -- so prefer an
+   explicit allowlist that only the known stale fixtures match. *)
+let known_stale_colors =
+  [ ("#0288cc40", "#0088cc40"); ("#0288cc80", "#0088cc80") ]
 
-(* The upstream fixtures store opacity-modified arbitrary colours as Tailwind's
-   rounded oklab, which round-trips back to hex a couple of units off (e.g.
-   [#0288cc80] vs the true [#0088cc80]). tw keeps full precision and matches the
-   real colour, so treat hex channels within [delta] of each other as equal. *)
 let colors_close expected actual =
-  String.trim expected = String.trim actual
-  ||
-  match (hex_channels expected, hex_channels actual) with
-  | Some xs, Some ys when List.length xs = List.length ys ->
-      List.for_all2 (fun x y -> abs (x - y) <= 2) xs ys
-  | _ -> false
+  let e = String.trim expected and a = String.trim actual in
+  String.equal e a
+  || List.exists
+       (fun (stale, correct) -> String.equal e stale && String.equal a correct)
+       known_stale_colors
 
 (* Split a value into its non-hex skeleton and the list of [#...] colours, so a
    colour embedded in a larger value (e.g. a shadow's [var(--c, #0288cc40)]) can
@@ -836,6 +829,21 @@ let run_test_case test () =
              (String.concat " " test.classes)
              (Buffer.contents buf) expected got))
 
+(* Guards [colors_close]: a documented stale fixture pair is accepted, but a
+   near-miss the previous [abs (x - y) <= 2] blanket would have wrongly accepted
+   is now rejected, so a real colour regression cannot hide behind the
+   tolerance. *)
+let test_color_tolerance () =
+  Alcotest.(check bool)
+    "stale fixture pair tolerated" true
+    (colors_close "#0288cc80" "#0088cc80");
+  Alcotest.(check bool)
+    "one-unit red skew rejected" false
+    (colors_close "#0188cc80" "#0088cc80");
+  Alcotest.(check bool)
+    "unrelated near colour rejected" false
+    (colors_close "#123456" "#123458")
+
 let file basename =
   let paths = [ basename; "test/upstream/" ^ basename ] in
   List.find_opt Sys.file_exists paths
@@ -872,8 +880,11 @@ let () =
       (fun tc -> test_case tc.name `Quick (run_test_case tc))
       variant_tests
   in
+  let tolerance_cases =
+    [ test_case "colour stale-fixture allowlist" `Quick test_color_tolerance ]
+  in
   let suites =
-    [ ("utilities", utility_cases) ]
+    [ ("utilities", utility_cases); ("tolerance", tolerance_cases) ]
     @ if variant_cases <> [] then [ ("variants", variant_cases) ] else []
   in
   Alcotest.run "upstream" suites


### PR DESCRIPTION
`colors_close` accepted any two hex colours within two units per channel. That blanket was calibrated to the one arbitrary fixture colour the upstream parity suite exercises — `#0088cc` at 25% and 50%, which Tailwind's pre-LightningCSS `*.test.ts` expectations store as rounded oklab (`#0288cc40` / `#0288cc80`, two units high in red) where the real v4.3.1 CLI and tw both emit the true `#0088cc40` / `#0088cc80`. The problem is that the same ±2 threshold would silently absorb a genuine one- or two-unit colour regression anywhere else in the suite, so the tolerance could mask real bugs.

This replaces the threshold with an explicit allowlist of the two known stale pairs: only the documented fixture skew passes, and every other colour difference now fails the comparison. A unit test guards the boundary (the stale pair is tolerated; a one-unit near-miss the old blanket accepted is now rejected).

This is the tw-side resolution of issue 3's colour tolerance. tw's colour output is already correct (it matches the live CLI); the divergence is purely the frozen upstream fixtures, so this hardens the harness rather than changing any tw output. `TW_UPSTREAM_STRICT=1` still surfaces the 21 documented fixture skews.