### PR TITLE
backgrounds: register full gradient @property family for stop positions

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1193,8 +1193,17 @@ module Handler = struct
     | Gradient_to -> ("to-", gradient_to_var, gradient_to_position_var)
 
   (* Shared @property rules for gradient positions *)
+  (* A gradient stop-position utility (from-10% etc.) registers the whole
+     --tw-gradient-* @property family, like the colour utilities do, matching
+     Tailwind (which declares the gradient properties as a unit). *)
   let gradient_position_property_rules () =
     [
+      Var.property_rule gradient_position_var;
+      Var.property_rule gradient_from_var;
+      Var.property_rule gradient_via_var;
+      Var.property_rule gradient_to_var;
+      Var.property_rule gradient_stops_var;
+      Var.property_rule gradient_via_stops_var;
       Var.property_rule gradient_from_position_var;
       Var.property_rule gradient_via_position_var;
       Var.property_rule gradient_to_position_var;

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -118,11 +118,32 @@ let test_gradient_rgba_stop () =
     (Astring.String.is_infix ~affix:"--tw-gradient-to"
        (css_of "to-[rgb(16,26,50,0.60)]"))
 
+(* A gradient stop-position utility (from-10%) registers the whole
+   --tw-gradient-* @property family, like the colour utilities, matching the
+   CLI. It used to register only the three *-position properties. *)
+let test_gradient_stop_position_properties () =
+  let css =
+    match Tw.of_string "from-10%" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.fail "could not parse from-10%"
+  in
+  Alcotest.(check bool)
+    "from-10% sets --tw-gradient-from-position" true
+    (Astring.String.is_infix ~affix:"--tw-gradient-from-position: 10%" css);
+  Alcotest.(check bool)
+    "from-10% registers @property --tw-gradient-from" true
+    (Astring.String.is_infix ~affix:"@property --tw-gradient-from" css);
+  Alcotest.(check bool)
+    "from-10% registers @property --tw-gradient-stops" true
+    (Astring.String.is_infix ~affix:"@property --tw-gradient-stops" css)
+
 let tests =
   [
     test_case "bg colors" `Quick test_bg_colors;
     test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
     test_case "arbitrary rgba gradient stop" `Quick test_gradient_rgba_stop;
+    test_case "gradient stop-position @property family" `Quick
+      test_gradient_stop_position_properties;
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
This PR makes gradient stop-position utilities (`from-10%`, `via-30%`, `to-90%`) register the whole `--tw-gradient-*` `@property` family, matching the colour utilities and the v4 CLI.

A stop-position utility only registered the three `*-position` `@property` rules, so its output was missing `@property --tw-gradient-from/via/to/stops/via-stops/position` that Tailwind emits for any gradient utility. The position path now registers the full family (the stop value itself was already correct).