### PR TITLE
restore fixes dropped by the stacked merge (fractions, position, bg-url, prose)

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -32,6 +32,16 @@ module Handler = struct
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'
 
+  (* An arbitrary url() value may already carry its own quotes (url('a.png') /
+     url("a.png")). Drop a matching outer pair so the typed [Url] pretty-printer
+     canonicalises it instead of double-wrapping it into the broken
+     url("'a.png'"). *)
+  let strip_outer_quotes s =
+    let n = String.length s in
+    if n >= 2 && (s.[0] = '\'' || s.[0] = '"') && s.[n - 1] = s.[0] then
+      String.sub s 1 (n - 2)
+    else s
+
   type position_name =
     | Pos_bottom
     | Pos_bottom_left
@@ -1342,7 +1352,8 @@ module Handler = struct
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style [ Css.background_image (Var var_ref) ]
-    | Bg_bracket_url url -> style [ Css.background_image (Url url) ]
+    | Bg_bracket_url url ->
+        style [ Css.background_image (Url (strip_outer_quotes url)) ]
     | Bg_bracket_url_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -123,38 +123,38 @@ module Handler = struct
     | Neg_inset_y_full
     | Inset_y_3_4
     | Inset of int
-    | Inset_arbitrary of Css.length
+    | Inset_arbitrary of string * Css.length
     | Inset_named of string (* Custom property reference like inset-shadowned *)
     | Inset_x of int
-    | Inset_x_arbitrary of Css.length
+    | Inset_x_arbitrary of string * Css.length
     | Inset_x_named of string
     | Inset_y of int
-    | Inset_y_arbitrary of Css.length
+    | Inset_y_arbitrary of string * Css.length
     | Inset_y_named of string
     (* Logical position utilities: inset-s, inset-e, inset-bs, inset-be *)
     | Inset_s of int
-    | Inset_s_arbitrary of Css.length
+    | Inset_s_arbitrary of string * Css.length
     | Inset_s_named of string
     | Inset_s_auto
     | Inset_s_full
     | Neg_inset_s_full
     | Inset_s_3_4
     | Inset_e of int
-    | Inset_e_arbitrary of Css.length
+    | Inset_e_arbitrary of string * Css.length
     | Inset_e_named of string
     | Inset_e_auto
     | Inset_e_full
     | Neg_inset_e_full
     | Inset_e_3_4
     | Inset_bs of int
-    | Inset_bs_arbitrary of Css.length
+    | Inset_bs_arbitrary of string * Css.length
     | Inset_bs_named of string
     | Inset_bs_auto
     | Inset_bs_full
     | Neg_inset_bs_full
     | Inset_bs_3_4
     | Inset_be of int
-    | Inset_be_arbitrary of Css.length
+    | Inset_be_arbitrary of string * Css.length
     | Inset_be_named of string
     | Inset_be_auto
     | Inset_be_full
@@ -166,21 +166,21 @@ module Handler = struct
     | Top_full
     | Neg_top_full
     | Top_3_4
-    | Top_arbitrary of Css.length
+    | Top_arbitrary of string * Css.length
     | Top_named of string
     | Right of int
     | Right_auto
     | Right_full
     | Neg_right_full
     | Right_3_4
-    | Right_arbitrary of Css.length
+    | Right_arbitrary of string * Css.length
     | Right_named of string
     | Bottom of int
     | Bottom_auto
     | Bottom_full
     | Neg_bottom_full
     | Bottom_3_4
-    | Bottom_arbitrary of Css.length
+    | Bottom_arbitrary of string * Css.length
     | Bottom_named of string
     | Left of int
     | Left_1_2
@@ -188,7 +188,7 @@ module Handler = struct
     | Left_full
     | Neg_left_full
     | Left_3_4
-    | Left_arbitrary of Css.length
+    | Left_arbitrary of string * Css.length
     | Neg_left_arbitrary of string * Css.length
       (* raw bracket suffix kept for the class name; value is negated *)
     | Left_named of string
@@ -241,21 +241,21 @@ module Handler = struct
     | Inset n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset [ value ] ])
-    | Inset_arbitrary len -> style [ Css.inset [ len ] ]
+    | Inset_arbitrary (_, len) -> style [ Css.inset [ len ] ]
     | Inset_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset [ value ] ])
     | Inset_x n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_inline [ value ] ])
