### PR TITLE
utilities: accept more arbitrary values (outline-offset, columns, delay)

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -256,6 +256,7 @@ module Handler = struct
     | Outline_offset_4
     | Outline_offset_8
     | Outline_offset_var of string (* outline-offset-[var(--value)] *)
+    | Outline_offset_arbitrary of string (* outline-offset-[3px] *)
     | Neg_outline_offset_1
     | Neg_outline_offset_2
     | Neg_outline_offset_4
@@ -1746,6 +1747,10 @@ module Handler = struct
     | Outline_offset_4 -> outline_offset_4
     | Outline_offset_8 -> outline_offset_8
     | Outline_offset_var v -> outline_offset_var_style v
+    | Outline_offset_arbitrary v -> (
+        match parse_length v with
+        | Some l -> style [ Css.outline_offset l ]
+        | None -> style [ Css.outline_offset (Px 0.) ])
     | Neg_outline_offset_1 -> neg_outline_offset_1
     | Neg_outline_offset_2 -> neg_outline_offset_2
     | Neg_outline_offset_4 -> neg_outline_offset_4
@@ -1897,6 +1902,7 @@ module Handler = struct
     | Outline_offset_4 -> 2213
     | Outline_offset_8 -> 2214
     | Outline_offset_var _ -> 2215
+    | Outline_offset_arbitrary _ -> 2215
 
   let of_class class_name =
     let parts = Parse.split_class class_name in
