### PR TITLE
text-shadow: reject bare text-shadow class

### DIFF
--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -520,7 +520,9 @@ module Handler = struct
     let parts = Parse.split_class class_name in
     match parts with
     | [ "text"; "shadow"; "none" ] -> Ok Text_shadow_none
-    | [ "text"; "shadow" ] -> Ok (Text_shadow_shape S_md)
+    (* Bare `text-shadow` is not a utility in v4 (no `--text-shadow` token); the
+       named scale is `text-shadow-{2xs,xs,sm,md,lg}`. *)
+    | [ "text"; "shadow" ] -> err_not_utility
     | [ "text"; "shadow"; size_str ] -> (
         let base, opacity = Color.parse_opacity_modifier size_str in
         let shape_opt =
@@ -583,20 +585,14 @@ module Handler = struct
     | S_2xs -> "2xs"
     | S_xs -> "xs"
     | S_sm -> "sm"
-    | S_md -> ""
+    | S_md -> "md"
     | S_lg -> "lg"
 
   let to_class = function
     | Text_shadow_none -> "text-shadow-none"
-    | Text_shadow_shape S_md -> "text-shadow"
     | Text_shadow_shape shape -> "text-shadow-" ^ shape_to_string shape
     | Text_shadow_shape_opacity (shape, opacity) ->
-        let base =
-          match shape with
-          | S_md -> "text-shadow"
-          | _ -> "text-shadow-" ^ shape_to_string shape
-        in
-        base ^ "/" ^ Color.pp_opacity opacity
+        "text-shadow-" ^ shape_to_string shape ^ "/" ^ Color.pp_opacity opacity
     | Text_shadow_color (c, shade) ->
         "text-shadow-" ^ Color.color_to_string c
         ^ if Color.is_shadeless c then "" else "-" ^ string_of_int shade
@@ -647,7 +643,6 @@ let text_shadow_none = utility Text_shadow_none
 let text_shadow_2xs = utility (Text_shadow_shape S_2xs)
 let text_shadow_xs = utility (Text_shadow_shape S_xs)
 let text_shadow_sm = utility (Text_shadow_shape S_sm)
-let text_shadow = utility (Text_shadow_shape S_md)
 let text_shadow_md = utility (Text_shadow_shape S_md)
 let text_shadow_lg = utility (Text_shadow_shape S_lg)
 let text_shadow_arbitrary arb = utility (Text_shadow_arbitrary arb)

--- a/lib/text_shadow.mli
+++ b/lib/text_shadow.mli
@@ -14,9 +14,6 @@ val text_shadow_xs : t
 val text_shadow_sm : t
 (** [text_shadow_sm] is the [text-shadow-sm] utility. *)
 
-val text_shadow : t
-(** [text_shadow] is the default [text-shadow] utility. *)
-
 val text_shadow_md : t
 (** [text_shadow_md] is the [text-shadow-md] utility. *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -2466,9 +2466,6 @@ val text_shadow_xs : t
 val text_shadow_sm : t
 (** [text_shadow_sm] applies the small text shadow. *)
 
-val text_shadow : t
-(** [text_shadow] applies the default (md) text shadow. *)
-
 val text_shadow_md : t
 (** [text_shadow_md] applies the medium text shadow. *)
 

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -5,13 +5,16 @@ let test_roundtrip () =
   check "text-shadow-2xs";
   check "text-shadow-xs";
   check "text-shadow-sm";
-  check "text-shadow";
+  check "text-shadow-md";
   check "text-shadow-lg"
 
 let test_invalid () =
   Test_helpers.check_invalid_input
     (module Tw.Text_shadow.Handler)
-    "text-shadow-foo"
+    "text-shadow-foo";
+  (* Bare `text-shadow` is not a v4 utility (the CLI emits nothing); only the
+     named scale `text-shadow-{2xs,xs,sm,md,lg}` is valid. *)
+  Test_helpers.check_invalid_input (module Tw.Text_shadow.Handler) "text-shadow"
 
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid


### PR DESCRIPTION
Bare `text-shadow` is not a utility in Tailwind v4 (there is no `--text-shadow` token); the named scale is `text-shadow-{2xs,xs,sm,md,lg}`. `of_class` accepted bare `text-shadow` as the `md` shape and emitted a rule the v4 CLI never produces, while `to_class` rendered the `md` shape back as bare `text-shadow`. This PR rejects the bare class and renders the `md` shape as `text-shadow-md`, so the named scale round-trips and tw stops emitting a class the CLI omits.