### PR TITLE
prose: implement prose-invert and add prose-orange

### DIFF
--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -1748,6 +1748,42 @@ let color_theme_bindings theme_name =
   | "stone" -> [] (* TODO: Add stone theme bindings *)
   | _ -> []
 
+(* prose-invert remaps every --tw-prose-* to its --tw-prose-invert-*
+   counterpart, the way Tailwind's [.prose-invert] does. *)
+let invert_remap_bindings =
+  bind_prose_vars
+    [
+      (prose_body_var, Css.Var (snd theme.invert_body));
+      (prose_headings_var, Css.Var (snd theme.invert_headings));
+      (prose_lead_var, Css.Var (snd theme.invert_lead));
+      (prose_links_var, Css.Var (snd theme.invert_links));
+      (prose_bold_var, Css.Var (snd theme.invert_bold));
+      (prose_counters_var, Css.Var (snd theme.invert_counters));
+      (prose_bullets_var, Css.Var (snd theme.invert_bullets));
+      (prose_hr_var, Css.Var (snd theme.invert_hr));
+      (prose_quotes_var, Css.Var (snd theme.invert_quotes));
+      (prose_quote_borders_var, Css.Var (snd theme.invert_quote_borders));
+      (prose_captions_var, Css.Var (snd theme.invert_captions));
+      (prose_kbd_var, Css.Var (snd theme.invert_kbd));
+      (prose_kbd_shadows_var, Css.Var (snd theme.invert_kbd_shadows));
+      (prose_code_var, Css.Var (snd theme.invert_code));
+      (prose_pre_code_var, Css.Var (snd theme.invert_pre_code));
+      (prose_pre_bg_var, Css.Var (snd theme.invert_pre_bg));
+      (prose_th_borders_var, Css.Var (snd theme.invert_th_borders));
+      (prose_td_borders_var, Css.Var (snd theme.invert_td_borders));
+    ]
+
+(* Accent colour themes (prose-orange, ...) only override the link colours,
+   normal and inverted. Values taken from the Tailwind typography plugin. *)
+let accent_color_bindings = function
+  | "orange" ->
+      bind_prose_vars
+        [
+          (prose_links_var, Css.oklch 64.6 0.222 41.116);
+          (prose_invert_links_var, Css.oklch 70.5 0.213 47.604);
+        ]
+  | _ -> []
+
 let to_css_rules variant =
   match variant with
   | `Base -> base_prose_rules ()
@@ -1785,6 +1821,18 @@ let to_css_rules variant =
           ~selector:(Css.Selector.class_ "prose-stone")
           (color_theme_bindings "stone");
       ]
+  | `Invert ->
+      [
+        Css.rule
+          ~selector:(Css.Selector.class_ "prose-invert")
+          invert_remap_bindings;
+      ]
+  | `Orange ->
+      [
+        Css.rule
+          ~selector:(Css.Selector.class_ "prose-orange")
+          (accent_color_bindings "orange");
+      ]
 
 let pp = function
   | `Base -> "Base"
@@ -1797,6 +1845,8 @@ let pp = function
   | `Zinc -> "Zinc"
   | `Neutral -> "Neutral"
   | `Stone -> "Stone"
+  | `Invert -> "Invert"
+  | `Orange -> "Orange"
 
 (** Prose utility constructors *)
 let prose_style variant =
@@ -1906,6 +1956,7 @@ module Color_Handler = struct
     | Prose_neutral
     | Prose_stone
     | Prose_invert
+    | Prose_orange
 
   (** Extensible variant for prose color utilities *)
   type Utility.base += Self of t
@@ -1923,7 +1974,8 @@ module Color_Handler = struct
     | Prose_zinc -> prose_style `Zinc
     | Prose_neutral -> prose_style `Neutral
     | Prose_stone -> prose_style `Stone
-    | Prose_invert -> niet
+    | Prose_invert -> prose_style `Invert
+    | Prose_orange -> prose_style `Orange
 
   let to_class = function
     | Prose_gray -> "prose-gray"
@@ -1932,6 +1984,7 @@ module Color_Handler = struct
     | Prose_neutral -> "prose-neutral"
     | Prose_stone -> "prose-stone"
     | Prose_invert -> "prose-invert"
+    | Prose_orange -> "prose-orange"
 
   let of_class class_name =
     let parts = Parse.split_class class_name in
@@ -1942,6 +1995,7 @@ module Color_Handler = struct
     | [ "prose"; "neutral" ] -> Ok Prose_neutral
     | [ "prose"; "stone" ] -> Ok Prose_stone
     | [ "prose"; "invert" ] -> Ok Prose_invert
+    | [ "prose"; "orange" ] -> Ok Prose_orange
     | _ -> Error (`Msg "Not a prose color utility")
 
   let suborder = function
@@ -1952,6 +2006,7 @@ module Color_Handler = struct
     | Prose_neutral -> 30003
     | Prose_stone -> 30004
     | Prose_invert -> 30005
+    | Prose_orange -> 30006
 end
 
 (** Register both handlers with Utility system *)
@@ -1973,5 +2028,7 @@ let prose_slate = color_utility Color_Handler.Prose_slate
 let prose_zinc = color_utility Color_Handler.Prose_zinc
 let prose_neutral = color_utility Color_Handler.Prose_neutral
 let prose_stone = color_utility Color_Handler.Prose_stone
+let prose_invert = color_utility Color_Handler.Prose_invert
+let prose_orange = color_utility Color_Handler.Prose_orange
 let prose_lead = utility Handler.Lead
 let not_prose = utility Handler.Not_prose

--- a/lib/prose.mli
+++ b/lib/prose.mli
@@ -94,6 +94,12 @@ val prose_neutral : t
 val prose_stone : t
 (** [prose_stone] applies stone color theme. *)
 
+val prose_invert : t
+(** [prose_invert] remaps the prose palette to its inverted (dark) variant. *)
+
+val prose_orange : t
+(** [prose_orange] applies the orange accent (link) color theme. *)
+
 val stylesheet : unit -> Css.statement list
 (** [stylesheet ()] generates complete CSS rules for all prose variants. *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3143,6 +3143,12 @@ val prose_gray : t
 val prose_slate : t
 (** [prose_slate] uses the slate prose color theme. *)
 
+val prose_invert : t
+(** [prose_invert] remaps the prose palette to its inverted (dark) variant. *)
+
+val prose_orange : t
+(** [prose_orange] uses the orange accent (link) prose color theme. *)
+
 (** {2 Prose markers}
 
     Convenience utilities to apply marker classes used by prose selectors. *)

--- a/test/test_prose.ml
+++ b/test/test_prose.ml
@@ -60,10 +60,24 @@ let test_inline_styles () =
   let inline_gray = to_inline_style [ prose_gray ] in
   Alcotest.(check string) "prose-gray has no inline styles" "" inline_gray
 
+(* prose-invert remaps the palette to the inverted vars; prose-orange overrides
+   the link accent colours. Both used to be no-ops / unknown. *)
+let test_color_variants () =
+  let invert = Css.to_string (to_css ~base:false [ prose_invert ]) in
+  Alcotest.(check bool)
+    "prose-invert remaps body to the invert var" true
+    (Astring.String.is_infix ~affix:"var(--tw-prose-invert-body)" invert);
+  let orange = Css.to_string (to_css ~base:false [ prose_orange ]) in
+  Alcotest.(check bool)
+    "prose-orange sets the link accent" true
+    (Astring.String.is_infix ~affix:"--tw-prose-links" orange
+    && Astring.String.is_infix ~affix:"--tw-prose-invert-links" orange)
+
 let suite =
   ( "prose",
     [
       Alcotest.test_case "classes" `Quick test_classes;
+      Alcotest.test_case "color variants" `Quick test_color_variants;
       Alcotest.test_case "combinations" `Quick test_combinations;
       Alcotest.test_case "CSS generation" `Quick test_css_generation;
       Alcotest.test_case "inline styles" `Quick test_inline_styles;


### PR DESCRIPTION
`prose-invert` parsed but emitted nothing (a `niet` no-op), so the dark palette never applied. It now remaps every `--tw-prose-*` to its `--tw-prose-invert-*` counterpart, matching Tailwind's `.prose-invert`.

`prose-orange` was rejected as an unknown class; it's now supported, overriding only the normal and inverted link colours (`--tw-prose-links` / `--tw-prose-invert-links`) as Tailwind's accent themes do. Both constructors are exposed on `Tw`.

Surfaced by `tw --diff` on the ocaml.org templates (`prose-invert` ×50, `prose-orange` ×24). Other accent colours follow the same one-line pattern as orange. Stacked on #35.