### PR TITLE
gap: order space-reverse @property vars after transforms

### DIFF
--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -25,16 +25,18 @@ module Handler = struct
   let name = "gap"
   let priority = 17
 
-  (** Space reverse variables for flex-reverse support. Property order -1
-      ensures these come FIRST in {i \@layer properties} (Tailwind places them
-      before --tw-border-style). *)
+  (* Space reverse variables for flex-reverse support. Property order 2/3 places
+     these after the transform group but before --tw-divide-*-reverse (4/5) and
+     --tw-border-style (6), matching Tailwind's @layer properties order. Like
+     divide, they must use ~family:`Border so they sort with that group by
+     property_order rather than being pushed to family-order. *)
   let space_x_reverse_var =
     Var.property_default Css.Number_percentage ~initial:(Css.Num 0.0)
-      ~property_order:(-2) "tw-space-x-reverse"
+      ~property_order:2 ~family:`Border "tw-space-x-reverse"
 
   let space_y_reverse_var =
     Var.property_default Css.Number_percentage ~initial:(Css.Num 0.0)
-      ~property_order:(-1) "tw-space-y-reverse"
+      ~property_order:3 ~family:`Border "tw-space-y-reverse"
 
   (** {2 Typed Gap Utilities} *)
 

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -259,6 +259,26 @@ let check_property_rules_order () =
   in
   check bool "@property after utilities" true (first_prop_idx > util_idx)
 
+(* Regression: --tw-space-y-reverse must sort AFTER the transform group in
+   @property, matching Tailwind (which places it after --tw-translate-* and
+   before --tw-border-style). It previously carried a negative property_order
+   with no family, which forced it ahead of the transforms. *)
+let check_space_reverse_after_transforms () =
+  let sheet =
+    Tw.to_css ~base:false ~layers:true [ Tw.translate_x 4; Tw.space_y 4. ]
+  in
+  let names = property_rule_names sheet in
+  let index_of n =
+    let rec loop i = function
+      | [] -> fail (n ^ " missing from @property rules")
+      | x :: _ when x = n -> i
+      | _ :: t -> loop (i + 1) t
+    in
+    loop 0 names
+  in
+  check bool "--tw-translate-x before --tw-space-y-reverse" true
+    (index_of "--tw-translate-x" < index_of "--tw-space-y-reverse")
+
 let test_resolve_dependencies () =
   (* Dependency resolution is now handled automatically by
      Css.vars_of_declarations This test is kept for compatibility but
@@ -741,6 +761,8 @@ let tests =
     test_case "properties layer internal order" `Quick
       check_properties_layer_internal_order;
     test_case "@property trailing and order" `Quick check_property_rules_order;
+    test_case "@property space-reverse after transforms" `Quick
+      check_space_reverse_after_transforms;
     test_case "resolve_dependencies" `Quick test_resolve_dependencies;
     test_case "inline_no_var_in_css_for_defaults" `Quick
       test_inline_no_vars_defaults;


### PR DESCRIPTION
This PR fixes the ordering of the `--tw-space-x-reverse` and `--tw-space-y-reverse` rules in `@layer properties` / `@property` so it matches Tailwind v4.

The two variables carried a negative `property_order` with no family, which the property sorter treats as "sort before everything", so they landed ahead of the entire transform group. Tailwind places them after the transforms and before `--tw-border-style`. They now use the `Border` family with a positive `property_order` below `--tw-divide-*-reverse`, mirroring the existing divide-reverse variables. On the in-repo `examples/` corpus this removes 12 of the 14 `@property` reorderings.

A residual `space`+`divide` edge remains (both live in the `Border` family, which sorts by first-usage, and the `space-y` utility currently sorts after `divide-y` in the utilities layer); that is a separate utilities-priority issue, tracked for follow-up.