### PR TITLE
sizing: max-w-screen-* references the breakpoint token

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -304,6 +304,15 @@ module Handler = struct
   let container_5xl = Var.theme Css.Length "container-5xl" ~order:(5, 10)
   let container_6xl = Var.theme Css.Length "container-6xl" ~order:(5, 11)
   let container_7xl = Var.theme Css.Length "container-7xl" ~order:(5, 12)
+
+  (* Breakpoint theme vars, referenced by the (v3) max-w-screen-* utilities.
+     Negative suborders keep them before --container-* in the theme layer, as
+     Tailwind emits them. *)
+  let breakpoint_sm = Var.theme Css.Length "breakpoint-sm" ~order:(5, -5)
+  let breakpoint_md = Var.theme Css.Length "breakpoint-md" ~order:(5, -4)
+  let breakpoint_lg = Var.theme Css.Length "breakpoint-lg" ~order:(5, -3)
+  let breakpoint_xl = Var.theme Css.Length "breakpoint-xl" ~order:(5, -2)
+  let breakpoint_2xl = Var.theme Css.Length "breakpoint-2xl" ~order:(5, -1)
   let max_w_none' = style [ max_width None ]
 
   let max_w_xs' =
@@ -355,11 +364,16 @@ module Handler = struct
   let max_w_max' = style [ max_width Max_content ]
   let max_w_fit' = style [ max_width Fit_content ]
   let max_w_prose' = style [ max_width (Ch 65.0) ]
-  let max_w_screen_sm' = style [ max_width (Px 640.) ]
-  let max_w_screen_md' = style [ max_width (Px 768.) ]
-  let max_w_screen_lg' = style [ max_width (Px 1024.) ]
-  let max_w_screen_xl' = style [ max_width (Px 1280.) ]
-  let max_w_screen_2xl' = style [ max_width (Px 1536.) ]
+
+  let max_w_screen_of var rem =
+    let decl, r = Var.binding var (Rem rem : Css.length) in
+    style (decl :: [ max_width (Var r) ])
+
+  let max_w_screen_sm' = max_w_screen_of breakpoint_sm 40.
+  let max_w_screen_md' = max_w_screen_of breakpoint_md 48.
+  let max_w_screen_lg' = max_w_screen_of breakpoint_lg 64.
+  let max_w_screen_xl' = max_w_screen_of breakpoint_xl 80.
+  let max_w_screen_2xl' = max_w_screen_of breakpoint_2xl 96.
 
   (* Int-based max-width function for Tailwind scale (n * 0.25rem) *)
 

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -209,10 +209,22 @@ let test_general_fractions () =
   rejected "w-1/7";
   rejected "w-13/12"
 
+(* max-w-screen-* references the breakpoint theme var (like the v4 CLI), not an
+   inlined px. *)
+let test_max_w_screen () =
+  let xl = css_of "max-w-screen-xl" in
+  Alcotest.(check bool)
+    "max-w-screen-xl references --breakpoint-xl" true
+    (Astring.String.is_infix ~affix:"max-width: var(--breakpoint-xl)" xl);
+  Alcotest.(check bool)
+    "max-w-screen-xl defines --breakpoint-xl: 80rem" true
+    (Astring.String.is_infix ~affix:"--breakpoint-xl: 80rem" xl)
+
 let tests =
   [
     test_case "fractional spacing" `Quick test_fractional_spacing;
     test_case "general fractions" `Quick test_general_fractions;
+    test_case "max-w-screen breakpoint var" `Quick test_max_w_screen;
     test_case "widths" `Quick test_widths;
     test_case "heights" `Quick test_heights;
     test_case "min sizes" `Quick test_min_sizes;


### PR DESCRIPTION
`max-w-screen-{sm,md,lg,xl,2xl}` inlined a fixed px value, but Tailwind emits `max-width: var(--breakpoint-X)` and defines `--breakpoint-X` in the theme. This adds `--breakpoint-*` theme vars (40/48/64/80/96rem), ordered before `--container-*` to match the CLI's theme-layer order, and references them. Same rendered value (e.g. 80rem = 1280px); now byte-matches the CLI.

Surfaced by `tw --diff` on the ocaml.org templates (`max-w-screen-xl`).