### PR TITLE
text-shadow: correct the size scale to v4.3.1 values

### DIFF
--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -130,16 +130,29 @@ module Handler = struct
 
   let shape_shadows (shape : shape) :
       (length * length * length option * string) list =
+    (* Values match Tailwind v4.3.1: 2xs/xs are single shadows, sm/md/lg are
+       three-shadow stacks. Alpha hex: .15=#26, .2=#33, .075=#13, .1=#1a. *)
     match shape with
-    | S_2xs -> [ ((Px 0. : length), Px 1., Some (Px 0.), "#0000001a") ]
-    | S_xs -> [ ((Px 0. : length), Px 1., Some (Px 1.), "#0000001a") ]
+    | S_2xs -> [ ((Px 0. : length), Px 1., Some (Px 0.), "#00000026") ]
+    | S_xs -> [ ((Px 0. : length), Px 1., Some (Px 1.), "#00000033") ]
     | S_sm ->
         [
-          ((Px 0. : length), Px 1., Some (Px 2.), "#0000000f");
-          (Px 0., Px 2., Some (Px 2.), "#0000000f");
+          ((Px 0. : length), Px 1., Some (Px 0.), "#00000013");
+          (Px 0., Px 1., Some (Px 1.), "#00000013");
+          (Px 0., Px 2., Some (Px 2.), "#00000013");
         ]
-    | S_md -> [ ((Px 0. : length), Px 2., Some (Px 4.), "#0000001a") ]
-    | S_lg -> [ ((Px 0. : length), Px 4., Some (Px 8.), "#0000001a") ]
+    | S_md ->
+        [
+          ((Px 0. : length), Px 1., Some (Px 1.), "#0000001a");
+          (Px 0., Px 1., Some (Px 2.), "#0000001a");
+          (Px 0., Px 2., Some (Px 4.), "#0000001a");
+        ]
+    | S_lg ->
+        [
+          ((Px 0. : length), Px 1., Some (Px 2.), "#0000001a");
+          (Px 0., Px 3., Some (Px 2.), "#0000001a");
+          (Px 0., Px 4., Some (Px 8.), "#0000001a");
+        ]
 
   let shape_text_shadow shape =
     let shadows = shape_shadows shape in
@@ -520,7 +533,7 @@ module Handler = struct
     let parts = Parse.split_class class_name in
     match parts with
     | [ "text"; "shadow"; "none" ] -> Ok Text_shadow_none
-    | [ "text"; "shadow" ] -> Ok (Text_shadow_shape S_md)
+    (* Tailwind v4 has no bare [text-shadow]; sizes are 2xs..lg. *)
     | [ "text"; "shadow"; size_str ] -> (
         let base, opacity = Color.parse_opacity_modifier size_str in
         let shape_opt =
@@ -583,20 +596,14 @@ module Handler = struct
     | S_2xs -> "2xs"
     | S_xs -> "xs"
     | S_sm -> "sm"
-    | S_md -> ""
+    | S_md -> "md"
     | S_lg -> "lg"
 
   let to_class = function
     | Text_shadow_none -> "text-shadow-none"
-    | Text_shadow_shape S_md -> "text-shadow"
     | Text_shadow_shape shape -> "text-shadow-" ^ shape_to_string shape
     | Text_shadow_shape_opacity (shape, opacity) ->
-        let base =
-          match shape with
-          | S_md -> "text-shadow"
-          | _ -> "text-shadow-" ^ shape_to_string shape
-        in
-        base ^ "/" ^ Color.pp_opacity opacity
+        "text-shadow-" ^ shape_to_string shape ^ "/" ^ Color.pp_opacity opacity
     | Text_shadow_color (c, shade) ->
         "text-shadow-" ^ Color.color_to_string c
         ^ if Color.is_shadeless c then "" else "-" ^ string_of_int shade

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -5,15 +5,36 @@ let test_roundtrip () =
   check "text-shadow-2xs";
   check "text-shadow-xs";
   check "text-shadow-sm";
-  check "text-shadow";
-  check "text-shadow-lg"
+  check "text-shadow-md";
+  check "text-shadow-lg";
+  check "text-shadow-md/50"
 
 let test_invalid () =
-  Test_helpers.check_invalid_input
-    (module Tw.Text_shadow.Handler)
-    "text-shadow-foo"
+  let bad = Test_helpers.check_invalid_input (module Tw.Text_shadow.Handler) in
+  bad "text-shadow-foo";
+  (* Tailwind v4 has no bare text-shadow (sizes are 2xs..lg). *)
+  bad "text-shadow"
+
+(* The sm/md/lg sizes are three-shadow stacks in v4.3.1: md = 0 1px 1px, 0 1px
+   2px, 0 2px 4px at alpha .1 (#0000001a). *)
+let test_md_three_shadows () =
+  let css =
+    match Tw.of_string "text-shadow-md" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.fail "could not parse text-shadow-md"
+  in
+  Alcotest.(check bool)
+    "text-shadow-md has the deepest 2px 4px shadow" true
+    (Astring.String.is_infix ~affix:"2px 4px" css);
+  Alcotest.(check bool)
+    "text-shadow-md is a multi-shadow stack" true
+    (Astring.String.is_infix ~affix:"1px 2px" css)
 
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "text-shadow-md three shadows" `Quick
+        test_md_three_shadows;
+    ]
 
 let suite = ("text_shadow", tests)

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -19832,11 +19832,11 @@ text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#008
 
     .text-shadow-sm\/25 {
       --tw-text-shadow-alpha: 25%;
-      text-shadow: 0px 1px 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .25)), 0px 2px 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .25));
+      text-shadow: 0px 1px 0px var(--tw-text-shadow-color, oklab(0% 0 0 / .25)), 0px 1px 1px var(--tw-text-shadow-color, oklab(0% 0 0 / .25)), 0px 2px 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .25));
     }
 
     .text-shadow-2xs {
-      text-shadow: 0px 1px 0px var(--tw-text-shadow-color, #0000001a);
+      text-shadow: 0px 1px 0px var(--tw-text-shadow-color, #00000026);
     }
 
     .text-shadow-\[\#0088cc\] {
@@ -20054,7 +20054,7 @@ text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#008
     }
 
     .text-shadow-sm {
-      text-shadow: 0px 1px 2px var(--tw-text-shadow-color, #0000000f), 0px 2px 2px var(--tw-text-shadow-color, #0000000f);
+      text-shadow: 0px 1px 0px var(--tw-text-shadow-color, #00000013), 0px 1px 1px var(--tw-text-shadow-color, #00000013), 0px 2px 2px var(--tw-text-shadow-color, #00000013);
     }
 
     .text-shadow-transparent {


### PR DESCRIPTION
This PR corrects the `text-shadow-*` size scale to match Tailwind v4.3.1.

The sizes emitted wrong values: `sm`/`md`/`lg` are three-shadow stacks in v4 but tw emitted one or two shadows with the wrong offsets, and every alpha was off (correct: 2xs=.15, xs=.2, sm=.075, md/lg=.1). tw also accepted a bare `text-shadow` (aliased to `md`) that v4 does not define, and rendered `md`'s class as `.text-shadow` instead of `.text-shadow-md`. The scale now matches the CLI for every size, including the `/<opacity>` variants; the bare utility is dropped and the `md` class name fixed.