### PR TITLE
flex: accept order-0

### DIFF
--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -277,7 +277,7 @@ module Handler = struct
           Ok (Order_arbitrary inner)
         else
           match int_of_string_opt value with
-          | Some n when n >= 1 -> Ok (Order n)
+          | Some n when n >= 0 -> Ok (Order n)
           | _ -> err_not_utility)
     | "" :: "order" :: rest when rest <> [] -> (
         (* Negative order: -order-4, -order-[var(--value)] *)

--- a/test/test_flex.ml
+++ b/test/test_flex.ml
@@ -64,7 +64,6 @@ let of_string_invalid () =
   fail_props [ "flex"; "invalid" ];
   fail_props [ "basis" ];
   fail_props [ "order" ];
-  fail_props [ "order"; "0" ];
   fail_props []
 
 let suborder_matches_tailwind () =

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -24,6 +24,7 @@ let of_string_valid () =
   check "basis-full";
 
   (* Order *)
+  check "order-0";
   check "order-1";
   check "order-2";
   check "order-3";
@@ -46,9 +47,6 @@ let of_string_invalid () =
   fail_maybe [ "basis" ];
   (* Missing value *)
   fail_maybe [ "order" ];
-  (* Missing value *)
-  fail_maybe [ "order"; "0" ];
-  (* Invalid - must be >= 1 *)
   fail_maybe []
 
 let suborder_matches_tailwind () =


### PR DESCRIPTION
`order-0` was rejected — the parser required the numeric order value to be `>= 1` (and a test asserted `order-0` invalid). Tailwind v4 generates `.order-0 { order: 0 }`, so accept 0 as well.

Surfaced by `tw --diff` on the ocaml.org templates (`.order-0`).