-    | Inset_x_arbitrary len -> style [ Css.inset_inline [ len ] ]
+    | Inset_x_arbitrary (_, len) -> style [ Css.inset_inline [ len ] ]
     | Inset_x_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_inline [ value ] ])
     | Inset_y n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_block [ value ] ])
-    | Inset_y_arbitrary len -> style [ Css.inset_block [ len ] ]
+    | Inset_y_arbitrary (_, len) -> style [ Css.inset_block [ len ] ]
     | Inset_y_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_block [ value ] ])
@@ -263,7 +263,7 @@ module Handler = struct
     | Inset_s n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_inline_start value ])
-    | Inset_s_arbitrary len -> style [ Css.inset_inline_start len ]
+    | Inset_s_arbitrary (_, len) -> style [ Css.inset_inline_start len ]
     | Inset_s_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_inline_start value ])
@@ -275,7 +275,7 @@ module Handler = struct
     | Inset_e n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_inline_end value ])
-    | Inset_e_arbitrary len -> style [ Css.inset_inline_end len ]
+    | Inset_e_arbitrary (_, len) -> style [ Css.inset_inline_end len ]
     | Inset_e_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_inline_end value ])
@@ -287,7 +287,7 @@ module Handler = struct
     | Inset_bs n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_block_start value ])
-    | Inset_bs_arbitrary len -> style [ Css.inset_block_start len ]
+    | Inset_bs_arbitrary (_, len) -> style [ Css.inset_block_start len ]
     | Inset_bs_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_block_start value ])
@@ -299,7 +299,7 @@ module Handler = struct
     | Inset_be n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_block_end value ])
-    | Inset_be_arbitrary len -> style [ Css.inset_block_end len ]
+    | Inset_be_arbitrary (_, len) -> style [ Css.inset_block_end len ]
     | Inset_be_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_block_end value ])
@@ -315,7 +315,7 @@ module Handler = struct
     | Top_full -> style [ Css.top (Pct 100.0) ]
     | Neg_top_full -> style [ Css.top (Pct (-100.0)) ]
     | Top_3_4 -> style [ Css.top (Pct 75.0) ]
-    | Top_arbitrary len -> style [ Css.top len ]
+    | Top_arbitrary (_, len) -> style [ Css.top len ]
     | Top_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.top value ])
@@ -326,7 +326,7 @@ module Handler = struct
     | Right_full -> style [ Css.right (Pct 100.0) ]
     | Neg_right_full -> style [ Css.right (Pct (-100.0)) ]
     | Right_3_4 -> style [ Css.right (Pct 75.0) ]
-    | Right_arbitrary len -> style [ Css.right len ]
+    | Right_arbitrary (_, len) -> style [ Css.right len ]
     | Right_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.right value ])
@@ -337,7 +337,7 @@ module Handler = struct
     | Bottom_full -> style [ Css.bottom (Pct 100.0) ]
     | Neg_bottom_full -> style [ Css.bottom (Pct (-100.0)) ]
     | Bottom_3_4 -> style [ Css.bottom (Pct 75.0) ]
-    | Bottom_arbitrary len -> style [ Css.bottom len ]
+    | Bottom_arbitrary (_, len) -> style [ Css.bottom len ]
     | Bottom_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.bottom value ])
@@ -349,7 +349,7 @@ module Handler = struct
     | Left_full -> style [ Css.left (Pct 100.0) ]
     | Neg_left_full -> style [ Css.left (Pct (-100.0)) ]
     | Left_3_4 -> style [ Css.left (Pct 75.0) ]
-    | Left_arbitrary len -> style [ Css.left len ]
+    | Left_arbitrary (_, len) -> style [ Css.left len ]
     | Neg_left_arbitrary (_, len) -> style [ Css.left len ]
     | Left_named name ->
         let decl, value = named_inset_value name in
@@ -521,7 +521,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_x x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_x_arbitrary len)
+            | Ok len -> Ok (Inset_x_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_x_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "x"; n ] ->
@@ -531,7 +531,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_y x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_y_arbitrary len)
+            | Ok len -> Ok (Inset_y_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_y_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "y"; n ] ->
@@ -546,7 +546,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_s x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_s_arbitrary len)
+            | Ok len -> Ok (Inset_s_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_s_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "s"; n ] ->
@@ -561,7 +561,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_e x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_e_arbitrary len)
+            | Ok len -> Ok (Inset_e_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_e_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "e"; n ] ->
@@ -576,7 +576,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_bs x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_bs_arbitrary len)
+            | Ok len -> Ok (Inset_bs_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_bs_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "bs"; n ] ->
@@ -591,7 +591,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_be x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_be_arbitrary len)
+            | Ok len -> Ok (Inset_be_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_be_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "be"; n ] ->
@@ -603,7 +603,7 @@ module Handler = struct
         | Ok x -> Ok (Inset x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Inset_arbitrary len)
