### PR TITLE
effects: fix shadow-2xl default shadow alpha

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -357,7 +357,7 @@ module Handler = struct
           (Zero, Px 20., Some (Px 25.), Some (Px (-5.)), "#0000001a");
           (Zero, Px 8., Some (Px 10.), Some (Px (-6.)), "#0000001a");
         ]
-    | Sh_2xl -> [ (Zero, Px 25., Some (Px 50.), Some (Px (-12.)), "#0000001a") ]
+    | Sh_2xl -> [ (Zero, Px 25., Some (Px 50.), Some (Px (-12.)), "#00000040") ]
 
   let shape_shadow_value shape =
     let data = shadow_shape_data shape in

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -93,8 +93,17 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"effects suborder matches Tailwind" shuffled
 
+(* shadow-2xl's default shadow alpha is .25 (#00000040) in v4, not the .10
+   (#0000001a) the smaller shadows use. *)
+let test_shadow_2xl_alpha () =
+  let css = Tw.to_css ~base:false [ Tw.shadow_2xl ] |> Tw.Css.to_string in
+  Alcotest.(check bool)
+    "shadow-2xl uses #00000040 alpha" true
+    (Astring.String.is_infix ~affix:"#00000040" css)
+
 let tests =
   [
+    test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "effects of_string - valid values" `Quick of_string_valid;
     test_case "effects of_string - invalid values" `Quick of_string_invalid;
     test_case "ring of_string - valid values" `Quick test_ring_of_string_valid;


### PR DESCRIPTION
`shadow-2xl` emitted its fallback shadow colour with alpha .10 (`#0000001a`) — the value the smaller shadows use — but Tailwind v4 uses .25 (`#00000040`) for the 2xl size (`0 25px 50px -12px rgb(0 0 0 / .25)`). The other shadow sizes were already correct; only 2xl diverged.

Surfaced by running `tw --diff` against the ocaml.org template set. Base of a stack fixing the parity gaps that sweep found.