@@ -2154,6 +2160,8 @@ module Handler = struct
     | [ "outline"; "offset"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         if Parse.is_var inner then Ok (Outline_offset_var inner)
+        else if parse_length inner <> None then
+          Ok (Outline_offset_arbitrary inner)
         else err_not_utility
     | [ "outline"; "offset"; "0" ] -> Ok Outline_offset_0
     | [ "outline"; "offset"; "1" ] -> Ok Outline_offset_1
@@ -2396,6 +2404,7 @@ module Handler = struct
     | Outline_offset_4 -> "outline-offset-4"
     | Outline_offset_8 -> "outline-offset-8"
     | Outline_offset_var v -> "outline-offset-[" ^ v ^ "]"
+    | Outline_offset_arbitrary v -> "outline-offset-[" ^ v ^ "]"
     | Neg_outline_offset_1 -> "-outline-offset-1"
     | Neg_outline_offset_2 -> "-outline-offset-2"
     | Neg_outline_offset_4 -> "-outline-offset-4"

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -26,6 +26,7 @@ module Handler = struct
     | Columns_6xl
     | Columns_7xl
     | Columns_arbitrary of int
+    | Columns_arbitrary_len of string (* columns-[16rem] *)
     | Columns_bracket_var of string
 
   type Utility.base += Self of t
@@ -38,6 +39,26 @@ module Handler = struct
   let columns_with_var var default_value =
     let decl, ref_ = Var.binding var default_value in
     style [ decl; columns (Width (Var ref_)) ]
+
+  (* Parse an arbitrary column width (columns-[16rem]). *)
+  let parse_columns_length str : Css.length option =
+    let len = String.length str in
+    let drop n = float_of_string_opt (String.sub str 0 (len - n)) in
+    let map (f : float -> Css.length) = function
+      | Some n -> Some (f n)
+      | None -> None
+    in
+    if len > 3 && String.sub str (len - 3) 3 = "rem" then
+      map (fun n -> Css.Rem n) (drop 3)
+    else if len > 2 && String.sub str (len - 2) 2 = "px" then
+      map (fun n -> Css.Px n) (drop 2)
+    else if len > 2 && String.sub str (len - 2) 2 = "em" then
+      map (fun n -> Css.Em n) (drop 2)
+    else if len > 2 && String.sub str (len - 2) 2 = "vw" then
+      map (fun n -> Css.Vw n) (drop 2)
+    else if len > 1 && str.[len - 1] = '%' then
+      map (fun n -> Css.Pct n) (drop 1)
+    else None
 
   let to_style = function
     | Columns_auto -> (
@@ -69,6 +90,10 @@ module Handler = struct
     | Columns_6xl -> columns_with_var Sizing.container_6xl (Rem 72.0)
     | Columns_7xl -> columns_with_var Sizing.container_7xl (Rem 80.0)
     | Columns_arbitrary n -> style [ columns (Count n) ]
+    | Columns_arbitrary_len s -> (
+        match parse_columns_length s with
+        | Some l -> style [ columns (Width l) ]
+        | None -> style [ columns Auto ])
     | Columns_bracket_var s ->
         let inner = Parse.extract_var_name s in
         let ref : Css.columns_value Css.var = Var.bracket inner in
@@ -113,6 +138,7 @@ module Handler = struct
       | Columns_6xl -> "6xl"
       | Columns_7xl -> "7xl"
       | Columns_arbitrary n -> "[" ^ string_of_int n ^ "]"
+      | Columns_arbitrary_len s -> "[" ^ s ^ "]"
       | Columns_bracket_var _ -> "[z"
     in
     string_to_sortkey suffix
@@ -142,6 +168,8 @@ module Handler = struct
           let inner = String.sub n 1 (len - 2) in
           match int_of_string_opt inner with
           | Some i -> Ok (Columns_arbitrary i)
+          | None when parse_columns_length inner <> None ->
+              Ok (Columns_arbitrary_len inner)
           | None -> Error (`Msg "Invalid columns arbitrary value")
         else
           match int_of_string_opt n with
@@ -166,6 +194,7 @@ module Handler = struct
     | Columns_6xl -> "columns-6xl"
     | Columns_7xl -> "columns-7xl"
     | Columns_arbitrary n -> "columns-[" ^ string_of_int n ^ "]"
+    | Columns_arbitrary_len s -> "columns-[" ^ s ^ "]"
     | Columns_bracket_var s -> "columns-[" ^ s ^ "]"
 end
 

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -547,11 +547,16 @@ module Handler = struct
     | [ "duration"; n ] ->
         Parse.int_pos ~name:"duration" n >|= fun n -> Duration n
     | [ "delay"; n ] when String.length n > 0 && n.[0] = '[' ->
-        (* Arbitrary delay: delay-[300ms] *)
+        (* Arbitrary delay: delay-[300ms], delay-[var(--d)] *)
         let len = String.length n in
         if len > 2 && n.[len - 1] = ']' then
           let inner = String.sub n 1 (len - 2) in
-          if String.ends_with ~suffix:"ms" inner then
+          if Parse.is_var inner then
+            let dref : Css.duration Css.var =
+              Var.bracket (Parse.extract_var_name inner)
+            in
+            Ok (Delay_arbitrary (inner, (Css.Var dref : Css.duration)))
+          else if String.ends_with ~suffix:"ms" inner then
             let num = String.sub inner 0 (String.length inner - 2) in
             match float_of_string_opt num with
             | Some _ ->

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -141,6 +141,19 @@ let test_outline_widths () =
     "outline-3 is not a utility" true
     (match Tw.of_string "outline-3" with Error _ -> true | Ok _ -> false)
 
+(* Arbitrary outline-offset lengths (outline-offset-[3px]) emit the length,
+   alongside the var() form (outline-offset-[var(--x)]). *)
+let test_outline_offset_arbitrary () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  Alcotest.(check bool)
+    "outline-offset-[3px] emits outline-offset: 3px" true
+    (Astring.String.is_infix ~affix:"outline-offset: 3px"
+       (css "outline-offset-[3px]"))
+
 (* Arbitrary per-side border widths (border-t-[1px], ...) emit the side width
    plus the side border-style var; they used to be unknown classes. *)
 let test_border_side_arbitrary_width () =
@@ -164,6 +177,8 @@ let tests =
     test_case "rounded-l-full inlined radius" `Quick
       test_rounded_side_full_inlined;
     test_case "outline numeric widths" `Quick test_outline_widths;
+    test_case "outline-offset arbitrary length" `Quick
+      test_outline_offset_arbitrary;
     test_case "border side arbitrary widths" `Quick
       test_border_side_arbitrary_width;
     test_case "borders of_string - valid values" `Quick of_string_valid;

--- a/test/test_columns.ml
+++ b/test/test_columns.ml
@@ -18,13 +18,33 @@ let test_roundtrip () =
   check "columns-4xl";
   check "columns-5xl";
   check "columns-6xl";
-  check "columns-7xl"
+  check "columns-7xl";
+  (* Arbitrary count ([3]) and width ([16rem]/[200px]) forms. *)
+  check "columns-[3]";
+  check "columns-[16rem]";
+  check "columns-[200px]"
 
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns";
   Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns-abc"
 
+(* columns-[16rem] is a column-WIDTH (columns: 16rem), distinct from the integer
+   count form (columns-[3]). *)
+let test_columns_arbitrary_width () =
+  let css =
+    match Tw.of_string "columns-[16rem]" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.fail "could not parse columns-[16rem]"
+  in
+  Alcotest.(check bool)
+    "columns-[16rem] sets columns: 16rem" true
+    (Astring.String.is_infix ~affix:"columns:16rem" css)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "columns arbitrary width" `Quick
+        test_columns_arbitrary_width;
+    ]
 
 let suite = ("columns", tests)

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -12,6 +12,9 @@ let test_roundtrip () =
   check "duration-300";
   check "delay-150";
   check "delay-300";
+  (* Arbitrary delay accepts both time units and var(). *)
+  check "delay-[300ms]";
+  check "delay-[var(--d)]";
   check "ease-linear";
   check "ease-in";
   check "ease-out";


### PR DESCRIPTION
This PR lets three utilities parse arbitrary values that were previously rejected as unknown classes:

- `outline-offset-[3px]` — only the `var()` bracket form was accepted; arbitrary lengths now emit `outline-offset: 3px`.
- `columns-[16rem]` — only an integer count in brackets was accepted; an arbitrary length now emits `columns: 16rem` (a column width).
- `delay-[var(--d)]` — `ms`/`s` values worked but the `var()` form was rejected; it now references the duration variable.

All match the v4 CLI; the existing var/count/named/ms/s forms are unchanged.