### PR TITLE
backgrounds: don't double-quote arbitrary url() values

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -32,6 +32,16 @@ module Handler = struct
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'
 
+  (* An arbitrary url() value may already carry its own quotes (url('a.png') /
+     url("a.png")). Drop a matching outer pair so the typed [Url] pretty-printer
+     canonicalises it instead of double-wrapping it into the broken
+     url("'a.png'"). *)
+  let strip_outer_quotes s =
+    let n = String.length s in
+    if n >= 2 && (s.[0] = '\'' || s.[0] = '"') && s.[n - 1] = s.[0] then
+      String.sub s 1 (n - 2)
+    else s
+
   type position_name =
     | Pos_bottom
     | Pos_bottom_left
@@ -1342,7 +1352,8 @@ module Handler = struct
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style [ Css.background_image (Var var_ref) ]
-    | Bg_bracket_url url -> style [ Css.background_image (Url url) ]
+    | Bg_bracket_url url ->
+        style [ Css.background_image (Url (strip_outer_quotes url)) ]
     | Bg_bracket_url_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -74,9 +74,36 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"backgrounds suborder matches Tailwind" shuffled
 
+(* An arbitrary url() with its own quotes must not be double-wrapped: tw used to
+   emit the broken url("'/img/x.png'"); it now canonicalises to a valid
+   url(). *)
+let test_bg_arbitrary_url () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  List.iter
+    (fun cls ->
+      let css = css_of cls in
+      Alcotest.(check bool)
+        (cls ^ " emits a valid url()")
+        true
+        (Astring.String.is_infix ~affix:"url(/img/x.png)" css);
+      Alcotest.(check bool)
+        (cls ^ " does not double-quote")
+        false
+        (Astring.String.is_infix ~affix:"url(\"'" css))
+    [
+      "bg-[url('/img/x.png')]";
+      "bg-[url(\"/img/x.png\")]";
+      "bg-[url(/img/x.png)]";
+    ]
+
 let tests =
   [
     test_case "bg colors" `Quick test_bg_colors;
+    test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
`bg-[url('/img/x.png')]` extracted the url content with its quotes intact and passed it to the typed `Url` pretty-printer, which quotes again — emitting the broken `url("'/img/x.png'")` (the path then contains literal quote characters). It now strips a matching outer quote pair first, so the value canonicalises to a valid `url(/img/x.png)` regardless of how the source quoted it (single, double, or none). The selector still round-trips verbatim.

Note: the real ocaml.org templates use literal single quotes (`bg-[url('/img/...')]`); the `&#39;` seen in a bulk `--diff` is the `--tailwind` harness HTML-escaping candidates before re-scanning, not tw or the site. The entity form itself already round-trips cleanly. Stacked on #33.