### PR TITLE
tw: support the ! important prefix

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1077,6 +1077,7 @@ let has_pseudo_elements tw_classes =
     | Utility.Base _ -> false
     | Utility.Modified (modifier, u) -> has_pseudo modifier || check_utility u
     | Utility.Group us -> List.exists check_utility us
+    | Utility.Important u -> check_utility u
   in
   List.exists check_utility tw_classes
 
@@ -1227,8 +1228,8 @@ let default_config = { base = true; forms = None; layers = true }
 
 let to_css ?(config = default_config) tw_classes =
   (* [Rule.outputs ~order_tbl] records each base utility's order under the class
-     name it already builds, so [order_of_base] looks it up instead of re-parsing
-     the class string while building/sorting rules. *)
+     name it already builds, so [order_of_base] looks it up instead of
+     re-parsing the class string while building/sorting rules. *)
   let order_map = Hashtbl.create 256 in
   let selector_props =
     List.concat_map (Rule.outputs ~order_tbl:order_map) tw_classes

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -680,6 +680,7 @@ let rec has_responsive_modifier = function
   | Utility.Modified (Responsive _, _) -> true
   | Utility.Modified (_, t) -> has_responsive_modifier t
   | Utility.Group styles -> List.exists has_responsive_modifier styles
+  | Utility.Important t -> has_responsive_modifier t
 
 (* Validate no nested responsive modifiers *)
 let validate_no_nested_responsive styles =

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -261,6 +261,35 @@ let style ?(rules = None) ?(property_rules = Css.empty) ?merge_key
     ?pseudo_suffix props =
   Style { props; rules; property_rules; merge_key; pseudo_suffix }
 
+(* Mark the property declarations a style emits as !important (the [!] utility
+   prefix), recursing through modifiers, groups and nested rules. Custom
+   properties (theme tokens such as the spacing and tw- variables) are left
+   untouched -- like Tailwind, [!] applies to the visible declaration, not the
+   variables it pulls in. *)
+let mark_important_decl d =
+  match Css.custom_declaration_name d with
+  | Some _ -> d
+  | None -> Css.important d
+
+let rec important_stmt stmt =
+  match Css.as_rule stmt with
+  | Some (selector, decls, nested) ->
+      Css.rule ~selector
+        ~nested:(List.map important_stmt nested)
+        (List.map mark_important_decl decls)
+  | None -> stmt
+
+let rec map_important = function
+  | Style s ->
+      Style
+        {
+          s with
+          props = List.map mark_important_decl s.props;
+          rules = Option.map (List.map important_stmt) s.rules;
+        }
+  | Modified (m, t) -> Modified (m, map_important t)
+  | Group ts -> Group (List.map map_important ts)
+
 let is_numeric s = s <> "" && String.for_all (fun c -> c >= '0' && c <= '9') s
 
 let pp_nth prefix expr =

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -224,8 +224,8 @@ type modifier =
           token and the resolved selector template ([&] is the own class). *)
   | Container_style of string * Css.Container.t
       (** [has-a:] — a [@custom-variant] whose body is a container query: the
-          class-name token and the structural container condition (so [not-]
-          can negate it soundly). *)
+          class-name token and the structural container condition (so [not-] can
+          negate it soundly). *)
   | Prose_element of string
       (** [prose-X:] — prose element variant for targeting specific HTML
           elements within prose content *)
@@ -275,3 +275,7 @@ val style :
       multiple rules with descendant selectors).
     - [property_rules]: Optional CSS property rules needed by this utility.
     - [props]: CSS properties to apply. *)
+
+val map_important : t -> t
+(** [map_important t] marks every declaration [t] emits as [!important] (the [!]
+    utility prefix), recursing through modifiers, groups and nested rules. *)

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -97,10 +97,24 @@ let split_whitespace s =
 (* Parse a single class string into a Tw.t *)
 let of_string class_str =
   let modifiers, base_class = modifiers_of_string class_str in
+  (* The [!] important marker sits right before the utility: [!flex],
+     [md:!flex]. (Tailwind v4's trailing form [flex!] keeps the suffix in the
+     selector, which would need form-preserving round-trips; not handled
+     yet.) *)
+  let important, base_class =
+    let n = String.length base_class in
+    if n > 1 && base_class.[0] = '!' then (true, String.sub base_class 1 (n - 1))
+    else (false, base_class)
+  in
   match Utility.base_of_class base_class with
   | Error _ -> Error (`Msg ("Unknown class: " ^ class_str))
   | Ok base_utility -> (
+      (* Wrap [important] around the base before applying modifiers, so a
+         responsive/state prefix stays outermost: md:!flex -> md:(!flex). *)
       let base_util = Utility.base base_utility in
+      let base_util =
+        if important then Utility.important base_util else base_util
+      in
       match Modifiers.apply modifiers base_util with
       | Some u -> Ok u
       | None -> Error (`Msg ("Unknown modifier in: " ^ class_str)))

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -1,9 +1,15 @@
 (** Utility module for common utility types and functions *)
 
 type base = ..
