### PR TITLE
merlint: forbid Fmt/Format/Printf in the core library

### DIFF
--- a/lib/merlint.toml
+++ b/lib/merlint.toml
@@ -1,0 +1,3 @@
+# Core library must not depend on Fmt/Format/Printf (JS bundle size);
+# use the Pp module. lib/tools is dev-only and exempt via its own merlint.toml.
+disallowed_modules = ["Fmt", "Format", "Printf"]

--- a/lib/tools/merlint.toml
+++ b/lib/tools/merlint.toml
@@ -1,0 +1,7 @@
+# tailwind_gen drives the reference tailwindcss CLI for differential tests; it
+# is dev-only (never in the JS bundle), so Fmt is fine there. Relax the lib/
+# disallowed_modules ban (E221) for that one file only -- every other file here
+# stays under the ban.
+[[rules]]
+files = ["tailwind_gen.ml"]
+exclude = ["E221"]


### PR DESCRIPTION
The core library compiles to JavaScript via js_of_ocaml, where `Fmt`/`Format`/`Printf` drag in heavy formatting machinery; the library uses string concatenation and the `Pp` module instead. This adds a `lib/merlint.toml` `disallowed_modules` ban (E221) to enforce it going forward, and a `lib/tools/merlint.toml` that relaxes the ban for `lib/tools` (dev-only CLI tooling, outside the JS bundle). The core library is already Fmt-free, so no code changes are needed.