+            | Ok len -> Ok (Inset_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; n ] ->
@@ -618,7 +618,7 @@ module Handler = struct
         | Ok x -> Ok (Top x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Top_arbitrary len)
+            | Ok len -> Ok (Top_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Top_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "top"; n ] ->
@@ -632,7 +632,7 @@ module Handler = struct
         | Ok x -> Ok (Right x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Right_arbitrary len)
+            | Ok len -> Ok (Right_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Right_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "right"; n ] ->
@@ -646,7 +646,7 @@ module Handler = struct
         | Ok x -> Ok (Bottom x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Bottom_arbitrary len)
+            | Ok len -> Ok (Bottom_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Bottom_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "bottom"; n ] ->
@@ -661,7 +661,7 @@ module Handler = struct
         | Ok x -> Ok (Left x)
         | Error _ -> (
             match parse_bracket_length n with
-            | Ok len -> Ok (Left_arbitrary len)
+            | Ok len -> Ok (Left_arbitrary (n, len))
             | Error _ when Parse.is_valid_theme_name n -> Ok (Left_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "left"; n ] -> (
@@ -710,27 +710,23 @@ module Handler = struct
     | Inset n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-" ^ string_of_int (abs n)
-    | Inset_arbitrary len ->
-        "inset-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_arbitrary (raw, _) -> "inset-" ^ raw
     | Inset_named name -> "inset-" ^ name
     | Inset_x n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-x-" ^ string_of_int (abs n)
-    | Inset_x_arbitrary len ->
-        "inset-x-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_x_arbitrary (raw, _) -> "inset-x-" ^ raw
     | Inset_x_named name -> "inset-x-" ^ name
     | Inset_y n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-y-" ^ string_of_int (abs n)
-    | Inset_y_arbitrary len ->
-        "inset-y-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_y_arbitrary (raw, _) -> "inset-y-" ^ raw
     | Inset_y_named name -> "inset-y-" ^ name
     (* inset-s = inset-inline-start *)
     | Inset_s n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-s-" ^ string_of_int (abs n)
-    | Inset_s_arbitrary len ->
-        "inset-s-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_s_arbitrary (raw, _) -> "inset-s-" ^ raw
     | Inset_s_named name -> "inset-s-" ^ name
     | Inset_s_auto -> "inset-s-auto"
     | Inset_s_full -> "inset-s-full"
@@ -740,8 +736,7 @@ module Handler = struct
     | Inset_e n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-e-" ^ string_of_int (abs n)
-    | Inset_e_arbitrary len ->
-        "inset-e-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_e_arbitrary (raw, _) -> "inset-e-" ^ raw
     | Inset_e_named name -> "inset-e-" ^ name
     | Inset_e_auto -> "inset-e-auto"
     | Inset_e_full -> "inset-e-full"
@@ -751,8 +746,7 @@ module Handler = struct
     | Inset_bs n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-bs-" ^ string_of_int (abs n)
-    | Inset_bs_arbitrary len ->
-        "inset-bs-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_bs_arbitrary (raw, _) -> "inset-bs-" ^ raw
     | Inset_bs_named name -> "inset-bs-" ^ name
     | Inset_bs_auto -> "inset-bs-auto"
     | Inset_bs_full -> "inset-bs-full"
@@ -762,8 +756,7 @@ module Handler = struct
     | Inset_be n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-be-" ^ string_of_int (abs n)
-    | Inset_be_arbitrary len ->
-        "inset-be-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Inset_be_arbitrary (raw, _) -> "inset-be-" ^ raw
     | Inset_be_named name -> "inset-be-" ^ name
     | Inset_be_auto -> "inset-be-auto"
     | Inset_be_full -> "inset-be-full"
@@ -777,8 +770,7 @@ module Handler = struct
     | Top n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "top-" ^ string_of_int (abs n)
-    | Top_arbitrary len ->
-        "top-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Top_arbitrary (raw, _) -> "top-" ^ raw
     | Top_named name -> "top-" ^ name
     | Right_3_4 -> "right-3/4"
     | Right_auto -> "right-auto"
@@ -787,8 +779,7 @@ module Handler = struct
     | Right n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "right-" ^ string_of_int (abs n)
-    | Right_arbitrary len ->
-        "right-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Right_arbitrary (raw, _) -> "right-" ^ raw
     | Right_named name -> "right-" ^ name
     | Bottom_3_4 -> "bottom-3/4"
     | Bottom_auto -> "bottom-auto"
@@ -797,8 +788,7 @@ module Handler = struct
     | Bottom n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "bottom-" ^ string_of_int (abs n)
-    | Bottom_arbitrary len ->
-        "bottom-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Bottom_arbitrary (raw, _) -> "bottom-" ^ raw
     | Bottom_named name -> "bottom-" ^ name
     | Left_1_2 -> "left-1/2"
     | Left_3_4 -> "left-3/4"
@@ -808,8 +798,7 @@ module Handler = struct
     | Left n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "left-" ^ string_of_int (abs n)
-    | Left_arbitrary len ->
-        "left-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) len ^ "]"
+    | Left_arbitrary (raw, _) -> "left-" ^ raw
     | Neg_left_arbitrary (raw, _) -> "-left-" ^ raw
     | Left_named name -> "left-" ^ name
     | Start_3_4 -> "start-3/4"

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -1748,6 +1748,42 @@ let color_theme_bindings theme_name =
   | "stone" -> [] (* TODO: Add stone theme bindings *)
   | _ -> []
 
+(* prose-invert remaps every --tw-prose-* to its --tw-prose-invert-*
+   counterpart, the way Tailwind's [.prose-invert] does. *)
+let invert_remap_bindings =
+  bind_prose_vars
+    [
+      (prose_body_var, Css.Var (snd theme.invert_body));
+      (prose_headings_var, Css.Var (snd theme.invert_headings));
+      (prose_lead_var, Css.Var (snd theme.invert_lead));
+      (prose_links_var, Css.Var (snd theme.invert_links));
+      (prose_bold_var, Css.Var (snd theme.invert_bold));
+      (prose_counters_var, Css.Var (snd theme.invert_counters));
+      (prose_bullets_var, Css.Var (snd theme.invert_bullets));
+      (prose_hr_var, Css.Var (snd theme.invert_hr));
+      (prose_quotes_var, Css.Var (snd theme.invert_quotes));
+      (prose_quote_borders_var, Css.Var (snd theme.invert_quote_borders));
+      (prose_captions_var, Css.Var (snd theme.invert_captions));
+      (prose_kbd_var, Css.Var (snd theme.invert_kbd));
+      (prose_kbd_shadows_var, Css.Var (snd theme.invert_kbd_shadows));
+      (prose_code_var, Css.Var (snd theme.invert_code));
+      (prose_pre_code_var, Css.Var (snd theme.invert_pre_code));
+      (prose_pre_bg_var, Css.Var (snd theme.invert_pre_bg));
+      (prose_th_borders_var, Css.Var (snd theme.invert_th_borders));
+      (prose_td_borders_var, Css.Var (snd theme.invert_td_borders));
+    ]
+
+(* Accent colour themes (prose-orange, ...) only override the link colours,
+   normal and inverted. Values taken from the Tailwind typography plugin. *)
+let accent_color_bindings = function
+  | "orange" ->
+      bind_prose_vars
+        [
+          (prose_links_var, Css.oklch 64.6 0.222 41.116);
+          (prose_invert_links_var, Css.oklch 70.5 0.213 47.604);
+        ]
+  | _ -> []
+
 let to_css_rules variant =
   match variant with
   | `Base -> base_prose_rules ()
@@ -1785,6 +1821,18 @@ let to_css_rules variant =
           ~selector:(Css.Selector.class_ "prose-stone")
           (color_theme_bindings "stone");
       ]
+  | `Invert ->
+      [
+        Css.rule
+          ~selector:(Css.Selector.class_ "prose-invert")
+          invert_remap_bindings;
+      ]
+  | `Orange ->
+      [
+        Css.rule
+          ~selector:(Css.Selector.class_ "prose-orange")
+          (accent_color_bindings "orange");
+      ]
 
 let pp = function
   | `Base -> "Base"
@@ -1797,6 +1845,8 @@ let pp = function
   | `Zinc -> "Zinc"
   | `Neutral -> "Neutral"
   | `Stone -> "Stone"
+  | `Invert -> "Invert"
+  | `Orange -> "Orange"
 
 (** Prose utility constructors *)
 let prose_style variant =
@@ -1906,6 +1956,7 @@ module Color_Handler = struct
     | Prose_neutral
     | Prose_stone
     | Prose_invert
+    | Prose_orange
 
   (** Extensible variant for prose color utilities *)
   type Utility.base += Self of t
@@ -1923,7 +1974,8 @@ module Color_Handler = struct
     | Prose_zinc -> prose_style `Zinc
     | Prose_neutral -> prose_style `Neutral
     | Prose_stone -> prose_style `Stone
-    | Prose_invert -> niet
+    | Prose_invert -> prose_style `Invert
+    | Prose_orange -> prose_style `Orange
 
   let to_class = function
     | Prose_gray -> "prose-gray"
@@ -1932,6 +1984,7 @@ module Color_Handler = struct
     | Prose_neutral -> "prose-neutral"
     | Prose_stone -> "prose-stone"
     | Prose_invert -> "prose-invert"
+    | Prose_orange -> "prose-orange"
 
   let of_class class_name =
     let parts = Parse.split_class class_name in
@@ -1942,6 +1995,7 @@ module Color_Handler = struct
     | [ "prose"; "neutral" ] -> Ok Prose_neutral
     | [ "prose"; "stone" ] -> Ok Prose_stone
     | [ "prose"; "invert" ] -> Ok Prose_invert
+    | [ "prose"; "orange" ] -> Ok Prose_orange
     | _ -> Error (`Msg "Not a prose color utility")
 
   let suborder = function
@@ -1952,6 +2006,7 @@ module Color_Handler = struct
     | Prose_neutral -> 30003
     | Prose_stone -> 30004
     | Prose_invert -> 30005
+    | Prose_orange -> 30006
 end
 
 (** Register both handlers with Utility system *)
@@ -1973,5 +2028,7 @@ let prose_slate = color_utility Color_Handler.Prose_slate
 let prose_zinc = color_utility Color_Handler.Prose_zinc
 let prose_neutral = color_utility Color_Handler.Prose_neutral
 let prose_stone = color_utility Color_Handler.Prose_stone
+let prose_invert = color_utility Color_Handler.Prose_invert
+let prose_orange = color_utility Color_Handler.Prose_orange
 let prose_lead = utility Handler.Lead
 let not_prose = utility Handler.Not_prose

--- a/lib/prose.mli
+++ b/lib/prose.mli
@@ -94,6 +94,12 @@ val prose_neutral : t
 val prose_stone : t
 (** [prose_stone] applies stone color theme. *)
 
+val prose_invert : t
+(** [prose_invert] remaps the prose palette to its inverted (dark) variant. *)
+
+val prose_orange : t
+(** [prose_orange] applies the orange accent (link) color theme. *)
+
 val stylesheet : unit -> Css.statement list
 (** [stylesheet ()] generates complete CSS rules for all prose variants. *)
 

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -227,15 +227,6 @@ module Handler = struct
   let w_min' = style [ width Min_content ]
   let w_max' = style [ width Max_content ]
   let w_fit' = style [ width Fit_content ]
-  let w_1_2' = style [ width (Pct 50.0) ]
-  let w_1_3' = style [ width (Pct 33.3333) ]
-  let w_2_3' = style [ width (Pct 66.6667) ]
-  let w_1_4' = style [ width (Pct 25.0) ]
-  let w_3_4' = style [ width (Pct 75.0) ]
-  let w_1_5' = style [ width (Pct 20.0) ]
-  let w_2_5' = style [ width (Pct 40.0) ]
-  let w_3_5' = style [ width (Pct 60.0) ]
-  let w_4_5' = style [ width (Pct 80.0) ]
 
   (* Int-based width function for Tailwind scale (n * 0.25rem) *)
 
@@ -259,15 +250,6 @@ module Handler = struct
   let h_min' = style [ height Min_content ]
   let h_max' = style [ height Max_content ]
   let h_fit' = style [ height Fit_content ]
-  let h_1_2' = style [ height (Pct 50.0) ]
-  let h_1_3' = style [ height (Pct 33.3333) ]
-  let h_2_3' = style [ height (Pct 66.6667) ]
-  let h_1_4' = style [ height (Pct 25.0) ]
-  let h_3_4' = style [ height (Pct 75.0) ]
-  let h_1_5' = style [ height (Pct 20.0) ]
-  let h_2_5' = style [ height (Pct 40.0) ]
-  let h_3_5' = style [ height (Pct 60.0) ]
-  let h_4_5' = style [ height (Pct 80.0) ]
 
   (* Int-based height function for Tailwind scale (n * 0.25rem) *)
 
@@ -425,20 +407,22 @@ module Handler = struct
 
   (* Int-based max-height function for Tailwind scale (n * 0.25rem) *)
 
-  let fraction_table =
-    [
-      ("1/2", 50.0);
-      ("1/3", 33.3333);
-      ("2/3", 66.6667);
-      ("1/4", 25.0);
-      ("3/4", 75.0);
-      ("1/5", 20.0);
-      ("2/5", 40.0);
-      ("3/5", 60.0);
-      ("4/5", 80.0);
-      ("1/6", 16.6667);
-      ("5/6", 83.3333);
-    ]
+  (* A Tailwind sizing fraction [n/m] resolves to [n/m * 100%]. Tailwind emits
+     calc(n / m * 100%) and folds it to 6 significant figures (e.g. 33.3333,
+     8.33333); we emit the percentage rounded the same way so the two match.
+     Denominators follow Tailwind's scale. *)
+  let fraction_pct frac =
+    match String.split_on_char '/' frac with
+    | [ n; m ] -> (
+        match (int_of_string_opt n, int_of_string_opt m) with
+        | Some n, Some m
+          when m > 0 && n > 0 && n < m && List.mem m [ 2; 3; 4; 5; 6; 12 ] ->
+            let pct = float_of_int n /. float_of_int m *. 100. in
+            let digits = 6. -. Float.ceil (Float.log10 pct) in
+            let factor = 10. ** digits in
+            Some (Float.round (pct *. factor) /. factor)
+        | _ -> None)
+    | _ -> None
 
   let aspect_auto' = style [ Css.aspect_ratio Auto ]
 
@@ -469,17 +453,9 @@ module Handler = struct
     | W_fit -> w_fit'
     | W_spacing n -> w' (`Rem n)
     | W_fraction f -> (
-        match f with
-        | "1/2" -> w_1_2'
-        | "1/3" -> w_1_3'
-        | "2/3" -> w_2_3'
-        | "1/4" -> w_1_4'
-        | "3/4" -> w_3_4'
-        | "1/5" -> w_1_5'
-        | "2/5" -> w_2_5'
-        | "3/5" -> w_3_5'
-        | "4/5" -> w_4_5'
-        | _ -> failwith ("Unknown width fraction: " ^ f))
+        match fraction_pct f with
+        | Some pct -> style [ width (Pct pct) ]
+        | None -> failwith ("Unknown width fraction: " ^ f))
     | W_arbitrary (_, len) -> style [ width len ]
     | W_dvw -> style [ width (Dvw 100.) ]
     | W_lvw -> style [ width (Lvw 100.) ]
@@ -497,17 +473,9 @@ module Handler = struct
     | H_fit -> h_fit'
     | H_spacing n -> h' (`Rem n)
     | H_fraction f -> (
-        match f with
-        | "1/2" -> h_1_2'
-        | "1/3" -> h_1_3'
-        | "2/3" -> h_2_3'
-        | "1/4" -> h_1_4'
-        | "3/4" -> h_3_4'
-        | "1/5" -> h_1_5'
-        | "2/5" -> h_2_5'
-        | "3/5" -> h_3_5'
-        | "4/5" -> h_4_5'
-        | _ -> failwith ("Unknown height fraction: " ^ f))
+        match fraction_pct f with
+        | Some pct -> style [ height (Pct pct) ]
+        | None -> failwith ("Unknown height fraction: " ^ f))
     | H_arbitrary (_, len) -> style [ height len ]
     | H_dvh -> style [ height (Dvh 100.) ]
     | H_lvh -> style [ height (Lvh 100.) ]
