### PR TITLE
borders: support numeric outline widths

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -242,6 +242,7 @@ module Handler = struct
     | (* Outline utilities *)
       Outline
     | Outline_0
+    | Outline_width of int (* outline-1, outline-2, outline-4, outline-8 *)
     | Outline_width_bracket of string (* outline-[12px], outline-[1.5], etc. *)
     | Outline_width_var of string (* outline-[length:var(...)], etc. *)
     (* Outline style utilities (dashed, dotted, etc.) are in
@@ -1352,6 +1353,20 @@ module Handler = struct
     style ~property_rules:property_rule
       [ Css.outline_style (Css.Var oref); Css.outline_width Zero ]
 
+  (* Outline numeric width: outline-1, outline-2, outline-4, outline-8 *)
+  let outline_width_style n =
+    let oref = Var.reference outline_style_var in
+    let property_rule =
+      match Var.property_rule outline_style_var with
+      | Some rule -> rule
+      | None -> Css.empty
+    in
+    style ~property_rules:property_rule
+      [
+        Css.outline_style (Css.Var oref);
+        Css.outline_width (Px (float_of_int n));
+      ]
+
   (* Outline bracket width: outline-[12px], outline-[1.5], outline-[50%] *)
   let outline_width_bracket_style inner =
     let oref = Var.reference outline_style_var in
@@ -1712,6 +1727,7 @@ module Handler = struct
     (* Outline utilities *)
     | Outline -> outline ()
     | Outline_0 -> outline_0
+    | Outline_width n -> outline_width_style n
     | Outline_width_bracket v -> outline_width_bracket_style v
     | Outline_width_var v -> outline_width_var_style v
     | Outline_hidden -> outline_hidden
@@ -1851,8 +1867,9 @@ module Handler = struct
     | Outline_hidden -> 1990
     | Outline -> 1999
     | Outline_0 -> 2000
-    | Outline_width_bracket _ -> 2001
-    | Outline_width_var _ -> 2002
+    | Outline_width n -> 2000 + n
+    | Outline_width_bracket _ -> 2009
+    | Outline_width_var _ -> 2010
     (* Outline styles come after colors (which are in Color handler at
        priority 23 > borders priority 19, so they naturally sort after) *)
     (* Outline offset — negatives before positives *)
@@ -2085,6 +2102,8 @@ module Handler = struct
         | _ -> err_not_utility)
     | [ "outline" ] -> Ok Outline
     | [ "outline"; "0" ] -> Ok Outline_0
+    | [ "outline"; (("1" | "2" | "4" | "8") as n) ] ->
+        Ok (Outline_width (int_of_string n))
     | [ "outline"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         let starts prefix s =
@@ -2344,6 +2363,7 @@ module Handler = struct
         prefix ^ "-[" ^ value ^ "]"
     | Outline -> "outline"
     | Outline_0 -> "outline-0"
+    | Outline_width n -> "outline-" ^ string_of_int n
     | Outline_width_bracket v -> "outline-[" ^ v ^ "]"
     | Outline_width_var v -> "outline-[" ^ v ^ "]"
     | Outline_hidden -> "outline-hidden"

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -123,11 +123,30 @@ let test_rounded_side_full_inlined () =
     "rounded-l-full is not the old 9999px" false
     (Astring.String.is_infix ~affix:"9999px" css)
 
+(* Numeric outline widths (outline-1/2/4/8) emit outline-width: Npx with the
+   outline-style var; they used to be unknown classes. *)
+let test_outline_widths () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  Alcotest.(check bool)
+    "outline-2 emits outline-width: 2px" true
+    (Astring.String.is_infix ~affix:"outline-width: 2px" (css "outline-2"));
+  Alcotest.(check bool)
+    "outline-1 emits outline-width: 1px" true
+    (Astring.String.is_infix ~affix:"outline-width: 1px" (css "outline-1"));
+  Alcotest.(check bool)
+    "outline-3 is not a utility" true
+    (match Tw.of_string "outline-3" with Error _ -> true | Ok _ -> false)
+
 let tests =
   [
     test_case "rounded-sm default radius" `Quick test_rounded_sm_default;
     test_case "rounded-l-full inlined radius" `Quick
       test_rounded_side_full_inlined;
+    test_case "outline numeric widths" `Quick test_outline_widths;
     test_case "borders of_string - valid values" `Quick of_string_valid;
     test_case "borders of_string - invalid values" `Quick of_string_invalid;
     test_case "borders suborder matches Tailwind" `Quick


### PR DESCRIPTION
`outline-1`, `outline-2`, `outline-4`, `outline-8` were rejected as unknown classes (only `outline`, `outline-0` and `outline-[Npx]` worked). They now emit `outline-style: var(--tw-outline-style)` with `outline-width: Npx`, matching the existing `outline-0`/bracket paths and the v4 theme outline-width scale.

Surfaced by `tw --diff` on the ocaml.org templates (`outline-2`, `focus-within:outline-2`).