### PR TITLE
typography: don't register @property --tw-content for content-none

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -925,7 +925,12 @@ let collect_all_property_rules vars_from_utilities set_var_names
     vars_needing_property vars_from_utilities
     |> List.filter (fun (Css.V v) ->
         let var_name = "--" ^ Css.var_name v in
-        Strings.mem var_name set_names_set)
+        (* --tw-content is special: Tailwind emits @property --tw-content (and
+           its universal seed) only for before/after pseudo-elements, never for
+           the content-* utilities that merely set the variable. The pseudo path
+           adds it explicitly via has_pseudo_elements, so exclude it from the
+           set-based auto-collection here. *)
+        var_name <> "--tw-content" && Strings.mem var_name set_names_set)
   in
   let explicit_names = property_names_of explicit_property_rules_statements in
   let generated_rules = property_rules_for needing_property explicit_names in

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2407,10 +2407,14 @@ module Typography_late = struct
             overflow Visible;
           ]
 
+  (* content-none sets --tw-content: none and uses a literal [content: none], so
+     it never references var(--tw-content) and Tailwind emits no @property rule
+     for it (unlike the value/theme variants below, which do reference the var).
+     The set-based auto-collection is suppressed for --tw-content in
+     build.ml. *)
   let content_none =
     let content_decl, _content_ref = Var.binding content_var None in
-    let property_rules = Var.property_rules content_var in
-    style ~property_rules [ content_decl; content None ]
+    style [ content_decl; content None ]
 
   let content s =
     (* Convert underscores to spaces in content values *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -279,6 +279,23 @@ let check_space_reverse_after_transforms () =
   check bool "--tw-translate-x before --tw-space-y-reverse" true
     (index_of "--tw-translate-x" < index_of "--tw-space-y-reverse")
 
+(* Regression: content-none uses a literal [content: none] and must NOT register
+   @property --tw-content, matching Tailwind (which emits it only for content
+   utilities that reference var(--tw-content), and for before/after
+   pseudo-elements). The value variant content-["x"] does reference the var and
+   keeps the @property rule. *)
+let check_content_none_no_property () =
+  let none_names =
+    property_rule_names (Tw.to_css ~base:false ~layers:true [ Tw.content_none ])
+  in
+  check bool "content-none emits no @property --tw-content" false
+    (List.mem "--tw-content" none_names);
+  let value_names =
+    property_rule_names (Tw.to_css ~base:false ~layers:true [ Tw.content "x" ])
+  in
+  check bool "content value keeps @property --tw-content" true
+    (List.mem "--tw-content" value_names)
+
 let test_resolve_dependencies () =
   (* Dependency resolution is now handled automatically by
      Css.vars_of_declarations This test is kept for compatibility but
@@ -763,6 +780,8 @@ let tests =
     test_case "@property trailing and order" `Quick check_property_rules_order;
     test_case "@property space-reverse after transforms" `Quick
       check_space_reverse_after_transforms;
+    test_case "content-none emits no @property --tw-content" `Quick
+      check_content_none_no_property;
     test_case "resolve_dependencies" `Quick test_resolve_dependencies;
     test_case "inline_no_var_in_css_for_defaults" `Quick
       test_inline_no_vars_defaults;


### PR DESCRIPTION
This PR stops tw from registering `@property --tw-content` (and the universal `--tw-content: ""` seed) for `content-none`.

`content-none` emits a literal `content: none` and never references `var(--tw-content)`, so Tailwind registers no `@property` rule for it. tw treated `content_var` as an ordinary set `property_default` and emitted the rule plus the universal seed, diverging on any sheet using `content-none`. The value and theme content utilities (`content-["x"]`, `content-slash`, …) do reference `var(--tw-content)` and keep their `@property` rule, and `before:`/`after:` pseudo-elements still get it via the rule builder, both verified against the live CLI.