@@ -608,7 +576,7 @@ module Handler = struct
     | Size_arbitrary (_, len) -> style [ width len; height len ]
     (* inline-size utilities *)
     | Inline_fraction f -> (
-        match List.assoc_opt f fraction_table with
+        match fraction_pct f with
         | Some pct -> style [ inline_size (Pct pct) ]
         | None -> failwith ("Unknown inline-size fraction: " ^ f))
     | Inline_spacing n -> spacing_utility inline_size n
@@ -648,7 +616,7 @@ module Handler = struct
         style [ decl; max_inline_size (Var ref_) ]
     (* block-size utilities *)
     | Block_fraction f -> (
-        match List.assoc_opt f fraction_table with
+        match fraction_pct f with
         | Some pct -> style [ block_size (Pct pct) ]
         | None -> failwith ("Unknown block-size fraction: " ^ f))
     | Block_spacing n -> spacing_utility block_size n
@@ -728,7 +696,7 @@ module Handler = struct
     | "svw" -> Ok W_svw
     | "xl" -> Ok W_xl
     | frac when String.contains frac '/' ->
-        if List.mem_assoc frac fraction_table then Ok (W_fraction frac)
+        if fraction_pct frac <> None then Ok (W_fraction frac)
         else err_invalid_value "width fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
