### PR TITLE
backgrounds: restore arbitrary rgb()/rgba() gradient stops (dropped by merge)

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -71,6 +71,8 @@ module Handler = struct
     | Gc_bracket_color_var_opacity of string * Color.opacity_modifier
     | Gc_bracket_var of string
     | Gc_bracket_var_opacity of string * Color.opacity_modifier
+    | Gc_bracket_color of string
+    | Gc_bracket_color_opacity of string * Color.opacity_modifier
 
   (* Gradient position source *)
   type gradient_position_source = Gp_pct of float | Gp_bracket of string
@@ -242,6 +244,9 @@ module Handler = struct
               "[color:" ^ v ^ "]" ^ opacity_suffix opacity
           | Gc_bracket_var v -> "[" ^ v ^ "]"
           | Gc_bracket_var_opacity (v, opacity) ->
+              "[" ^ v ^ "]" ^ opacity_suffix opacity
+          | Gc_bracket_color v -> "[" ^ v ^ "]"
+          | Gc_bracket_color_opacity (v, opacity) ->
               "[" ^ v ^ "]" ^ opacity_suffix opacity
         in
         prefix ^ color_class src
@@ -1246,6 +1251,10 @@ module Handler = struct
     | Gc_bracket_color_var v | Gc_bracket_color_var_opacity (v, _) ->
         color_var_ref v
     | Gc_bracket_var v | Gc_bracket_var_opacity (v, _) -> color_var_ref v
+    | Gc_bracket_color v | Gc_bracket_color_opacity (v, _) -> (
+        match Color.parse_bracket_color v with
+        | Some c -> c
+        | None -> Css.Transparent)
     | Gc_named _ | Gc_named_opacity _ -> assert false
 
   (** Extract opacity from a gradient_color_source, if present *)
@@ -1253,7 +1262,8 @@ module Handler = struct
     | Gc_current_opacity o
     | Gc_bracket_hex_opacity (_, o)
     | Gc_bracket_color_var_opacity (_, o)
-    | Gc_bracket_var_opacity (_, o) ->
+    | Gc_bracket_var_opacity (_, o)
+    | Gc_bracket_color_opacity (_, o) ->
         Some o
     | _ -> None
 
@@ -1544,6 +1554,8 @@ module Handler = struct
                    (String.sub inner 1 (String.length inner - 1), opacity))
             else if Parse.is_var inner then
               gc (Gc_bracket_var_opacity (inner, opacity))
+            else if Color.parse_bracket_color inner <> None then
+              gc (Gc_bracket_color_opacity (inner, opacity))
             else Error (`Msg "Invalid gradient bracket with opacity")
         | _ -> (
             (* Named color with opacity *)
@@ -1560,6 +1572,8 @@ module Handler = struct
         else if String.length inner > 0 && inner.[0] = '#' then
           gc (Gc_bracket_hex (String.sub inner 1 (String.length inner - 1)))
         else if Parse.is_var inner then gc (Gc_bracket_var inner)
+        else if Color.parse_bracket_color inner <> None then
+          gc (Gc_bracket_color inner)
         else gp (Gp_bracket inner)
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -100,10 +100,29 @@ let test_bg_arbitrary_url () =
       "bg-[url(/img/x.png)]";
     ]
 
+(* Arbitrary rgb()/rgba() gradient stops set the gradient colour rather than
+   being silently dropped as a position (they used to produce no
+   --tw-gradient-from). *)
+let test_gradient_rgba_stop () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  Alcotest.(check bool)
+    "from-[rgba(...)] sets --tw-gradient-from" true
+    (Astring.String.is_infix ~affix:"--tw-gradient-from"
+       (css_of "from-[rgba(5,74,218,0.60)]"));
+  Alcotest.(check bool)
+    "to-[rgb(...)] sets --tw-gradient-to" true
+    (Astring.String.is_infix ~affix:"--tw-gradient-to"
+       (css_of "to-[rgb(16,26,50,0.60)]"))
+
 let tests =
   [
     test_case "bg colors" `Quick test_bg_colors;
     test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
+    test_case "arbitrary rgba gradient stop" `Quick test_gradient_rgba_stop;
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
#35 shows merged but its code never reached `main` — same stacked-merge drop that hit #31/#32/#33/#34/#36. On current `main`, `from-[rgba(5,74,218,0.60)]` and `to-[rgb(...)]` produce no `--tw-gradient-from`/`--tw-gradient-to` (the only `Gc_bracket_color` symbols present are the pre-existing `Gc_bracket_color_var`). This re-applies #35's commit unchanged onto current main; `from-[rgba(...)]`/`to-[rgb(...)]` are clean against the CLI again. Full suite + upstream green.