-type t = Base of base | Modified of Style.modifier * t | Group of t list
+
+type t =
+  | Base of base
+  | Modified of Style.modifier * t
+  | Group of t list
+  | Important of t
 
 let base x = Base x
+let important x = Important x
 
 module type Handler = sig
   type t
@@ -77,6 +83,7 @@ let rec to_style = function
   | Base u -> base_to_style u
   | Modified (m, u) -> Style.Modified (m, to_style u)
   | Group us -> Style.Group (List.map to_style us)
+  | Important u -> Style.map_important (to_style u)
 
 let rec to_class = function
   | Base u -> class_of_base u
@@ -89,11 +96,13 @@ let rec to_class = function
             (List.map (fun item -> to_class (Modified (m, item))) us)
       | _ -> Style.pp_modifier m ^ ":" ^ to_class u)
   | Group us -> String.concat " " (List.map to_class us)
+  | Important u -> "!" ^ to_class u
 
 let rec pp = function
   | Base u -> "Base " ^ class_of_base u
   | Modified (m, u) -> "Modified (" ^ Style.pp_modifier m ^ ", " ^ pp u ^ ")"
   | Group us -> "Group [" ^ String.concat "; " (List.map pp us) ^ "]"
+  | Important u -> "Important (" ^ pp u ^ ")"
 
 let order (u : base) : int * int =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -57,10 +57,18 @@ type base = ..
 (** Base utility type without modifiers - extensible variant *)
 
 (** Unified utility type with modifiers support *)
-type t = Base of base | Modified of Style.modifier * t | Group of t list
+type t =
+  | Base of base
+  | Modified of Style.modifier * t
+  | Group of t list
+  | Important of t
 
 val base : base -> t
 (** [base u] wraps a base utility into a Utility.t. *)
+
+val important : t -> t
+(** [important u] marks every declaration [u] emits as [!important] (the [!]
+    utility prefix). *)
 
 val pp : t -> string
 (** [pp u] is a human-readable representation of [u] for debugging. *)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -286,8 +286,33 @@ let test_motion_reduce_transition_none () =
   check bool "should NOT have shorthand transition: none 0s" false has_shorthand
 
 (* Test suite *)
+(* The [!] prefix marks the utility's own declarations !important, leaves theme
+   tokens (--spacing) normal, preserves the class name, and nests under a
+   modifier (md:!flex). *)
+let test_important_prefix () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.fail m
+  in
+  let flex = css "!flex" in
+  Alcotest.(check bool)
+    "!flex marks display important" true
+    (Astring.String.is_infix ~affix:"display:flex!important" flex);
+  (match Tw.of_string "!flex" with
+  | Ok u -> Alcotest.(check string) "!flex class round-trips" "!flex" (Tw.pp u)
+  | Error (`Msg m) -> Alcotest.fail m);
+  (match Tw.of_string "md:!flex" with
+  | Ok u ->
+      Alcotest.(check string) "md:!flex class round-trips" "md:!flex" (Tw.pp u)
+  | Error (`Msg m) -> Alcotest.fail m);
+  Alcotest.(check bool)
+    "!p-4 leaves the --spacing theme token normal" false
+    (Astring.String.is_infix ~affix:"--spacing:.25rem!important" (css "!p-4"))
+
 let tests =
   [
+    test_case "important prefix" `Quick test_important_prefix;
     test_case "has_responsive_modifier" `Quick test_has_responsive_modifier;
     test_case "validate_no_nested_responsive" `Quick
       test_validate_no_nested_responsive;


### PR DESCRIPTION
Utilities marked important with a leading `!` (`!flex`, `!max-h-screen`, `md:!flex`) were rejected as unknown classes. `of_string` now parses the prefix and carries it as a new `Utility.Important` wrapper; `Style.map_important` maps `Css.important` over the utility's own declarations, leaving theme tokens (`--spacing`, `--tw-*`) untouched — matching Tailwind, where `!` affects the visible declaration, not the variables it references. The marker nests inside modifiers, so `md:!flex` is `md:(!flex)`.

The v4 trailing form (`flex!`) keeps the suffix in the selector (`.flex\!`), which needs form-preserving round-trips to avoid generating a selector that won't match the HTML; it's rejected for now rather than silently normalised. Pre-existing `build.ml:1136` polymorphic-compare (E106) is left for a dedicated cleanup.

Surfaced by `tw --diff` on the ocaml.org templates (`!flex`, `!max-h-screen`). Stacked on #36.