@@ -752,7 +720,7 @@ module Handler = struct
     | "svh" -> Ok H_svh
     | "lh" -> Ok H_lh
     | frac when String.contains frac '/' ->
-        if List.mem_assoc frac fraction_table then Ok (H_fraction frac)
+        if fraction_pct frac <> None then Ok (H_fraction frac)
         else err_invalid_value "height fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
@@ -863,7 +831,7 @@ module Handler = struct
     | "max" -> Ok Size_max
     | "fit" -> Ok Size_fit
     | frac when String.contains frac '/' ->
-        if List.mem_assoc frac fraction_table then Ok (Size_fraction frac)
+        if fraction_pct frac <> None then Ok (Size_fraction frac)
         else err_invalid_value "size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
@@ -886,7 +854,7 @@ module Handler = struct
     | "svw" -> Ok Inline_svw
     | "xl" -> Ok Inline_xl
     | frac when String.contains frac '/' ->
-        if List.mem_assoc frac fraction_table then Ok (Inline_fraction frac)
+        if fraction_pct frac <> None then Ok (Inline_fraction frac)
         else err_invalid_value "inline-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
@@ -940,7 +908,7 @@ module Handler = struct
     | "screen" -> Ok Block_screen
     | "svh" -> Ok Block_svh
     | frac when String.contains frac '/' ->
