### PR TITLE
test: feed candidates to the tailwindcss CLI verbatim

### DIFF
--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -6,29 +6,14 @@ let write_file path content =
   close_out oc
 
 let tailwind_files ?(forms = false) temp_dir classnames =
-  (* Use single-quoted class attribute to allow double quotes inside arbitrary
-     variants (e.g., content-["→"]). Also escape any single quotes to HTML
-     entity to keep HTML valid. *)
-  let escape_single_quotes s =
-    let b = Buffer.create (String.length s) in
-    String.iter
-      (fun c ->
-        if c = '\'' then Buffer.add_string b "&#39;" else Buffer.add_char b c)
-      s;
-    Buffer.contents b
-  in
-  let classes = classnames |> String.concat " " |> escape_single_quotes in
-  let html_content =
-    Fmt.str
-      {|<!DOCTYPE html>
-<html>
-<head></head>
-<body>
-  <div class='%s'></div>
-</body>
-</html>|}
-      classes
-  in
+  (* Feed candidates to the extractor verbatim, space-separated, as raw file
+     text rather than inside an HTML class attribute. An attribute forces
+     escaping one quote style into an HTML entity, and Tailwind's extractor
+     reads that entity literally into the selector (e.g. bg-[url('x')] ->
+     .bg-\[url\(\&\#39\;x\&\#39\;\)\]), diverging from tw's selector. Raw text
+     preserves both single and double quotes exactly as a real source file
+     would, so arbitrary url() and content-["..."] values round-trip. *)
+  let html_content = String.concat " " classnames in
   let input_css_content =
     if forms then
       (* forms plugin with strategy: 'class' requires a config file *)

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -53,12 +53,46 @@ let test_arbitrary_color_opacity_matches_cli () =
   check_class "accent-[#0088cc]/50";
   check_class "accent-[#0088cc]/25"
 
+(* Regression: candidates are fed to the real CLI verbatim, not inside an
+   escaped HTML class attribute. The attribute forced single quotes to the HTML
+   entity [&#39;], which the extractor read literally into the selector
+   ([.bg-\[url\(\&\#39\;...\)\]]), diverging from tw's [.bg-\[url\(\'...\'\)\]].
+   Arbitrary url() values with single quotes must round-trip with no entity
+   mangling. Skips when tailwindcss is unavailable. *)
+let test_arbitrary_url_matches_cli () =
+  let cls = "bg-[url('/img/x.svg')]" in
+  try
+    let cli = generate ~minify:true ~optimize:true [ cls ] in
+    check bool
+      (cls ^ ": CLI reference is not HTML-entity mangled")
+      false
+      (Astring.String.is_infix ~affix:"&#39;" cli);
+    let tw =
+      match Tw.of_string cls with
+      | Ok u ->
+          Tw.to_css ~base:true [ u ]
+          |> Tw.Css.optimize ~prune_unused_custom_props:true
+          |> Tw.Css.to_string ~minify:true
+      | Error _ -> Alcotest.failf "tw could not parse %s" cls
+    in
+    let diff =
+      Cascade_diff.Css_compare.diff ~mode:`Canonical
+        ~prune_unused_custom_props:true cli tw
+    in
+    match diff.Cascade_diff.Css_compare.result with
+    | Cascade_diff.Css_compare.No_diff _ ->
+        check bool (cls ^ ": tw matches live Tailwind CLI") true true
+    | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
+  with Failure _ -> check bool "skipped (tailwindcss unavailable)" true true
+
 let tests =
   [
     test_case "check tailwindcss available" `Quick test_check_available;
     test_case "generate simple CSS" `Quick test_generate_simple;
     test_case "arbitrary colour opacity matches live CLI" `Quick
       test_arbitrary_color_opacity_matches_cli;
+    test_case "arbitrary url() round-trips through the CLI harness" `Quick
+      test_arbitrary_url_matches_cli;
   ]
 
 let suite = ("tailwind_gen", tests)


### PR DESCRIPTION
This PR changes the parity diff harness to write candidate classes as raw, space-separated file text instead of wrapping them in a single-quoted HTML class attribute.

The attribute form escaped `'` to the HTML entity `&#39;` to keep the markup valid, and the tailwindcss extractor then read `&#39;` literally into the generated selector. An arbitrary value such as `bg-[url('x')]` therefore produced `.bg-[url(&#39;x&#39;)]` on the reference side while tw emitted `.bg-[url('x')]` from the source's literal quote, a spurious parity difference on every arbitrary `url()` (and any single-quoted arbitrary value). Raw text preserves both single and double quotes verbatim, so these values now round-trip. The added test asserts the reference CSS is no longer entity-mangled and that tw matches the live CLI.