### PR TITLE
sizing: inline aspect-square's 1/1 ratio

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -441,14 +441,11 @@ module Handler = struct
   let aspect_auto' = style [ Css.aspect_ratio Auto ]
 
   (* Theme variables for aspect ratios *)
-  let aspect_square_var =
-    Var.theme Css.Aspect_ratio "aspect-square" ~order:(4, 0)
-
   let aspect_video_var = Var.theme Css.Aspect_ratio "aspect-video" ~order:(4, 1)
 
-  let aspect_square' =
-    let decl, r = Var.binding aspect_square_var (Ratio (1., 1.)) in
-    style (decl :: [ Css.aspect_ratio (Var r) ])
+  (* aspect-square inlines the 1/1 ratio in v4 (no --aspect-square theme token),
+     unlike aspect-video which references the --aspect-video token. *)
+  let aspect_square' = style [ Css.aspect_ratio (Ratio (1., 1.)) ]
 
   let aspect_video' =
     let decl, r = Var.binding aspect_video_var (Ratio (16., 9.)) in

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -106,6 +106,18 @@ let test_aspect_css () =
   Alcotest.check bool "has 16/9" true
     (Astring.String.is_infix ~affix:"16/9" css)
 
+(* aspect-square inlines the 1/1 ratio in v4; it used to emit aspect-ratio:
+   var(--aspect-square) with a stray --aspect-square theme token that bare
+   Tailwind does not define. *)
+let test_aspect_square_inlined () =
+  let css = Tw.(to_css [ aspect_square ]) |> Tw.Css.pp ~minify:true in
+  Alcotest.check bool "aspect-square inlines the ratio" true
+    (Astring.String.is_infix ~affix:"aspect-ratio:1" css);
+  Alcotest.check bool "aspect-square references no var" false
+    (Astring.String.is_infix ~affix:"var(--aspect-square)" css);
+  Alcotest.check bool "aspect-square emits no --aspect-square token" false
+    (Astring.String.is_infix ~affix:"--aspect-square" css)
+
 (** Test that the programmatic API generates correct class names *)
 let test_class_generation () =
   let open Tw in
@@ -233,6 +245,7 @@ let tests =
     test_case "sizing of_string - invalid values" `Quick of_string_invalid;
     test_case "aspect classes" `Quick test_aspect_classes;
     test_case "aspect css" `Quick test_aspect_css;
+    test_case "aspect-square inlined 1/1" `Quick test_aspect_square_inlined;
     test_case "class generation" `Quick test_class_generation;
     test_case "sizing suborder matches Tailwind" `Quick
       suborder_matches_tailwind;


### PR DESCRIPTION
This PR makes `aspect-square` emit `aspect-ratio: 1 / 1` inline instead of `aspect-ratio: var(--aspect-square)`.

tw defined a `--aspect-square` theme token and referenced it, but Tailwind v4 inlines the `1 / 1` ratio for `aspect-square` and defines no such token (only `aspect-video` keeps a theme variable). The stray token also showed up in the theme layer. The ratio is now inlined and the unused token dropped; `aspect-video` is unchanged.