-        if List.mem_assoc frac fraction_table then Ok (Block_fraction frac)
+        if fraction_pct frac <> None then Ok (Block_fraction frac)
         else err_invalid_value "block-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3143,6 +3143,12 @@ val prose_gray : t
 val prose_slate : t
 (** [prose_slate] uses the slate prose color theme. *)
 
+val prose_invert : t
+(** [prose_invert] remaps the prose palette to its inverted (dark) variant. *)
+
+val prose_orange : t
+(** [prose_orange] uses the orange accent (link) prose color theme. *)
+
 (** {2 Prose markers}
 
     Convenience utilities to apply marker classes used by prose selectors. *)

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -74,9 +74,36 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"backgrounds suborder matches Tailwind" shuffled
 
+(* An arbitrary url() with its own quotes must not be double-wrapped: tw used to
+   emit the broken url("'/img/x.png'"); it now canonicalises to a valid
+   url(). *)
+let test_bg_arbitrary_url () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  List.iter
+    (fun cls ->
+      let css = css_of cls in
+      Alcotest.(check bool)
+        (cls ^ " emits a valid url()")
+        true
+        (Astring.String.is_infix ~affix:"url(/img/x.png)" css);
+      Alcotest.(check bool)
+        (cls ^ " does not double-quote")
+        false
+        (Astring.String.is_infix ~affix:"url(\"'" css))
+    [
+      "bg-[url('/img/x.png')]";
+      "bg-[url(\"/img/x.png\")]";
+      "bg-[url(/img/x.png)]";
+    ]
+
 let tests =
   [
     test_case "bg colors" `Quick test_bg_colors;
+    test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -17,6 +17,17 @@ let test_position_utilities () =
   check "relative";
   check "sticky"
 
+(* Arbitrary values round-trip verbatim in the class name: the leading zero of
+   0.67rem (and the sign of negatives) is preserved, not re-serialised to a
+   normalised .67rem that would no longer match the HTML class. *)
+let test_arbitrary_roundtrip () =
+  check "top-[0.67rem]";
+  check "right-[-0.9rem]";
+  check "bottom-[5rem]";
+  check "left-[0.5rem]";
+  check "inset-[0.25rem]";
+  check "inset-x-[0.5rem]"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -31,6 +42,7 @@ let tests =
   [
     test_case "inset and z" `Quick test_inset_and_z;
     test_case "negative top" `Quick test_negative;
+    test_case "arbitrary value roundtrip" `Quick test_arbitrary_roundtrip;
     test_case "position utilities" `Quick test_position_utilities;
     test_case "position suborder matches Tailwind" `Quick
       suborder_matches_tailwind;

--- a/test/test_prose.ml
+++ b/test/test_prose.ml
@@ -60,10 +60,24 @@ let test_inline_styles () =
   let inline_gray = to_inline_style [ prose_gray ] in
   Alcotest.(check string) "prose-gray has no inline styles" "" inline_gray
 
+(* prose-invert remaps the palette to the inverted vars; prose-orange overrides
+   the link accent colours. Both used to be no-ops / unknown. *)
+let test_color_variants () =
+  let invert = Css.to_string (to_css ~base:false [ prose_invert ]) in
+  Alcotest.(check bool)
+    "prose-invert remaps body to the invert var" true
+    (Astring.String.is_infix ~affix:"var(--tw-prose-invert-body)" invert);
+  let orange = Css.to_string (to_css ~base:false [ prose_orange ]) in
+  Alcotest.(check bool)
+    "prose-orange sets the link accent" true
+    (Astring.String.is_infix ~affix:"--tw-prose-links" orange
+    && Astring.String.is_infix ~affix:"--tw-prose-invert-links" orange)
+
 let suite =
   ( "prose",
     [
       Alcotest.test_case "classes" `Quick test_classes;
+      Alcotest.test_case "color variants" `Quick test_color_variants;
       Alcotest.test_case "combinations" `Quick test_combinations;
       Alcotest.test_case "CSS generation" `Quick test_css_generation;
       Alcotest.test_case "inline styles" `Quick test_inline_styles;

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -187,9 +187,32 @@ let test_fractional_spacing () =
   has "size-0.5" "calc(var(--spacing) * .5)";
   has "h-2.5" "height: calc(var(--spacing) * 2.5)"
 
+(* Fractional sizing accepts any n/m with a Tailwind denominator (2,3,4,5,6,12),
+   not just the originally hardcoded handful; the percentage matches the CLI's
+   folded calc(n/m*100%) at 6 significant figures. *)
+let test_general_fractions () =
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " contains " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css_of cls))
+  in
+  has "w-4/12" "width: 33.3333%";
+  has "w-8/12" "width: 66.6667%";
+  has "w-1/12" "width: 8.33333%";
+  has "h-2/6" "height: 33.3333%";
+  let rejected cls =
+    match Tw.of_string cls with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.fail ("expected rejection of " ^ cls)
+  in
+  rejected "w-1/7";
+  rejected "w-13/12"
+
 let tests =
   [
     test_case "fractional spacing" `Quick test_fractional_spacing;
+    test_case "general fractions" `Quick test_general_fractions;
     test_case "widths" `Quick test_widths;
     test_case "heights" `Quick test_heights;
     test_case "min sizes" `Quick test_min_sizes;


### PR DESCRIPTION
Four already-reviewed fixes show as merged (#32, #33, #34, #36) but their code never reached `main` — the stacked-merge/close sequence dropped them (same way #31 was). On current `main`: `w-4/12` and `prose-orange` are unknown classes, `top-[0.67rem]` re-serialises to `.top-[.67rem]`, and `bg-[url('...')]` emits the broken `url("'...'")`.

This re-applies the four original commits, unchanged, onto current `main` as independent (non-stacked) commits so they can't re-tangle:

- 118803e7 sizing: any fractional width/height (`w-4/12`, `h-2/6`)
- 82840386 position: preserve the raw arbitrary value in the class name (`top-[0.67rem]`)
- fc5a17a3 prose: `prose-invert` + `prose-orange`
- 235a1c16 backgrounds: don't double-quote arbitrary `url()` values

Full suite + upstream parity green; each fix re-verified with `tw --diff`.