### PR TITLE
tw: support the v4 trailing ! important form

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1077,7 +1077,7 @@ let has_pseudo_elements tw_classes =
     | Utility.Base _ -> false
     | Utility.Modified (modifier, u) -> has_pseudo modifier || check_utility u
     | Utility.Group us -> List.exists check_utility us
-    | Utility.Important u -> check_utility u
+    | Utility.Important (_, u) -> check_utility u
   in
   List.exists check_utility tw_classes
 

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -680,7 +680,7 @@ let rec has_responsive_modifier = function
   | Utility.Modified (Responsive _, _) -> true
   | Utility.Modified (_, t) -> has_responsive_modifier t
   | Utility.Group styles -> List.exists has_responsive_modifier styles
-  | Utility.Important t -> has_responsive_modifier t
+  | Utility.Important (_, t) -> has_responsive_modifier t
 
 (* Validate no nested responsive modifiers *)
 let validate_no_nested_responsive styles =

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -97,14 +97,16 @@ let split_whitespace s =
 (* Parse a single class string into a Tw.t *)
 let of_string class_str =
   let modifiers, base_class = modifiers_of_string class_str in
-  (* The [!] important marker sits right before the utility: [!flex],
-     [md:!flex]. (Tailwind v4's trailing form [flex!] keeps the suffix in the
-     selector, which would need form-preserving round-trips; not handled
-     yet.) *)
-  let important, base_class =
+  (* The [!] important marker sits right next to the utility: the v3 prefix
+     ([!flex], [md:!flex]) or the v4 trailing form ([flex!]). Each keeps its
+     form in the generated selector so it matches the source class. *)
+  let importance, base_class =
     let n = String.length base_class in
-    if n > 1 && base_class.[0] = '!' then (true, String.sub base_class 1 (n - 1))
-    else (false, base_class)
+    if n > 1 && base_class.[0] = '!' then
+      (`Prefix, String.sub base_class 1 (n - 1))
+    else if n > 1 && base_class.[n - 1] = '!' then
+      (`Suffix, String.sub base_class 0 (n - 1))
+    else (`None, base_class)
   in
   match Utility.base_of_class base_class with
   | Error _ -> Error (`Msg ("Unknown class: " ^ class_str))
@@ -113,7 +115,10 @@ let of_string class_str =
          responsive/state prefix stays outermost: md:!flex -> md:(!flex). *)
       let base_util = Utility.base base_utility in
       let base_util =
-        if important then Utility.important base_util else base_util
+        match importance with
+        | `Prefix -> Utility.important base_util
+        | `Suffix -> Utility.important ~suffix:true base_util
+        | `None -> base_util
       in
       match Modifiers.apply modifiers base_util with
       | Some u -> Ok u

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -6,10 +6,10 @@ type t =
   | Base of base
   | Modified of Style.modifier * t
   | Group of t list
-  | Important of t
+  | Important of bool * t  (** [bool] is [true] for the v4 trailing [!] form. *)
 
 let base x = Base x
-let important x = Important x
+let important ?(suffix = false) x = Important (suffix, x)
 
 module type Handler = sig
   type t
@@ -83,7 +83,7 @@ let rec to_style = function
   | Base u -> base_to_style u
   | Modified (m, u) -> Style.Modified (m, to_style u)
   | Group us -> Style.Group (List.map to_style us)
-  | Important u -> Style.map_important (to_style u)
+  | Important (_, u) -> Style.map_important (to_style u)
 
 let rec to_class = function
   | Base u -> class_of_base u
@@ -96,13 +96,14 @@ let rec to_class = function
             (List.map (fun item -> to_class (Modified (m, item))) us)
       | _ -> Style.pp_modifier m ^ ":" ^ to_class u)
   | Group us -> String.concat " " (List.map to_class us)
-  | Important u -> "!" ^ to_class u
+  | Important (suffix, u) ->
+      if suffix then to_class u ^ "!" else "!" ^ to_class u
 
 let rec pp = function
   | Base u -> "Base " ^ class_of_base u
   | Modified (m, u) -> "Modified (" ^ Style.pp_modifier m ^ ", " ^ pp u ^ ")"
   | Group us -> "Group [" ^ String.concat "; " (List.map pp us) ^ "]"
-  | Important u -> "Important (" ^ pp u ^ ")"
+  | Important (_, u) -> "Important (" ^ pp u ^ ")"
 
 let order (u : base) : int * int =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -61,14 +61,14 @@ type t =
   | Base of base
   | Modified of Style.modifier * t
   | Group of t list
-  | Important of t
+  | Important of bool * t  (** [bool] is [true] for the v4 trailing [!] form. *)
 
 val base : base -> t
 (** [base u] wraps a base utility into a Utility.t. *)
 
-val important : t -> t
-(** [important u] marks every declaration [u] emits as [!important] (the [!]
-    utility prefix). *)
+val important : ?suffix:bool -> t -> t
+(** [important ?suffix u] marks every declaration [u] emits as [!important]: the
+    [!] utility prefix, or the v4 trailing [!] form when [suffix] is [true]. *)
 
 val pp : t -> string
 (** [pp u] is a human-readable representation of [u] for debugging. *)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -306,6 +306,13 @@ let test_important_prefix () =
   | Ok u ->
       Alcotest.(check string) "md:!flex class round-trips" "md:!flex" (Tw.pp u)
   | Error (`Msg m) -> Alcotest.fail m);
+  (* v4 trailing form keeps the suffix in the class name *)
+  Alcotest.(check bool)
+    "flex! marks display important" true
+    (Astring.String.is_infix ~affix:"display:flex!important" (css "flex!"));
+  (match Tw.of_string "flex!" with
+  | Ok u -> Alcotest.(check string) "flex! class round-trips" "flex!" (Tw.pp u)
+  | Error (`Msg m) -> Alcotest.fail m);
   Alcotest.(check bool)
     "!p-4 leaves the --spacing theme token normal" false
     (Astring.String.is_infix ~affix:"--spacing:.25rem!important" (css "!p-4"))


### PR DESCRIPTION
The `!` important marker was only accepted as a prefix (`!flex`). Tailwind v4 writes it as a suffix (`flex!`), and the suffix has to be preserved in the generated selector so it matches the source class (`.flex\!` vs `.\!flex`). `Utility.Important` now carries the form, and `of_string` detects prefix vs suffix; `md:flex!` and the existing prefix forms keep working.