### PR TITLE
color: support per-side border colors

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1527,6 +1527,19 @@ let shade_and_opacity_of_strings = function
 (** {1 Parsing Functions} *)
 
 module Handler = struct
+  (* Per-side border colour: which physical border edge a border-{side}-{color}
+     utility paints. (border-x/border-y map to the logical inline/block colour
+     properties and aren't handled here yet.) *)
+  type border_side = Bs_t | Bs_r | Bs_b | Bs_l
+
+  (* The colour value of a border-{side}-{color}: a named theme colour, an
+     arbitrary bracket colour, or a keyword. *)
+  type border_side_color =
+    | Bsc_named of color * int
+    | Bsc_bracket of string * Css.color
+    | Bsc_transparent
+    | Bsc_current
+
   (** Local color utility type *)
   type t =
     (* Background colors *)
@@ -1557,6 +1570,7 @@ module Handler = struct
     | Border_current_opacity of opacity_modifier
     | Border_bracket_color of string * Css.color
     | Border_bracket_color_opacity of string * Css.color * opacity_modifier
+    | Border_side_color of border_side * border_side_color
     (* Accent colors *)
     | Accent of color * int
     | Accent_opacity of color * int * opacity_modifier
@@ -1790,6 +1804,28 @@ module Handler = struct
                   (Border_bracket_color_opacity (base_inner, css_color, opacity))
             )
         | None -> Error (`Msg ("Invalid border bracket value: " ^ base_inner)))
+    | "border" :: side :: rest
+      when rest <> []
+           && match side with "t" | "r" | "b" | "l" -> true | _ -> false -> (
+        let bs =
+          match side with "t" -> Bs_t | "r" -> Bs_r | "b" -> Bs_b | _ -> Bs_l
+        in
+        match rest with
+        | [ "transparent" ] -> Ok (Border_side_color (bs, Bsc_transparent))
+        | [ "current" ] -> Ok (Border_side_color (bs, Bsc_current))
+        | [ v ]
+          when String.length v > 0 && v.[0] = '[' && Parse.is_bracket_value v
+          -> (
+            let inner = Parse.bracket_inner v in
+            match parse_bracket_color inner with
+            | Some css_color ->
+                Ok (Border_side_color (bs, Bsc_bracket (inner, css_color)))
+            | None -> Error (`Msg ("Invalid border side bracket: " ^ v)))
+        | color_parts -> (
+            match shade_of_strings color_parts with
+            | Ok (color, shade) ->
+                Ok (Border_side_color (bs, Bsc_named (color, shade)))
+            | Error e -> Error e))
     | "border" :: color_parts when List.exists has_opacity color_parts -> (
         match shade_and_opacity_of_strings color_parts with
         | Ok (color, shade, opacity) ->
@@ -2003,6 +2039,30 @@ module Handler = struct
 
   let border_transparent = style [ Css.border_color (Css.hex "#0000") ]
   let border_current = style [ Css.border_color Current ]
+
+  (* Per-side border colour emission. *)
+  let setters_of_side : border_side -> (Css.color -> Css.declaration) list =
+    function
+    | Bs_t -> [ Css.border_top_color ]
+    | Bs_r -> [ Css.border_right_color ]
+    | Bs_b -> [ Css.border_bottom_color ]
+    | Bs_l -> [ Css.border_left_color ]
+
+  let border_side_color_style side value =
+    let sides = setters_of_side side in
+    let apply c = style (List.map (fun set -> set c) sides) in
+    match value with
+    | Bsc_named (color, shade) ->
+        if is_custom_color color then apply (to_css color shade)
+        else
+          let color_var = color_var color shade in
+          let color_value = get_color_value color shade in
+          let decl, color_ref = Var.binding color_var color_value in
+          style
+            (decl :: List.map (fun set -> set (Var color_ref : Css.color)) sides)
+    | Bsc_bracket (_, css_color) -> apply css_color
+    | Bsc_transparent -> apply (Css.hex "#0000")
+    | Bsc_current -> apply Current
 
   (** Accent color utilities *)
 
@@ -2459,6 +2519,7 @@ module Handler = struct
         in
         style ~merge_key:"text-" ~rules:(Some [ supports_block ])
           [ fallback_decl ]
+    | Border_side_color (side, value) -> border_side_color_style side value
     | Border (color, shade) -> border_color' color shade
     | Border_opacity (color, shade, opacity) ->
         border_with_opacity color shade opacity
@@ -2588,6 +2649,7 @@ module Handler = struct
     | Border_current -> 0
     | Border_current_opacity _ -> 0
     | Border_bracket_color _ -> 0
+    | Border_side_color _ -> 0
     | Border_bracket_color_opacity _ -> 0
     | Accent (color, shade) ->
         (* All accent colors use the same suborder (50000) to allow alphabetical
@@ -2730,6 +2792,24 @@ module Handler = struct
     | Border_current_opacity opacity ->
         "border-current" ^ opacity_suffix opacity
     | Border_bracket_color (v, _) -> "border-[" ^ v ^ "]"
+    | Border_side_color (side, value) ->
+        let s =
+          match side with
+          | Bs_t -> "t"
+          | Bs_r -> "r"
+          | Bs_b -> "b"
+          | Bs_l -> "l"
+        in
+        let v =
+          match value with
+          | Bsc_named (c, shade) ->
+              if is_base_color c || is_custom_color c then color_to_string c
+              else color_to_string c ^ "-" ^ string_of_int shade
+          | Bsc_bracket (orig, _) -> "[" ^ orig ^ "]"
+          | Bsc_transparent -> "transparent"
+          | Bsc_current -> "current"
+        in
+        "border-" ^ s ^ "-" ^ v
     | Border_bracket_color_opacity (v, _, opacity) ->
         "border-[" ^ v ^ "]" ^ opacity_suffix opacity
     | Accent (c, shade) ->

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1528,9 +1528,10 @@ let shade_and_opacity_of_strings = function
 
 module Handler = struct
   (* Per-side border colour: which physical border edge a border-{side}-{color}
-     utility paints. (border-x/border-y map to the logical inline/block colour
-     properties and aren't handled here yet.) *)
-  type border_side = Bs_t | Bs_r | Bs_b | Bs_l
+     utility paints. Bs_x is the logical inline axis (border-inline-color);
+     border-y (block axis) needs a border-block-color setter cascade does not
+     expose yet, so it is not handled here. *)
+  type border_side = Bs_t | Bs_r | Bs_b | Bs_l | Bs_x
 
   (* The colour value of a border-{side}-{color}: a named theme colour, an
      arbitrary bracket colour, or a keyword. *)
@@ -1806,9 +1807,15 @@ module Handler = struct
         | None -> Error (`Msg ("Invalid border bracket value: " ^ base_inner)))
     | "border" :: side :: rest
       when rest <> []
-           && match side with "t" | "r" | "b" | "l" -> true | _ -> false -> (
+           && match side with "t" | "r" | "b" | "l" | "x" -> true | _ -> false
+      -> (
         let bs =
-          match side with "t" -> Bs_t | "r" -> Bs_r | "b" -> Bs_b | _ -> Bs_l
+          match side with
+          | "t" -> Bs_t
+          | "r" -> Bs_r
+          | "b" -> Bs_b
+          | "x" -> Bs_x
+          | _ -> Bs_l
         in
         match rest with
         | [ "transparent" ] -> Ok (Border_side_color (bs, Bsc_transparent))
@@ -2047,6 +2054,8 @@ module Handler = struct
     | Bs_r -> [ Css.border_right_color ]
     | Bs_b -> [ Css.border_bottom_color ]
     | Bs_l -> [ Css.border_left_color ]
+    | Bs_x ->
+        [ (fun c -> Css.border_inline_color (Css.logical_border_color c)) ]
 
   let border_side_color_style side value =
     let sides = setters_of_side side in
@@ -2799,6 +2808,7 @@ module Handler = struct
           | Bs_r -> "r"
           | Bs_b -> "b"
           | Bs_l -> "l"
+          | Bs_x -> "x"
         in
         let v =
           match value with

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -183,9 +183,35 @@ let test_css_mode_with_colors () =
     "Contains text-red-500 class" true
     (Astring.String.is_infix ~affix:".text-red-500" css_string)
 
+(* Per-side border colors (border-{t,r,b,l}-{color}) paint the matching physical
+   edge; named, arbitrary and keyword forms. Widths (border-l-2) still resolve
+   via the borders handler. *)
+let test_border_side_color () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  Alcotest.(check bool)
+    "border-l-[#575959] sets border-left-color" true
+    (Astring.String.is_infix ~affix:"border-left-color: #575959"
+       (css "border-l-[#575959]"));
+  Alcotest.(check bool)
+    "border-b-transparent sets border-bottom-color" true
+    (Astring.String.is_infix ~affix:"border-bottom-color:"
+       (css "border-b-transparent"));
+  Alcotest.(check bool)
+    "border-l-red-500 sets border-left-color" true
+    (Astring.String.is_infix ~affix:"border-left-color:"
+       (css "border-l-red-500"));
+  Alcotest.(check bool)
+    "border-l-2 is still a width" true
+    (Astring.String.is_infix ~affix:"border-left-width: 2px" (css "border-l-2"))
+
 (* Test suite *)
 let tests =
   [
+    ("Per-side border colors", `Quick, test_border_side_color);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);
     ("RGB to hex", `Quick, test_rgb_to_hex);

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -206,7 +206,11 @@ let test_border_side_color () =
        (css "border-l-red-500"));
   Alcotest.(check bool)
     "border-l-2 is still a width" true
-    (Astring.String.is_infix ~affix:"border-left-width: 2px" (css "border-l-2"))
+    (Astring.String.is_infix ~affix:"border-left-width: 2px" (css "border-l-2"));
+  Alcotest.(check bool)
+    "border-x-red-500 uses the logical inline color" true
+    (Astring.String.is_infix ~affix:"border-inline-color:"
+       (css "border-x-red-500"))
 
 (* Test suite *)
 let tests =


### PR DESCRIPTION
Per-side border colors were unknown classes — only the all-side `border-{color}` existed. A side-parameterised `Border_side_color` in the color handler now paints:

- physical edges `border-{t,r,b,l}-{color}` → `border-top/right/bottom/left-color`
- the inline axis `border-x-{color}` → `border-inline-color` (via the logical-border-color constructor)

for named (`border-l-red-500`), arbitrary (`border-l-[#575959]`) and keyword (`border-b-transparent`/`border-l-current`) colors. Border widths (`border-l-2`) still resolve via the borders handler.

`border-y-{color}` maps to `border-block-color`, for which cascade exposes no setter yet, so it stays unsupported (the only per-side colour gap).

Surfaced by `tw --diff` on the ocaml.org templates.