### PR TITLE
grid: support repeat()/minmax()/fit-content() in arbitrary templates

### DIFF
--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -20,8 +20,8 @@ module Css = Cascade.Css
 module Handler = struct
   open Style
 
-  (* Bind tw's [Pp.float : float -> string] before [open Css] shadows [Pp]
-     with cascade's context-based [Css.Pp]. *)
+  (* Bind tw's [Pp.float : float -> string] before [open Css] shadows [Pp] with
+     cascade's context-based [Css.Pp]. *)
   let pp_float = Pp.float
 
   open Css
@@ -121,39 +121,123 @@ module Handler = struct
       | Some n -> Some (Px (float_of_int n))
       | None -> None
 
-  let parse_single_track value : Css.grid_template option =
-    match parse_arbitrary_length value with
-    | Some (Px n) -> Some (Px n)
-    | Some (Rem n) -> Some (Rem n)
-    | Some (Em n) -> Some (Em n)
-    | Some (Pct n) -> Some (Pct n)
-    | Some (Vw n) -> Some (Vw n)
-    | Some (Vh n) -> Some (Vh n)
-    | Some _ -> None
-    | None ->
-        let len = String.length value in
-        if len >= 2 && String.sub value (len - 2) 2 = "fr" then
-          match float_of_string_opt (String.sub value 0 (len - 2)) with
-          | Some n -> Some (Fr n)
-          | None -> None
-        else if value = "auto" then Some Auto
-        else if value = "min-content" then Some Min_content
-        else if value = "max-content" then Some Max_content
-        else None
+  let rec all_some = function
+    | [] -> Some []
+    | x :: xs -> (
+        match (x, all_some xs) with
+        | Some v, Some vs -> Some (v :: vs)
+        | _ -> None)
+
+  (* Split [s] on [sep] only at the top nesting level, so separators inside
+     repeat()/minmax()/fit-content() are preserved. *)
+  let split_top_level sep s =
+    let len = String.length s in
+    let buf = Buffer.create len in
+    let rec loop i depth acc =
+      if i >= len then List.rev (Buffer.contents buf :: acc)
+      else
+        let c = s.[i] in
+        if c = '(' then (
+          Buffer.add_char buf c;
+          loop (i + 1) (depth + 1) acc)
+        else if c = ')' then (
+          Buffer.add_char buf c;
+          loop (i + 1) (max 0 (depth - 1)) acc)
+        else if c = sep && depth = 0 then (
+          let part = Buffer.contents buf in
+          Buffer.clear buf;
+          loop (i + 1) depth (part :: acc))
+        else (
+          Buffer.add_char buf c;
+          loop (i + 1) depth acc)
+    in
+    loop 0 0 []
+
+  (* If [value] is [name(...)], return the inner argument string. *)
+  let fn_args name value =
+    let nl = String.length name and vl = String.length value in
+    if
+      vl > nl + 1
+      && String.sub value 0 nl = name
+      && value.[nl] = '('
+      && value.[vl - 1] = ')'
+    then Some (String.sub value (nl + 1) (vl - nl - 2))
+    else None
+
+  let parse_track_keyword value : Css.grid_template option =
+    (* Unitless zero stays bare (minmax(0,1fr)), not 0px. *)
+    if value = "0" then Some Css.Zero
+    else
+      match parse_arbitrary_length value with
+      | Some (Px n) -> Some (Px n)
+      | Some (Rem n) -> Some (Rem n)
+      | Some (Em n) -> Some (Em n)
+      | Some (Pct n) -> Some (Pct n)
+      | Some (Vw n) -> Some (Vw n)
+      | Some (Vh n) -> Some (Vh n)
+      | Some _ -> None
+      | None ->
+          let len = String.length value in
+          if len >= 2 && String.sub value (len - 2) 2 = "fr" then
+            match float_of_string_opt (String.sub value 0 (len - 2)) with
+            | Some n -> Some (Fr n)
+            | None -> None
+          else if value = "auto" then Some Auto
+          else if value = "min-content" then Some Min_content
+          else if value = "max-content" then Some Max_content
+          else None
+
+  (* A single grid track: a length/keyword, or one of the grid functions
+     minmax()/fit-content()/repeat() (which may nest). *)
+  let rec parse_single_track value : Css.grid_template option =
+    match fn_args "minmax" value with
+    | Some inner -> (
+        match List.map String.trim (split_top_level ',' inner) with
+        | [ a; b ] -> (
+            match (parse_single_track a, parse_single_track b) with
+            | Some ta, Some tb -> Some (Css.Min_max (ta, tb))
+            | _ -> None)
+        | _ -> None)
+    | None -> (
+        match fn_args "fit-content" value with
+        | Some inner -> (
+            match parse_arbitrary_length (String.trim inner) with
+            | Some l -> Some (Css.Fit_content l)
+            | None -> None)
+        | None -> (
+            match fn_args "repeat" value with
+            | Some inner -> parse_repeat inner
+            | None -> parse_track_keyword value))
+
+  and parse_repeat inner =
+    match split_top_level ',' inner with
+    | count_s :: rest when rest <> [] -> (
+        let count =
+          match String.trim count_s with
+          | "auto-fill" -> Some Css.Auto_fill
+          | "auto-fit" -> Some Css.Auto_fit
+          | n -> (
+              match int_of_string_opt n with
+              | Some i -> Some (Css.Count i)
+              | None -> None)
+        in
+        (* The track list after the count is space-separated (underscores in the
+           bracket); commas only separated count from the list. *)
+        let tracks =
+          String.concat "," rest |> split_top_level '_'
+          |> List.filter (fun s -> s <> "")
+          |> List.map String.trim
+        in
+        match (count, all_some (List.map parse_single_track tracks)) with
+        | Some c, Some ts -> Some (Css.Repeat (c, ts))
+        | _ -> None)
+    | _ -> None
 
   let parse_arbitrary_grid_template s : Css.grid_template option =
     let value = String.trim s in
-    (* Tailwind converts underscores to spaces in bracket values *)
-    let parts =
-      String.split_on_char '_' value |> List.filter (fun s -> s <> "")
-    in
-    let rec all_some = function
-      | [] -> Some []
-      | x :: xs -> (
-          match (x, all_some xs) with
-          | Some v, Some vs -> Some (v :: vs)
-          | _ -> None)
-    in
+    (* Underscores are spaces in bracket values; split tracks at the top level
+       so functions like repeat(2,1fr_2fr) keep their inner underscores. *)
+    let parts = split_top_level '_' value |> List.filter (fun s -> s <> "") in
     match parts with
     | [] -> None
     | [ single ] -> parse_single_track single

--- a/test/test_grid_template.ml
+++ b/test/test_grid_template.ml
@@ -50,7 +50,16 @@ let of_string_valid () =
   check "grid-cols-[auto_1fr_auto]";
   check "grid-rows-[min-content_1fr_max-content]";
   check "auto-cols-[50%]";
-  check "auto-rows-[1.5rem]"
+  check "auto-rows-[1.5rem]";
+
+  (* Arbitrary grid functions: repeat()/minmax()/fit-content(), incl. nesting
+     and auto-fill/auto-fit (used to be rejected as unknown classes). *)
+  check "grid-cols-[minmax(0,1fr)]";
+  check "grid-cols-[repeat(3,minmax(0,1fr))]";
+  check "grid-cols-[repeat(2,1fr_2fr)]";
+  check "grid-cols-[repeat(auto-fill,minmax(0,1fr))]";
+  check "grid-cols-[fit-content(200px)]";
+  check "grid-rows-[repeat(4,minmax(100px,auto))]"
 
 let of_string_invalid () =
   let fail_maybe input =
@@ -110,6 +119,27 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"grid_template suborder matches Tailwind" shuffled
 
+(* Arbitrary grid functions emit their values verbatim, including bare 0 inside
+   minmax (not 0px) and nested repeat()/minmax(). *)
+let test_grid_functions_css () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " contains " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "grid-cols-[repeat(3,minmax(0,1fr))]"
+    "grid-template-columns:repeat(3,minmax(0,1fr))";
+  has "grid-rows-[repeat(4,minmax(100px,auto))]"
+    "grid-template-rows:repeat(4,minmax(100px,auto))";
+  has "grid-cols-[fit-content(200px)]"
+    "grid-template-columns:fit-content(200px)"
+
 let tests =
   [
     test_case "grid_template of_string - valid values" `Quick of_string_valid;
@@ -117,6 +147,8 @@ let tests =
       of_string_invalid;
     test_case "grid_template suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "grid_template arbitrary functions css" `Quick
+      test_grid_functions_css;
   ]
 
 let suite = ("grid_template", tests)


### PR DESCRIPTION
This PR adds support for the grid functions `repeat()`, `minmax()` and `fit-content()` in arbitrary grid-template utilities (`grid-cols-[...]`, `grid-rows-[...]`).

Classes like `grid-cols-[repeat(3,minmax(0,1fr))]` were rejected as unknown: the track parser only understood lengths, `fr`, `auto` and the `*-content` keywords, and the top-level track split broke on commas/underscores inside function calls. Tracks are now split paren-aware, and the three functions (which may nest, e.g. `repeat(auto-fill,minmax(0,1fr))`) parse into the existing typed `grid_template` constructors. A bare `0` inside `minmax` stays `0` rather than becoming `0px`, matching the v4 CLI.