### PR TITLE
theme: thread the theme explicitly, removing global state

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -54,6 +54,7 @@ let setup_test_scheme () =
       default_border_width = 1;
       default_outline_width = 1;
       breakpoints = [];
+      token_overrides = [];
     }
   in
   Tw.Color.Handler.set_scheme scheme;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -42,26 +42,22 @@ type gen_opts = {
   test_scheme : bool;
 }
 
-(* Set up the test scheme matching Tailwind's test @theme. This uses hex colors
-   and explicit spacing variables. *)
-let setup_test_scheme () =
-  let scheme : Tw.Scheme.t =
-    {
-      colors = [ ("red-500", Tw.Scheme.Hex "#ef4444") ];
-      spacing = [ (4, Css.Rem 1.0) ];
-      radius = [];
-      default_ring_width = 1;
-      default_border_width = 1;
-      default_outline_width = 1;
-      breakpoints = [];
-      token_overrides = [];
-    }
-  in
-  Tw.Color.Handler.set_scheme scheme;
-  Tw.Theme.set_scheme scheme;
-  Tw.Borders.set_scheme scheme;
-  Tw.Effects.set_scheme scheme;
-  Tw.Divide.set_scheme scheme
+(* The test scheme matching Tailwind's test @theme: hex colors and explicit
+   spacing variables. Threaded into to_css via ~theme under --test-scheme. *)
+let test_scheme : Tw.Scheme.t =
+  {
+    colors = [ ("red-500", Tw.Scheme.Hex "#ef4444") ];
+    spacing = [ (4, Css.Rem 1.0) ];
+    radius = [];
+    default_ring_width = 1;
+    default_border_width = 1;
+    default_outline_width = 1;
+    breakpoints = [];
+    token_overrides = [];
+  }
+
+let theme_of (opts : gen_opts) =
+  if opts.test_scheme then test_scheme else Tw.Scheme.default
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default
@@ -100,7 +96,7 @@ let diff_single_class class_str ~(opts : gen_opts) =
     in
     let tw_styles = parse_classes ~warn:false class_str in
     let styles = match tw_styles with [] -> [] | s -> s in
-    let stylesheet = Tw.to_css ~base:true styles in
+    let stylesheet = Tw.to_css ~theme:(theme_of opts) ~base:true styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
       Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
@@ -120,7 +116,6 @@ let diff_single_class class_str ~(opts : gen_opts) =
     `Error (false, Fmt.str "Error during comparison: %s" (Printexc.to_string e))
 
 let process_single_class class_str flag ~(opts : gen_opts) =
-  if opts.test_scheme then setup_test_scheme ();
   match opts.backend with
   | Diff -> diff_single_class class_str ~opts
   | Tailwind -> (
@@ -144,7 +139,9 @@ let process_single_class class_str flag ~(opts : gen_opts) =
       | [] when class_str <> "" ->
           `Error (false, Fmt.str "Error: Unknown class: %s" class_str)
       | _ ->
-          let stylesheet = Tw.to_css ~base:include_base styles in
+          let stylesheet =
+            Tw.to_css ~theme:(theme_of opts) ~base:include_base styles
+          in
           print_string (render_css ~opts stylesheet);
           `Ok ())
 
@@ -185,7 +182,7 @@ let diff_files paths ~(opts : gen_opts) =
         ~forms:true all_classes
     in
     let tw_styles = parse_known_candidates all_classes |> List.map snd in
-    let stylesheet = Tw.to_css ~base:true tw_styles in
+    let stylesheet = Tw.to_css ~theme:(theme_of opts) ~base:true tw_styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
       Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
@@ -206,7 +203,9 @@ let native_files paths flag ~(opts : gen_opts) =
     in
     let known = parse_known_candidates all_classes in
     let tw_styles = List.map snd known in
-    let stylesheet = Tw.to_css ~base:include_base tw_styles in
+    let stylesheet =
+      Tw.to_css ~theme:(theme_of opts) ~base:include_base tw_styles
+    in
     print_string (render_css ~opts stylesheet);
     print_stats ~quiet:opts.quiet ~candidate_count:(List.length all_classes)
       ~known_count:(List.length known);
@@ -214,7 +213,6 @@ let native_files paths flag ~(opts : gen_opts) =
   with e -> `Error (false, Fmt.str "Error: %s" (Printexc.to_string e))
 
 let process_files paths flag ~(opts : gen_opts) =
-  if opts.test_scheme then setup_test_scheme ();
   match opts.backend with
   | Diff -> diff_files paths ~opts
   | Tailwind -> (

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -39,25 +39,7 @@ type gen_opts = {
   quiet : bool;
   css_mode : Tw.Css.mode;
   backend : backend;
-  test_scheme : bool;
 }
-
-(* The test scheme matching Tailwind's test @theme: hex colors and explicit
-   spacing variables. Threaded into to_css via ~theme under --test-scheme. *)
-let test_scheme : Tw.Scheme.t =
-  {
-    colors = [ ("red-500", Tw.Scheme.Hex "#ef4444") ];
-    spacing = [ (4, Css.Rem 1.0) ];
-    radius = [];
-    default_ring_width = 1;
-    default_border_width = 1;
-    default_outline_width = 1;
-    breakpoints = [];
-    token_overrides = [];
-  }
-
-let theme_of (opts : gen_opts) =
-  if opts.test_scheme then test_scheme else Tw.Scheme.default
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default
@@ -96,7 +78,7 @@ let diff_single_class class_str ~(opts : gen_opts) =
     in
     let tw_styles = parse_classes ~warn:false class_str in
     let styles = match tw_styles with [] -> [] | s -> s in
-    let stylesheet = Tw.to_css ~theme:(theme_of opts) ~base:true styles in
+    let stylesheet = Tw.to_css ~base:true styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
       Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
@@ -139,9 +121,7 @@ let process_single_class class_str flag ~(opts : gen_opts) =
       | [] when class_str <> "" ->
           `Error (false, Fmt.str "Error: Unknown class: %s" class_str)
       | _ ->
-          let stylesheet =
-            Tw.to_css ~theme:(theme_of opts) ~base:include_base styles
-          in
+          let stylesheet = Tw.to_css ~base:include_base styles in
           print_string (render_css ~opts stylesheet);
           `Ok ())
 
@@ -182,7 +162,7 @@ let diff_files paths ~(opts : gen_opts) =
         ~forms:true all_classes
     in
     let tw_styles = parse_known_candidates all_classes |> List.map snd in
-    let stylesheet = Tw.to_css ~theme:(theme_of opts) ~base:true tw_styles in
+    let stylesheet = Tw.to_css ~base:true tw_styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
       Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
@@ -203,9 +183,7 @@ let native_files paths flag ~(opts : gen_opts) =
     in
     let known = parse_known_candidates all_classes in
     let tw_styles = List.map snd known in
-    let stylesheet =
-      Tw.to_css ~theme:(theme_of opts) ~base:include_base tw_styles
-    in
+    let stylesheet = Tw.to_css ~base:include_base tw_styles in
     print_string (render_css ~opts stylesheet);
     print_stats ~quiet:opts.quiet ~candidate_count:(List.length all_classes)
       ~known_count:(List.length known);
@@ -236,7 +214,7 @@ let process_files paths flag ~(opts : gen_opts) =
   | Native -> native_files paths flag ~opts
 
 let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
-    ~test_scheme paths =
+    paths =
   (* Resolve default CSS mode based on operation kind when not provided *)
   let resolved_css_mode : Css.mode =
     match (single_class, backend, css_mode) with
@@ -256,7 +234,6 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
       quiet;
       css_mode = resolved_css_mode;
       backend;
-      test_scheme;
     }
   in
   match single_class with
@@ -329,13 +306,6 @@ let paths_arg =
   let doc = "Files or directories to scan for Tailwind classes" in
   Arg.(value & pos_all file [] & info [] ~docv:"PATH" ~doc)
 
-let test_scheme_flag =
-  let doc =
-    "Use Tailwind test scheme (hex colors like #ef4444 for red-500, explicit \
-     spacing variables). Matches Tailwind's test @theme configuration."
-  in
-  Arg.(value & flag & info [ "test-scheme" ] ~doc)
-
 let cmd =
   let doc = "A Tailwind CSS-like utility class generator for OCaml" in
   let man =
@@ -375,10 +345,10 @@ let cmd =
   Cmd.v info
     Term.(
       ret
-        (const (fun s b css_m m o q backend test_scheme paths ->
+        (const (fun s b css_m m o q backend paths ->
              tw_main s b ~css_mode:css_m ~minify:m ~optimize:o ~quiet:q ~backend
-               ~test_scheme paths)
+               paths)
         $ single_flag $ base_flag $ css_mode_vflag $ minify_flag $ optimize_flag
-        $ quiet_flag $ backend_vflag $ test_scheme_flag $ paths_arg))
+        $ quiet_flag $ backend_vflag $ paths_arg))
 
 let () = exit (Cmd.eval cmd)

--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -34,7 +34,7 @@ module Handler = struct
     | Forced_color_adjust_auto -> 0
     | Forced_color_adjust_none -> 1
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "forced"; "color"; "adjust"; "auto" ] -> Ok Forced_color_adjust_auto

--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -26,7 +26,7 @@ module Handler = struct
     | Forced_color_adjust_auto -> "forced-color-adjust-auto"
     | Forced_color_adjust_none -> "forced-color-adjust-none"
 
-  let to_style = function
+  let to_style _theme = function
     | Forced_color_adjust_auto -> style [ forced_color_adjust Auto ]
     | Forced_color_adjust_none -> style [ forced_color_adjust None ]
 

--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -351,7 +351,7 @@ module Handler = struct
   let to_class t = List.assoc t to_class_map
   let suborder t = List.assoc t suborder_map
 
-  let of_class cls =
+  let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not an alignment utility")

--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -347,7 +347,7 @@ module Handler = struct
   let of_class_map = List.map (fun (t, cls, _, _) -> (cls, t)) alignment_data
 
   (* Handler functions derived from maps *)
-  let to_style t = List.assoc t to_style_map
+  let to_style _theme t = List.assoc t to_style_map
   let to_class t = List.assoc t to_class_map
   let suborder t = List.assoc t suborder_map
 

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -314,7 +314,7 @@ module Handler = struct
     | Animate_pulse -> 5
     | Animate_spin -> 6
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "animate"; "none" ] -> Ok Animate_none

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -290,7 +290,7 @@ module Handler = struct
     in
     style [ theme_decl; Css.animation (Css.Var theme_ref) ]
 
-  let to_style = function
+  let to_style _theme = function
     | Animate_none -> animate_none ()
     | Animate_spin -> animate_spin ()
     | Animate_ping -> animate_ping ()

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -35,10 +35,10 @@ module Handler = struct
   (* Match Tailwind ordering: animations after transforms, before cursor *)
   let priority = 10
 
-  let animate_none () =
+  let animate_none ?theme () =
     (* If theme defines --animate-none, use the theme variable. Otherwise use
        animation: none directly. *)
-    match Var.theme_value "animate-none" with
+    match Scheme.theme_value theme "animate-none" with
     | Some _ ->
         let tv = Var.theme Css.Animation "animate-none" ~order:(7, 12) in
         let none_animation : Css.animation =
@@ -63,7 +63,7 @@ module Handler = struct
      9-11) *)
   let animate_spin_var = Var.theme Css.Animation "animate-spin" ~order:(7, 13)
 
-  let animate_spin () =
+  let animate_spin ?theme () =
     let spin_animation : Css.animation =
       Css.Shorthand
         {
@@ -81,7 +81,7 @@ module Handler = struct
     let theme_decl, spin_var = Var.binding animate_spin_var spin_animation in
     (* Only include @keyframes when theme doesn't define the animation *)
     let rules =
-      if Var.theme_value "animate-spin" <> opt_none then opt_none
+      if Scheme.theme_value theme "animate-spin" <> opt_none then opt_none
       else
         opt_some
           [
@@ -102,7 +102,7 @@ module Handler = struct
      animate-spin (7, 13) *)
   let animate_ping_var = Var.theme Css.Animation "animate-ping" ~order:(7, 14)
 
-  let animate_ping () =
+  let animate_ping ?theme () =
     let ping_animation : Css.animation =
       Css.Shorthand
         {
@@ -119,7 +119,7 @@ module Handler = struct
     in
     let theme_decl, ping_var = Var.binding animate_ping_var ping_animation in
     let rules =
-      if Var.theme_value "animate-ping" <> opt_none then opt_none
+      if Scheme.theme_value theme "animate-ping" <> opt_none then opt_none
       else
         opt_some
           [
@@ -144,7 +144,7 @@ module Handler = struct
      animate-ping (7, 14) *)
   let animate_pulse_var = Var.theme Css.Animation "animate-pulse" ~order:(7, 15)
 
-  let animate_pulse () =
+  let animate_pulse ?theme () =
     let pulse_animation : Css.animation =
       Css.Shorthand
         {
@@ -161,7 +161,7 @@ module Handler = struct
     in
     let theme_decl, pulse_var = Var.binding animate_pulse_var pulse_animation in
     let rules =
-      if Var.theme_value "animate-pulse" <> opt_none then opt_none
+      if Scheme.theme_value theme "animate-pulse" <> opt_none then opt_none
       else
         opt_some
           [
@@ -183,7 +183,7 @@ module Handler = struct
   let animate_bounce_var =
     Var.theme Css.Animation "animate-bounce" ~order:(7, 16)
 
-  let animate_bounce () =
+  let animate_bounce ?theme () =
     let bounce_animation : Css.animation =
       Css.Shorthand
         {
@@ -202,7 +202,7 @@ module Handler = struct
       Var.binding animate_bounce_var bounce_animation
     in
     let rules =
-      if Var.theme_value "animate-bounce" <> opt_none then opt_none
+      if Scheme.theme_value theme "animate-bounce" <> opt_none then opt_none
       else
         opt_some
           [
@@ -290,7 +290,13 @@ module Handler = struct
     in
     style [ theme_decl; Css.animation (Css.Var theme_ref) ]
 
-  let to_style _theme = function
+  let to_style theme =
+    let animate_none () = animate_none ~theme () in
+    let animate_spin () = animate_spin ~theme () in
+    let animate_ping () = animate_ping ~theme () in
+    let animate_pulse () = animate_pulse ~theme () in
+    let animate_bounce () = animate_bounce ~theme () in
+    function
     | Animate_none -> animate_none ()
     | Animate_spin -> animate_spin ()
     | Animate_ping -> animate_ping ()

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -314,7 +314,7 @@ module Handler = struct
     | Animate_pulse -> 5
     | Animate_spin -> 6
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "animate"; "none" ] -> Ok Animate_none
@@ -329,7 +329,8 @@ module Handler = struct
         else
           (* Check if it's a named animation with a theme value *)
           let var_name = "animate-" ^ value in
-          if Var.theme_value var_name <> None then Ok (Animate_named value)
+          if Scheme.theme_value (Some theme) var_name <> None then
+            Ok (Animate_named value)
           else Error (`Msg "Not an animation utility")
     | _ -> Error (`Msg "Not an animation utility")
 

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -181,7 +181,7 @@ module Handler = struct
     in
     "[" ^ property ^ ":" ^ value ^ "]" ^ opacity_suffix
 
-  let of_class class_name =
+  let of_class _theme class_name =
     (* Must start with [ and contain : *)
     let len = String.length class_name in
     if len < 3 || class_name.[0] <> '[' then err_not_utility

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -181,7 +181,7 @@ module Handler = struct
     in
     "[" ^ property ^ ":" ^ value ^ "]" ^ opacity_suffix
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     (* Must start with [ and contain : *)
     let len = String.length class_name in
     if len < 3 || class_name.[0] <> '[' then err_not_utility
@@ -252,7 +252,9 @@ module Handler = struct
                     | _ ->
                         if
                           Parse.is_valid_theme_name op_part
-                          && Var.theme_value ("opacity-" ^ op_part) <> None
+                          && Scheme.theme_value (Some theme)
+                               ("opacity-" ^ op_part)
+                             <> None
                         then Color.Opacity_named op_part
                         else Color.No_opacity
                 else Color.No_opacity

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -63,7 +63,7 @@ module Handler = struct
   let name = "arbitrary"
   let priority = 36
 
-  let to_style _theme (Color_opacity { property; value; opacity }) =
+  let to_style theme (Color_opacity { property; value; opacity }) =
     match (color_property_of_name property, parse_css_color value) with
     | Some prop, Some color -> (
         match opacity with
@@ -71,12 +71,12 @@ module Handler = struct
             let bare = Parse.extract_var_name name in
             let var_name = "opacity-" ^ bare in
             let fallback =
-              Color.opacity_fallback_for_theme_value var_name bare
+              Color.opacity_fallback_for_theme_value ~theme var_name bare
             in
             (* srgb fallback: resolve the theme value to get the actual
                percentage *)
             let srgb_percent =
-              match Var.theme_value var_name with
+              match Scheme.theme_value (Some theme) var_name with
               | Some v -> (
                   match float_of_string_opt (String.trim v) with
                   | Some f -> f *. 100.0

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -63,7 +63,7 @@ module Handler = struct
   let name = "arbitrary"
   let priority = 36
 
-  let to_style (Color_opacity { property; value; opacity }) =
+  let to_style _theme (Color_opacity { property; value; opacity }) =
     match (color_property_of_name property, parse_css_color value) with
     | Some prop, Some color -> (
         match opacity with

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -952,10 +952,13 @@ module Handler = struct
   (* Gradient color with opacity - generates same structure as Tailwind: 1.
      Fallback rule with hex alpha (for scheme colors) 2. @supports block with
      color-mix using theme variable 3. Separate rule with --tw-gradient-stops *)
-  let gradient_color_opacity ~prefix ~set_var ?(shade = 500) color opacity =
+  let gradient_color_opacity ?theme ~prefix ~set_var ?(shade = 500) color opacity
+      =
     let percent = Color.opacity_to_percent opacity in
     let color_name = Color.scheme_color_name color shade in
-    let scheme = Color.current_scheme () in
+    let scheme =
+      match theme with Some t -> t | None -> Color.current_scheme ()
+    in
 
     (* Build variable references for gradient stops *)
     let position_ref = Var.reference gradient_position_var in
@@ -1276,7 +1279,14 @@ module Handler = struct
         Some o
     | _ -> None
 
-  let to_style _theme = function
+  let to_style theme =
+    let gradient_color_opacity ~prefix ~set_var ?(shade = 500) color opacity =
+      gradient_color_opacity ~theme ~prefix ~set_var ~shade color opacity
+    in
+    let bg_with_opacity c shade opacity =
+      Color.bg_with_opacity ~theme c shade opacity
+    in
+    function
     | Bg (color, shade) -> bg' ~shade color
     | Bg_gradient_to dir -> bg_gradient_to' dir
     | Gradient_color (target, src) -> (
@@ -1415,12 +1425,12 @@ module Handler = struct
         style [ Css.background_color c ]
     | Bg_bracket_color_opacity (orig, _, opacity) ->
         let c = Color.bracket_color_to_custom orig in
-        Color.bg_with_opacity c 500 opacity
+        bg_with_opacity c 500 opacity
     | Bg_current -> style [ Css.background_color Css.Current ]
     | Bg_current_opacity opacity -> Color.bg_current_with_opacity opacity
     | Bg_transparent -> style [ Css.background_color (Css.hex "#0000") ]
     | Bg_opacity (color, shade, opacity) ->
-        Color.bg_with_opacity color shade opacity
+        bg_with_opacity color shade opacity
     | Bg_bracket_length inner -> (
         match parse_bracket_size inner with
         | Some decl -> style [ decl ]

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1527,14 +1527,14 @@ module Handler = struct
     | None -> (s, None)
 
   (** Parse gradient color/position from token list for a given target *)
-  let parse_gradient_color target rest =
+  let parse_gradient_color ?theme target rest =
     let gc src = Ok (Gradient_color (target, src)) in
     let gp src = Ok (Gradient_stop_position (target, src)) in
     match rest with
     (* Keywords *)
     | [ "current" ] -> gc Gc_current
     | [ current_str ] when String.starts_with ~prefix:"current/" current_str ->
-        let _, opacity = Color.parse_opacity_modifier current_str in
+        let _, opacity = Color.parse_opacity_modifier ?theme current_str in
         gc (Gc_current_opacity opacity)
     | [ "inherit" ] -> gc Gc_inherit
     | [ "transparent" ] -> gc Gc_transparent
@@ -1546,7 +1546,9 @@ module Handler = struct
         | None -> Error (`Msg "Invalid gradient position"))
     (* Bracket with opacity: [#0088cc]/50, [#0088cc]/[0.5], [var(--x)]/50 *)
     | [ bracket_opacity ] when has_opacity bracket_opacity -> (
-        let base, opacity_opt = Color.parse_opacity_modifier bracket_opacity in
+        let base, opacity_opt =
+          Color.parse_opacity_modifier ?theme bracket_opacity
+        in
         match opacity_opt with
         | Color.No_opacity when Parse.is_bracket_value bracket_opacity ->
             (* No valid opacity found — treat as plain bracket *)
@@ -1576,7 +1578,7 @@ module Handler = struct
             else Error (`Msg "Invalid gradient bracket with opacity")
         | _ -> (
             (* Named color with opacity *)
-            match Color.shade_and_opacity_of_strings rest with
+            match Color.shade_and_opacity_of_strings ?theme rest with
             | Ok (color, shade, opacity) ->
                 gc (Gc_named_opacity (color, shade, opacity))
             | Error e -> Error e))
@@ -1594,7 +1596,7 @@ module Handler = struct
         else gp (Gp_bracket inner)
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (
-        match Color.shade_and_opacity_of_strings rest with
+        match Color.shade_and_opacity_of_strings ?theme rest with
         | Ok (color, shade, opacity) ->
             gc (Gc_named_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -1604,7 +1606,7 @@ module Handler = struct
         | Ok (color, shade) -> gc (Gc_named (color, shade))
         | Error _ -> Error (`Msg "Invalid gradient color"))
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "bg"; "gradient"; "to"; "b" ] -> Ok (Bg_gradient_to Bottom)
@@ -1627,7 +1629,7 @@ module Handler = struct
     | [ "bg"; "transparent" ] -> Ok Bg_transparent
     | [ "bg"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Bg_current
         | Color.No_opacity -> Error (`Msg ("Invalid bg: " ^ current_str))
@@ -1848,16 +1850,16 @@ module Handler = struct
                       else Error (`Msg ("Unknown bg bracket value: " ^ inner))))
         )
     | "bg" :: rest when List.exists has_opacity rest -> (
-        match Color.shade_and_opacity_of_strings rest with
+        match Color.shade_and_opacity_of_strings ~theme rest with
         | Ok (color, shade, opacity) -> Ok (Bg_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "bg" :: rest -> (
         match Color.shade_of_strings rest with
         | Ok (color, shade) -> Ok (Bg (color, shade))
         | Error _ -> Error (`Msg "Invalid background color"))
-    | "from" :: rest -> parse_gradient_color Gradient_from rest
-    | "via" :: rest -> parse_gradient_color Gradient_via rest
-    | "to" :: rest -> parse_gradient_color Gradient_to rest
+    | "from" :: rest -> parse_gradient_color ~theme Gradient_from rest
+    | "via" :: rest -> parse_gradient_color ~theme Gradient_via rest
+    | "to" :: rest -> parse_gradient_color ~theme Gradient_to rest
     | _ -> Error (`Msg "Unknown background class")
 end
 

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1276,7 +1276,7 @@ module Handler = struct
         Some o
     | _ -> None
 
-  let to_style = function
+  let to_style _theme = function
     | Bg (color, shade) -> bg' ~shade color
     | Bg_gradient_to dir -> bg_gradient_to' dir
     | Gradient_color (target, src) -> (

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -952,13 +952,11 @@ module Handler = struct
   (* Gradient color with opacity - generates same structure as Tailwind: 1.
      Fallback rule with hex alpha (for scheme colors) 2. @supports block with
      color-mix using theme variable 3. Separate rule with --tw-gradient-stops *)
-  let gradient_color_opacity ?theme ~prefix ~set_var ?(shade = 500) color opacity
-      =
+  let gradient_color_opacity ?theme ~prefix ~set_var ?(shade = 500) color
+      opacity =
     let percent = Color.opacity_to_percent opacity in
     let color_name = Color.scheme_color_name color shade in
-    let scheme =
-      match theme with Some t -> t | None -> Color.current_scheme ()
-    in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
 
     (* Build variable references for gradient stops *)
     let position_ref = Var.reference gradient_position_var in
@@ -1429,8 +1427,7 @@ module Handler = struct
     | Bg_current -> style [ Css.background_color Css.Current ]
     | Bg_current_opacity opacity -> Color.bg_current_with_opacity opacity
     | Bg_transparent -> style [ Css.background_color (Css.hex "#0000") ]
-    | Bg_opacity (color, shade, opacity) ->
-        bg_with_opacity color shade opacity
+    | Bg_opacity (color, shade, opacity) -> bg_with_opacity color shade opacity
     | Bg_bracket_length inner -> (
         match parse_bracket_size inner with
         | Some decl -> style [ decl ]

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -570,13 +570,13 @@ module Handler = struct
 
     style ~property_rules declarations
 
-  let bg' ?(shade = 500) color =
+  let bg' ?theme ?(shade = 500) color =
     let bg_var_name =
       let base = Color.pp color in
       if Color.is_base_color color then "background-color-" ^ base
       else "background-color-" ^ base ^ "-" ^ string_of_int shade
     in
-    match Var.theme_value bg_var_name with
+    match Scheme.theme_value theme bg_var_name with
     | Some theme_val ->
         (* Property-scoped bg color: --background-color-<name> *)
         let tv = Var.theme Css.Color bg_var_name ~order:(5, 50) in
@@ -1284,6 +1284,7 @@ module Handler = struct
     let bg_with_opacity c shade opacity =
       Color.bg_with_opacity ~theme c shade opacity
     in
+    let bg' ?(shade = 500) color = bg' ~theme ~shade color in
     function
     | Bg (color, shade) -> bg' ~shade color
     | Bg_gradient_to dir -> bg_gradient_to' dir
@@ -1425,7 +1426,7 @@ module Handler = struct
         let c = Color.bracket_color_to_custom orig in
         bg_with_opacity c 500 opacity
     | Bg_current -> style [ Css.background_color Css.Current ]
-    | Bg_current_opacity opacity -> Color.bg_current_with_opacity opacity
+    | Bg_current_opacity opacity -> Color.bg_current_with_opacity ~theme opacity
     | Bg_transparent -> style [ Css.background_color (Css.hex "#0000") ]
     | Bg_opacity (color, shade, opacity) -> bg_with_opacity color shade opacity
     | Bg_bracket_length inner -> (

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1604,7 +1604,7 @@ module Handler = struct
         | Ok (color, shade) -> gc (Gc_named (color, shade))
         | Error _ -> Error (`Msg "Invalid gradient color"))
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "bg"; "gradient"; "to"; "b" ] -> Ok (Bg_gradient_to Bottom)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1534,7 +1534,7 @@ module Handler = struct
     | Some len -> style (make_decls len)
     | None -> style (make_decls (Px 0.))
 
-  let to_style : t -> Style.t = function
+  let to_style _theme : t -> Style.t = function
     (* Border width utilities *)
     | Border -> border_default ()
     | Border_0 -> border_0
@@ -2430,7 +2430,7 @@ module Outline_style_handler = struct
   let name = "outline_style"
   let priority = 26
 
-  let to_style = function
+  let to_style _theme = function
     | Dashed ->
         let decl, _ = Var.binding Handler.outline_style_var Css.Dashed in
         style [ decl; Css.outline_style Css.Dashed ]

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -17,16 +17,8 @@
 
 module Css = Cascade.Css
 
-(* Current scheme for radius overrides *)
-let current_scheme : Scheme.t ref = ref Scheme.default
-
-(* Set the current scheme for radius generation *)
-let set_scheme scheme = current_scheme := scheme
-
-(* Resolve the scheme to read from: the threaded [theme] when given, else the
-   global. Migration scaffold while the radius/width helpers move onto the
-   explicitly threaded scheme. *)
-let resolve_scheme = function Some s -> s | None -> !current_scheme
+(* Resolve the optionally-threaded theme, defaulting to the base scheme. *)
+let resolve_scheme = function Some s -> s | None -> Scheme.default
 
 type rounded_position =
   | Rp_all

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -522,14 +522,14 @@ module Handler = struct
   (* Helper: return (decls, length_val) for the bare --radius variable. When
      theme_value "radius" is set (e.g. @config theme), emit the var declaration
      and use var(--radius). Otherwise inline .25rem directly. *)
-  let radius_decl_and_val () : Css.declaration list * Css.length =
-    if Var.theme_value "radius" <> None then
+  let radius_decl_and_val ?theme () : Css.declaration list * Css.length =
+    if Scheme.theme_value theme "radius" <> None then
       let decl, r = Var.binding radius_var (Rem 0.25) in
       ([ decl ], Css.Var r)
     else ([], Css.Rem 0.25)
 
-  let rounded () =
-    let extra, v = radius_decl_and_val () in
+  let rounded ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_radius (radius_value v) ])
 
   let rounded_md =
@@ -563,8 +563,8 @@ module Handler = struct
         style [ Css.border_radius (radius_value radius_full_len) ]
 
   (** Side-specific rounded utilities - top *)
-  let rounded_t () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_t ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style
       (extra @ [ Css.border_top_left_radius v; Css.border_top_right_radius v ])
 
@@ -630,8 +630,8 @@ module Handler = struct
       ]
 
   (** Side-specific rounded utilities - right *)
-  let rounded_r () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_r ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style
       (extra
       @ [ Css.border_top_right_radius v; Css.border_bottom_right_radius v ])
@@ -698,8 +698,8 @@ module Handler = struct
       ]
 
   (** Side-specific rounded utilities - bottom *)
-  let rounded_b () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_b ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style
       (extra
       @ [ Css.border_bottom_right_radius v; Css.border_bottom_left_radius v ])
@@ -768,8 +768,8 @@ module Handler = struct
       ]
 
   (** Side-specific rounded utilities - left *)
-  let rounded_l () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_l ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style
       (extra @ [ Css.border_top_left_radius v; Css.border_bottom_left_radius v ])
 
@@ -835,8 +835,8 @@ module Handler = struct
       ]
 
   (** Corner-specific rounded utilities - top-left *)
-  let rounded_tl () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_tl ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_top_left_radius v ])
 
   let rounded_tl_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_left_radius ]
@@ -868,8 +868,8 @@ module Handler = struct
   let rounded_tl_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_top_left_radius ]
 
   (** Corner-specific rounded utilities - top-right *)
-  let rounded_tr () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_tr ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_top_right_radius v ])
 
   let rounded_tr_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_right_radius ]
@@ -901,8 +901,8 @@ module Handler = struct
   let rounded_tr_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_top_right_radius ]
 
   (** Corner-specific rounded utilities - bottom-right *)
-  let rounded_br () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_br ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_bottom_right_radius v ])
 
   let rounded_br_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_bottom_right_radius ]
@@ -934,8 +934,8 @@ module Handler = struct
   let rounded_br_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_bottom_right_radius ]
 
   (** Corner-specific rounded utilities - bottom-left *)
-  let rounded_bl () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_bl ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_bottom_left_radius v ])
 
   let rounded_bl_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_bottom_left_radius ]
@@ -967,8 +967,8 @@ module Handler = struct
   let rounded_bl_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_bottom_left_radius ]
 
   (** Logical property rounded utilities - start (inline-start) *)
-  let rounded_s () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_s ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style
       (extra
       @ [ Css.border_start_start_radius v; Css.border_end_start_radius v ])
@@ -1061,8 +1061,8 @@ module Handler = struct
           ]
 
   (** Logical property rounded utilities - end (inline-end) *)
-  let rounded_e () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_e ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style
       (extra @ [ Css.border_start_end_radius v; Css.border_end_end_radius v ])
 
@@ -1152,8 +1152,8 @@ module Handler = struct
           ]
 
   (** Logical corner rounded utilities - start-start *)
-  let rounded_ss () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_ss ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_start_start_radius v ])
 
   let rounded_ss_none ?theme () =
@@ -1195,8 +1195,8 @@ module Handler = struct
     | None -> style [ Css.border_start_start_radius (Px 3.40282e38) ]
 
   (** Logical corner rounded utilities - start-end *)
-  let rounded_se () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_se ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_start_end_radius v ])
 
   let rounded_se_none ?theme () =
@@ -1238,8 +1238,8 @@ module Handler = struct
     | None -> style [ Css.border_start_end_radius (Px 3.40282e38) ]
 
   (** Logical corner rounded utilities - end-end *)
-  let rounded_ee () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_ee ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_end_end_radius v ])
 
   let rounded_ee_none ?theme () =
@@ -1281,8 +1281,8 @@ module Handler = struct
     | None -> style [ Css.border_end_end_radius (Px 3.40282e38) ]
 
   (** Logical corner rounded utilities - end-start *)
-  let rounded_es () =
-    let extra, v = radius_decl_and_val () in
+  let rounded_es ?theme () =
+    let extra, v = radius_decl_and_val ?theme () in
     style (extra @ [ Css.border_end_start_radius v ])
 
   let rounded_es_none ?theme () =
@@ -1563,6 +1563,21 @@ module Handler = struct
     let rounded_br_full () = rounded_br_full ~theme () in
     let rounded_bl_none () = rounded_bl_none ~theme () in
     let rounded_bl_full () = rounded_bl_full ~theme () in
+    let rounded () = rounded ~theme () in
+    let rounded_t () = rounded_t ~theme () in
+    let rounded_r () = rounded_r ~theme () in
+    let rounded_b () = rounded_b ~theme () in
+    let rounded_l () = rounded_l ~theme () in
+    let rounded_tl () = rounded_tl ~theme () in
+    let rounded_tr () = rounded_tr ~theme () in
+    let rounded_br () = rounded_br ~theme () in
+    let rounded_bl () = rounded_bl ~theme () in
+    let rounded_s () = rounded_s ~theme () in
+    let rounded_e () = rounded_e ~theme () in
+    let rounded_ss () = rounded_ss ~theme () in
+    let rounded_se () = rounded_se ~theme () in
+    let rounded_ee () = rounded_ee ~theme () in
+    let rounded_es () = rounded_es ~theme () in
     let outline () = outline ~theme () in
     function
     (* Border width utilities *)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -576,7 +576,7 @@ module Handler = struct
     style
       (extra @ [ Css.border_top_left_radius v; Css.border_top_right_radius v ])
 
-  let rounded_t_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_top_left_radius; Css.border_top_right_radius ]
+  let rounded_t_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_left_radius; Css.border_top_right_radius ]
 
   let rounded_t_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -632,7 +632,7 @@ module Handler = struct
            Css.border_top_right_radius (Var r);
          ])
 
-  let rounded_t_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [
+  let rounded_t_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [
         Css.border_top_left_radius;
         Css.border_top_right_radius;
       ]
@@ -644,7 +644,7 @@ module Handler = struct
       (extra
       @ [ Css.border_top_right_radius v; Css.border_bottom_right_radius v ])
 
-  let rounded_r_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_top_right_radius; Css.border_bottom_right_radius ]
+  let rounded_r_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_right_radius; Css.border_bottom_right_radius ]
 
   let rounded_r_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -700,7 +700,7 @@ module Handler = struct
            Css.border_bottom_right_radius (Var r);
          ])
 
-  let rounded_r_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [
+  let rounded_r_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [
         Css.border_top_right_radius;
         Css.border_bottom_right_radius;
       ]
@@ -712,7 +712,7 @@ module Handler = struct
       (extra
       @ [ Css.border_bottom_right_radius v; Css.border_bottom_left_radius v ])
 
-  let rounded_b_none () = scheme_radius "none" radius_none_var ~default:Zero [
+  let rounded_b_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [
         Css.border_bottom_right_radius; Css.border_bottom_left_radius;
       ]
 
@@ -770,7 +770,7 @@ module Handler = struct
            Css.border_bottom_left_radius (Var r);
          ])
 
-  let rounded_b_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [
+  let rounded_b_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [
         Css.border_bottom_right_radius;
         Css.border_bottom_left_radius;
       ]
@@ -781,7 +781,7 @@ module Handler = struct
     style
       (extra @ [ Css.border_top_left_radius v; Css.border_bottom_left_radius v ])
 
-  let rounded_l_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_top_left_radius; Css.border_bottom_left_radius ]
+  let rounded_l_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_left_radius; Css.border_bottom_left_radius ]
 
   let rounded_l_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -837,7 +837,7 @@ module Handler = struct
            Css.border_bottom_left_radius (Var r);
          ])
 
-  let rounded_l_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [
+  let rounded_l_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [
         Css.border_top_left_radius;
         Css.border_bottom_left_radius;
       ]
@@ -847,7 +847,7 @@ module Handler = struct
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_top_left_radius v ])
 
-  let rounded_tl_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_top_left_radius ]
+  let rounded_tl_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_left_radius ]
 
   let rounded_tl_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -873,14 +873,14 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_top_left_radius (Var r) ])
 
-  let rounded_tl_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [ Css.border_top_left_radius ]
+  let rounded_tl_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_top_left_radius ]
 
   (** Corner-specific rounded utilities - top-right *)
   let rounded_tr () =
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_top_right_radius v ])
 
-  let rounded_tr_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_top_right_radius ]
+  let rounded_tr_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_top_right_radius ]
 
   let rounded_tr_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -906,14 +906,14 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_top_right_radius (Var r) ])
 
-  let rounded_tr_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [ Css.border_top_right_radius ]
+  let rounded_tr_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_top_right_radius ]
 
   (** Corner-specific rounded utilities - bottom-right *)
   let rounded_br () =
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_bottom_right_radius v ])
 
-  let rounded_br_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_bottom_right_radius ]
+  let rounded_br_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_bottom_right_radius ]
 
   let rounded_br_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -939,14 +939,14 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_bottom_right_radius (Var r) ])
 
-  let rounded_br_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [ Css.border_bottom_right_radius ]
+  let rounded_br_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_bottom_right_radius ]
 
   (** Corner-specific rounded utilities - bottom-left *)
   let rounded_bl () =
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_bottom_left_radius v ])
 
-  let rounded_bl_none () = scheme_radius "none" radius_none_var ~default:Zero [ Css.border_bottom_left_radius ]
+  let rounded_bl_none ?theme () = scheme_radius ?theme "none" radius_none_var ~default:Zero [ Css.border_bottom_left_radius ]
 
   let rounded_bl_sm () =
     let decl, r = Var.binding radius_sm_var (Rem 0.25) in
@@ -972,7 +972,7 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_bottom_left_radius (Var r) ])
 
-  let rounded_bl_full () = scheme_radius "full" radius_full_var ~default:radius_full_len [ Css.border_bottom_left_radius ]
+  let rounded_bl_full ?theme () = scheme_radius ?theme "full" radius_full_var ~default:radius_full_len [ Css.border_bottom_left_radius ]
 
   (** Logical property rounded utilities - start (inline-start) *)
   let rounded_s () =
@@ -1555,6 +1555,22 @@ module Handler = struct
     let rounded_ee_full () = rounded_ee_full ~theme () in
     let rounded_es_none () = rounded_es_none ~theme () in
     let rounded_es_full () = rounded_es_full ~theme () in
+    let rounded_t_none () = rounded_t_none ~theme () in
+    let rounded_t_full () = rounded_t_full ~theme () in
+    let rounded_r_none () = rounded_r_none ~theme () in
+    let rounded_r_full () = rounded_r_full ~theme () in
+    let rounded_b_none () = rounded_b_none ~theme () in
+    let rounded_b_full () = rounded_b_full ~theme () in
+    let rounded_l_none () = rounded_l_none ~theme () in
+    let rounded_l_full () = rounded_l_full ~theme () in
+    let rounded_tl_none () = rounded_tl_none ~theme () in
+    let rounded_tl_full () = rounded_tl_full ~theme () in
+    let rounded_tr_none () = rounded_tr_none ~theme () in
+    let rounded_tr_full () = rounded_tr_full ~theme () in
+    let rounded_br_none () = rounded_br_none ~theme () in
+    let rounded_br_full () = rounded_br_full ~theme () in
+    let rounded_bl_none () = rounded_bl_none ~theme () in
+    let rounded_bl_full () = rounded_bl_full ~theme () in
     let outline () = outline ~theme () in
     function
     (* Border width utilities *)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1949,7 +1949,7 @@ module Handler = struct
     | Outline_offset_var _ -> 2215
     | Outline_offset_arbitrary _ -> 2215
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "border" ] -> Ok Border
@@ -2501,7 +2501,7 @@ module Outline_style_handler = struct
 
   let err_not_utility = Error (`Msg "Not an outline style utility")
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "outline"; "dashed" ] -> Ok Dashed

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -23,6 +23,11 @@ let current_scheme : Scheme.t ref = ref Scheme.default
 (* Set the current scheme for radius generation *)
 let set_scheme scheme = current_scheme := scheme
 
+(* Resolve the scheme to read from: the threaded [theme] when given, else the
+   global. Migration scaffold while the radius/width helpers move onto the
+   explicitly threaded scheme. *)
+let resolve_scheme = function Some s -> s | None -> !current_scheme
+
 type rounded_position =
   | Rp_all
   | Rp_s
@@ -293,11 +298,11 @@ module Handler = struct
     let decl, _ = Var.binding border_style_var border_style_value in
     style [ decl; border_style border_style_value ]
 
-  let border_default () =
+  let border_default ?theme () =
     make_border_util
       [
         Css.border_width
-          (Px (float_of_int !current_scheme.default_border_width));
+          (Px (float_of_int (resolve_scheme theme).default_border_width));
       ]
 
   let border_0 = make_border_util [ Css.border_width (Px 0.) ]
@@ -500,16 +505,16 @@ module Handler = struct
      fixtures use), otherwise inline the literal -- matching Tailwind, which
      inlines calc(infinity*1px)/0 by default but keys off the token when set.
      Mirrors [rounded_full]/[rounded_none] for the per-corner properties. *)
-  let scheme_radius key var ~(default : Css.length)
+  let scheme_radius ?theme key var ~(default : Css.length)
       (setters : (Css.length -> Css.declaration) list) =
-    match Scheme.radius !current_scheme key with
+    match Scheme.radius (resolve_scheme theme) key with
     | Some explicit ->
         let decl, r = Var.binding var explicit in
         style (decl :: List.map (fun set -> set (Var r : Css.length)) setters)
     | None -> style (List.map (fun set -> set default) setters)
 
-  let rounded_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         (* Scheme has explicit radius: use var(--radius-none) *)
         let decl, r = Var.binding radius_none_var explicit_length in
@@ -555,8 +560,8 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_radius (radius_value (Var r)) ])
 
-  let rounded_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         (* Scheme has explicit radius: use var(--radius-full) *)
         let decl, r = Var.binding radius_full_var explicit_length in
@@ -976,8 +981,8 @@ module Handler = struct
       (extra
       @ [ Css.border_start_start_radius v; Css.border_end_start_radius v ])
 
-  let rounded_s_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_s_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_none_var explicit_length in
         style
@@ -1046,8 +1051,8 @@ module Handler = struct
            Css.border_end_start_radius (Var r);
          ])
 
-  let rounded_s_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_s_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_full_var explicit_length in
         style
@@ -1069,8 +1074,8 @@ module Handler = struct
     style
       (extra @ [ Css.border_start_end_radius v; Css.border_end_end_radius v ])
 
-  let rounded_e_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_e_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_none_var explicit_length in
         style
@@ -1137,8 +1142,8 @@ module Handler = struct
            Css.border_end_end_radius (Var r);
          ])
 
-  let rounded_e_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_e_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_full_var explicit_length in
         style
@@ -1159,8 +1164,8 @@ module Handler = struct
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_start_start_radius v ])
 
-  let rounded_ss_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_ss_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_none_var explicit_length in
         style (decl :: [ Css.border_start_start_radius (Var r) ])
@@ -1190,8 +1195,8 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_start_start_radius (Var r) ])
 
-  let rounded_ss_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_ss_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_full_var explicit_length in
         style (decl :: [ Css.border_start_start_radius (Var r) ])
@@ -1202,8 +1207,8 @@ module Handler = struct
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_start_end_radius v ])
 
-  let rounded_se_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_se_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_none_var explicit_length in
         style (decl :: [ Css.border_start_end_radius (Var r) ])
@@ -1233,8 +1238,8 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_start_end_radius (Var r) ])
 
-  let rounded_se_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_se_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_full_var explicit_length in
         style (decl :: [ Css.border_start_end_radius (Var r) ])
@@ -1245,8 +1250,8 @@ module Handler = struct
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_end_end_radius v ])
 
-  let rounded_ee_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_ee_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_none_var explicit_length in
         style (decl :: [ Css.border_end_end_radius (Var r) ])
@@ -1276,8 +1281,8 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_end_end_radius (Var r) ])
 
-  let rounded_ee_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_ee_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_full_var explicit_length in
         style (decl :: [ Css.border_end_end_radius (Var r) ])
@@ -1288,8 +1293,8 @@ module Handler = struct
     let extra, v = radius_decl_and_val () in
     style (extra @ [ Css.border_end_start_radius v ])
 
-  let rounded_es_none () =
-    match Scheme.radius !current_scheme "none" with
+  let rounded_es_none ?theme () =
+    match Scheme.radius (resolve_scheme theme) "none" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_none_var explicit_length in
         style (decl :: [ Css.border_end_start_radius (Var r) ])
@@ -1319,8 +1324,8 @@ module Handler = struct
     let decl, r = Var.binding radius_3xl_var (Rem 1.5) in
     style (decl :: [ Css.border_end_start_radius (Var r) ])
 
-  let rounded_es_full () =
-    match Scheme.radius !current_scheme "full" with
+  let rounded_es_full ?theme () =
+    match Scheme.radius (resolve_scheme theme) "full" with
     | Some explicit_length ->
         let decl, r = Var.binding radius_full_var explicit_length in
         style (decl :: [ Css.border_end_start_radius (Var r) ])
@@ -1333,14 +1338,14 @@ module Handler = struct
       ~property_order:0 ~family:`Border "tw-outline-style"
 
   (* Base outline utility - sets outline-style from var and width from scheme *)
-  let outline () =
+  let outline ?theme () =
     let oref = Var.reference outline_style_var in
     let property_rule =
       match Var.property_rule outline_style_var with
       | Some rule -> rule
       | None -> Css.empty
     in
-    let width = float_of_int !current_scheme.default_outline_width in
+    let width = float_of_int (resolve_scheme theme).default_outline_width in
     style ~property_rules:property_rule
       [ Css.outline_style (Css.Var oref); Css.outline_width (Px width) ]
 
@@ -1534,7 +1539,24 @@ module Handler = struct
     | Some len -> style (make_decls len)
     | None -> style (make_decls (Px 0.))
 
-  let to_style _theme : t -> Style.t = function
+  let to_style theme : t -> Style.t =
+    let border_default () = border_default ~theme () in
+    let rounded_none () = rounded_none ~theme () in
+    let rounded_full () = rounded_full ~theme () in
+    let rounded_s_none () = rounded_s_none ~theme () in
+    let rounded_s_full () = rounded_s_full ~theme () in
+    let rounded_e_none () = rounded_e_none ~theme () in
+    let rounded_e_full () = rounded_e_full ~theme () in
+    let rounded_ss_none () = rounded_ss_none ~theme () in
+    let rounded_ss_full () = rounded_ss_full ~theme () in
+    let rounded_se_none () = rounded_se_none ~theme () in
+    let rounded_se_full () = rounded_se_full ~theme () in
+    let rounded_ee_none () = rounded_ee_none ~theme () in
+    let rounded_ee_full () = rounded_ee_full ~theme () in
+    let rounded_es_none () = rounded_es_none ~theme () in
+    let rounded_es_full () = rounded_es_full ~theme () in
+    let outline () = outline ~theme () in
+    function
     (* Border width utilities *)
     | Border -> border_default ()
     | Border_0 -> border_0

--- a/lib/borders.mli
+++ b/lib/borders.mli
@@ -541,11 +541,4 @@ val outline_offset_4 : t
 val outline_offset_8 : t
 (** [outline_offset_8] sets outline offset to 8px. *)
 
-(** {1 Configuration} *)
-
-val set_scheme : Scheme.t -> unit
-(** [set_scheme scheme] sets the current theme scheme for radius generation.
-    When a radius is defined in the scheme, utilities use [var(--radius-NAME)]
-    instead of raw values. *)
-
 module Handler : Utility.Handler

--- a/lib/box_sizing.ml
+++ b/lib/box_sizing.ml
@@ -14,7 +14,7 @@ module Handler = struct
   let suborder = function Border -> 0 | Content -> 1
   let to_class = function Border -> "box-border" | Content -> "box-content"
 
-  let to_style = function
+  let to_style _theme = function
     | Border -> style [ box_sizing Border_box ]
     | Content -> style [ box_sizing Content_box ]
 

--- a/lib/box_sizing.ml
+++ b/lib/box_sizing.ml
@@ -18,7 +18,7 @@ module Handler = struct
     | Border -> style [ box_sizing Border_box ]
     | Content -> style [ box_sizing Content_box ]
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "box"; "border" ] -> Ok Border

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1055,7 +1055,7 @@ let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
 
 (* Extract variables, set var names, and property rules from all utilities *)
 let extract_vars_and_rules utilities =
-  let styles = List.map Utility.to_style utilities in
+  let styles = List.map (Utility.to_style Scheme.default) utilities in
   let results = List.map extract_style_vars_and_rules styles in
   let vars_list, set_names_list, prop_rules_list =
     List.fold_right
@@ -1177,7 +1177,7 @@ let sort_keyframes_by_var_order keyframes =
 (** Build all CSS layers from utilities and rules *)
 let layers ~layers ~include_base ?forms ~selector_props ~sorted_rules tw_classes
     statements =
-  let styles = List.map Utility.to_style tw_classes in
+  let styles = List.map (Utility.to_style Scheme.default) tw_classes in
   let vars_from_utilities, set_var_names, property_rules_lists =
     extract_vars_and_rules tw_classes
   in
@@ -1271,7 +1271,7 @@ let rec collect_declarations acc = function
   | Style.Group ts -> List.fold_left collect_declarations acc ts
 
 let to_inline_style utilities =
-  let styles = List.map Utility.to_style utilities in
+  let styles = List.map (Utility.to_style Scheme.default) utilities in
   let all_props = List.rev (List.fold_left collect_declarations [] styles) in
   let non_vars =
     List.filter (fun d -> Css.custom_declaration_name d = None) all_props

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1054,8 +1054,8 @@ let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
   layers_without_property @ property_rules_css @ keyframes_css
 
 (* Extract variables, set var names, and property rules from all utilities *)
-let extract_vars_and_rules utilities =
-  let styles = List.map (Utility.to_style Scheme.default) utilities in
+let extract_vars_and_rules theme utilities =
+  let styles = List.map (Utility.to_style theme) utilities in
   let results = List.map extract_style_vars_and_rules styles in
   let vars_list, set_names_list, prop_rules_list =
     List.fold_right
@@ -1175,11 +1175,11 @@ let sort_keyframes_by_var_order keyframes =
       else String.compare name1 name2 (* Stable sort for same order *))
 
 (** Build all CSS layers from utilities and rules *)
-let layers ~layers ~include_base ?forms ~selector_props ~sorted_rules tw_classes
-    statements =
-  let styles = List.map (Utility.to_style Scheme.default) tw_classes in
+let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
+    tw_classes statements =
+  let styles = List.map (Utility.to_style theme) tw_classes in
   let vars_from_utilities, set_var_names, property_rules_lists =
-    extract_vars_and_rules tw_classes
+    extract_vars_and_rules theme tw_classes
   in
   (* Build first-usage order from ALL vars per utility in utility order. For
      each utility, collects SET vars then REFERENCED vars needing @property.
@@ -1231,13 +1231,13 @@ type config = { base : bool; forms : bool option; layers : bool }
 
 let default_config = { base = true; forms = None; layers = true }
 
-let to_css ?(config = default_config) tw_classes =
+let to_css ?(theme = Scheme.default) ?(config = default_config) tw_classes =
   (* [Rule.outputs ~order_tbl] records each base utility's order under the class
      name it already builds, so [order_of_base] looks it up instead of
      re-parsing the class string while building/sorting rules. *)
   let order_map = Hashtbl.create 256 in
   let selector_props =
-    List.concat_map (Rule.outputs ~order_tbl:order_map) tw_classes
+    List.concat_map (Rule.outputs ~theme ~order_tbl:order_map) tw_classes
   in
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute
@@ -1245,8 +1245,8 @@ let to_css ?(config = default_config) tw_classes =
   let sorted_rules = sorted_indexed_rules order_map selector_props in
   let statements = List.map indexed_rule_to_statement sorted_rules in
   let layer_results =
-    layers ~layers:config.layers ~include_base:config.base ?forms:config.forms
-      ~selector_props ~sorted_rules tw_classes statements
+    layers ~theme ~layers:config.layers ~include_base:config.base
+      ?forms:config.forms ~selector_props ~sorted_rules tw_classes statements
   in
   Css.concat layer_results
 
@@ -1270,8 +1270,8 @@ let rec collect_declarations acc = function
   | Style.Modified (_, t) -> collect_declarations acc t
   | Style.Group ts -> List.fold_left collect_declarations acc ts
 
-let to_inline_style utilities =
-  let styles = List.map (Utility.to_style Scheme.default) utilities in
+let to_inline_style ?(theme = Scheme.default) utilities =
+  let styles = List.map (Utility.to_style theme) utilities in
   let all_props = List.rev (List.fold_left collect_declarations [] styles) in
   let non_vars =
     List.filter (fun d -> Css.custom_declaration_name d = None) all_props

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -44,7 +44,7 @@ let extract_base_utility class_name_no_pseudo =
 (** Parse utility and get ordering, with fallback for non-utility classes *)
 let parse_utility_order base_utility =
   let parts = String.split_on_char '-' base_utility in
-  match Utility.base_of_strings parts with
+  match Utility.base_of_strings Scheme.default parts with
   | Ok u -> Utility.order u
   | Error _ ->
       (* Some selectors (like .group, .peer, .container) are marker classes that
@@ -72,7 +72,7 @@ let selector_props_pairs rules =
           let order =
             match base_class with
             | Some class_name -> (
-                match Utility.base_of_class class_name with
+                match Utility.base_of_class Scheme.default class_name with
                 | Ok u -> Utility.order u
                 | Error _ ->
                     (* base_class doesn't parse as a utility (e.g. "group"
@@ -308,7 +308,7 @@ let order_of_base order_map base_class selector =
       | Some order -> adjust_pseudo class_name order
       | None -> (
           let parts = String.split_on_char '-' base_utility in
-          match Utility.base_of_strings parts with
+          match Utility.base_of_strings Scheme.default parts with
           | Ok u -> adjust_pseudo class_name (Utility.order u)
           | Error _ -> conflict_order (Css.Selector.to_string selector)))
   | None -> conflict_order (Css.Selector.to_string selector)

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -563,6 +563,22 @@ let extract_non_tw_custom_declarations selector_props =
   (* Return in original insertion order *)
   List.rev !insertion_order
 
+(* Substitute per-render [@theme] token overrides into extracted theme-layer
+   declarations. This is the threaded replacement for the override seam that
+   used to live in [Var.binding]: a Theme-role variable whose token is
+   overridden in [theme] emits the override value instead of its registered
+   default. [custom_declaration_name] returns the full [--name] form; the scheme
+   keys overrides by the bare name. *)
+let apply_token_override theme decl =
+  match Css.custom_declaration_name decl with
+  | Some full_name
+    when String.length full_name > 2 && String.sub full_name 0 2 = "--" -> (
+      let bare = String.sub full_name 2 (String.length full_name - 2) in
+      match Scheme.token_override theme bare with
+      | Some css -> Css.custom_property ~layer:"theme" full_name css
+      | None -> decl)
+  | _ -> decl
+
 (* Check if declaration name is a default font family indirection *)
 let is_default_family_name = function
   | "default-font-family" | "default-mono-font-family" -> true
@@ -631,8 +647,12 @@ let theme_layer_rule ~layers = function
       else Css.v [ rule ]
 
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
-let theme_layer_of_props ?(layers = true) ?(default_decls = []) selector_props =
-  let extracted = extract_non_tw_custom_declarations selector_props in
+let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
+    ?(default_decls = []) selector_props =
+  let extracted =
+    extract_non_tw_custom_declarations selector_props
+    |> List.map (apply_token_override theme)
+  in
   let pre_defaults, post_defaults = split_defaults default_decls in
 
   (* Filter defaults to remove duplicates of extracted vars *)
@@ -1115,7 +1135,7 @@ type layers_result = {
   property_rules : Css.statement list;
 }
 
-let individual_layers ~layers ~include_base ~forms_base first_usage_order
+let individual_layers ~theme ~layers ~include_base ~forms_base first_usage_order
     selector_props all_property_statements statements =
   let theme_defaults =
     let font_defaults =
@@ -1129,7 +1149,8 @@ let individual_layers ~layers ~include_base ~forms_base first_usage_order
     font_defaults @ transition_defaults
   in
   let theme_layer =
-    theme_layer_of_props ~layers ~default_decls:theme_defaults selector_props
+    theme_layer_of_props ~theme ~layers ~default_decls:theme_defaults
+      selector_props
   in
   let base_layer = base_layer ~supports:placeholder_supports ~forms_base () in
   let properties_layer, property_rules =
@@ -1209,7 +1230,7 @@ let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
      flag, so utility presence must not auto-enable the global base. *)
   let forms_base = match forms with Some f -> f | None -> false in
   let individual =
-    individual_layers ~layers ~include_base ~forms_base first_usage_order
+    individual_layers ~theme ~layers ~include_base ~forms_base first_usage_order
       selector_props all_property_statements statements
   in
   let keyframes =

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -40,15 +40,17 @@ type config = {
 val default_config : config
 (** The default configuration. Base layer enabled. *)
 
-val to_css : ?config:config -> Utility.t list -> Css.t
-(** [to_css ?config utilities] generates a full CSS stylesheet for [utilities].
-    This is the main entry point for the library. Rendering concerns such as
-    inlining and optimization are handled by {!Css.to_string}. *)
+val to_css : ?theme:Scheme.t -> ?config:config -> Utility.t list -> Css.t
+(** [to_css ?theme ?config utilities] generates a full CSS stylesheet for
+    [utilities]. This is the main entry point for the library. [theme] (default
+    {!Scheme.default}) supplies the theme values utilities read while generating
+    CSS. Rendering concerns such as inlining and optimization are handled by
+    {!Css.to_string}. *)
 
-val to_inline_style : Utility.t list -> string
-(** [to_inline_style utilities] returns a CSS [style] attribute string (e.g.
-    ["color: red; font-size: 1rem"]) suitable for embedding in HTML. Custom
-    properties are stripped; only concrete declarations are included. *)
+val to_inline_style : ?theme:Scheme.t -> Utility.t list -> string
+(** [to_inline_style ?theme utilities] returns a CSS [style] attribute string
+    (e.g. ["color: red; font-size: 1rem"]) suitable for embedding in HTML.
+    Custom properties are stripped; only concrete declarations are included. *)
 
 (** {1 Layer building} *)
 

--- a/lib/clipping.ml
+++ b/lib/clipping.ml
@@ -54,7 +54,7 @@ module Handler = struct
 
   let to_style _theme = function Clip_polygon points -> clip_polygon' points
   let suborder = function Clip_polygon _ -> 0
-  let of_class _class_name = Error (`Msg "Not a clipping utility")
+  let of_class _theme _class_name = Error (`Msg "Not a clipping utility")
 end
 
 open Handler

--- a/lib/clipping.ml
+++ b/lib/clipping.ml
@@ -52,7 +52,7 @@ module Handler = struct
         in
         "clip-[polygon(" ^ coords ^ ")]"
 
-  let to_style = function Clip_polygon points -> clip_polygon' points
+  let to_style _theme = function Clip_polygon points -> clip_polygon' points
   let suborder = function Clip_polygon _ -> 0
   let of_class _class_name = Error (`Msg "Not a clipping utility")
 end

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2000,14 +2000,14 @@ module Handler = struct
         | Error e -> Error e)
     | _ -> Error (`Msg "Not a color utility")
 
-  let bg' c shade =
+  let bg' ?theme c shade =
     if is_custom_color c then
       let css_color = to_css c shade in
       style [ Css.background_color css_color ]
     else
       (* Use shared color variable to match tailwindcss output exactly. *)
       let cv = color_var c shade in
-      let color_value = get_color_value c shade in
+      let color_value = get_color_value ?theme c shade in
       let decl, color_ref = Var.binding cv color_value in
       style (decl :: [ Css.background_color (Css.Var color_ref) ])
 
@@ -2016,7 +2016,7 @@ module Handler = struct
 
   (** Text color utilities *)
 
-  let text' color shade =
+  let text' ?theme color shade =
     if is_custom_color color then
       let css_color = to_css color shade in
       style [ Css.color css_color ]
@@ -2027,8 +2027,9 @@ module Handler = struct
       let cv, color_value =
         if has_property_scoped then
           ( property_color_var ~property_prefix:"text-color" color shade,
-            property_color_value ~property_prefix:"text-color" color shade )
-        else (color_var color shade, get_color_value color shade)
+            property_color_value ?theme ~property_prefix:"text-color" color shade
+          )
+        else (color_var color shade, get_color_value ?theme color shade)
       in
       let decl, color_ref = Var.binding cv color_value in
       style (decl :: [ Css.color (Var color_ref) ])
@@ -2039,13 +2040,13 @@ module Handler = struct
 
   (** Border color utilities *)
 
-  let border_color' color shade =
+  let border_color' ?theme color shade =
     if is_custom_color color then
       let css_color = to_css color shade in
       style [ Css.border_color css_color ]
     else
       let color_var = color_var color shade in
-      let color_value = get_color_value color shade in
+      let color_value = get_color_value ?theme color shade in
       let decl, color_ref = Var.binding color_var color_value in
       style (decl :: [ Css.border_color (Var color_ref) ])
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1711,7 +1711,7 @@ module Handler = struct
         | Ok c -> Some (to_css c 500)
         | Error _ -> None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "bg"; "transparent" ] -> Ok Bg_transparent

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1617,16 +1617,8 @@ module Handler = struct
   (** Extensible variant for color utilities *)
   type Utility.base += Self of t
 
-  (** Current scheme for color generation. Default uses oklch/color-mix. *)
-  let current_scheme : Scheme.t ref = ref Scheme.default
-
-  (** Set the current scheme for color generation *)
-  let set_scheme scheme = current_scheme := scheme
-
-  (** Resolve the scheme to read from: the explicitly threaded [theme] when
-      given, otherwise the current global scheme. Migration scaffold while
-      callers move from the global to the threaded [Scheme.t]. *)
-  let resolve_scheme = function Some s -> s | None -> !current_scheme
+  (** Resolve the optionally-threaded theme, defaulting to the base scheme. *)
+  let resolve_scheme = function Some s -> s | None -> Scheme.default
 
   (** Get the scheme color name for a color and shade (e.g., "red-500"). Must be
       defined before [open Css] to use the outer [color] type. *)
@@ -2027,8 +2019,8 @@ module Handler = struct
       let cv, color_value =
         if has_property_scoped then
           ( property_color_var ~property_prefix:"text-color" color shade,
-            property_color_value ?theme ~property_prefix:"text-color" color shade
-          )
+            property_color_value ?theme ~property_prefix:"text-color" color
+              shade )
         else (color_var color shade, get_color_value ?theme color shade)
       in
       let decl, color_ref = Var.binding cv color_value in
@@ -2962,8 +2954,6 @@ let pp_opacity = function
   | Opacity_named name -> name
   | Opacity_var v -> "[" ^ v ^ "]"
 
-let current_scheme () = !Handler.current_scheme
-let scheme () = !Handler.current_scheme
 let shorten_hex_str = shorten_hex_str
 let bracket_color_to_custom = Handler.bracket_color_to_custom
 let css_color_to_hex = Handler.css_color_to_hex

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2970,11 +2970,11 @@ let css_color_to_hex = Handler.css_color_to_hex
 let parse_bracket_color = Handler.parse_bracket_color
 let round_n = round_n
 
-let hex_alpha_color c shade opacity =
+let hex_alpha_color ?theme c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   let color_name = scheme_color_name c shade in
-  match Scheme.hex_color !current_scheme color_name with
+  match Scheme.hex_color (resolve_scheme theme) color_name with
   | Some hex_value -> Some (hex_with_alpha hex_value percent)
   | None -> None
 
@@ -3014,7 +3014,7 @@ let oklab_with_supports ~property ~fallback_decl c shade percent =
   let supports_block = color_mix_supports ~decls:[ theme_decl; oklab_decl ] in
   Style.style ~rules:(Some [ supports_block ]) [ fallback_decl ]
 
-let generic_color_with_opacity ~property c shade opacity =
+let generic_color_with_opacity ?theme ~property c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   if is_custom_color c then
@@ -3024,7 +3024,7 @@ let generic_color_with_opacity ~property c shade opacity =
     Style.style [ property oklab_value ]
   else
     let color_name = scheme_color_name c shade in
-    match Scheme.hex_color !current_scheme color_name with
+    match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex_value ->
         let fallback_decl =
           property (Css.hex (hex_with_alpha hex_value percent))
@@ -3054,13 +3054,13 @@ let generic_current_with_opacity ?merge_key ~fallback_decl ~property opacity =
   Style.style ?merge_key ~rules:(Some [ supports_block ]) [ fallback_decl ]
 
 (* Fill/stroke helpers for SVG utilities *)
-let fill_with_opacity c shade opacity =
-  generic_color_with_opacity
+let fill_with_opacity ?theme c shade opacity =
+  generic_color_with_opacity ?theme
     ~property:(fun color -> Css.fill (Css.Color color))
     c shade opacity
 
-let stroke_with_opacity c shade opacity =
-  generic_color_with_opacity
+let stroke_with_opacity ?theme c shade opacity =
+  generic_color_with_opacity ?theme
     ~property:(fun color -> Css.stroke (Css.Color color))
     c shade opacity
 
@@ -3117,7 +3117,7 @@ let bg_opacity_via_property c shade percent =
   Style.style ~rules:(Some [ supports_block ]) [ fallback_decl ]
 
 (* Divide helpers with custom selector *)
-let divide_with_opacity_selector ~selector c shade opacity =
+let divide_with_opacity_selector ?theme ~selector c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   if is_custom_color c then
@@ -3128,7 +3128,7 @@ let divide_with_opacity_selector ~selector c shade opacity =
     Style.style ~rules:(Some [ rule ]) []
   else
     let color_name = scheme_color_name c shade in
-    match Scheme.hex_color !current_scheme color_name with
+    match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex_value ->
         let hex_alpha = hex_with_alpha hex_value percent in
         let fallback_rule =
@@ -3149,8 +3149,8 @@ let divide_with_opacity_selector ~selector c shade opacity =
         Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
     | None -> divide_opacity_via_property ~selector c shade percent
 
-let divide_with_opacity c shade opacity selector =
-  divide_with_opacity_selector ~selector c shade opacity
+let divide_with_opacity ?theme c shade opacity selector =
+  divide_with_opacity_selector ?theme ~selector c shade opacity
 
 let divide_current_with_opacity_selector ~selector opacity =
   let open Handler in
@@ -3171,7 +3171,7 @@ let divide_current_with_opacity opacity selector =
 
 (** Background color with opacity - scheme-aware. Uses hex+alpha fallback with
     theme variable in [@supports] block. *)
-let bg_with_opacity c shade opacity =
+let bg_with_opacity ?theme c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   if percent >= 100.0 then
@@ -3188,7 +3188,7 @@ let bg_with_opacity c shade opacity =
     Style.style [ Css.background_color oklab_value ]
   else
     let color_name = scheme_color_name c shade in
-    match Scheme.hex_color !current_scheme color_name with
+    match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex_value ->
         let fallback_decl =
           Css.background_color (Css.hex (hex_with_alpha hex_value percent))

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2081,7 +2081,7 @@ module Handler = struct
 
   (** Accent color utilities *)
 
-  let accent' color shade =
+  let accent' ?theme color shade =
     if is_custom_color color then
       let css_color = to_css color shade in
       style [ Css.accent_color css_color ]
@@ -2090,7 +2090,7 @@ module Handler = struct
         property_color_var ~property_prefix:"accent-color" color shade
       in
       let color_value =
-        property_color_value ~property_prefix:"accent-color" color shade
+        property_color_value ?theme ~property_prefix:"accent-color" color shade
       in
       let decl, color_ref = Var.binding color_var color_value in
       style (decl :: [ Css.accent_color (Var color_ref) ])
@@ -2101,7 +2101,7 @@ module Handler = struct
 
   (** Caret color utilities *)
 
-  let caret' color shade =
+  let caret' ?theme color shade =
     if is_custom_color color then
       let css_color = to_css color shade in
       style [ Css.caret_color css_color ]
@@ -2110,7 +2110,7 @@ module Handler = struct
         property_color_var ~property_prefix:"caret-color" color shade
       in
       let color_value =
-        property_color_value ~property_prefix:"caret-color" color shade
+        property_color_value ?theme ~property_prefix:"caret-color" color shade
       in
       let decl, color_ref = Var.binding color_var color_value in
       style (decl :: [ Css.caret_color (Var color_ref) ])
@@ -2121,7 +2121,7 @@ module Handler = struct
 
   (** Outline color utilities *)
 
-  let outline' color shade =
+  let outline' ?theme color shade =
     if is_custom_color color then
       let css_color = to_css color shade in
       style [ Css.outline_color css_color ]
@@ -2130,7 +2130,7 @@ module Handler = struct
         property_color_var ~property_prefix:"outline-color" color shade
       in
       let color_value =
-        property_color_value ~property_prefix:"outline-color" color shade
+        property_color_value ?theme ~property_prefix:"outline-color" color shade
       in
       let decl, color_ref = Var.binding color_var color_value in
       style (decl :: [ Css.outline_color (Var color_ref) ])
@@ -2252,8 +2252,8 @@ module Handler = struct
       - With hex scheme: fallback is hex+alpha, [\@supports] has color-mix
       - With oklch scheme (default): fallback is color-mix(srgb), [\@supports]
         has color-mix(oklab) *)
-  let color_with_opacity_style ~property ?property_prefix ?merge_key c shade
-      opacity =
+  let color_with_opacity_style ?theme ~property ?property_prefix ?merge_key c
+      shade opacity =
     let percent = opacity_to_percent opacity in
     if is_custom_color c then
       (* Custom/arbitrary colors (hex, rgb): output oklab() directly. No theme
@@ -2272,7 +2272,7 @@ module Handler = struct
       let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
       style ?merge_key [ property oklab_value ]
     else
-      let scheme = !current_scheme in
+      let scheme = resolve_scheme theme in
       let color_name = scheme_color_name c shade in
       (* Check if color is defined as hex in the scheme *)
       match Scheme.hex_color scheme color_name with
@@ -2311,7 +2311,7 @@ module Handler = struct
           let color_value =
             match property_prefix with
             | Some prefix ->
-                property_color_value ~property_prefix:prefix c shade
+                property_color_value ?theme ~property_prefix:prefix c shade
             | Stdlib.Option.None ->
                 to_css c (if is_base_color c then 500 else shade)
           in
@@ -2335,12 +2335,12 @@ module Handler = struct
             [ theme_decl; fallback_decl ]
 
   (** Background color with opacity *)
-  let bg_with_opacity c shade opacity =
-    color_with_opacity_style ~property:Css.background_color
+  let bg_with_opacity ?theme c shade opacity =
+    color_with_opacity_style ?theme ~property:Css.background_color
       ~property_prefix:"background-color" c shade opacity
 
   (** Text color with opacity *)
-  let text_with_opacity c shade opacity =
+  let text_with_opacity ?theme c shade opacity =
     let property_prefix =
       if not (is_custom_color c) then
         let color_name = scheme_color_name c shade in
@@ -2348,26 +2348,26 @@ module Handler = struct
         if Var.theme_value prop_name <> None then Some "text-color" else None
       else None
     in
-    color_with_opacity_style ~property:Css.color ?property_prefix c shade
+    color_with_opacity_style ?theme ~property:Css.color ?property_prefix c shade
       opacity
 
   (** Border color with opacity *)
-  let border_with_opacity c shade opacity =
-    color_with_opacity_style ~property:Css.border_color c shade opacity
+  let border_with_opacity ?theme c shade opacity =
+    color_with_opacity_style ?theme ~property:Css.border_color c shade opacity
 
   (** Accent color with opacity *)
-  let accent_with_opacity c shade opacity =
-    color_with_opacity_style ~property:Css.accent_color
+  let accent_with_opacity ?theme c shade opacity =
+    color_with_opacity_style ?theme ~property:Css.accent_color
       ~property_prefix:"accent-color" c shade opacity
 
   (** Caret color with opacity *)
-  let caret_with_opacity c shade opacity =
-    color_with_opacity_style ~property:Css.caret_color
+  let caret_with_opacity ?theme c shade opacity =
+    color_with_opacity_style ?theme ~property:Css.caret_color
       ~property_prefix:"caret-color" c shade opacity
 
   (** Outline color with opacity *)
-  let outline_with_opacity c shade opacity =
-    color_with_opacity_style ~property:Css.outline_color
+  let outline_with_opacity ?theme c shade opacity =
+    color_with_opacity_style ?theme ~property:Css.outline_color
       ~property_prefix:"outline-color" c shade opacity
 
   (** Current color with opacity using color-mix with progressive enhancement *)
@@ -2471,7 +2471,34 @@ module Handler = struct
     | Style.Style s -> Style.Style { s with pseudo_suffix = Some pseudo }
     | other -> other
 
-  let to_style _theme = function
+  let to_style theme =
+    (* Shadow the scheme-reading colour helpers with theme-applied versions so
+       the match arms below read from the explicitly threaded scheme. *)
+    let bg' color shade = bg' ~theme color shade in
+    let text' color shade = text' ~theme color shade in
+    let border_color' color shade = border_color' ~theme color shade in
+    let accent' color shade = accent' ~theme color shade in
+    let caret' color shade = caret' ~theme color shade in
+    let outline' color shade = outline' ~theme color shade in
+    let bg_with_opacity color shade opacity =
+      bg_with_opacity ~theme color shade opacity
+    in
+    let text_with_opacity color shade opacity =
+      text_with_opacity ~theme color shade opacity
+    in
+    let border_with_opacity color shade opacity =
+      border_with_opacity ~theme color shade opacity
+    in
+    let accent_with_opacity color shade opacity =
+      accent_with_opacity ~theme color shade opacity
+    in
+    let caret_with_opacity color shade opacity =
+      caret_with_opacity ~theme color shade opacity
+    in
+    let outline_with_opacity color shade opacity =
+      outline_with_opacity ~theme color shade opacity
+    in
+    function
     | Bg (color, shade) -> bg' color shade
     | Bg_opacity (color, shade, opacity) ->
         (* 100% opacity: same as base color, no @supports needed *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1451,7 +1451,7 @@ type opacity_modifier =
   | Opacity_var of string (* e.g., /[var(--x)] - var ref used as percentage *)
 
 (** Parse opacity modifier from a string that may contain /NN or /[N.N] *)
-let parse_opacity_modifier s =
+let parse_opacity_modifier ?theme s =
   match String.index_opt s '/' with
   | None -> (s, No_opacity)
   | Some idx -> (
@@ -1484,7 +1484,7 @@ let parse_opacity_modifier s =
                (e.g., /half when --opacity-half exists) *)
             if
               Parse.is_valid_theme_name opacity_str
-              && Var.theme_value ("opacity-" ^ opacity_str) <> None
+              && Scheme.theme_value theme ("opacity-" ^ opacity_str) <> None
             then (base, Opacity_named opacity_str)
             else (s, No_opacity))
 
@@ -1506,9 +1506,11 @@ let shade_of_strings = function
 
 (* Parse color, shade, and optional opacity modifier from string list. Handles
    formats like ["red"; "500/50"] or ["red"; "500/[0.5]"] *)
-let shade_and_opacity_of_strings = function
+let shade_and_opacity_of_strings ?theme = function
   | [ color_str; shade_opacity_str ] -> (
-      let shade_str, opacity = parse_opacity_modifier shade_opacity_str in
+      let shade_str, opacity =
+        parse_opacity_modifier ?theme shade_opacity_str
+      in
       match of_string color_str with
       | Ok color -> (
           match int_of_string_opt shade_str with
@@ -1517,7 +1519,7 @@ let shade_and_opacity_of_strings = function
       | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
   | [ color_str ] -> (
       (* Could be "current/50" or just "black" *)
-      let base_str, opacity = parse_opacity_modifier color_str in
+      let base_str, opacity = parse_opacity_modifier ?theme color_str in
       match of_string base_str with
       | Ok color -> Ok (color, 500, opacity)
       | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
@@ -1711,19 +1713,19 @@ module Handler = struct
         | Ok c -> Some (to_css c 500)
         | Error _ -> None
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "bg"; "transparent" ] -> Ok Bg_transparent
     | [ "bg"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Bg_current
         | No_opacity -> Error (`Msg ("Invalid bg: " ^ current_str))
         | _ -> Ok (Bg_current_opacity opacity))
     | "bg" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) -> Ok (Bg_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "bg" :: color_parts -> (
@@ -1734,7 +1736,7 @@ module Handler = struct
     | [ "text"; "inherit" ] -> Ok Text_inherit
     | [ "text"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Text_current
         | No_opacity -> Error (`Msg ("Invalid text: " ^ current_str))
@@ -1742,8 +1744,9 @@ module Handler = struct
     | [ "text"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (parse_opacity_modifier v)) -> (
-        let base_str, opacity = parse_opacity_modifier v in
+           && Parse.is_bracket_value (fst (parse_opacity_modifier ~theme v))
+      -> (
+        let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         let starts prefix s =
           String.length s >= String.length prefix
@@ -1771,7 +1774,7 @@ module Handler = struct
               )
           | None -> Error (`Msg ("Invalid text bracket value: " ^ base_inner)))
     | "text" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Text_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -1782,7 +1785,7 @@ module Handler = struct
     | [ "border"; "transparent" ] -> Ok Border_transparent
     | [ "border"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Border_current
         | No_opacity -> Error (`Msg ("Invalid border: " ^ current_str))
@@ -1790,8 +1793,9 @@ module Handler = struct
     | [ "border"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (parse_opacity_modifier v)) -> (
-        let base_str, opacity = parse_opacity_modifier v in
+           && Parse.is_bracket_value (fst (parse_opacity_modifier ~theme v))
+      -> (
+        let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         match parse_bracket_color base_inner with
         | Some css_color -> (
@@ -1831,7 +1835,7 @@ module Handler = struct
                 Ok (Border_side_color (bs, Bsc_named (color, shade)))
             | Error e -> Error e))
     | "border" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Border_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -1843,7 +1847,7 @@ module Handler = struct
     | [ "accent"; "inherit" ] -> Ok Accent_inherit
     | [ "accent"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Accent_current
         | No_opacity -> Error (`Msg ("Invalid accent: " ^ current_str))
@@ -1851,8 +1855,9 @@ module Handler = struct
     | [ "accent"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (parse_opacity_modifier v)) -> (
-        let base_str, opacity = parse_opacity_modifier v in
+           && Parse.is_bracket_value (fst (parse_opacity_modifier ~theme v))
+      -> (
+        let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         match parse_bracket_color base_inner with
         | Some css_color -> (
@@ -1864,7 +1869,7 @@ module Handler = struct
             )
         | None -> Error (`Msg ("Invalid accent bracket value: " ^ base_inner)))
     | "accent" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Accent_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -1876,7 +1881,7 @@ module Handler = struct
     | [ "caret"; "transparent" ] -> Ok Caret_transparent
     | [ "caret"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Caret_current
         | No_opacity -> Error (`Msg ("Invalid caret: " ^ current_str))
@@ -1884,8 +1889,9 @@ module Handler = struct
     | [ "caret"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (parse_opacity_modifier v)) -> (
-        let base_str, opacity = parse_opacity_modifier v in
+           && Parse.is_bracket_value (fst (parse_opacity_modifier ~theme v))
+      -> (
+        let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         match parse_bracket_color base_inner with
         | Some css_color -> (
@@ -1897,7 +1903,7 @@ module Handler = struct
             )
         | None -> Error (`Msg ("Invalid caret bracket value: " ^ base_inner)))
     | "caret" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Caret_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -1909,7 +1915,7 @@ module Handler = struct
     | [ "outline"; "inherit" ] -> Ok Outline_inherit
     | [ "outline"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Outline_current
         | No_opacity -> Error (`Msg ("Invalid outline: " ^ current_str))
@@ -1917,8 +1923,9 @@ module Handler = struct
     | [ "outline"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (parse_opacity_modifier v)) -> (
-        let base_str, opacity = parse_opacity_modifier v in
+           && Parse.is_bracket_value (fst (parse_opacity_modifier ~theme v))
+      -> (
+        let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         let starts prefix s =
           String.length s >= String.length prefix
@@ -1947,7 +1954,7 @@ module Handler = struct
           | None ->
               Error (`Msg ("Invalid outline bracket value: " ^ base_inner)))
     | "outline" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Outline_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -1959,7 +1966,7 @@ module Handler = struct
     | [ "placeholder"; "inherit" ] -> Ok Placeholder_inherit
     | [ "placeholder"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier current_str in
+        let base, opacity = parse_opacity_modifier ~theme current_str in
         match opacity with
         | No_opacity when base = "current" -> Ok Placeholder_current
         | No_opacity -> Error (`Msg ("Invalid placeholder: " ^ current_str))
@@ -1967,8 +1974,9 @@ module Handler = struct
     | [ "placeholder"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (parse_opacity_modifier v)) -> (
-        let base_str, opacity = parse_opacity_modifier v in
+           && Parse.is_bracket_value (fst (parse_opacity_modifier ~theme v))
+      -> (
+        let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         match parse_bracket_color base_inner with
         | Some css_color -> (
@@ -1982,7 +1990,7 @@ module Handler = struct
         | None ->
             Error (`Msg ("Invalid placeholder bracket value: " ^ base_inner)))
     | "placeholder" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings color_parts with
+        match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Placeholder_opacity (color, shade, opacity))
         | Error e -> Error e)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1640,10 +1640,10 @@ module Handler = struct
       value exists (e.g., [--accent-color-blue-500]) and if so creates a
       property-scoped variable. Otherwise falls back to the generic
       [--color-{name}] variable. *)
-  let property_color_var ~property_prefix (c : color) shade =
+  let property_color_var ?theme ~property_prefix (c : color) shade =
     let color_name = scheme_color_name c shade in
     let prop_name = property_prefix ^ "-" ^ color_name in
-    match Var.theme_value prop_name with
+    match Scheme.theme_value theme prop_name with
     | Some _ -> (
         (* Property-scoped theme value exists, create scoped variable *)
         let name = prop_name in
@@ -1668,7 +1668,7 @@ module Handler = struct
   let property_color_value ?theme ~property_prefix (c : color) shade =
     let color_name = scheme_color_name c shade in
     let prop_name = property_prefix ^ "-" ^ color_name in
-    match Var.theme_value prop_name with
+    match Scheme.theme_value theme prop_name with
     | Some value -> Css.hex value
     | None -> (
         match Scheme.hex_color (resolve_scheme theme) color_name with
@@ -1676,7 +1676,7 @@ module Handler = struct
         | None -> (
             (* Check theme value overrides for standard color name *)
             let std_name = "color-" ^ color_name in
-            match Var.theme_value std_name with
+            match Scheme.theme_value theme std_name with
             | Some value -> Css.hex value
             | None -> to_css c (if is_base_color c then 500 else shade)))
 
@@ -2015,10 +2015,10 @@ module Handler = struct
     else
       let color_name = scheme_color_name color shade in
       let prop_name = "text-color-" ^ color_name in
-      let has_property_scoped = Var.theme_value prop_name <> None in
+      let has_property_scoped = Scheme.theme_value theme prop_name <> None in
       let cv, color_value =
         if has_property_scoped then
-          ( property_color_var ~property_prefix:"text-color" color shade,
+          ( property_color_var ?theme ~property_prefix:"text-color" color shade,
             property_color_value ?theme ~property_prefix:"text-color" color
               shade )
         else (color_var color shade, get_color_value ?theme color shade)
@@ -2079,7 +2079,7 @@ module Handler = struct
       style [ Css.accent_color css_color ]
     else
       let color_var =
-        property_color_var ~property_prefix:"accent-color" color shade
+        property_color_var ?theme ~property_prefix:"accent-color" color shade
       in
       let color_value =
         property_color_value ?theme ~property_prefix:"accent-color" color shade
@@ -2099,7 +2099,7 @@ module Handler = struct
       style [ Css.caret_color css_color ]
     else
       let color_var =
-        property_color_var ~property_prefix:"caret-color" color shade
+        property_color_var ?theme ~property_prefix:"caret-color" color shade
       in
       let color_value =
         property_color_value ?theme ~property_prefix:"caret-color" color shade
@@ -2119,7 +2119,7 @@ module Handler = struct
       style [ Css.outline_color css_color ]
     else
       let color_var =
-        property_color_var ~property_prefix:"outline-color" color shade
+        property_color_var ?theme ~property_prefix:"outline-color" color shade
       in
       let color_value =
         property_color_value ?theme ~property_prefix:"outline-color" color shade
@@ -2297,7 +2297,8 @@ module Handler = struct
           (* Non-scheme color: use property-scoped variable if prefix given *)
           let color_var =
             match property_prefix with
-            | Some prefix -> property_color_var ~property_prefix:prefix c shade
+            | Some prefix ->
+                property_color_var ?theme ~property_prefix:prefix c shade
             | Stdlib.Option.None -> color_var c shade
           in
           let color_value =
@@ -2337,7 +2338,8 @@ module Handler = struct
       if not (is_custom_color c) then
         let color_name = scheme_color_name c shade in
         let prop_name = "text-color-" ^ color_name in
-        if Var.theme_value prop_name <> None then Some "text-color" else None
+        if Scheme.theme_value theme prop_name <> None then Some "text-color"
+        else None
       else None
     in
     color_with_opacity_style ?theme ~property:Css.color ?property_prefix c shade
@@ -3066,8 +3068,10 @@ let stroke_current_with_opacity opacity =
     ~property:(fun color -> Css.stroke (Css.Color color))
     opacity
 
-let divide_opacity_via_property ~selector c shade percent =
-  let cvar = property_color_var ~property_prefix:"border-color" c shade in
+let divide_opacity_via_property ?theme ~selector c shade percent =
+  let cvar =
+    property_color_var ?theme ~property_prefix:"border-color" c shade
+  in
   let color_value =
     property_color_value ~property_prefix:"border-color" c shade
   in
@@ -3137,7 +3141,7 @@ let divide_with_opacity_selector ?theme ~selector c shade opacity =
           color_mix_supports_stmts ~stmts:[ supports_rule ]
         in
         Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
-    | None -> divide_opacity_via_property ~selector c shade percent
+    | None -> divide_opacity_via_property ?theme ~selector c shade percent
 
 let divide_with_opacity ?theme c shade opacity selector =
   divide_with_opacity_selector ?theme ~selector c shade opacity
@@ -3200,9 +3204,9 @@ let bg_with_opacity ?theme c shade opacity =
     theme defines a var reference (e.g., "var(--custom-opacity)"), use
     [Var_fallback] with the inner var name. Otherwise fall back to the
     conventional [name-opacity] pattern. *)
-let opacity_fallback_for_theme_value var_name bare : Css.percentage Css.fallback
-    =
-  match Var.theme_value var_name with
+let opacity_fallback_for_theme_value ?theme var_name bare :
+    Css.percentage Css.fallback =
+  match Scheme.theme_value theme var_name with
   | Some value when String.length value > 4 && String.sub value 0 4 = "var(" ->
       (* Theme value is a var reference like "var(--custom-opacity)" *)
       let inner = String.sub value 4 (String.length value - 5) in
@@ -3219,7 +3223,7 @@ let opacity_fallback_for_theme_value var_name bare : Css.percentage Css.fallback
   | None -> Css.Var_fallback (bare ^ "-opacity")
 
 (** Background currentColor with opacity *)
-let bg_current_with_opacity opacity =
+let bg_current_with_opacity ?theme opacity =
   let open Handler in
   let fallback_decl = Css.background_color Css.Current in
   let oklab_color =
@@ -3227,7 +3231,7 @@ let bg_current_with_opacity opacity =
     | Opacity_named name ->
         let bare = Parse.extract_var_name name in
         let var_name = "opacity-" ^ bare in
-        let fallback = opacity_fallback_for_theme_value var_name bare in
+        let fallback = opacity_fallback_for_theme_value ?theme var_name bare in
         Css.color_mix_var_pct_fallback ~in_space:Oklab ~var_name ~fallback
           Css.Current Css.Transparent
     | Opacity_var var_str ->

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2465,7 +2465,7 @@ module Handler = struct
     | Style.Style s -> Style.Style { s with pseudo_suffix = Some pseudo }
     | other -> other
 
-  let to_style = function
+  let to_style _theme = function
     | Bg (color, shade) -> bg' color shade
     | Bg_opacity (color, shade, opacity) ->
         (* 100% opacity: same as base color, no @supports needed *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1623,6 +1623,11 @@ module Handler = struct
   (** Set the current scheme for color generation *)
   let set_scheme scheme = current_scheme := scheme
 
+  (** Resolve the scheme to read from: the explicitly threaded [theme] when
+      given, otherwise the current global scheme. Migration scaffold while
+      callers move from the global to the threaded [Scheme.t]. *)
+  let resolve_scheme = function Some s -> s | None -> !current_scheme
+
   (** Get the scheme color name for a color and shade (e.g., "red-500"). Must be
       defined before [open Css] to use the outer [color] type. *)
   let scheme_color_name (c : color) shade =
@@ -1633,9 +1638,9 @@ module Handler = struct
 
   (** Get the color value for a color and shade, checking scheme first. When
       scheme defines the color as hex, returns hex. Otherwise returns oklch. *)
-  let get_color_value (c : color) shade =
+  let get_color_value ?theme (c : color) shade =
     let color_name = scheme_color_name c shade in
-    match Scheme.hex_color !current_scheme color_name with
+    match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex -> Css.hex hex
     | None -> to_css c (if is_base_color c then 500 else shade)
 
@@ -1668,13 +1673,13 @@ module Handler = struct
   (** Get the color value for use with color variables. Checks for
       property-scoped theme value first, then scheme, then generic theme value,
       then converts from oklch as fallback. *)
-  let property_color_value ~property_prefix (c : color) shade =
+  let property_color_value ?theme ~property_prefix (c : color) shade =
     let color_name = scheme_color_name c shade in
     let prop_name = property_prefix ^ "-" ^ color_name in
     match Var.theme_value prop_name with
     | Some value -> Css.hex value
     | None -> (
-        match Scheme.hex_color !current_scheme color_name with
+        match Scheme.hex_color (resolve_scheme theme) color_name with
         | Some hex -> Css.hex hex
         | None -> (
             (* Check theme value overrides for standard color name *)

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -198,9 +198,11 @@ val property_color_var :
 (** [property_color_var ~property_prefix color shade] gets or creates a
     property-scoped color variable (e.g., [--border-color-blue-500]). *)
 
-val property_color_value : property_prefix:string -> color -> int -> Css.color
-(** [property_color_value ~property_prefix color shade] returns the CSS color
-    value for a property-scoped color variable. *)
+val property_color_value :
+  ?theme:Scheme.t -> property_prefix:string -> color -> int -> Css.color
+(** [property_color_value ?theme ~property_prefix color shade] returns the CSS
+    color value for a property-scoped color variable, reading scheme colors from
+    [theme] when given (default: the current global scheme). *)
 
 val scheme_color_name : color -> int -> string
 (** [scheme_color_name color shade] returns the scheme color name (e.g.,

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -194,9 +194,14 @@ val color_var : color -> int -> Css.color Var.theme
     given color and shade. *)
 
 val property_color_var :
-  property_prefix:string -> color -> int -> Css.color Var.theme
-(** [property_color_var ~property_prefix color shade] gets or creates a
-    property-scoped color variable (e.g., [--border-color-blue-500]). *)
+  ?theme:Scheme.t ->
+  property_prefix:string ->
+  color ->
+  int ->
+  Css.color Var.theme
+(** [property_color_var ?theme ~property_prefix color shade] gets or creates a
+    property-scoped color variable (e.g., [--border-color-blue-500]), checking
+    [theme] for a property-scoped token override when given. *)
 
 val property_color_value :
   ?theme:Scheme.t -> property_prefix:string -> color -> int -> Css.color
@@ -222,9 +227,10 @@ val color_mix_supports_condition : Css.Supports.t
     [(color: color-mix(in lab, red, red))]. *)
 
 val opacity_fallback_for_theme_value :
-  string -> string -> Css.percentage Css.fallback
-(** [opacity_fallback_for_theme_value var_name bare] determines the appropriate
-    fallback for an opacity theme variable. *)
+  ?theme:Scheme.t -> string -> string -> Css.percentage Css.fallback
+(** [opacity_fallback_for_theme_value ?theme var_name bare] determines the
+    appropriate fallback for an opacity theme variable, reading token overrides
+    from [theme] when given. *)
 
 (** {1 Tailwind Colors} *)
 
@@ -308,7 +314,8 @@ type opacity_modifier =
 val parse_opacity_modifier : string -> string * opacity_modifier
 (** [parse_opacity_modifier s] parses an opacity modifier from a string. Returns
     the base string and the opacity modifier. Example: "500/50" -> ("500",
-    Opacity_percent 50.0). *)
+    Opacity_percent 50.0). Named opacities are validated at parse time against
+    the theme tokens registered via {!Var.set_theme_value}. *)
 
 val shade_of_strings : string list -> (color * int, [ `Msg of string ]) result
 (** [shade_of_strings parts] parses a color and shade from a list of strings.
@@ -398,9 +405,9 @@ val bg_with_opacity :
     style with opacity. Scheme-aware: uses hex+alpha fallback with theme
     variable in [\@supports] block. *)
 
-val bg_current_with_opacity : opacity_modifier -> Style.t
-(** [bg_current_with_opacity opacity] generates background-color currentColor
-    with opacity using color-mix progressive enhancement. *)
+val bg_current_with_opacity : ?theme:Scheme.t -> opacity_modifier -> Style.t
+(** [bg_current_with_opacity ?theme opacity] generates background-color
+    currentColor with opacity using color-mix progressive enhancement. *)
 
 val rgb_to_oklab : rgb -> float * float * float
 (** [rgb_to_oklab rgb] converts RGB to OKLab (L, a, b) components. *)

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -217,9 +217,6 @@ val hex_to_oklab_alpha : string -> float -> Css.color
     with the given alpha (0.0-1.0). Used for bracket hex colors with opacity
     where the color is known at compile time. *)
 
-val current_scheme : unit -> Scheme.t
-(** [current_scheme ()] returns the current color scheme. *)
-
 val color_mix_supports_condition : Css.Supports.t
 (** [color_mix_supports_condition] is the CSS supports condition for color-mix:
     [(color: color-mix(in lab, red, red))]. *)
@@ -341,11 +338,6 @@ val suborder_with_shade : string -> int
 
 module Handler : sig
   include Utility.Handler
-
-  val set_scheme : Scheme.t -> unit
-  (** Set the current scheme for color generation. When a color is defined as
-      hex in the scheme, opacity modifiers will use hex+alpha fallback instead
-      of color-mix. *)
 end
 
 (** {1 Color with Opacity Helpers}
@@ -432,6 +424,3 @@ val css_color_to_hex : Css.color -> Css.color option
 
 val round_n : int -> float -> float
 (** [round_n n f] rounds [f] to [n] decimal places. *)
-
-val scheme : unit -> Scheme.t
-(** [scheme ()] returns the current color scheme reference. *)

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -354,13 +354,15 @@ end
     enhancement. They produce a fallback declaration plus a [\@supports] block
     for color-mix. *)
 
-val fill_with_opacity : color -> int -> opacity_modifier -> Style.t
-(** [fill_with_opacity color shade opacity] generates fill style with opacity.
-*)
+val fill_with_opacity :
+  ?theme:Scheme.t -> color -> int -> opacity_modifier -> Style.t
+(** [fill_with_opacity ?theme color shade opacity] generates fill style with
+    opacity, reading scheme colours from [theme] when given. *)
 
-val stroke_with_opacity : color -> int -> opacity_modifier -> Style.t
-(** [stroke_with_opacity color shade opacity] generates stroke style with
-    opacity. *)
+val stroke_with_opacity :
+  ?theme:Scheme.t -> color -> int -> opacity_modifier -> Style.t
+(** [stroke_with_opacity ?theme color shade opacity] generates stroke style with
+    opacity, reading scheme colours from [theme] when given. *)
 
 val fill_current_with_opacity : opacity_modifier -> Style.t
 (** [fill_current_with_opacity opacity] generates fill currentColor with
@@ -371,8 +373,13 @@ val stroke_current_with_opacity : opacity_modifier -> Style.t
     opacity. *)
 
 val divide_with_opacity :
-  color -> int -> opacity_modifier -> Css.Selector.t -> Style.t
-(** [divide_with_opacity color shade opacity selector] generates divide
+  ?theme:Scheme.t ->
+  color ->
+  int ->
+  opacity_modifier ->
+  Css.Selector.t ->
+  Style.t
+(** [divide_with_opacity ?theme color shade opacity selector] generates divide
     border-color with opacity using the given selector. *)
 
 val divide_current_with_opacity : opacity_modifier -> Css.Selector.t -> Style.t
@@ -387,15 +394,17 @@ val pp_opacity : opacity_modifier -> string
     modifier for use in class names. E.g., Opacity_percent 50. -> "50",
     Opacity_arbitrary 0.5 -> "[0.5]". *)
 
-val hex_alpha_color : color -> int -> opacity_modifier -> string option
-(** [hex_alpha_color color shade opacity] returns a hex color with alpha if the
-    color is defined in the scheme, otherwise None. This is useful for
+val hex_alpha_color :
+  ?theme:Scheme.t -> color -> int -> opacity_modifier -> string option
+(** [hex_alpha_color ?theme color shade opacity] returns a hex color with alpha
+    if the color is defined in the scheme, otherwise None. This is useful for
     properties where Tailwind outputs simple hex+alpha without [@supports]. *)
 
-val bg_with_opacity : color -> int -> opacity_modifier -> Style.t
-(** [bg_with_opacity color shade opacity] generates background-color style with
-    opacity. Scheme-aware: uses hex+alpha fallback with theme variable in
-    [\@supports] block. *)
+val bg_with_opacity :
+  ?theme:Scheme.t -> color -> int -> opacity_modifier -> Style.t
+(** [bg_with_opacity ?theme color shade opacity] generates background-color
+    style with opacity. Scheme-aware: uses hex+alpha fallback with theme
+    variable in [\@supports] block. *)
 
 val bg_current_with_opacity : opacity_modifier -> Style.t
 (** [bg_current_with_opacity opacity] generates background-color currentColor

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -311,21 +311,24 @@ type opacity_modifier =
   | Opacity_var of string
       (** e.g., /[var(--x)] - var ref used directly as percentage *)
 
-val parse_opacity_modifier : string -> string * opacity_modifier
-(** [parse_opacity_modifier s] parses an opacity modifier from a string. Returns
-    the base string and the opacity modifier. Example: "500/50" -> ("500",
-    Opacity_percent 50.0). Named opacities are validated at parse time against
-    the theme tokens registered via {!Var.set_theme_value}. *)
+val parse_opacity_modifier :
+  ?theme:Scheme.t -> string -> string * opacity_modifier
+(** [parse_opacity_modifier ?theme s] parses an opacity modifier from a string.
+    Returns the base string and the opacity modifier. Example: "500/50" ->
+    ("500", Opacity_percent 50.0). Named opacities are validated at parse time
+    against the [@theme] tokens in [theme]. *)
 
 val shade_of_strings : string list -> (color * int, [ `Msg of string ]) result
 (** [shade_of_strings parts] parses a color and shade from a list of strings.
     Example: ["blue"; "500"] -> Ok (Blue, 500). *)
 
 val shade_and_opacity_of_strings :
-  string list -> (color * int * opacity_modifier, [ `Msg of string ]) result
-(** [shade_and_opacity_of_strings parts] parses a color, shade, and optional
-    opacity modifier from a list of strings. Example: ["blue"; "500/50"] -> Ok
-    (Blue, 500, Opacity_percent 50.0). *)
+  ?theme:Scheme.t ->
+  string list ->
+  (color * int * opacity_modifier, [ `Msg of string ]) result
+(** [shade_and_opacity_of_strings ?theme parts] parses a color, shade, and
+    optional opacity modifier from a list of strings. Example:
+    ["blue"; "500/50"] -> Ok (Blue, 500, Opacity_percent 50.0). *)
 
 val theme_order : string -> int * int
 (** [theme_order c] returns the theme layer order for a color variable. *)

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -143,7 +143,7 @@ module Handler = struct
     in
     string_to_sortkey suffix
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "columns"; "auto" ] -> Ok Columns_auto

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -60,7 +60,7 @@ module Handler = struct
       map (fun n -> Css.Pct n) (drop 1)
     else None
 
-  let to_style _theme = function
+  let to_style theme = function
     | Columns_auto -> (
         let var_name = "columns-auto" in
         let ref =
@@ -68,7 +68,7 @@ module Handler = struct
             ~default:(Auto : Css.columns_value)
             ~default_css:"auto"
         in
-        match Var.theme_value var_name with
+        match Scheme.theme_value (Some theme) var_name with
         | Some value ->
             let theme_decl =
               Css.custom_property ~layer:"theme" ("--" ^ var_name) value

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -60,7 +60,7 @@ module Handler = struct
       map (fun n -> Css.Pct n) (drop 1)
     else None
 
-  let to_style = function
+  let to_style _theme = function
     | Columns_auto -> (
         let var_name = "columns-auto" in
         let ref =

--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -139,7 +139,7 @@ module Handler = struct
   let of_class_map =
     List.map (fun (t, s, _) -> ("contain-" ^ s, t)) contain_data
 
-  let of_class class_name =
+  let of_class _theme class_name =
     match List.assoc_opt class_name of_class_map with
     | Some t -> Ok t
     | None ->

--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -107,7 +107,7 @@ module Handler = struct
     style ~property_rules:contain_property_rules
       [ decl; contain composable_contain_value ]
 
-  let to_style = function
+  let to_style _theme = function
     | None -> style [ contain Css.None ]
     | Strict -> style [ contain Css.Strict ]
     | Content -> style [ contain Css.Content ]

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -68,7 +68,7 @@ module Handler = struct
     | Container_normal -> 2
     | Layout_container -> 3 (* After @container utilities *)
 
-  let of_class = function
+  let of_class _theme = function
     | "container" -> Ok Layout_container
     | "@container" -> Ok Container
     | "@container-normal" -> Ok Container_normal

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -56,7 +56,7 @@ module Handler = struct
   let container_named_style name =
     style [ Css.Declaration.container ~type_:Inline_size name ]
 
-  let to_style = function
+  let to_style _theme = function
     | Layout_container -> layout_container_style
     | Container -> container_query
     | Container_normal -> container_normal_style

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -154,7 +154,7 @@ module Handler = struct
     | Cursor_theme name -> theme_suborder name
     | t -> List.assoc t suborder_map
 
-  let of_class cls =
+  let of_class _theme cls =
     let parts = Parse.split_class cls in
     match parts with
     | [ "cursor"; value ] when Parse.is_bracket_var value ->

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -115,7 +115,7 @@ module Handler = struct
     | Cursor_theme name -> "cursor-" ^ name
     | t -> List.assoc t to_class_map
 
-  let to_style = function
+  let to_style _theme = function
     | Cursor_bracket_var s ->
         let inner = Parse.extract_var_name s in
         let ref : Css.cursor Css.var = Var.bracket inner in

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -115,7 +115,7 @@ module Handler = struct
     | Cursor_theme name -> "cursor-" ^ name
     | t -> List.assoc t to_class_map
 
-  let to_style _theme = function
+  let to_style theme = function
     | Cursor_bracket_var s ->
         let inner = Parse.extract_var_name s in
         let ref : Css.cursor Css.var = Var.bracket inner in
@@ -127,7 +127,7 @@ module Handler = struct
             ~default:(Auto : Css.cursor)
             ~default_css:"auto"
         in
-        match Var.theme_value var_name with
+        match Scheme.theme_value (Some theme) var_name with
         | Some value ->
             let theme_decl =
               Css.custom_property ~layer:"theme" ("--" ^ var_name) value

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -459,7 +459,7 @@ module Handler = struct
       else None
     else None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "divide"; "x" ] -> Ok (Divide_x 1)

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -161,7 +161,7 @@ module Handler = struct
   (* Divide color utilities use nested rules with :where(.divide-X >
      :not(:last-child)) We construct the full class name in the selector like
      space-x-reverse does. *)
-  let divide_color_style color shade =
+  let divide_color_style ?theme color shade =
     let class_name =
       if Color.is_shadeless color then "divide-" ^ Color.color_to_string color
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
@@ -179,7 +179,8 @@ module Handler = struct
         Color.property_color_var ~property_prefix:"border-color" color shade
       in
       let color_value =
-        Color.property_color_value ~property_prefix:"border-color" color shade
+        Color.property_color_value ?theme ~property_prefix:"border-color" color
+          shade
       in
       let decl, color_ref = Var.binding color_var color_value in
       let rule =
@@ -316,7 +317,7 @@ module Handler = struct
     | Color.Opacity_var v -> "/[" ^ v ^ "]"
 
   (* Divide color with opacity using Color helpers *)
-  let divide_color_opacity_style color shade opacity =
+  let divide_color_opacity_style ?theme color shade opacity =
     let base_class_name =
       if Color.is_shadeless color then "divide-" ^ Color.color_to_string color
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
@@ -326,7 +327,7 @@ module Handler = struct
       Css.Selector.(
         where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
     in
-    Color.divide_with_opacity color shade opacity selector
+    Color.divide_with_opacity ?theme color shade opacity selector
 
   let divide_current_opacity_style opacity =
     let class_name = "divide-current" ^ opacity_suffix opacity in
@@ -385,18 +386,23 @@ module Handler = struct
         "divide-[" ^ v ^ "]" ^ opacity_suffix opacity
     | Divide_style bs -> "divide-" ^ border_style_to_string bs
 
-  let to_style _theme = function
+  let to_style theme =
+    let divide_color_style color shade = divide_color_style ~theme color shade in
+    let divide_color_opacity_style color shade opacity =
+      divide_color_opacity_style ~theme color shade opacity
+    in
+    function
     | Divide_x n ->
         let class_name =
           if n = 1 then "divide-x" else "divide-x-" ^ string_of_int n
         in
-        let w = if n = 1 then !current_scheme.default_border_width else n in
+        let w = if n = 1 then theme.Scheme.default_border_width else n in
         divide_x_width_style ~class_name ~width:(Px (float_of_int w))
     | Divide_y n ->
         let class_name =
           if n = 1 then "divide-y" else "divide-y-" ^ string_of_int n
         in
-        let w = if n = 1 then !current_scheme.default_border_width else n in
+        let w = if n = 1 then theme.Scheme.default_border_width else n in
         divide_y_width_style ~class_name ~width:(Px (float_of_int w))
     | Divide_x_arb len ->
         let class_name = to_class (Divide_x_arb len) in

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -385,7 +385,7 @@ module Handler = struct
         "divide-[" ^ v ^ "]" ^ opacity_suffix opacity
     | Divide_style bs -> "divide-" ^ border_style_to_string bs
 
-  let to_style = function
+  let to_style _theme = function
     | Divide_x n ->
         let class_name =
           if n = 1 then "divide-x" else "divide-x-" ^ string_of_int n

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -459,7 +459,7 @@ module Handler = struct
       else None
     else None
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "divide"; "x" ] -> Ok (Divide_x 1)
@@ -487,14 +487,15 @@ module Handler = struct
         Ok (Divide_style (Stdlib.Option.get (divide_style_of_string style_str)))
     | [ "divide"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Divide_current
         | Color.No_opacity -> Error (`Msg ("Invalid divide: " ^ current_str))
         | _ -> Ok (Divide_current_opacity opacity))
     | [ "divide"; v ]
-      when Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
-        let base_str, opacity = Color.parse_opacity_modifier v in
+      when Parse.is_bracket_value (fst (Color.parse_opacity_modifier ~theme v))
+      ->
+        let base_str, opacity = Color.parse_opacity_modifier ~theme v in
         let inner = Parse.bracket_inner base_str in
         let normalized =
           String.map (fun c -> if c = '_' then ' ' else c) inner
@@ -516,16 +517,17 @@ module Handler = struct
           | None -> Error (`Msg ("Invalid divide bracket color: " ^ inner))
         else Error (`Msg ("Invalid divide bracket value: " ^ inner))
     | "divide" :: color_parts when List.exists has_opacity color_parts -> (
-        match Color.shade_and_opacity_of_strings color_parts with
+        match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Divide_color_opacity (color, shade, opacity))
         | Error _ ->
             (* Try as theme-named color *)
             let name = String.concat "-" color_parts in
-            let base, opacity = Color.parse_opacity_modifier name in
+            let base, opacity = Color.parse_opacity_modifier ~theme name in
             if
-              Var.theme_value ("color-" ^ base) <> None
-              || Var.theme_value ("border-color-" ^ base) <> None
+              Scheme.theme_value (Some theme) ("color-" ^ base) <> None
+              || Scheme.theme_value (Some theme) ("border-color-" ^ base)
+                 <> None
             then Ok (Divide_color_opacity (Theme_named base, 500, opacity))
             else Error (`Msg ("Invalid divide color: " ^ name)))
     | "divide" :: color_parts -> (
@@ -536,8 +538,9 @@ module Handler = struct
                theme values *)
             let name = String.concat "-" color_parts in
             if
-              Var.theme_value ("color-" ^ name) <> None
-              || Var.theme_value ("border-color-" ^ name) <> None
+              Scheme.theme_value (Some theme) ("color-" ^ name) <> None
+              || Scheme.theme_value (Some theme) ("border-color-" ^ name)
+                 <> None
             then Ok (Divide_color (Theme_named name, 500))
             else Error (`Msg ("Invalid divide color: " ^ name)))
     | _ -> Error (`Msg "Not a divide utility")

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -170,7 +170,8 @@ module Handler = struct
       style ~rules:(Some [ rule ]) []
     else
       let color_var =
-        Color.property_color_var ~property_prefix:"border-color" color shade
+        Color.property_color_var ?theme ~property_prefix:"border-color" color
+          shade
       in
       let color_value =
         Color.property_color_value ?theme ~property_prefix:"border-color" color

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -5,12 +5,6 @@
 
 module Css = Cascade.Css
 
-(* Current scheme for default border width *)
-let current_scheme : Scheme.t ref = ref Scheme.default
-
-(* Set the current scheme for divide generation *)
-let set_scheme scheme = current_scheme := scheme
-
 module Handler = struct
   open Style
 
@@ -387,7 +381,9 @@ module Handler = struct
     | Divide_style bs -> "divide-" ^ border_style_to_string bs
 
   let to_style theme =
-    let divide_color_style color shade = divide_color_style ~theme color shade in
+    let divide_color_style color shade =
+      divide_color_style ~theme color shade
+    in
     let divide_color_opacity_style color shade opacity =
       divide_color_opacity_style ~theme color shade opacity
     in

--- a/lib/divide.mli
+++ b/lib/divide.mli
@@ -5,10 +5,6 @@
 
 open Utility
 
-val set_scheme : Scheme.t -> unit
-(** [set_scheme scheme] sets the current theme scheme for divide width defaults.
-*)
-
 (** {1 Divide Reverse Utilities} *)
 
 val divide_x_reverse : t

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -652,10 +652,10 @@ module Handler = struct
     | Stdlib.Option.None -> (
         (* Check property-scoped theme value first *)
         let prop_name = property_prefix ^ "-" ^ color_name in
-        match Var.theme_value prop_name with
+        match Scheme.theme_value theme prop_name with
         | Stdlib.Option.Some h -> h
         | Stdlib.Option.None -> (
-            match Var.theme_value ("color-" ^ color_name) with
+            match Scheme.theme_value theme ("color-" ^ color_name) with
             | Stdlib.Option.Some h -> h
             | Stdlib.Option.None ->
                 let oklch = Color.to_oklch c shade in
@@ -668,7 +668,7 @@ module Handler = struct
     in
     let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_value) in
     let theme_color_var =
-      Color.property_color_var ~property_prefix:"box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -690,7 +690,7 @@ module Handler = struct
     let hex_with_alpha = Color.hex_with_alpha hex_value percent in
     let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_with_alpha) in
     let theme_color_var =
-      Color.property_color_var ~property_prefix:"box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -1167,10 +1167,10 @@ module Handler = struct
     | Stdlib.Option.Some h -> h
     | Stdlib.Option.None -> (
         let prop_name = property_prefix ^ "-" ^ color_name in
-        match Var.theme_value prop_name with
+        match Scheme.theme_value theme prop_name with
         | Stdlib.Option.Some h -> h
         | Stdlib.Option.None -> (
-            match Var.theme_value ("color-" ^ color_name) with
+            match Scheme.theme_value theme ("color-" ^ color_name) with
             | Stdlib.Option.Some h -> h
             | Stdlib.Option.None ->
                 let oklch = Color.to_oklch c shade in
@@ -1184,7 +1184,7 @@ module Handler = struct
     in
     let base_decl, _ = Var.binding inset_shadow_color_var (Css.hex hex_value) in
     let theme_color_var =
-      Color.property_color_var ~property_prefix:"inset-box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color" c shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -1209,7 +1209,7 @@ module Handler = struct
       Var.binding inset_shadow_color_var (Css.hex hex_with_alpha)
     in
     let theme_color_var =
-      Color.property_color_var ~property_prefix:"inset-box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color" c shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -1476,9 +1476,9 @@ module Handler = struct
     in
     style [ decl ]
 
-  let ring_color color shade =
+  let ring_color ?theme color shade =
     let cvar =
-      Color.property_color_var ~property_prefix:"ring-color" color shade
+      Color.property_color_var ?theme ~property_prefix:"ring-color" color shade
     in
     let color_value =
       Color.property_color_value ~property_prefix:"ring-color" color shade
@@ -1493,7 +1493,7 @@ module Handler = struct
     | Some hex_alpha ->
         let fallback, _ = Var.binding ring_color_var (Css.hex hex_alpha) in
         let cvar =
-          Color.property_color_var ~property_prefix:"ring-color" color shade
+          Color.property_color_var ?theme ~property_prefix:"ring-color" color shade
         in
         let color_value =
           Color.property_color_value ~property_prefix:"ring-color" color shade
@@ -1512,7 +1512,7 @@ module Handler = struct
             ]
         in
         Style.style ~rules:(Some [ supports_block ]) [ fallback ]
-    | None -> ring_color color shade
+    | None -> ring_color ?theme color shade
 
   let ring_offset_width n =
     (* Sets --tw-ring-offset-width and --tw-ring-offset-shadow Format:
@@ -1529,11 +1529,11 @@ module Handler = struct
     let d_shadow, _ = Var.binding ring_offset_shadow_var shadow_value in
     style [ d_width; d_shadow ]
 
-  let ring_offset_color color shade =
+  let ring_offset_color ?theme color shade =
     (* Sets --tw-ring-offset-color to reference theme color variable. Uses
        property-scoped variable: --ring-offset-color-blue-500 *)
     let color_theme_var =
-      Color.property_color_var ~property_prefix:"ring-offset-color" color shade
+      Color.property_color_var ?theme ~property_prefix:"ring-offset-color" color shade
     in
     let color_value =
       Color.property_color_value ~property_prefix:"ring-offset-color" color
@@ -1595,7 +1595,7 @@ module Handler = struct
           Var.binding ring_offset_color_var (Css.hex hex_alpha)
         in
         let cvar =
-          Color.property_color_var ~property_prefix:"ring-offset-color" color
+          Color.property_color_var ?theme ~property_prefix:"ring-offset-color" color
             shade
         in
         let color_value =
@@ -1616,7 +1616,7 @@ module Handler = struct
             ]
         in
         Style.style ~rules:(Some [ supports_block ]) [ fallback ]
-    | None -> ring_offset_color color shade
+    | None -> ring_offset_color ?theme color shade
 
   let ring_offset_transparent =
     let d, _ = Var.binding ring_offset_color_var Css.Transparent in
@@ -1722,9 +1722,9 @@ module Handler = struct
       [ fallback ]
 
   (* Inset-ring utilities *)
-  let inset_ring_color color shade =
+  let inset_ring_color ?theme color shade =
     let cvar =
-      Color.property_color_var ~property_prefix:"inset-ring-color" color shade
+      Color.property_color_var ?theme ~property_prefix:"inset-ring-color" color shade
     in
     let color_value =
       Color.property_color_value ~property_prefix:"inset-ring-color" color shade
@@ -1741,7 +1741,7 @@ module Handler = struct
           Var.binding inset_ring_color_var (Css.hex hex_alpha)
         in
         let cvar =
-          Color.property_color_var ~property_prefix:"inset-ring-color" color
+          Color.property_color_var ?theme ~property_prefix:"inset-ring-color" color
             shade
         in
         let color_value =
@@ -1762,7 +1762,7 @@ module Handler = struct
             ]
         in
         Style.style ~rules:(Some [ supports_block ]) [ fallback ]
-    | None -> inset_ring_color color shade
+    | None -> inset_ring_color ?theme color shade
 
   let inset_ring_transparent =
     let d, _ = Var.binding inset_ring_color_var Css.Transparent in
@@ -2005,6 +2005,9 @@ module Handler = struct
       inset_ring_color_with_opacity ~theme color shade opacity
     in
     let ring_default () = ring_default ~theme () in
+    let ring_color color shade = ring_color ~theme color shade in
+    let ring_offset_color color shade = ring_offset_color ~theme color shade in
+    let inset_ring_color color shade = inset_ring_color ~theme color shade in
     function
     | Shadow_none -> shadow_none
     | Shadow_2xs -> shadow_2xs

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2417,7 +2417,7 @@ module Handler = struct
           | Color.No_opacity -> Ok (Inset_shadow_arbitrary inner)
           | _ -> Ok (Inset_shadow_arbitrary_opacity (inner, opacity)))
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "shadow"; "none" ] -> Ok Shadow_none

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2,9 +2,6 @@
 
 module Css = Cascade.Css
 
-let current_scheme : Scheme.t ref = ref Scheme.default
-let set_scheme scheme = current_scheme := scheme
-
 module Handler = struct
   open Style
 
@@ -649,7 +646,7 @@ module Handler = struct
 
   let shadow_color_hex ?theme ~property_prefix c shade =
     let color_name = Color.scheme_color_name c shade in
-    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     match Scheme.hex_color scheme color_name with
     | Stdlib.Option.Some h -> h
     | Stdlib.Option.None -> (
@@ -1165,7 +1162,7 @@ module Handler = struct
 
   let inset_shadow_color_hex ?theme ~property_prefix c shade =
     let color_name = Color.scheme_color_name c shade in
-    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     match Scheme.hex_color scheme color_name with
     | Stdlib.Option.Some h -> h
     | Stdlib.Option.None -> (
@@ -1418,7 +1415,7 @@ module Handler = struct
   (** Bare [ring] — uses scheme's [default_ring_width] (configurable via
       Tailwind's [@theme \{ --default-ring-width \}], default 1px). *)
   let ring_default ?theme () =
-    let scheme = match theme with Some t -> t | None -> !current_scheme in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     ring_internal scheme.Scheme.default_ring_width
 
   let inset_ring_internal width_px =

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -647,9 +647,10 @@ module Handler = struct
 
   (* ============ Shadow color utilities ============ *)
 
-  let shadow_color_hex ~property_prefix c shade =
+  let shadow_color_hex ?theme ~property_prefix c shade =
     let color_name = Color.scheme_color_name c shade in
-    match Scheme.hex_color (Color.scheme ()) color_name with
+    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    match Scheme.hex_color scheme color_name with
     | Stdlib.Option.Some h -> h
     | Stdlib.Option.None -> (
         (* Check property-scoped theme value first *)
@@ -664,9 +665,9 @@ module Handler = struct
                 let rgb = Color.oklch_to_rgb oklch in
                 Color.rgb_to_hex rgb))
 
-  let set_shadow_color c shade =
+  let set_shadow_color ?theme c shade =
     let hex_value =
-      shadow_color_hex ~property_prefix:"box-shadow-color" c shade
+      shadow_color_hex ?theme ~property_prefix:"box-shadow-color" c shade
     in
     let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_value) in
     let theme_color_var =
@@ -684,10 +685,10 @@ module Handler = struct
     style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
       [ base_decl ]
 
-  let set_shadow_color_opacity c shade opacity =
+  let set_shadow_color_opacity ?theme c shade opacity =
     let percent = Color.opacity_to_percent opacity in
     let hex_value =
-      shadow_color_hex ~property_prefix:"box-shadow-color" c shade
+      shadow_color_hex ?theme ~property_prefix:"box-shadow-color" c shade
     in
     let hex_with_alpha = Color.hex_with_alpha hex_value percent in
     let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_with_alpha) in
@@ -1162,9 +1163,10 @@ module Handler = struct
 
   (* ============ Inset shadow color utilities ============ *)
 
-  let inset_shadow_color_hex ~property_prefix c shade =
+  let inset_shadow_color_hex ?theme ~property_prefix c shade =
     let color_name = Color.scheme_color_name c shade in
-    match Scheme.hex_color (Color.scheme ()) color_name with
+    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    match Scheme.hex_color scheme color_name with
     | Stdlib.Option.Some h -> h
     | Stdlib.Option.None -> (
         let prop_name = property_prefix ^ "-" ^ color_name in
@@ -1178,9 +1180,10 @@ module Handler = struct
                 let rgb = Color.oklch_to_rgb oklch in
                 Color.rgb_to_hex rgb))
 
-  let set_inset_shadow_color c shade =
+  let set_inset_shadow_color ?theme c shade =
     let hex_value =
-      inset_shadow_color_hex ~property_prefix:"inset-box-shadow-color" c shade
+      inset_shadow_color_hex ?theme ~property_prefix:"inset-box-shadow-color" c
+        shade
     in
     let base_decl, _ = Var.binding inset_shadow_color_var (Css.hex hex_value) in
     let theme_color_var =
@@ -1198,10 +1201,11 @@ module Handler = struct
     style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
       [ base_decl ]
 
-  let set_inset_shadow_color_opacity c shade opacity =
+  let set_inset_shadow_color_opacity ?theme c shade opacity =
     let percent = Color.opacity_to_percent opacity in
     let hex_value =
-      inset_shadow_color_hex ~property_prefix:"inset-box-shadow-color" c shade
+      inset_shadow_color_hex ?theme ~property_prefix:"inset-box-shadow-color" c
+        shade
     in
     let hex_with_alpha = Color.hex_with_alpha hex_value percent in
     let base_decl, _ =
@@ -1413,7 +1417,9 @@ module Handler = struct
 
   (** Bare [ring] — uses scheme's [default_ring_width] (configurable via
       Tailwind's [@theme \{ --default-ring-width \}], default 1px). *)
-  let ring_default () = ring_internal !current_scheme.default_ring_width
+  let ring_default ?theme () =
+    let scheme = match theme with Some t -> t | None -> !current_scheme in
+    ring_internal scheme.Scheme.default_ring_width
 
   let inset_ring_internal width_px =
     let spread : Css.length = Px (float_of_int width_px) in
@@ -1484,9 +1490,9 @@ module Handler = struct
     let d, _ = Var.binding ring_color_var (Css.Var color_ref) in
     style [ color_decl; d ]
 
-  let ring_color_with_opacity color shade opacity =
+  let ring_color_with_opacity ?theme color shade opacity =
     let percent = Color.opacity_to_percent opacity in
-    match Color.hex_alpha_color color shade opacity with
+    match Color.hex_alpha_color ?theme color shade opacity with
     | Some hex_alpha ->
         let fallback, _ = Var.binding ring_color_var (Css.hex hex_alpha) in
         let cvar =
@@ -1584,9 +1590,9 @@ module Handler = struct
       | None -> None
 
   (* Ring-offset color utilities *)
-  let ring_offset_color_with_opacity color shade opacity =
+  let ring_offset_color_with_opacity ?theme color shade opacity =
     let percent = Color.opacity_to_percent opacity in
-    match Color.hex_alpha_color color shade opacity with
+    match Color.hex_alpha_color ?theme color shade opacity with
     | Some hex_alpha ->
         let fallback, _ =
           Var.binding ring_offset_color_var (Css.hex hex_alpha)
@@ -1730,9 +1736,9 @@ module Handler = struct
     let d, _ = Var.binding inset_ring_color_var (Css.Var color_ref) in
     style [ color_decl; d ]
 
-  let inset_ring_color_with_opacity color shade opacity =
+  let inset_ring_color_with_opacity ?theme color shade opacity =
     let percent = Color.opacity_to_percent opacity in
-    match Color.hex_alpha_color color shade opacity with
+    match Color.hex_alpha_color ?theme color shade opacity with
     | Some hex_alpha ->
         let fallback, _ =
           Var.binding inset_ring_color_var (Css.hex hex_alpha)
@@ -1981,7 +1987,28 @@ module Handler = struct
   let bg_blend_color = style [ background_blend_mode Color ]
   let bg_blend_luminosity = style [ background_blend_mode Luminosity ]
 
-  let to_style _theme = function
+  let to_style theme =
+    let set_shadow_color c shade = set_shadow_color ~theme c shade in
+    let set_shadow_color_opacity c shade opacity =
+      set_shadow_color_opacity ~theme c shade opacity
+    in
+    let set_inset_shadow_color c shade =
+      set_inset_shadow_color ~theme c shade
+    in
+    let set_inset_shadow_color_opacity c shade opacity =
+      set_inset_shadow_color_opacity ~theme c shade opacity
+    in
+    let ring_color_with_opacity color shade opacity =
+      ring_color_with_opacity ~theme color shade opacity
+    in
+    let ring_offset_color_with_opacity color shade opacity =
+      ring_offset_color_with_opacity ~theme color shade opacity
+    in
+    let inset_ring_color_with_opacity color shade opacity =
+      inset_ring_color_with_opacity ~theme color shade opacity
+    in
+    let ring_default () = ring_default ~theme () in
+    function
     | Shadow_none -> shadow_none
     | Shadow_2xs -> shadow_2xs
     | Shadow_xs -> shadow_xs

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2417,7 +2417,7 @@ module Handler = struct
           | Color.No_opacity -> Ok (Inset_shadow_arbitrary inner)
           | _ -> Ok (Inset_shadow_arbitrary_opacity (inner, opacity)))
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "shadow"; "none" ] -> Ok Shadow_none
@@ -2426,7 +2426,7 @@ module Handler = struct
     | [ "shadow"; "sm" ] -> Ok Shadow_sm
     | [ "shadow" ] -> Ok Shadow
     | [ base ] when String.starts_with ~prefix:"shadow/" base -> (
-        let _, opacity = Color.parse_opacity_modifier base in
+        let _, opacity = Color.parse_opacity_modifier ~theme base in
         match opacity with
         | Color.No_opacity -> err_not_utility
         | op -> Ok (Shadow_shape_opacity (Default, op)))
@@ -2439,7 +2439,7 @@ module Handler = struct
     | [ "shadow"; "transparent" ] -> Ok Shadow_transparent
     | [ "shadow"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Shadow_current
         | Color.No_opacity -> err_not_utility
@@ -2450,7 +2450,7 @@ module Handler = struct
            && Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
         parse_shadow_bracket v
     | [ "shadow"; name ] when String.contains name '/' -> (
-        let base, opacity = Color.parse_opacity_modifier name in
+        let base, opacity = Color.parse_opacity_modifier ~theme name in
         match (base, opacity) with
         | _, Color.No_opacity -> err_not_utility
         | "2xs", op -> Ok (Shadow_shape_opacity (Two_xs, op))
@@ -2462,7 +2462,7 @@ module Handler = struct
         | "2xl", op -> Ok (Shadow_shape_opacity (Two_xl, op))
         | _ -> err_not_utility)
     | [ "shadow"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier shade in
+        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
         match (Color.of_string color, Parse.int_any shade_str) with
         | Ok c, Ok s -> (
             match opacity with
@@ -2473,7 +2473,7 @@ module Handler = struct
     | [ "inset"; "shadow"; "sm" ] -> Ok Inset_shadow_sm
     | [ "inset"; "shadow" ] -> Ok Inset_shadow
     | [ base ] when String.starts_with ~prefix:"inset-shadow/" base -> (
-        let _, opacity = Color.parse_opacity_modifier base in
+        let _, opacity = Color.parse_opacity_modifier ~theme base in
         match opacity with
         | Color.No_opacity -> err_not_utility
         | op -> Ok (Inset_shadow_shape_opacity (Ish_default, op)))
@@ -2485,7 +2485,7 @@ module Handler = struct
     | [ "inset"; "shadow"; "transparent" ] -> Ok Inset_shadow_transparent
     | [ "inset"; "shadow"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Inset_shadow_current
         | Color.No_opacity -> err_not_utility
@@ -2496,7 +2496,7 @@ module Handler = struct
            && Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
         parse_inset_shadow_bracket v
     | [ "inset"; "shadow"; name ] when String.contains name '/' -> (
-        let base, opacity = Color.parse_opacity_modifier name in
+        let base, opacity = Color.parse_opacity_modifier ~theme name in
         match (base, opacity) with
         | _, Color.No_opacity -> err_not_utility
         | "sm", op -> Ok (Inset_shadow_shape_opacity (Ish_sm, op))
@@ -2506,7 +2506,7 @@ module Handler = struct
         | "2xl", op -> Ok (Inset_shadow_shape_opacity (Ish_2xl, op))
         | _ -> err_not_utility)
     | [ "inset"; "shadow"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier shade in
+        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
         match (Color.of_string color, Parse.int_any shade_str) with
         | Ok c, Ok s -> (
             match opacity with
@@ -2541,7 +2541,7 @@ module Handler = struct
     | [ "ring"; "inherit" ] -> Ok Ring_inherit
     | [ "ring"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Ring_current
         | Color.No_opacity -> err_not_utility
@@ -2555,7 +2555,7 @@ module Handler = struct
     | [ "ring"; "offset"; "inherit" ] -> Ok Ring_offset_inherit
     | [ "ring"; "offset"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Ring_offset_current
         | Color.No_opacity -> err_not_utility
@@ -2572,7 +2572,7 @@ module Handler = struct
     | [ "ring"; color; shade ] -> (
         (* Check for opacity modifier in shade (e.g., "500/50" or
            "500/[0.5]") *)
-        let shade_str, opacity = Color.parse_opacity_modifier shade in
+        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
         match (Color.of_string color, Parse.int_any shade_str) with
         | Ok c, Ok s -> (
             match opacity with
@@ -2580,7 +2580,7 @@ module Handler = struct
             | _ -> Ok (Ring_color_opacity (c, s, opacity)))
         | _ -> err_not_utility)
     | [ "ring"; "offset"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier shade in
+        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
         match (Color.of_string color, Parse.int_any shade_str) with
         | Ok c, Ok s -> (
             match opacity with
@@ -2592,7 +2592,7 @@ module Handler = struct
     | [ "inset"; "ring"; "inherit" ] -> Ok Inset_ring_inherit
     | [ "inset"; "ring"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = Color.parse_opacity_modifier current_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity when base = "current" -> Ok Inset_ring_current
         | Color.No_opacity -> err_not_utility
@@ -2607,7 +2607,7 @@ module Handler = struct
         | Ok width -> Ok (Inset_ring_width width)
         | Error _ -> err_not_utility)
     | [ "inset"; "ring"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier shade in
+        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
         match (Color.of_string color, Parse.int_any shade_str) with
         | Ok c, Ok s -> (
             match opacity with

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -1981,7 +1981,7 @@ module Handler = struct
   let bg_blend_color = style [ background_blend_mode Color ]
   let bg_blend_luminosity = style [ background_blend_mode Luminosity ]
 
-  let to_style = function
+  let to_style _theme = function
     | Shadow_none -> shadow_none
     | Shadow_2xs -> shadow_2xs
     | Shadow_xs -> shadow_xs

--- a/lib/effects.mli
+++ b/lib/effects.mli
@@ -8,10 +8,6 @@ open Cascade
 open Utility
 open Color
 
-val set_scheme : Scheme.t -> unit
-(** [set_scheme scheme] sets the current theme scheme for ring width defaults.
-*)
-
 val order : base -> (int * int) option
 (** [order u] returns the priority and suborder for the given effect utility. *)
 

--- a/lib/field_sizing.ml
+++ b/lib/field_sizing.ml
@@ -17,7 +17,7 @@ module Handler = struct
     | Content -> "field-sizing-content"
     | Fixed -> "field-sizing-fixed"
 
-  let to_style = function
+  let to_style _theme = function
     | Content -> style [ field_sizing Content ]
     | Fixed -> style [ field_sizing Fixed ]
 

--- a/lib/field_sizing.ml
+++ b/lib/field_sizing.ml
@@ -21,7 +21,7 @@ module Handler = struct
     | Content -> style [ field_sizing Content ]
     | Fixed -> style [ field_sizing Fixed ]
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "field"; "sizing"; "content" ] -> Ok Content

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1197,7 +1197,7 @@ module Handler = struct
     | Backdrop_sepia n -> 20000 + (100 - n)
     | Backdrop_sepia_arbitrary _ -> 20500
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "filter" ] -> Ok Filter

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1197,7 +1197,7 @@ module Handler = struct
     | Backdrop_sepia n -> 20000 + (100 - n)
     | Backdrop_sepia_arbitrary _ -> 20500
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "filter" ] -> Ok Filter
@@ -1255,7 +1255,7 @@ module Handler = struct
     (* Drop shadow with opacity modifier on the base: drop-shadow/25 *)
     | [ "drop"; s ] when String.length s > 7 && String.sub s 0 7 = "shadow/"
       -> (
-        let _, opacity = Color.parse_opacity_modifier s in
+        let _, opacity = Color.parse_opacity_modifier ~theme s in
         match opacity with
         | Color.No_opacity -> err_not_utility
         | op -> Ok (Drop_shadow_opacity op))
@@ -1273,12 +1273,13 @@ module Handler = struct
         Ok (Drop_shadow_arbitrary s)
     | "drop" :: "shadow" :: rest -> (
         let full = String.concat "-" rest in
-        let base, opacity = Color.parse_opacity_modifier full in
+        let base, opacity = Color.parse_opacity_modifier ~theme full in
         match opacity with
         | Color.No_opacity -> (
             (* Try to parse as color *)
             match
-              Color.shade_and_opacity_of_strings (String.split_on_char '-' base)
+              Color.shade_and_opacity_of_strings ~theme
+                (String.split_on_char '-' base)
             with
             | Ok (c, shade, Color.No_opacity) ->
                 Ok (Drop_shadow_color (c, shade))

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1020,7 +1020,7 @@ module Handler = struct
           style [ Css.webkit_backdrop_filter value; backdrop_filter value ]
       | Error _ -> style []
 
-  let to_style = function
+  let to_style _theme = function
     | Filter -> filter_
     | Filter_none -> filter_none
     | Filter_arbitrary s -> filter_arbitrary s

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -691,9 +691,10 @@ module Handler = struct
         bind_drop_shadow drop_shadow_size_ref;
       ]
 
-  let drop_shadow_color c shade =
+  let drop_shadow_color ?theme c shade =
     let color_name = Color.scheme_color_name c shade in
-    match Scheme.hex_color (Color.current_scheme ()) color_name with
+    let scheme = match theme with Some t -> t | None -> Color.current_scheme () in
+    match Scheme.hex_color scheme color_name with
     | Option.Some hex ->
         let color_ref : Css.color Css.var =
           Var.bracket ("color-" ^ color_name)
@@ -721,9 +722,10 @@ module Handler = struct
           ("drop-shadow color not found in scheme: "
           ^ Color.scheme_color_name c shade)
 
-  let drop_shadow_color_opacity c shade opacity =
+  let drop_shadow_color_opacity ?theme c shade opacity =
     let color_name = Color.scheme_color_name c shade in
-    match Scheme.hex_color (Color.current_scheme ()) color_name with
+    let scheme = match theme with Some t -> t | None -> Color.current_scheme () in
+    match Scheme.hex_color scheme color_name with
     | Option.Some hex ->
         let percent = Color.opacity_to_percent opacity in
         let hex_with_alpha = Color.hex_with_alpha hex percent in
@@ -1020,7 +1022,12 @@ module Handler = struct
           style [ Css.webkit_backdrop_filter value; backdrop_filter value ]
       | Error _ -> style []
 
-  let to_style _theme = function
+  let to_style theme =
+    let drop_shadow_color c shade = drop_shadow_color ~theme c shade in
+    let drop_shadow_color_opacity c shade opacity =
+      drop_shadow_color_opacity ~theme c shade opacity
+    in
+    function
     | Filter -> filter_
     | Filter_none -> filter_none
     | Filter_arbitrary s -> filter_arbitrary s

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -468,8 +468,8 @@ module Handler = struct
      [--drop-shadow-<size>] design token in the theme layer and references it
      from [--tw-drop-shadow]. These tokens sort after border-radius (order 7)
      and before blur (order 8). Bound via [Var.binding] so the theme declaration
-     is always emitted with its default value and stays overridable through
-     [set_theme_value]. *)
+     is always emitted with its default value and stays overridable through an
+     [@theme] token override threaded via [Scheme.t]. *)
   let drop_shadow_sm_var = Var.theme Css.Shadow "drop-shadow-sm" ~order:(7, 9)
   let drop_shadow_md_var = Var.theme Css.Shadow "drop-shadow-md" ~order:(7, 10)
   let drop_shadow_lg_var = Var.theme Css.Shadow "drop-shadow-lg" ~order:(7, 11)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -693,7 +693,7 @@ module Handler = struct
 
   let drop_shadow_color ?theme c shade =
     let color_name = Color.scheme_color_name c shade in
-    let scheme = match theme with Some t -> t | None -> Color.current_scheme () in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     match Scheme.hex_color scheme color_name with
     | Option.Some hex ->
         let color_ref : Css.color Css.var =
@@ -724,7 +724,7 @@ module Handler = struct
 
   let drop_shadow_color_opacity ?theme c shade opacity =
     let color_name = Color.scheme_color_name c shade in
-    let scheme = match theme with Some t -> t | None -> Color.current_scheme () in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     match Scheme.hex_color scheme color_name with
     | Option.Some hex ->
         let percent = Color.opacity_to_percent opacity in

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -245,8 +245,8 @@ module Handler = struct
 
   (* Generate a theme-layer declaration for a theme variable if its value is
      set. This produces the --name: value entry for the :root, :host block. *)
-  let theme_decl_if_set name =
-    match Var.theme_value name with
+  let theme_decl_if_set ?theme name =
+    match Scheme.theme_value theme name with
     | Some value -> [ Css.custom_property ~layer:"theme" ("--" ^ name) value ]
     | None -> []
 
@@ -255,20 +255,20 @@ module Handler = struct
      generates a theme-layer declaration for the theme variable. Returns a
      function (unit -> Style.t) so that theme_decl_if_set is evaluated lazily at
      utility evaluation time, not at module init time. *)
-  let set_filter_var_theme var_name theme_name
+  let set_filter_var_theme ?theme var_name theme_name
       (make_filter : Css.length -> Css.filter) () =
     let ref_ : Css.length Css.var = Var.theme_ref theme_name in
     style ~property_rules:filter_property_rules
-      (theme_decl_if_set theme_name
+      (theme_decl_if_set ?theme theme_name
       @ [
           filter_var_decl var_name (make_filter (Var ref_));
           filter composable_filter_chain;
         ])
 
-  let blur_none () =
-    match Var.theme_value "blur-none" with
+  let blur_none ?theme () =
+    match Scheme.theme_value theme "blur-none" with
     | Some _ ->
-        set_filter_var_theme "--tw-blur" "blur-none" (fun l -> Blur l) ()
+        set_filter_var_theme ?theme "--tw-blur" "blur-none" (fun l -> Blur l) ()
     | None ->
         style
           [
@@ -500,9 +500,9 @@ module Handler = struct
      two-shadow stack inlined as a literal (no [--drop-shadow] theme var). When
      a custom theme overrides [--drop-shadow] with a single shadow value, it is
      referenced via [drop-shadow(var(--drop-shadow))] instead. *)
-  let drop_shadow_override () =
+  let drop_shadow_override ?theme () =
     style ~property_rules:filter_property_rules
-      (theme_decl_if_set "drop-shadow"
+      (theme_decl_if_set ?theme "drop-shadow"
       @ [
           bind_drop_shadow_size
             (drop_shadow_filter Zero (Px 1.) (Some (Px 1.))
@@ -539,9 +539,9 @@ module Handler = struct
         filter composable_filter_chain;
       ]
 
-  let drop_shadow_ () =
-    match Var.theme_value "drop-shadow" with
-    | Some _ -> drop_shadow_override ()
+  let drop_shadow_ ?theme () =
+    match Scheme.theme_value theme "drop-shadow" with
+    | Some _ -> drop_shadow_override ?theme ()
     | None -> drop_shadow_default ()
 
   (* A sized drop-shadow utility: [drop-shadow-{sm,md,lg,xl,2xl}].
@@ -601,9 +601,9 @@ module Handler = struct
      [--drop-shadow-<name>] theme value. Parses the theme value into one or more
      shadow bodies, hoists each colour into [--tw-drop-shadow-color], and
      references the token from [--tw-drop-shadow]. *)
-  let drop_shadow_named name =
+  let drop_shadow_named ?theme name =
     let theme_name = "drop-shadow-" ^ name in
-    match Var.theme_value theme_name with
+    match Scheme.theme_value theme theme_name with
     | None -> style []
     | Some value ->
         let cursor = Cascade.Cursor.of_string value in
@@ -712,7 +712,7 @@ module Handler = struct
         Group
           [
             style ~rules:(Option.Some [ supports_block ])
-              (theme_decl_if_set ("color-" ^ color_name)
+              (theme_decl_if_set ?theme ("color-" ^ color_name)
               @ [ bind_drop_shadow_color (Css.hex hex) ]);
             style ~property_rules:filter_property_rules
               [ bind_drop_shadow drop_shadow_size_ref ];
@@ -748,7 +748,7 @@ module Handler = struct
         Group
           [
             style ~rules:(Option.Some [ supports_block ])
-              (theme_decl_if_set ("color-" ^ color_name)
+              (theme_decl_if_set ?theme ("color-" ^ color_name)
               @ [ bind_drop_shadow_color (Css.hex hex_with_alpha) ]);
             style ~property_rules:filter_property_rules
               [ bind_drop_shadow drop_shadow_size_ref ];
@@ -758,7 +758,7 @@ module Handler = struct
           ("drop-shadow color not found in scheme: "
           ^ Color.scheme_color_name c shade)
 
-  let drop_shadow_opacity opacity =
+  let drop_shadow_opacity ?theme opacity =
     let alpha_str =
       match opacity with
       | Color.Opacity_percent p -> string_of_int (int_of_float p) ^ "%"
@@ -769,7 +769,7 @@ module Handler = struct
     in
     let fallback = Color.hex_to_oklab_alpha "#000000" (percent /. 100.) in
     style ~property_rules:filter_property_rules
-      (theme_decl_if_set "drop-shadow"
+      (theme_decl_if_set ?theme "drop-shadow"
       @ [
           Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
             alpha_str;
@@ -819,7 +819,7 @@ module Handler = struct
         backdrop_filter composable_backdrop_filter_chain;
       ]
 
-  let set_backdrop_var_theme var_name theme_name
+  let set_backdrop_var_theme ?theme var_name theme_name
       (make_filter : Css.length -> Css.filter) () =
     (* Tailwind uses themeKeys: ['--backdrop-X', '--X'] fallback. Check
        backdrop-specific theme first, then base theme. *)
@@ -832,33 +832,36 @@ module Handler = struct
       else None
     in
     let actual_theme_name =
-      match Var.theme_value theme_name with
+      match Scheme.theme_value theme theme_name with
       | Some _ -> theme_name
       | None -> (
           match fallback_name with
           | Some fb -> (
-              match Var.theme_value fb with Some _ -> fb | None -> theme_name)
+              match Scheme.theme_value theme fb with
+              | Some _ -> fb
+              | None -> theme_name)
           | None -> theme_name)
     in
     let ref_ : Css.length Css.var = Var.theme_ref actual_theme_name in
     style ~property_rules:backdrop_filter_property_rules
-      (theme_decl_if_set actual_theme_name
+      (theme_decl_if_set ?theme actual_theme_name
       @ [
           filter_var_decl var_name (make_filter (Var ref_));
           Css.webkit_backdrop_filter composable_backdrop_filter_chain;
           backdrop_filter composable_backdrop_filter_chain;
         ])
 
-  let backdrop_blur_none () =
-    match Var.theme_value "backdrop-blur-none" with
+  let backdrop_blur_none ?theme () =
+    match Scheme.theme_value theme "backdrop-blur-none" with
     | Some _ ->
-        set_backdrop_var_theme "--tw-backdrop-blur" "backdrop-blur-none"
+        set_backdrop_var_theme ?theme "--tw-backdrop-blur" "backdrop-blur-none"
           (fun l -> Blur l)
           ()
     | None -> (
-        match Var.theme_value "blur-none" with
+        match Scheme.theme_value theme "blur-none" with
         | Some _ ->
-            set_backdrop_var_theme "--tw-backdrop-blur" "backdrop-blur-none"
+            set_backdrop_var_theme ?theme "--tw-backdrop-blur"
+              "backdrop-blur-none"
               (fun l -> Blur l)
               ()
         | None ->
@@ -1027,6 +1030,11 @@ module Handler = struct
     let drop_shadow_color_opacity c shade opacity =
       drop_shadow_color_opacity ~theme c shade opacity
     in
+    let blur_none () = blur_none ~theme () in
+    let drop_shadow_ () = drop_shadow_ ~theme () in
+    let drop_shadow_named name = drop_shadow_named ~theme name in
+    let drop_shadow_opacity op = drop_shadow_opacity ~theme op in
+    let backdrop_blur_none () = backdrop_blur_none ~theme () in
     function
     | Filter -> filter_
     | Filter_none -> filter_none

--- a/lib/flex.ml
+++ b/lib/flex.ml
@@ -19,7 +19,7 @@ module Handler = struct
   let priority = 4
   let flex = style [ display Flex ]
   let inline_flex = style [ display Inline_flex ]
-  let to_style = function Flex -> flex | Inline_flex -> inline_flex
+  let to_style _theme = function Flex -> flex | Inline_flex -> inline_flex
 
   let suborder = function
     (* Alphabetical among all display utilities (shared priority 4). block=1,

--- a/lib/flex.ml
+++ b/lib/flex.ml
@@ -30,7 +30,7 @@ module Handler = struct
 
   let err_not_utility = Error (`Msg "Not a flex display utility")
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "flex" ] -> Ok Flex

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -53,7 +53,7 @@ module Handler = struct
   let suborder t = List.assoc t suborder_map
   let to_class t = List.assoc t to_class_map
 
-  let of_class cls =
+  let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not a flex layout utility")

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -49,7 +49,7 @@ module Handler = struct
   let to_style_map = List.map (fun (t, _, f, _) -> (t, f)) flex_data
   let suborder_map = List.map (fun (t, _, _, o) -> (t, o)) flex_data
   let of_class_map = List.map (fun (t, s, _, _) -> ("flex-" ^ s, t)) flex_data
-  let to_style t = (List.assoc t to_style_map) ()
+  let to_style _theme t = (List.assoc t to_style_map) ()
   let suborder t = List.assoc t suborder_map
   let to_class t = List.assoc t to_class_map
 

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -95,9 +95,9 @@ module Handler = struct
     let pct_value = Float.round (raw *. 10000.0) /. 10000.0 in
     style [ flex_basis (Pct pct_value) ]
 
-  let basis_named_style name =
+  let basis_named_style ?theme name =
     let var_name = "container-" ^ name in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value_str ->
         let decl =
           Css.custom_property ~layer:"theme" ("--" ^ var_name) value_str
@@ -119,19 +119,23 @@ module Handler = struct
   (* Order *)
   let order_style n = style [ order (Int n) ]
 
-  let themed_order name default =
-    match Var.theme_value name with
+  let themed_order ?theme name default =
+    match Scheme.theme_value theme name with
     | None -> style [ order (Int default) ]
     | Some value ->
         let decl = Css.custom_property ~layer:"theme" ("--" ^ name) value in
         let var_ref = Css.var_ref ~layer:"theme" name in
         style [ decl; order (Var var_ref) ]
 
-  let order_first () = themed_order "order-first" (-9999)
-  let order_last () = themed_order "order-last" 9999
+  let order_first ?theme () = themed_order ?theme "order-first" (-9999)
+  let order_last ?theme () = themed_order ?theme "order-last" 9999
   let order_none = style [ order (Int 0) ]
 
-  let to_style _theme = function
+  let to_style theme =
+    let basis_named_style name = basis_named_style ~theme name in
+    let order_first () = order_first ~theme () in
+    let order_last () = order_last ~theme () in
+    function
     | Flex_1 -> flex_1
     | Flex_auto -> flex_auto
     | Flex_initial -> flex_initial

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -223,7 +223,7 @@ module Handler = struct
         | _ -> None)
     | _ -> None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "flex"; "1" ] -> Ok Flex_1

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -131,7 +131,7 @@ module Handler = struct
   let order_last () = themed_order "order-last" 9999
   let order_none = style [ order (Int 0) ]
 
-  let to_style = function
+  let to_style _theme = function
     | Flex_1 -> flex_1
     | Flex_auto -> flex_auto
     | Flex_initial -> flex_initial

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -342,7 +342,7 @@ module Handler = struct
     in
     style ~rules:(Some rules) []
 
-  let to_style = function
+  let to_style _theme = function
     | Form_input -> form_input
     | Form_checkbox -> form_checkbox
     | Form_radio -> form_radio
@@ -476,7 +476,7 @@ module Select = struct
     in
     style ~rules:(Some rules) []
 
-  let to_style = function
+  let to_style _theme = function
     | Form_select -> form_select
     | Form_textarea -> form_textarea
 

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -352,7 +352,7 @@ module Handler = struct
     | Form_radio -> 1
     | Form_input -> 2
 
-  let of_class = function
+  let of_class _theme = function
     | "form-input" -> Ok Form_input
     | "form-checkbox" -> Ok Form_checkbox
     | "form-radio" -> Ok Form_radio
@@ -482,7 +482,7 @@ module Select = struct
 
   let suborder = function Form_select -> 0 | Form_textarea -> 1
 
-  let of_class = function
+  let of_class _theme = function
     | "form-select" -> Ok Form_select
     | "form-textarea" -> Ok Form_textarea
     | _ -> Error (`Msg "Not a form select utility")

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -395,7 +395,7 @@ module Handler = struct
           else if value = "full" then Some (Standard `Full)
           else None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     let err_not_utility = Error (`Msg "Not a gap utility") in
     let parse_class = function

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -42,7 +42,8 @@ module Handler = struct
 
   (** Convert spacing to (declaration, length) using Theme.spacing_calc_float.
   *)
-  let spacing_to_decl_len (s : spacing) : Css.declaration option * length =
+  let spacing_to_decl_len ?theme (s : spacing) : Css.declaration option * length
+      =
     match s with
     | `Px ->
         let len : length = Px 1. in
@@ -57,20 +58,20 @@ module Handler = struct
         (None, len)
     | `Rem f ->
         let n = f /. 0.25 in
-        let decl, len = Theme.spacing_calc_float n in
+        let decl, len = Theme.spacing_calc_float ?theme n in
         (Some decl, len)
 
-  let gap_standard (s : spacing) =
-    let decl, len = spacing_to_decl_len s in
+  let gap_standard ?theme (s : spacing) =
+    let decl, len = spacing_to_decl_len ?theme s in
     let gap_value = Lengths { row_gap = Some len; column_gap = Some len } in
     style (Option.to_list decl @ [ gap gap_value ])
 
-  let gap_x_standard (s : spacing) =
-    let decl, len = spacing_to_decl_len s in
+  let gap_x_standard ?theme (s : spacing) =
+    let decl, len = spacing_to_decl_len ?theme s in
     style (Option.to_list decl @ [ column_gap len ])
 
-  let gap_y_standard (s : spacing) =
-    let decl, len = spacing_to_decl_len s in
+  let gap_y_standard ?theme (s : spacing) =
+    let decl, len = spacing_to_decl_len ?theme s in
     style (Option.to_list decl @ [ row_gap len ])
 
   let gap_arb len =
@@ -84,13 +85,13 @@ module Handler = struct
     let bare_name = Parse.extract_var_name var_str in
     Css.Var (Var.bracket bare_name)
 
-  let gap_value axis (v : gap_value) =
+  let gap_value ?theme axis (v : gap_value) =
     match v with
     | Standard s -> (
         match axis with
-        | `All -> gap_standard s
-        | `X -> gap_x_standard s
-        | `Y -> gap_y_standard s)
+        | `All -> gap_standard ?theme s
+        | `X -> gap_x_standard ?theme s
+        | `Y -> gap_y_standard ?theme s)
     | Arbitrary len -> (
         match axis with
         | `All -> gap_arb len
@@ -121,7 +122,7 @@ module Handler = struct
     let end_expr = Css.Calc.(mul base one_minus_reverse) in
     ((Css.Calc start_expr : Css.length), (Css.Calc end_expr : Css.length))
 
-  let space_x n =
+  let space_x ?theme n =
     (* [Float.sign_bit] (not [n < 0.0]) so negative zero keeps its sign: the
        class [-space-x-0] must render [.-space-x-0], distinct from [.space-x-0],
        even though the value collapses to the same [margin-inline: 0]. *)
@@ -134,7 +135,7 @@ module Handler = struct
     let selector =
       Css.Selector.(where [ class_ class_name >> not [ Last_child ] ])
     in
-    let spacing_decl, spacing_len = Theme.spacing_calc_float n in
+    let spacing_decl, spacing_len = Theme.spacing_calc_float ?theme n in
     let reverse_decl, reverse_ref =
       Var.binding space_x_reverse_var (Css.Num 0.0)
     in
@@ -156,7 +157,7 @@ module Handler = struct
     in
     style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
 
-  let space_y n =
+  let space_y ?theme n =
     (* See [space_x]: negative zero ([-space-y-0]) must keep its sign. *)
     let negative = Float.sign_bit n in
     let abs_n = Float.abs n in
@@ -167,7 +168,7 @@ module Handler = struct
     let selector =
       Css.Selector.(where [ class_ class_name >> not [ Last_child ] ])
     in
-    let spacing_decl, spacing_len = Theme.spacing_calc_float n in
+    let spacing_decl, spacing_len = Theme.spacing_calc_float ?theme n in
     let reverse_decl, reverse_ref =
       Var.binding space_y_reverse_var (Css.Num 0.0)
     in
@@ -285,7 +286,10 @@ module Handler = struct
     if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
     else s
 
-  let to_style _theme t =
+  let to_style theme t =
+    let gap_value axis value = gap_value ~theme axis value in
+    let space_x n = space_x ~theme n in
+    let space_y n = space_y ~theme n in
     match t with
     | Gap { axis; value } -> gap_value axis value
     | Space { negative; axis; value } -> (

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -285,7 +285,7 @@ module Handler = struct
     if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
     else s
 
-  let to_style t =
+  let to_style _theme t =
     match t with
     | Gap { axis; value } -> gap_value axis value
     | Space { negative; axis; value } -> (

--- a/lib/grid.ml
+++ b/lib/grid.ml
@@ -19,7 +19,7 @@ module Handler = struct
   let priority = 4
   let grid = style [ display Grid ]
   let inline_grid = style [ display Inline_grid ]
-  let to_style = function Grid -> grid | Inline_grid -> inline_grid
+  let to_style _theme = function Grid -> grid | Inline_grid -> inline_grid
 
   let suborder = function
     (* Alphabetical among all display utilities (shared priority 4). block=1,

--- a/lib/grid.ml
+++ b/lib/grid.ml
@@ -30,7 +30,7 @@ module Handler = struct
 
   let err_not_utility = Error (`Msg "Not a grid display utility")
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "grid" ] -> Ok Grid

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -12,34 +12,36 @@ let themed_decl name value_str =
   | Some n -> Css.custom_property ~layer:"theme" ("--" ^ name) (string_of_int n)
   | None -> Css.custom_property ~layer:"theme" ("--" ^ name) value_str
 
-let themed_grid_line name (declaration : Css.grid_line -> Css.declaration) =
+let themed_grid_line ?theme name
+    (declaration : Css.grid_line -> Css.declaration) =
   let ref : Css.grid_line Css.var =
     Var.theme_ref name ~default:(Css.Auto : Css.grid_line) ~default_css:"auto"
   in
   let grid_line : Css.grid_line = Css.Var ref in
   let grid_decl = declaration grid_line in
-  match Var.theme_value name with
+  match Scheme.theme_value theme name with
   | Some value_str ->
       let decl = themed_decl name value_str in
       Style.style [ decl; grid_decl ]
   | None -> Style.style [ grid_decl ]
 
-let grid_col_start_themed_style name () =
-  themed_grid_line name Css.grid_column_start
+let grid_col_start_themed_style ?theme name () =
+  themed_grid_line ?theme name Css.grid_column_start
 
-let grid_col_end_themed_style name () =
-  themed_grid_line name Css.grid_column_end
+let grid_col_end_themed_style ?theme name () =
+  themed_grid_line ?theme name Css.grid_column_end
 
-let grid_row_start_themed_style name () =
-  themed_grid_line name Css.grid_row_start
+let grid_row_start_themed_style ?theme name () =
+  themed_grid_line ?theme name Css.grid_row_start
 
-let grid_row_end_themed_style name () = themed_grid_line name Css.grid_row_end
+let grid_row_end_themed_style ?theme name () =
+  themed_grid_line ?theme name Css.grid_row_end
 
-let themed_grid_shorthand name property =
+let themed_grid_shorthand ?theme name property =
   let ref : Css.grid_line_pair Css.var = Var.bracket name in
   let value : Css.grid_line_pair = Css.Var ref in
   let grid_decl = Css.Declaration.v property value in
-  match Var.theme_value name with
+  match Scheme.theme_value theme name with
   | Some value_str ->
       let decl = themed_decl name value_str in
       Style.style [ decl; grid_decl ]
@@ -109,10 +111,11 @@ module Handler = struct
 
   let col_arbitrary s = style [ grid_column (read_grid_line_pair s) ]
 
-  let col_auto () =
-    match Var.theme_value "grid-column-auto" with
+  let col_auto ?theme () =
+    match Scheme.theme_value theme "grid-column-auto" with
     | Some _ ->
-        themed_grid_shorthand "grid-column-auto" Css.Properties.Grid_column
+        themed_grid_shorthand ?theme "grid-column-auto"
+          Css.Properties.Grid_column
     | None -> style [ grid_column (Auto, Auto) ]
 
   let col_span n = style [ grid_column (Span n, Span n) ]
@@ -128,31 +131,34 @@ module Handler = struct
   let neg_col_start n = style [ grid_column_start (Num (-n)) ]
   let col_start_arbitrary s = style [ grid_column_start (read_gl s) ]
 
-  let col_start_auto () =
-    match Var.theme_value "grid-column-start-auto" with
-    | Some _ -> grid_col_start_themed_style "grid-column-start-auto" ()
+  let col_start_auto ?theme () =
+    match Scheme.theme_value theme "grid-column-start-auto" with
+    | Some _ -> grid_col_start_themed_style ?theme "grid-column-start-auto" ()
     | None -> style [ grid_column_start Auto ]
 
-  let col_start_named s =
-    grid_col_start_themed_style ("grid-column-start-" ^ s) ()
+  let col_start_named ?theme s =
+    grid_col_start_themed_style ?theme ("grid-column-start-" ^ s) ()
 
   let col_end n = style [ grid_column_end (Num n) ]
   let neg_col_end n = style [ grid_column_end (Num (-n)) ]
   let col_end_arbitrary s = style [ grid_column_end (read_gl s) ]
 
-  let col_end_auto () =
-    match Var.theme_value "grid-column-end-auto" with
-    | Some _ -> grid_col_end_themed_style "grid-column-end-auto" ()
+  let col_end_auto ?theme () =
+    match Scheme.theme_value theme "grid-column-end-auto" with
+    | Some _ -> grid_col_end_themed_style ?theme "grid-column-end-auto" ()
     | None -> style [ grid_column_end Auto ]
 
-  let col_end_named s = grid_col_end_themed_style ("grid-column-end-" ^ s) ()
+  let col_end_named ?theme s =
+    grid_col_end_themed_style ?theme ("grid-column-end-" ^ s) ()
+
   let row n = style [ grid_row (Num n, Auto) ]
   let neg_row n = style [ grid_row (Num (-n), Auto) ]
   let row_arbitrary s = style [ grid_row (read_grid_line_pair s) ]
 
-  let row_auto () =
-    match Var.theme_value "grid-row-auto" with
-    | Some _ -> themed_grid_shorthand "grid-row-auto" Css.Properties.Grid_row
+  let row_auto ?theme () =
+    match Scheme.theme_value theme "grid-row-auto" with
+    | Some _ ->
+        themed_grid_shorthand ?theme "grid-row-auto" Css.Properties.Grid_row
     | None -> style [ grid_row (Auto, Auto) ]
 
   let row_span n = style [ grid_row (Span n, Span n) ]
@@ -168,24 +174,38 @@ module Handler = struct
   let neg_row_start n = style [ grid_row_start (Num (-n)) ]
   let row_start_arbitrary s = style [ grid_row_start (read_gl s) ]
 
-  let row_start_auto () =
-    match Var.theme_value "grid-row-start-auto" with
-    | Some _ -> grid_row_start_themed_style "grid-row-start-auto" ()
+  let row_start_auto ?theme () =
+    match Scheme.theme_value theme "grid-row-start-auto" with
+    | Some _ -> grid_row_start_themed_style ?theme "grid-row-start-auto" ()
     | None -> style [ grid_row_start Auto ]
 
-  let row_start_named s = grid_row_start_themed_style ("grid-row-start-" ^ s) ()
+  let row_start_named ?theme s =
+    grid_row_start_themed_style ?theme ("grid-row-start-" ^ s) ()
+
   let row_end n = style [ grid_row_end (Num n) ]
   let neg_row_end n = style [ grid_row_end (Num (-n)) ]
   let row_end_arbitrary s = style [ grid_row_end (read_gl s) ]
 
-  let row_end_auto () =
-    match Var.theme_value "grid-row-end-auto" with
-    | Some _ -> grid_row_end_themed_style "grid-row-end-auto" ()
+  let row_end_auto ?theme () =
+    match Scheme.theme_value theme "grid-row-end-auto" with
+    | Some _ -> grid_row_end_themed_style ?theme "grid-row-end-auto" ()
     | None -> style [ grid_row_end Auto ]
 
-  let row_end_named s = grid_row_end_themed_style ("grid-row-end-" ^ s) ()
+  let row_end_named ?theme s =
+    grid_row_end_themed_style ?theme ("grid-row-end-" ^ s) ()
 
-  let to_style _theme = function
+  let to_style theme =
+    let col_auto () = col_auto ~theme () in
+    let col_start_auto () = col_start_auto ~theme () in
+    let col_start_named s = col_start_named ~theme s in
+    let col_end_auto () = col_end_auto ~theme () in
+    let col_end_named s = col_end_named ~theme s in
+    let row_auto () = row_auto ~theme () in
+    let row_start_auto () = row_start_auto ~theme () in
+    let row_start_named s = row_start_named ~theme s in
+    let row_end_auto () = row_end_auto ~theme () in
+    let row_end_named s = row_end_named ~theme s in
+    function
     | Col n -> col n
     | Neg_col n -> neg_col n
     | Col_arbitrary s -> col_arbitrary s

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -290,7 +290,7 @@ module Handler = struct
       Some (String.map (fun c -> if c = '_' then ' ' else c) inner)
     else None
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "col"; "auto" ] -> Ok Col_auto
@@ -314,7 +314,8 @@ module Handler = struct
         | Error _ ->
             if
               (not (String.contains n '/'))
-              && Var.theme_value ("grid-column-start-" ^ n) <> None
+              && Scheme.theme_value (Some theme) ("grid-column-start-" ^ n)
+                 <> None
             then Ok (Col_start_named n)
             else err_not_utility)
     | [ ""; "col"; "start"; n ] -> (
@@ -333,7 +334,8 @@ module Handler = struct
         | Error _ ->
             if
               (not (String.contains n '/'))
-              && Var.theme_value ("grid-column-end-" ^ n) <> None
+              && Scheme.theme_value (Some theme) ("grid-column-end-" ^ n)
+                 <> None
             then Ok (Col_end_named n)
             else err_not_utility)
     | [ ""; "col"; "end"; n ] -> (
@@ -390,7 +392,7 @@ module Handler = struct
         | Error _ ->
             if
               (not (String.contains n '/'))
-              && Var.theme_value ("grid-row-start-" ^ n) <> None
+              && Scheme.theme_value (Some theme) ("grid-row-start-" ^ n) <> None
             then Ok (Row_start_named n)
             else err_not_utility)
     | [ ""; "row"; "start"; n ] -> (
@@ -409,7 +411,7 @@ module Handler = struct
         | Error _ ->
             if
               (not (String.contains n '/'))
-              && Var.theme_value ("grid-row-end-" ^ n) <> None
+              && Scheme.theme_value (Some theme) ("grid-row-end-" ^ n) <> None
             then Ok (Row_end_named n)
             else err_not_utility)
     | [ ""; "row"; "end"; n ] -> (

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -290,7 +290,7 @@ module Handler = struct
       Some (String.map (fun c -> if c = '_' then ' ' else c) inner)
     else None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "col"; "auto" ] -> Ok Col_auto

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -185,7 +185,7 @@ module Handler = struct
 
   let row_end_named s = grid_row_end_themed_style ("grid-row-end-" ^ s) ()
 
-  let to_style = function
+  let to_style _theme = function
     | Col n -> col n
     | Neg_col n -> neg_col n
     | Col_arbitrary s -> col_arbitrary s

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -390,7 +390,7 @@ module Handler = struct
     | Auto_rows_max -> 15104
     | Auto_rows_min -> 15105
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "grid"; "cols"; "none" ] -> Ok Grid_cols_none

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -298,8 +298,8 @@ module Handler = struct
 
   (* [auto-cols-<n>] sizes implicit columns to a spacing-scaled track,
      [grid-auto-columns: calc(var(--spacing) * n)]. *)
-  let auto_cols_spacing n =
-    let decl, len = Theme.spacing_calc_float n in
+  let auto_cols_spacing ?theme n =
+    let decl, len = Theme.spacing_calc_float ?theme n in
     style [ decl; Css.grid_auto_columns (Css.Length len) ]
 
   (** {1 Grid Auto Rows} *)
@@ -317,12 +317,15 @@ module Handler = struct
   let auto_rows_arbitrary s =
     style [ Css.grid_auto_rows (parse_arbitrary_grid_template_exn s) ]
 
-  let auto_rows_spacing n =
-    let decl, len = Theme.spacing_calc_float n in
+  let auto_rows_spacing ?theme n =
+    let decl, len = Theme.spacing_calc_float ?theme n in
     style [ decl; Css.grid_auto_rows (Css.Length len) ]
 
   (** Convert grid template utility to style *)
-  let to_style _theme = function
+  let to_style theme =
+    let auto_cols_spacing n = auto_cols_spacing ~theme n in
+    let auto_rows_spacing n = auto_rows_spacing ~theme n in
+    function
     | Grid_cols n -> grid_cols n
     | Grid_cols_none -> grid_cols_none ()
     | Grid_cols_subgrid -> grid_cols_subgrid

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -85,9 +85,9 @@ module Handler = struct
     let prop_decl = property value in
     style [ theme_decl; prop_decl ]
 
-  let grid_cols_none () =
+  let grid_cols_none ?theme () =
     let var_name = "grid-template-columns-none" in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value -> themed_property var_name Css.grid_template_columns value
     | None -> style [ Css.grid_template_columns None ]
 
@@ -270,9 +270,9 @@ module Handler = struct
           Css.grid_template_rows (Repeat (Count n, [ Min_max (Zero, Fr 1.0) ]));
         ]
 
-  let grid_rows_none () =
+  let grid_rows_none ?theme () =
     let var_name = "grid-template-rows-none" in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value -> themed_property var_name Css.grid_template_rows value
     | None -> style [ Css.grid_template_rows None ]
 
@@ -283,9 +283,9 @@ module Handler = struct
   let grid_flow_row_dense = style [ Css.grid_auto_flow Row_dense ]
   let grid_flow_col_dense = style [ Css.grid_auto_flow Column_dense ]
 
-  let auto_cols_auto () =
+  let auto_cols_auto ?theme () =
     let var_name = "grid-auto-columns-auto" in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value -> themed_property var_name Css.grid_auto_columns value
     | None -> style [ Css.grid_auto_columns Auto ]
 
@@ -304,9 +304,9 @@ module Handler = struct
 
   (** {1 Grid Auto Rows} *)
 
-  let auto_rows_auto () =
+  let auto_rows_auto ?theme () =
     let var_name = "grid-auto-rows-auto" in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value -> themed_property var_name Css.grid_auto_rows value
     | None -> style [ Css.grid_auto_rows Auto ]
 
@@ -325,6 +325,10 @@ module Handler = struct
   let to_style theme =
     let auto_cols_spacing n = auto_cols_spacing ~theme n in
     let auto_rows_spacing n = auto_rows_spacing ~theme n in
+    let grid_cols_none () = grid_cols_none ~theme () in
+    let grid_rows_none () = grid_rows_none ~theme () in
+    let auto_cols_auto () = auto_cols_auto ~theme () in
+    let auto_rows_auto () = auto_rows_auto ~theme () in
     function
     | Grid_cols n -> grid_cols n
     | Grid_cols_none -> grid_cols_none ()

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -322,7 +322,7 @@ module Handler = struct
     style [ decl; Css.grid_auto_rows (Css.Length len) ]
 
   (** Convert grid template utility to style *)
-  let to_style = function
+  let to_style _theme = function
     | Grid_cols n -> grid_cols n
     | Grid_cols_none -> grid_cols_none ()
     | Grid_cols_subgrid -> grid_cols_subgrid

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -248,7 +248,7 @@ module Handler = struct
     | Scheme_only_dark -> 44
     | Scheme_only_light -> 45
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "select"; "none" ] -> Ok Select_none

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -158,7 +158,7 @@ module Handler = struct
   let scheme_only_dark_s = style [ color_scheme Only_dark ]
   let scheme_only_light_s = style [ color_scheme Only_light ]
 
-  let to_style = function
+  let to_style _theme = function
     | Select_none -> select_none_s
     | Select_text -> select_text_s
     | Select_all -> select_all_s

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -59,7 +59,7 @@ module Screen_reader_handler = struct
             overflow Visible;
           ]
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "sr"; "only" ] -> Ok Sr_only
@@ -542,7 +542,7 @@ module Handler = struct
 
   (** {1 Parsing Functions} *)
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "block" ] -> Ok Block

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -20,7 +20,7 @@ module Screen_reader_handler = struct
 
   let to_class = function Sr_only -> "sr-only" | Not_sr_only -> "not-sr-only"
 
-  let to_style = function
+  let to_style _theme = function
     | Sr_only ->
         (* Property order matches Tailwind: clip-path, white-space,
            border-width, width, height, margin, padding, position, overflow *)
@@ -401,7 +401,7 @@ module Handler = struct
     | Break_inside_avoid_column -> "break-inside-avoid-column"
     | Break_inside_avoid_page -> "break-inside-avoid-page"
 
-  let to_style = function
+  let to_style _theme = function
     | Block -> style [ display Block ]
     | Inline -> style [ display Inline ]
     | Inline_block -> style [ display Inline_block ]

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -74,8 +74,8 @@ let z_index_auto_var = Var.theme Css.Z_index "z-index-auto" ~order:(4, 750)
 
 (* Generate z-auto style: either theme var with custom declaration, or bare
    theme_ref fallback *)
-let z_auto_style () =
-  match Var.theme_value "z-index-auto" with
+let z_auto_style ?theme () =
+  match Scheme.theme_value theme "z-index-auto" with
   | Some value_str ->
       (* Parse theme value as z_index *)
       let z_value : Css.z_index =
@@ -401,7 +401,9 @@ module Handler = struct
     | Break_inside_avoid_column -> "break-inside-avoid-column"
     | Break_inside_avoid_page -> "break-inside-avoid-page"
 
-  let to_style _theme = function
+  let to_style theme =
+    let z_auto_style () = z_auto_style ~theme () in
+    function
     | Block -> style [ display Block ]
     | Inline -> style [ display Inline ]
     | Inline_block -> style [ display Inline_block ]
@@ -475,7 +477,7 @@ module Handler = struct
               ("object-position-top-right", Top_right, "right top")
           | _ -> assert false
         in
-        match Var.theme_value name with
+        match Scheme.theme_value (Some theme) name with
         | Some value ->
             let theme_decl =
               Css.custom_property ~layer:"theme" ("--" ^ name) value

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -67,9 +67,9 @@ module Screen_reader_handler = struct
     | _ -> Error (`Msg "Not a screen reader utility")
 end
 
-(* Theme variable for z-index-auto. When a theme override is set (e.g., via
-   set_theme_value "z-index-auto" "42"), produces a custom declaration
-   --z-index-auto: 42 in the :root, :host block. *)
+(* Theme variable for z-index-auto. When the threaded theme overrides this token
+   (e.g. an [@theme] block sets [--z-index-auto: 42]), produces a custom
+   declaration --z-index-auto: 42 in the :root, :host block. *)
 let z_index_auto_var = Var.theme Css.Z_index "z-index-auto" ~order:(4, 750)
 
 (* Generate z-auto style: either theme var with custom declaration, or bare

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -151,7 +151,7 @@ module Handler = struct
     | `Be -> margin_block_end
 
   (** Convert margin utility to style *)
-  let to_style { negative; axis; value } =
+  let to_style _theme { negative; axis; value } =
     let prop = prop_for_axis axis in
     match value with
     | Arbitrary len ->

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -43,7 +43,7 @@ module Handler = struct
         (Some decl, len)
     | `Named name -> (
         let prop_name = "spacing-" ^ name in
-        match Var.theme_value prop_name with
+        match Scheme.theme_value theme prop_name with
         | Some value_str ->
             let decl =
               Css.custom_property ~layer:"theme" ("--" ^ prop_name) value_str
@@ -83,9 +83,9 @@ module Handler = struct
         let decl, len = spacing_to_decl_len ?theme ~negative:false s in
         style (Option.to_list decl @ [ prop [ len ] ])
 
-  let named_margin_value name : Css.declaration option * Css.length =
+  let named_margin_value ?theme name : Css.declaration option * Css.length =
     let prop_name = "spacing-" ^ name in
-    match Var.theme_value prop_name with
+    match Scheme.theme_value theme prop_name with
     | Some value_str ->
         let decl =
           Css.custom_property ~layer:"theme" ("--" ^ prop_name) value_str
@@ -154,6 +154,7 @@ module Handler = struct
     let mbe m = v ~theme margin_block_end m in
     let margin_util_neg prop s = margin_util_neg ~theme prop s in
     let margin_list_util_neg prop s = margin_list_util_neg ~theme prop s in
+    let named_margin_value name = named_margin_value ~theme name in
     let prop = prop_for_axis axis in
     match value with
     | Arbitrary len ->

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -30,7 +30,7 @@ module Handler = struct
   (** Convert spacing to (declaration option, length) using
       Theme.spacing_calc_float. For rem values, checks scheme for explicit
       spacing variables. *)
-  let spacing_to_decl_len ~negative (s : Style.spacing) :
+  let spacing_to_decl_len ?theme ~negative (s : Style.spacing) :
       Css.declaration option * length =
     match s with
     | `Px ->
@@ -66,34 +66,22 @@ module Handler = struct
     | `Rem f ->
         let n = f /. 0.25 in
         let n = if negative then -.n else n in
-        let decl, len = Theme.spacing_calc_float n in
+        let decl, len = Theme.spacing_calc_float ?theme n in
         (Some decl, len)
 
-  let v (prop : length -> declaration) (m : margin) =
+  let v ?theme (prop : length -> declaration) (m : margin) =
     match m with
     | `Auto -> style [ prop Auto ]
     | #Style.spacing as s ->
-        let decl, len = spacing_to_decl_len ~negative:false s in
+        let decl, len = spacing_to_decl_len ?theme ~negative:false s in
         style (Option.to_list decl @ [ prop len ])
 
-  let vs (prop : length list -> declaration) (m : margin) =
+  let vs ?theme (prop : length list -> declaration) (m : margin) =
     match m with
     | `Auto -> style [ prop [ Auto ] ]
     | #Style.spacing as s ->
-        let decl, len = spacing_to_decl_len ~negative:false s in
+        let decl, len = spacing_to_decl_len ?theme ~negative:false s in
         style (Option.to_list decl @ [ prop [ len ] ])
-
-  let m_fn = vs margin
-  let mx = v margin_inline
-  let my = v margin_block
-  let mt = v margin_top
-  let mr = v margin_right
-  let mb = v margin_bottom
-  let ml = v margin_left
-  let ms = v margin_inline_start
-  let me = v margin_inline_end
-  let mbs = v margin_block_start
-  let mbe = v margin_block_end
 
   let named_margin_value name : Css.declaration option * Css.length =
     let prop_name = "spacing-" ^ name in
@@ -114,13 +102,14 @@ module Handler = struct
 
   (** {1 Conversion Functions} *)
 
-  let margin_util_neg (prop : length -> declaration) (s : Style.spacing) =
-    let decl, len = spacing_to_decl_len ~negative:true s in
+  let margin_util_neg ?theme (prop : length -> declaration) (s : Style.spacing)
+      =
+    let decl, len = spacing_to_decl_len ?theme ~negative:true s in
     style (Option.to_list decl @ [ prop len ])
 
-  let margin_list_util_neg (prop : length list -> declaration)
+  let margin_list_util_neg ?theme (prop : length list -> declaration)
       (s : Style.spacing) =
-    let decl, len = spacing_to_decl_len ~negative:true s in
+    let decl, len = spacing_to_decl_len ?theme ~negative:true s in
     style (Option.to_list decl @ [ prop [ len ] ])
 
   let spacing_value_order = function
@@ -151,7 +140,20 @@ module Handler = struct
     | `Be -> margin_block_end
 
   (** Convert margin utility to style *)
-  let to_style _theme { negative; axis; value } =
+  let to_style theme { negative; axis; value } =
+    let m_fn m = vs ~theme margin m in
+    let mx m = v ~theme margin_inline m in
+    let my m = v ~theme margin_block m in
+    let mt m = v ~theme margin_top m in
+    let mr m = v ~theme margin_right m in
+    let mb m = v ~theme margin_bottom m in
+    let ml m = v ~theme margin_left m in
+    let ms m = v ~theme margin_inline_start m in
+    let me m = v ~theme margin_inline_end m in
+    let mbs m = v ~theme margin_block_start m in
+    let mbe m = v ~theme margin_block_end m in
+    let margin_util_neg prop s = margin_util_neg ~theme prop s in
+    let margin_list_util_neg prop s = margin_list_util_neg ~theme prop s in
     let prop = prop_for_axis axis in
     match value with
     | Arbitrary len ->

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -336,7 +336,7 @@ module Handler = struct
     | _ -> None
 
   (** Parse string parts to margin utility using shared logic *)
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* Handle arbitrary values: mx-[4px], mx-[var(--value)] *)

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -707,7 +707,7 @@ module Handler = struct
     let common_decls = mask_image_decls @ linear_decl @ dir_decls in
     style ~property_rules (common_decls @ composite_decls)
 
-  let to_style = function
+  let to_style _theme = function
     | Mask_position (Top, pos_end, value) ->
         build_directional_style Top pos_end value
     | Mask_position (Right, pos_end, value) ->

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -101,9 +101,9 @@ module Handler = struct
   let position_end_name = function From -> "from" | To -> "to"
 
   (* Format the position value as CSS *)
-  let format_position_value = function
+  let format_position_value ?theme = function
     | Spacing n ->
-        let _, len = Theme.spacing_calc_float n in
+        let _, len = Theme.spacing_calc_float ?theme n in
         Css.Pp.to_string ~minify:false Css.pp_length len
     | Percent p ->
         if Float.is_integer p then pp_int (int_of_float p) ^ "%"
@@ -315,10 +315,10 @@ module Handler = struct
     | Conic -> conic_property_rules
 
   (* Build the style for a directional mask position *)
-  let build_directional_style dir pos_end value =
+  let build_directional_style ?theme dir pos_end value =
     let dir_name = direction_name dir in
     let pos_name = position_end_name pos_end in
-    let pos_value = format_position_value value in
+    let pos_value = format_position_value ?theme value in
 
     (* The variable being set *)
     let var_name = "--tw-mask-" ^ dir_name ^ "-" ^ pos_name ^ "-position" in
@@ -338,9 +338,9 @@ module Handler = struct
     style ~property_rules (common_decls @ composite_decls)
 
   (* Build the style for mask-x (both left and right) *)
-  let build_x_style pos_end value =
+  let build_x_style ?theme pos_end value =
     let pos_name = position_end_name pos_end in
-    let pos_value = format_position_value value in
+    let pos_value = format_position_value ?theme value in
 
     let common_decls =
       spacing_theme_decl value @ mask_image_decls
@@ -362,9 +362,9 @@ module Handler = struct
     style ~property_rules:x_property_rules (common_decls @ composite_decls)
 
   (* Build the style for mask-y (both top and bottom) *)
-  let build_y_style pos_end value =
+  let build_y_style ?theme pos_end value =
     let pos_name = position_end_name pos_end in
-    let pos_value = format_position_value value in
+    let pos_value = format_position_value ?theme value in
 
     let common_decls =
       spacing_theme_decl value @ mask_image_decls
@@ -386,9 +386,9 @@ module Handler = struct
     style ~property_rules:y_property_rules (common_decls @ composite_decls)
 
   (* Build the style for mask-linear (generic linear gradient) *)
-  let build_linear_style pos_end value =
+  let build_linear_style ?theme pos_end value =
     let pos_name = position_end_name pos_end in
-    let pos_value = format_position_value value in
+    let pos_value = format_position_value ?theme value in
 
     let common_decls =
       spacing_theme_decl value @ mask_image_decls
@@ -405,9 +405,9 @@ module Handler = struct
     style ~property_rules:linear_property_rules (common_decls @ composite_decls)
 
   (* Build the style for mask-radial position *)
-  let build_radial_style pos_end value =
+  let build_radial_style ?theme pos_end value =
     let pos_name = position_end_name pos_end in
-    let pos_value = format_position_value value in
+    let pos_value = format_position_value ?theme value in
 
     let common_decls =
       spacing_theme_decl value @ mask_image_decls
@@ -481,9 +481,9 @@ module Handler = struct
           ]
 
   (* Build the style for mask-conic position *)
-  let build_conic_style pos_end value =
+  let build_conic_style ?theme pos_end value =
     let pos_name = position_end_name pos_end in
-    let pos_value = format_position_value value in
+    let pos_value = format_position_value ?theme value in
 
     let common_decls =
       spacing_theme_decl value @ mask_image_decls
@@ -707,7 +707,22 @@ module Handler = struct
     let common_decls = mask_image_decls @ linear_decl @ dir_decls in
     style ~property_rules (common_decls @ composite_decls)
 
-  let to_style _theme = function
+  let to_style theme =
+    let build_directional_style dir pos_end value =
+      build_directional_style ~theme dir pos_end value
+    in
+    let build_x_style pos_end value = build_x_style ~theme pos_end value in
+    let build_y_style pos_end value = build_y_style ~theme pos_end value in
+    let build_linear_style pos_end value =
+      build_linear_style ~theme pos_end value
+    in
+    let build_radial_style pos_end value =
+      build_radial_style ~theme pos_end value
+    in
+    let build_conic_style pos_end value =
+      build_conic_style ~theme pos_end value
+    in
+    function
     | Mask_position (Top, pos_end, value) ->
         build_directional_style Top pos_end value
     | Mask_position (Right, pos_end, value) ->

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -871,7 +871,7 @@ module Handler = struct
                  ("Invalid mask-" ^ direction_short dir ^ "-"
                 ^ position_end_name pos_end ^ " value")))
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* mask-t-from-*, mask-t-to-* *)

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -500,7 +500,7 @@ module Handler = struct
     | Mask_size_bracket _ -> 407
     | Mask_size_bracket_var _ -> 408
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "mask"; "none" ] -> Ok Mask_none

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -307,7 +307,7 @@ module Handler = struct
           (parse_pos_val v)
     | _ -> None
 
-  let to_style = function
+  let to_style _theme = function
     | Mask_none -> mask_none
     | Mask_add -> mask_add
     | Mask_exclude -> mask_exclude

--- a/lib/overflow.ml
+++ b/lib/overflow.ml
@@ -67,7 +67,7 @@ module Handler = struct
   (* Handler functions derived from maps *)
   let suborder t = List.assoc t suborder_map
   let to_class t = List.assoc t to_class_map
-  let to_style t = (List.assoc t to_style_map) ()
+  let to_style _theme t = (List.assoc t to_style_map) ()
 
   let of_class cls =
     match List.assoc_opt cls of_class_map with

--- a/lib/overflow.ml
+++ b/lib/overflow.ml
@@ -69,7 +69,7 @@ module Handler = struct
   let to_class t = List.assoc t to_class_map
   let to_style _theme t = (List.assoc t to_style_map) ()
 
-  let of_class cls =
+  let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not an overflow utility")

--- a/lib/overflow_wrap.ml
+++ b/lib/overflow_wrap.ml
@@ -30,7 +30,7 @@ module Handler = struct
     | Break_word -> style [ overflow_wrap Break_word ]
     | Anywhere -> style [ overflow_wrap Anywhere ]
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "wrap"; "normal" ] -> Ok Normal

--- a/lib/overflow_wrap.ml
+++ b/lib/overflow_wrap.ml
@@ -25,7 +25,7 @@ module Handler = struct
     | Break_word -> "wrap-break-word"
     | Anywhere -> "wrap-anywhere"
 
-  let to_style = function
+  let to_style _theme = function
     | Normal -> style [ overflow_wrap Normal ]
     | Break_word -> style [ overflow_wrap Break_word ]
     | Anywhere -> style [ overflow_wrap Anywhere ]

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -72,7 +72,7 @@ module Handler = struct
   let to_class t = List.assoc t to_class_map
   let to_style _theme t = (List.assoc t to_style_map) ()
 
-  let of_class cls =
+  let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not an overscroll utility")

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -70,7 +70,7 @@ module Handler = struct
   (* Handler functions derived from maps *)
   let suborder t = List.assoc t suborder_map
   let to_class t = List.assoc t to_class_map
-  let to_style t = (List.assoc t to_style_map) ()
+  let to_style _theme t = (List.assoc t to_style_map) ()
 
   let of_class cls =
     match List.assoc_opt cls of_class_map with

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -58,8 +58,8 @@ module Handler = struct
 
   (** Convert spacing to (declaration option, length) using
       Theme.spacing_calc_float. *)
-  let spacing_to_decl_len (s : Style.spacing) : Css.declaration option * length
-      =
+  let spacing_to_decl_len ?theme (s : Style.spacing) :
+      Css.declaration option * length =
     match s with
     | `Px ->
         let len : length = Px 1. in
@@ -72,15 +72,16 @@ module Handler = struct
     | `Named name -> Spacing.named_spacing_binding name
     | `Rem f ->
         let n = f /. 0.25 in
-        let decl, len = Theme.spacing_calc_float n in
+        let decl, len = Theme.spacing_calc_float ?theme n in
         (Some decl, len)
 
-  let v_spacing (prop : length -> declaration) (s : Style.spacing) =
-    let decl, len = spacing_to_decl_len s in
+  let v_spacing ?theme (prop : length -> declaration) (s : Style.spacing) =
+    let decl, len = spacing_to_decl_len ?theme s in
     style (Option.to_list decl @ [ prop len ])
 
-  let vs_spacing (prop : length list -> declaration) (s : Style.spacing) =
-    let decl, len = spacing_to_decl_len s in
+  let vs_spacing ?theme (prop : length list -> declaration) (s : Style.spacing)
+      =
+    let decl, len = spacing_to_decl_len ?theme s in
     style (Option.to_list decl @ [ prop [ len ] ])
 
   let spacing_value_order = function
@@ -96,23 +97,25 @@ module Handler = struct
     | Arbitrary _ -> 20000
     | Arbitrary_var _ -> 20000
 
-  let apply_prop_list (prop : length list -> declaration) value =
+  let apply_prop_list ?theme (prop : length list -> declaration) value =
     match value with
-    | Standard s -> vs_spacing prop s
+    | Standard s -> vs_spacing ?theme prop s
     | Arbitrary len -> style [ prop [ len ] ]
     | Arbitrary_var var_str ->
         let bare_name = Parse.extract_var_name var_str in
         style [ prop [ Var (Var.bracket bare_name) ] ]
 
-  let apply_prop (prop : length -> declaration) value =
+  let apply_prop ?theme (prop : length -> declaration) value =
     match value with
-    | Standard s -> v_spacing prop s
+    | Standard s -> v_spacing ?theme prop s
     | Arbitrary len -> style [ prop len ]
     | Arbitrary_var var_str ->
         let bare_name = Parse.extract_var_name var_str in
         style [ prop (Var (Var.bracket bare_name)) ]
 
-  let to_style _theme t =
+  let to_style theme t =
+    let apply_prop_list prop value = apply_prop_list ~theme prop value in
+    let apply_prop prop value = apply_prop ~theme prop value in
     match t.axis with
     | `All -> apply_prop_list padding t.value
     | `X -> apply_prop_list padding_inline t.value

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -178,7 +178,7 @@ module Handler = struct
     | "pbe" -> Some `Be
     | _ -> None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* Handle arbitrary values: p-[4px], px-[var(--value)] *)

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -112,7 +112,7 @@ module Handler = struct
         let bare_name = Parse.extract_var_name var_str in
         style [ prop (Var (Var.bracket bare_name)) ]
 
-  let to_style t =
+  let to_style _theme t =
     match t.axis with
     | `All -> apply_prop_list padding t.value
     | `X -> apply_prop_list padding_inline t.value

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -94,7 +94,8 @@ let named_inset_value name : Css.declaration * Css.length =
 
 (* Create a spacing value using calc(var(--spacing) * n). Returns the theme
    declaration and a length that references the variable. *)
-let spacing_value n : Css.declaration * Css.length = Theme.spacing_calc n
+let spacing_value ?theme n : Css.declaration * Css.length =
+  Theme.spacing_calc ?theme n
 
 module Handler = struct
   open Style
@@ -211,7 +212,9 @@ module Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style _theme = function
+  let to_style theme =
+    let spacing_value n = spacing_value ~theme n in
+    function
     | Position_static -> style [ position Static ]
     | Position_relative -> style [ position Relative ]
     | Position_absolute -> style [ position Absolute ]

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -496,7 +496,7 @@ module Handler = struct
     | End_full -> 952
     | End n -> 1000 + n
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "static" ] -> Ok Position_static

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -211,7 +211,7 @@ module Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style = function
+  let to_style _theme = function
     | Position_static -> style [ position Static ]
     | Position_relative -> style [ position Relative ]
     | Position_absolute -> style [ position Absolute ]

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2061,7 +2061,7 @@ module Handler = struct
     | Lead -> "lead"
     | Not_prose -> "not-prose"
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "prose" ] -> Ok Prose
@@ -2125,7 +2125,7 @@ module Color_Handler = struct
     | Prose_invert -> "prose-invert"
     | Prose_orange -> "prose-orange"
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "prose"; "gray" ] -> Ok Prose_gray

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2043,7 +2043,7 @@ module Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style = function
+  let to_style _theme = function
     | Prose -> prose_style `Base
     | Prose_sm -> prose_style `Sm
     | Prose_lg -> prose_style `Lg
@@ -2107,7 +2107,7 @@ module Color_Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style = function
+  let to_style _theme = function
     | Prose_gray -> prose_style `Gray
     | Prose_slate -> prose_style `Slate
     | Prose_zinc -> prose_style `Zinc

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1772,7 +1772,7 @@ let extract_style_with_rules ~sel ~class_name ?merge_key ~props rule_list =
   if !has_regular_rules then ordered_entries @ base_rule
   else base_rule @ ordered_entries
 
-let outputs ?order_tbl util =
+let outputs ?(theme = Scheme.default) ?order_tbl util =
   let rec extract_with_class class_name util_inner = function
     | Style.Style { props; rules; merge_key; pseudo_suffix; _ } -> (
         (* Record the base utility's order under the class name we already built,
@@ -1805,5 +1805,5 @@ let outputs ?order_tbl util =
         handle_group class_name util_inner styles extract_with_class
   in
   let class_name = Utility.to_class util in
-  let style = Utility.to_style Scheme.default util in
+  let style = Utility.to_style theme util in
   extract_with_class class_name util style

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -146,9 +146,7 @@ module Rules_selector = struct
     transform selector
 end
 
-let current_scheme = ref Scheme.default
-let set_scheme scheme = current_scheme := scheme
-let resolve_scheme = function Some s -> s | None -> !current_scheme
+let resolve_scheme = function Some s -> s | None -> Scheme.default
 
 let breakpoint_rem = function
   | `Sm -> 40.

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -148,6 +148,7 @@ end
 
 let current_scheme = ref Scheme.default
 let set_scheme scheme = current_scheme := scheme
+let resolve_scheme = function Some s -> s | None -> !current_scheme
 
 let breakpoint_rem = function
   | `Sm -> 40.
@@ -189,24 +190,24 @@ let negate_media = function
 
 (** Get the media condition for a breakpoint, using px from scheme if available,
     otherwise rem. *)
-let breakpoint_condition bp =
+let breakpoint_condition ?theme bp =
   let name = string_of_breakpoint bp in
-  match Scheme.breakpoint !current_scheme name with
+  match Scheme.breakpoint (resolve_scheme theme) name with
   | Some px -> media_min_width_px px
   | None -> media_min_width_rem (breakpoint_rem bp)
 
 (** Get the negated media condition for max-* breakpoints. *)
-let breakpoint_not_condition bp =
+let breakpoint_not_condition ?theme bp =
   let name = string_of_breakpoint bp in
-  match Scheme.breakpoint !current_scheme name with
+  match Scheme.breakpoint (resolve_scheme theme) name with
   | Some px -> media_not_min_width_px px
   | None -> media_not_min_width_rem (breakpoint_rem bp)
 
 (** Get the media condition and class prefix for a responsive modifier. *)
-let responsive_modifier_condition = function
+let responsive_modifier_condition ?theme = function
   | Style.Responsive bp ->
       let prefix = string_of_breakpoint bp in
-      (breakpoint_condition bp, prefix)
+      (breakpoint_condition ?theme bp, prefix)
   | Style.Min_responsive bp ->
       let prefix =
         match bp with
@@ -216,7 +217,7 @@ let responsive_modifier_condition = function
         | `Xl -> "min-xl"
         | `Xl_2 -> "min-2xl"
       in
-      (breakpoint_condition bp, prefix)
+      (breakpoint_condition ?theme bp, prefix)
   | Style.Max_responsive bp ->
       let prefix =
         match bp with
@@ -226,7 +227,7 @@ let responsive_modifier_condition = function
         | `Xl -> "max-xl"
         | `Xl_2 -> "max-2xl"
       in
-      (breakpoint_not_condition bp, prefix)
+      (breakpoint_not_condition ?theme bp, prefix)
   | Style.Min_arbitrary px ->
       let px_str =
         if Float.is_integer px then Int.to_string (Float.to_int px)
@@ -247,21 +248,21 @@ let responsive_modifier_condition = function
       (Css.media_not_min_width_length l, "max-[" ^ len_str ^ "]")
   | Style.Custom_responsive name ->
       let px =
-        match Scheme.breakpoint !current_scheme name with
+        match Scheme.breakpoint (resolve_scheme theme) name with
         | Some px -> px
         | None -> failwith ("unknown custom breakpoint: " ^ name)
       in
       (media_min_width_px px, name)
   | Style.Min_custom name ->
       let px =
-        match Scheme.breakpoint !current_scheme name with
+        match Scheme.breakpoint (resolve_scheme theme) name with
         | Some px -> px
         | None -> failwith ("unknown custom breakpoint: " ^ name)
       in
       (media_min_width_px px, "min-" ^ name)
   | Style.Max_custom name ->
       let px =
-        match Scheme.breakpoint !current_scheme name with
+        match Scheme.breakpoint (resolve_scheme theme) name with
         | Some px -> px
         | None -> failwith ("unknown custom breakpoint: " ^ name)
       in
@@ -281,10 +282,10 @@ let media_rule_with_prefix prefix condition base_class selector props =
   media_query ~condition ~selector:new_selector ~props
     ~base_class:modified_class ()
 
-let responsive_rule breakpoint base_class selector props =
+let responsive_rule ?theme breakpoint base_class selector props =
   media_rule_with_prefix
     (string_of_breakpoint breakpoint)
-    (breakpoint_condition breakpoint)
+    (breakpoint_condition ?theme breakpoint)
     base_class selector props
 
 let responsive_breakpoint_prefix prefix breakpoint =
@@ -298,16 +299,16 @@ let responsive_breakpoint_prefix prefix breakpoint =
   in
   prefix ^ "-" ^ suffix
 
-let min_responsive_rule breakpoint base_class selector props =
+let min_responsive_rule ?theme breakpoint base_class selector props =
   media_rule_with_prefix
     (responsive_breakpoint_prefix "min" breakpoint)
-    (breakpoint_condition breakpoint)
+    (breakpoint_condition ?theme breakpoint)
     base_class selector props
 
-let max_responsive_rule breakpoint base_class selector props =
+let max_responsive_rule ?theme breakpoint base_class selector props =
   media_rule_with_prefix
     (responsive_breakpoint_prefix "max" breakpoint)
-    (breakpoint_not_condition breakpoint)
+    (breakpoint_not_condition ?theme breakpoint)
     base_class selector props
 
 let arbitrary_px_string px =
@@ -341,26 +342,28 @@ let max_arbitrary_length_rule l base_class selector props =
     (Css.media_not_min_width_length l)
     l base_class selector props
 
-let custom_breakpoint name =
-  match Scheme.breakpoint !current_scheme name with
+let custom_breakpoint ?theme name =
+  match Scheme.breakpoint (resolve_scheme theme) name with
   | Some px -> px
   | None -> failwith ("unknown custom breakpoint: " ^ name)
 
-let custom_media_rule prefix condition_of_px name base_class selector props =
-  let px = custom_breakpoint name in
+let custom_media_rule ?theme prefix condition_of_px name base_class selector
+    props =
+  let px = custom_breakpoint ?theme name in
   media_rule_with_prefix (prefix name) (condition_of_px px) base_class selector
     props
 
-let custom_responsive_rule name base_class selector props =
-  custom_media_rule Fun.id media_min_width_px name base_class selector props
+let custom_responsive_rule ?theme name base_class selector props =
+  custom_media_rule ?theme Fun.id media_min_width_px name base_class selector
+    props
 
-let min_custom_rule name base_class selector props =
-  custom_media_rule
+let min_custom_rule ?theme name base_class selector props =
+  custom_media_rule ?theme
     (fun name -> "min-" ^ name)
     media_min_width_px name base_class selector props
 
-let max_custom_rule name base_class selector props =
-  custom_media_rule
+let max_custom_rule ?theme name base_class selector props =
+  custom_media_rule ?theme
     (fun name -> "max-" ^ name)
     media_not_min_width_px name base_class selector props
 
@@ -1001,7 +1004,7 @@ let not_media_rule ~nvo ~condition modified_class props =
 (** Handle :not() pseudo-class modifier: dispatches to the right rule type based
     on the inner modifier. Returns a list of rules since some modifiers (like
     hover) produce both a selector rule and a media rule. *)
-let handle_not_modifier inner_modifier base_class _selector props =
+let handle_not_modifier ?theme inner_modifier base_class _selector props =
   let modified_class =
     "not-" ^ not_class_prefix inner_modifier ^ ":" ^ base_class
   in
@@ -1033,11 +1036,12 @@ let handle_not_modifier inner_modifier base_class _selector props =
       ]
   | Style.Responsive bp | Style.Min_responsive bp ->
       not_media_rule ~nvo
-        ~condition:(breakpoint_not_condition bp)
+        ~condition:(breakpoint_not_condition ?theme bp)
         modified_class props
   | Style.Max_responsive bp ->
-      not_media_rule ~nvo ~condition:(breakpoint_condition bp) modified_class
-        props
+      not_media_rule ~nvo
+        ~condition:(breakpoint_condition ?theme bp)
+        modified_class props
   | Style.Min_arbitrary px ->
       not_media_rule ~nvo
         ~condition:(media_not_min_width_px px)
@@ -1403,8 +1407,8 @@ let custom_variant_rule token template base_class props =
 (** Convert a modifier and its context to a CSS rule. [inner_has_hover]
     indicates if the inner rule has a hover modifier that needs to be wrapped in
     CSS nesting with {i \@media (hover:hover)}. *)
-let modifier_to_rule ?(inner_has_hover = false) modifier base_class selector
-    props =
+let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier base_class
+    selector props =
   match modifier with
   (* Data modifiers *)
   | Style.Data_state _ | Style.Data_variant _ ->
@@ -1431,11 +1435,11 @@ let modifier_to_rule ?(inner_has_hover = false) modifier base_class selector
       handle_supports_modifier condition_str base_class selector props
   (* Responsive and container *)
   | Style.Responsive breakpoint ->
-      responsive_rule breakpoint base_class selector props
+      responsive_rule ?theme breakpoint base_class selector props
   | Style.Min_responsive breakpoint ->
-      min_responsive_rule breakpoint base_class selector props
+      min_responsive_rule ?theme breakpoint base_class selector props
   | Style.Max_responsive breakpoint ->
-      max_responsive_rule breakpoint base_class selector props
+      max_responsive_rule ?theme breakpoint base_class selector props
   | Style.Min_arbitrary px -> min_arbitrary_rule px base_class selector props
   | Style.Max_arbitrary px -> max_arbitrary_rule px base_class selector props
   | Style.Min_arbitrary_length l ->
@@ -1443,9 +1447,9 @@ let modifier_to_rule ?(inner_has_hover = false) modifier base_class selector
   | Style.Max_arbitrary_length l ->
       max_arbitrary_length_rule l base_class selector props
   | Style.Custom_responsive name ->
-      custom_responsive_rule name base_class selector props
-  | Style.Min_custom name -> min_custom_rule name base_class selector props
-  | Style.Max_custom name -> max_custom_rule name base_class selector props
+      custom_responsive_rule ?theme name base_class selector props
+  | Style.Min_custom name -> min_custom_rule ?theme name base_class selector props
+  | Style.Max_custom name -> max_custom_rule ?theme name base_class selector props
   | Style.Container query -> container_rule query base_class selector props
   (* :not(), :not-bracket, group-not, peer-not — handled in
      apply_modifier_to_rule for multi-rule support *)
@@ -1517,6 +1521,9 @@ let modifier_to_rule ?(inner_has_hover = false) modifier base_class selector
       handle_fallback_modifier ~inner_has_hover modifier base_class selector
         props
 
+let modifier_to_rule ?inner_has_hover modifier base_class selector props =
+  modifier_to_rule_themed ?inner_has_hover modifier base_class selector props
+
 (** Generate pseudo-element rules with separate selectors for browser
     compatibility. An invalid pseudo-element in a comma list causes the entire
     rule to be dropped, so each variant gets its own rule. *)
@@ -1534,8 +1541,8 @@ let pseudo_element_rules ~pseudo_selectors bc props prefix =
 (** Apply a modifier to a Media_query rule by wrapping it in an outer media
     query. Handles media-like modifiers, responsive modifiers, and falls back to
     returning the rule unchanged. *)
-let apply_modifier_to_media_query modifier ~inner_condition ~selector ~props
-    ~base_class ~nested =
+let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
+    ~props ~base_class ~nested =
   let bc = Option.value base_class ~default:"" in
   let modified_base_selector = Modifiers.to_selector modifier bc in
   let modified_class =
@@ -1563,7 +1570,9 @@ let apply_modifier_to_media_query modifier ~inner_condition ~selector ~props
       | Style.Min_arbitrary _ | Style.Max_arbitrary _
       | Style.Min_arbitrary_length _ | Style.Max_arbitrary_length _
       | Style.Custom_responsive _ | Style.Min_custom _ | Style.Max_custom _ ->
-          let outer_condition, _ = responsive_modifier_condition modifier in
+          let outer_condition, _ =
+            responsive_modifier_condition ?theme modifier
+          in
           wrap_in_media outer_condition
       | _ ->
           [
@@ -1580,7 +1589,7 @@ let apply_modifier_to_media_query modifier ~inner_condition ~selector ~props
 
 (* Extract selector and properties from a single Utility *)
 (* Apply modifier to extracted rule *)
-let apply_modifier_to_rule modifier = function
+let apply_modifier_to_rule ?theme modifier = function
   | Regular { selector; props; base_class; has_hover; _ } -> (
       let bc = Option.value base_class ~default:"" in
       match modifier with
@@ -1596,7 +1605,7 @@ let apply_modifier_to_rule modifier = function
       | Style.Not inner_modifier -> (
           match inner_modifier with
           | Style.In_bracket content -> handle_not_in_bracket content bc props
-          | _ -> handle_not_modifier inner_modifier bc selector props)
+          | _ -> handle_not_modifier ?theme inner_modifier bc selector props)
       | Style.Not_bracket content -> handle_not_bracket content bc props
       | Style.In_bracket content -> handle_in_bracket content bc props
       | Style.In_data attr -> handle_in_data attr bc props
@@ -1615,18 +1624,18 @@ let apply_modifier_to_rule modifier = function
       | _ -> (
           try
             [
-              modifier_to_rule ~inner_has_hover:has_hover modifier bc selector
-                props;
+              modifier_to_rule_themed ?theme ~inner_has_hover:has_hover modifier
+                bc selector props;
             ]
           with Invalid_argument _ -> []))
   | Media_query
       { condition = inner_condition; selector; props; base_class; nested; _ } ->
-      apply_modifier_to_media_query modifier ~inner_condition ~selector ~props
-        ~base_class ~nested
+      apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
+        ~props ~base_class ~nested
   | other -> [ other ]
 
 (* Handle Modified style by recursively extracting and applying modifier *)
-let handle_modified util_inner modifier base_style extract_fn =
+let handle_modified ?theme util_inner modifier base_style extract_fn =
   (* Strip the outermost modifier if it matches the one being applied, to avoid
      doubled prefixes like .focus\:focus\:ring. But preserve inner modifiers for
      nested cases like dark [ aria_selected [...] ] ->
@@ -1642,7 +1651,7 @@ let handle_modified util_inner modifier base_style extract_fn =
   in
   let base_class_name = Utility.to_class inner_util in
   let base_rules = extract_fn base_class_name inner_util style in
-  List.concat_map (apply_modifier_to_rule modifier) base_rules
+  List.concat_map (apply_modifier_to_rule ?theme modifier) base_rules
 
 (* Handle Group style by extracting each item *)
 let handle_group class_name util_inner styles extract_fn =
@@ -1800,7 +1809,7 @@ let outputs ?(theme = Scheme.default) ?order_tbl util =
             extract_style_with_rules ~sel ~class_name ?merge_key ~props
               rule_list)
     | Style.Modified (modifier, base_style) ->
-        handle_modified util_inner modifier base_style extract_with_class
+        handle_modified ~theme util_inner modifier base_style extract_with_class
     | Style.Group styles ->
         handle_group class_name util_inner styles extract_with_class
   in

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1805,5 +1805,5 @@ let outputs ?order_tbl util =
         handle_group class_name util_inner styles extract_with_class
   in
   let class_name = Utility.to_class util in
-  let style = Utility.to_style util in
+  let style = Utility.to_style Scheme.default util in
   extract_with_class class_name util style

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -30,8 +30,12 @@ val set_scheme : Scheme.t -> unit
 (** {1 Rule extraction} *)
 
 val outputs :
-  ?order_tbl:(string, int * int) Hashtbl.t -> Utility.t -> Output.t list
-(** [outputs u] extracts the CSS rules for utility [u].
+  ?theme:Scheme.t ->
+  ?order_tbl:(string, int * int) Hashtbl.t ->
+  Utility.t ->
+  Output.t list
+(** [outputs ?theme u] extracts the CSS rules for utility [u], reading any theme
+    values it needs from [theme] (default {!Scheme.default}).
 
     Returns a list because a single utility can produce more than one rule — for
     example a container utility emits one plain rule plus one [@media] rule per

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -17,16 +17,6 @@
 
 open Cascade
 
-(** {1 Scheme}
-
-    The scheme determines whether responsive breakpoints are expressed as
-    [rem]-based media queries (default) or [px]-based ones (when a custom scheme
-    with pixel breakpoints is active). *)
-
-val set_scheme : Scheme.t -> unit
-(** [set_scheme s] installs [s] as the active breakpoint scheme. Call once at
-    application start if the default rem breakpoints are not appropriate. *)
-
 (** {1 Rule extraction} *)
 
 val outputs :

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -40,8 +40,23 @@ type t = {
       (** Explicit breakpoint values in px. Key is breakpoint name (e.g., "sm").
           When defined, responsive media queries use [@media (min-width: Xpx)]
           instead of rem-based values. *)
+  token_overrides : (string * string) list;
+      (** Per-render theme token overrides (from a [@theme] block). Key is the
+          variable name without the leading [--] (e.g. "text-shadow-2xs"), value
+          is the CSS string. Threaded replacement for the global
+          [Var.theme_value_overrides]. *)
 }
 (** Theme scheme configuration *)
+
+(** Process-global registry of theme token DEFAULTS (the v4.3.1 baseline).
+    Populated once at module-init by the utilities that own theme tokens
+    (replaces the [Var.theme_ref_registry] defaults). Defaults are static, so
+    they live here rather than in the per-render {!t}; overrides are threaded via
+    {!t.token_overrides}. *)
+let default_tokens : (string, string) Hashtbl.t = Hashtbl.create 64
+
+let register_default_token name css = Hashtbl.replace default_tokens name css
+let token_default name = Hashtbl.find_opt default_tokens name
 
 (** Default scheme - uses oklch colors and calc-based spacing (matches Tailwind
     v4 default) *)
@@ -54,6 +69,7 @@ let default : t =
     default_border_width = 1;
     default_outline_width = 1;
     breakpoints = [];
+    token_overrides = [];
   }
 
 let pp t =
@@ -101,3 +117,17 @@ let has_explicit_radius scheme name = Option.is_some (radius scheme name)
 
 (** Lookup a breakpoint px value in the scheme *)
 let breakpoint scheme name = List.assoc_opt name scheme.breakpoints
+
+(** Lookup a per-render theme token override (from a [@theme] block). *)
+let token_override scheme name = List.assoc_opt name scheme.token_overrides
+
+(** Resolve a theme token: override (if any) else the registered default. *)
+let token scheme name =
+  match token_override scheme name with
+  | Some _ as v -> v
+  | None -> token_default name
+
+(** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
+    on top of any existing token overrides (new entries win). *)
+let with_overrides scheme overrides =
+  { scheme with token_overrides = overrides @ scheme.token_overrides }

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -51,8 +51,8 @@ type t = {
 (** Process-global registry of theme token DEFAULTS (the v4.3.1 baseline).
     Populated once at module-init by the utilities that own theme tokens
     (replaces the [Var.theme_ref_registry] defaults). Defaults are static, so
-    they live here rather than in the per-render {!t}; overrides are threaded via
-    {!t.token_overrides}. *)
+    they live here rather than in the per-render {!t}; overrides are threaded
+    via {!t.token_overrides}. *)
 let default_tokens : (string, string) Hashtbl.t = Hashtbl.create 64
 
 let register_default_token name css = Hashtbl.replace default_tokens name css
@@ -120,6 +120,12 @@ let breakpoint scheme name = List.assoc_opt name scheme.breakpoints
 
 (** Lookup a per-render theme token override (from a [@theme] block). *)
 let token_override scheme name = List.assoc_opt name scheme.token_overrides
+
+(** [theme_value theme name] looks up a per-render token override from the
+    optionally-threaded [theme] ([None] when no theme is threaded). Threaded
+    replacement for the global [Var.theme_value]. *)
+let theme_value theme name =
+  match theme with Some s -> token_override s name | None -> None
 
 (** Resolve a theme token: override (if any) else the registered default. *)
 let token scheme name =

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -63,7 +63,13 @@ val token_default : string -> string option
 (** [token_default name] returns the registered baseline default for [name]. *)
 
 val token_override : t -> string -> string option
-(** [token_override t name] returns the per-render override for [name], if any. *)
+(** [token_override t name] returns the per-render override for [name], if any.
+*)
+
+val theme_value : t option -> string -> string option
+(** [theme_value theme name] looks up a per-render token override from the
+    optionally-threaded [theme] ([None] when no theme is threaded). Threaded
+    replacement for the global [Var.theme_value]. *)
 
 val token : t -> string -> string option
 (** [token t name] resolves a theme token: override (if any) else default. *)

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -40,6 +40,10 @@ type t = {
       (** Explicit breakpoint values in px. Key is breakpoint name (e.g., "sm").
           When defined, responsive media queries use [@media (min-width: Xpx)]
           instead of rem-based values. *)
+  token_overrides : (string * string) list;
+      (** Per-render theme token overrides (from a [@theme] block). Key is the
+          variable name without the leading [--]; value is the CSS string.
+          Threaded replacement for the global [Var.theme_value_overrides]. *)
 }
 (** Theme scheme configuration *)
 
@@ -49,6 +53,24 @@ val pp : t -> string
 val default : t
 (** [default] is the default scheme using oklch colors and calc-based spacing
     (matches Tailwind v4 default). *)
+
+val register_default_token : string -> string -> unit
+(** [register_default_token name css] registers the v4.3.1 baseline default CSS
+    for theme token [name] (without [--]) in the process-global registry. Called
+    once at module-init by the utility that owns the token. *)
+
+val token_default : string -> string option
+(** [token_default name] returns the registered baseline default for [name]. *)
+
+val token_override : t -> string -> string option
+(** [token_override t name] returns the per-render override for [name], if any. *)
+
+val token : t -> string -> string option
+(** [token t name] resolves a theme token: override (if any) else default. *)
+
+val with_overrides : t -> (string * string) list -> t
+(** [with_overrides t overrides] applies [overrides] on top of [t]'s existing
+    token overrides (new entries win). *)
 
 val color : t -> string -> color_value option
 (** [color t name] looks up a color in the scheme. *)

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -107,7 +107,7 @@ module Handler = struct
     | Padding, Bs -> Css.scroll_padding_block_start len
     | Padding, Be -> Css.scroll_padding_block_end len
 
-  let to_style { kind; negative; axis; value } =
+  let to_style _theme { kind; negative; axis; value } =
     match value with
     | Spacing n ->
         let decl, len = spacing_to_decl_len ~negative n in

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -214,7 +214,7 @@ module Handler = struct
     | "be" -> Some Be
     | _ -> None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* scroll-m-4, scroll-p-4, scroll-mx-4, scroll-py-4, etc. *)

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -41,13 +41,13 @@ module Handler = struct
 
   (** Get (declaration, length) for spacing value using Theme.spacing_calc_float
   *)
-  let spacing_to_decl_len ~negative n : Css.declaration * Css.length =
+  let spacing_to_decl_len ?theme ~negative n : Css.declaration * Css.length =
     if n = 0.0 then
       let decl, _ = Var.binding Theme.spacing_var (Css.Rem 0.25) in
       (decl, Css.Px 0.)
     else
       let mult = if negative then -.n else n in
-      Theme.spacing_calc_float mult
+      Theme.spacing_calc_float ?theme mult
 
   let try_parse_length inner =
     let unit_table : (string * int * (float -> Css.length)) list =
@@ -107,7 +107,10 @@ module Handler = struct
     | Padding, Bs -> Css.scroll_padding_block_start len
     | Padding, Be -> Css.scroll_padding_block_end len
 
-  let to_style _theme { kind; negative; axis; value } =
+  let to_style theme { kind; negative; axis; value } =
+    let spacing_to_decl_len ~negative n =
+      spacing_to_decl_len ~theme ~negative n
+    in
     match value with
     | Spacing n ->
         let decl, len = spacing_to_decl_len ~negative n in

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -219,24 +219,25 @@ module Handler = struct
 
   let has_opacity s = String.contains s '/'
 
-  let parse_color mk rest =
+  let parse_color ?theme mk rest =
     match rest with
     | [ "inherit" ] -> Ok (mk Inherit)
     | [ "transparent" ] -> Ok (mk Transparent)
     | [ current_str ] when String.starts_with ~prefix:"current" current_str -> (
-        let _, op = Color.parse_opacity_modifier current_str in
+        let _, op = Color.parse_opacity_modifier ?theme current_str in
         match op with
         | Color.No_opacity -> Ok (mk Current)
         | _ -> Error (`Msg "Not a scrollbar utility"))
-    | [ v ] when Parse.is_bracket_value (fst (Color.parse_opacity_modifier v))
+    | [ v ]
+      when Parse.is_bracket_value (fst (Color.parse_opacity_modifier ?theme v))
       -> (
-        let base, op = Color.parse_opacity_modifier v in
+        let base, op = Color.parse_opacity_modifier ?theme v in
         let inner = Parse.bracket_inner base in
         match Color.parse_bracket_color inner with
         | Some c -> Ok (mk (Bracket (base, c, op)))
         | None -> Error (`Msg "Not a scrollbar utility"))
     | parts when List.exists has_opacity parts -> (
-        match Color.shade_and_opacity_of_strings parts with
+        match Color.shade_and_opacity_of_strings ?theme parts with
         | Ok (c, shade, op) -> Ok (mk (Theme (c, shade, op)))
         | Error e -> Error e)
     | parts -> (
@@ -244,7 +245,7 @@ module Handler = struct
         | Ok (c, shade) -> Ok (mk (Theme (c, shade, Color.No_opacity)))
         | Error e -> Error e)
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     match Parse.split_class class_name with
     | [ "scrollbar"; "auto" ] -> Ok Width_auto
     | [ "scrollbar"; "none" ] -> Ok Width_none
@@ -252,8 +253,10 @@ module Handler = struct
     | [ "scrollbar"; "gutter"; "auto" ] -> Ok Gutter_auto
     | [ "scrollbar"; "gutter"; "stable" ] -> Ok Gutter_stable
     | [ "scrollbar"; "gutter"; "both" ] -> Ok Gutter_both
-    | "scrollbar" :: "thumb" :: rest -> parse_color (fun s -> Thumb s) rest
-    | "scrollbar" :: "track" :: rest -> parse_color (fun s -> Track s) rest
+    | "scrollbar" :: "thumb" :: rest ->
+        parse_color ~theme (fun s -> Thumb s) rest
+    | "scrollbar" :: "track" :: rest ->
+        parse_color ~theme (fun s -> Track s) rest
     | _ -> Error (`Msg "Not a scrollbar utility")
 end
 

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -203,7 +203,7 @@ module Handler = struct
         in
         style ~property_rules ~rules:(Some ordered) []
 
-  let to_style = function
+  let to_style _theme = function
     | Width_auto -> style [ Css.scrollbar_width Auto ]
     | Width_none -> style [ Css.scrollbar_width None ]
     | Width_thin -> style [ Css.scrollbar_width Thin ]

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -244,7 +244,7 @@ module Handler = struct
         | Ok (c, shade) -> Ok (mk (Theme (c, shade, Color.No_opacity)))
         | Error e -> Error e)
 
-  let of_class class_name =
+  let of_class _theme class_name =
     match Parse.split_class class_name with
     | [ "scrollbar"; "auto" ] -> Ok Width_auto
     | [ "scrollbar"; "none" ] -> Ok Width_none

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -122,7 +122,7 @@ module Handler = struct
 
   (* Return (declarations placed on the rule, optional @supports rules) that set
      [set_var] to the resolved colour. *)
-  let value_decls ~set_var ~prop_name spec :
+  let value_decls ?theme ~set_var ~prop_name spec :
       Css.declaration list * Css.statement list =
     match spec with
     (* Tailwind keeps these keywords literal in the custom property, where
@@ -141,7 +141,7 @@ module Handler = struct
     | Theme (color, shade, op) ->
         let percent = Color.opacity_to_percent op in
         let fallback_hex =
-          match Color.hex_alpha_color color shade op with
+          match Color.hex_alpha_color ?theme color shade op with
           | Some h -> h
           | None -> "#000000"
         in
@@ -176,8 +176,10 @@ module Handler = struct
         in
         ([ fst (Var.binding set_var oklab) ], [])
 
-  let compose ~set_var ~prop_name spec =
-    let main_decls, supports_rules = value_decls ~set_var ~prop_name spec in
+  let compose ?theme ~set_var ~prop_name spec =
+    let main_decls, supports_rules =
+      value_decls ?theme ~set_var ~prop_name spec
+    in
     let scrollbar_color_decl =
       Css.scrollbar_color
         (Colors
@@ -203,7 +205,9 @@ module Handler = struct
         in
         style ~property_rules ~rules:(Some ordered) []
 
-  let to_style _theme = function
+  let to_style theme =
+    let compose ~set_var ~prop_name s = compose ~theme ~set_var ~prop_name s in
+    function
     | Width_auto -> style [ Css.scrollbar_width Auto ]
     | Width_none -> style [ Css.scrollbar_width None ]
     | Width_thin -> style [ Css.scrollbar_width Thin ]

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -207,7 +207,7 @@ module Handler = struct
     let decl, spacing_value = Theme.spacing_calc_float ?theme (n *. 4.) in
     style (decl :: [ css_prop spacing_value ])
 
-  let w' size =
+  let w' ?theme size =
     match size with
     | `None -> style [ width (Px 0.) ]
     | `Xs -> style [ width (Rem 0.5) ]
@@ -218,7 +218,7 @@ module Handler = struct
     | `Xl_2 -> style [ width (Rem 4.0) ]
     | `Xl_3 -> style [ width (Rem 6.0) ]
     | `Full -> style [ width (Pct 100.0) ]
-    | `Rem n -> spacing_utility width n
+    | `Rem n -> spacing_utility ?theme width n
 
   let w_auto' = style [ width Auto ]
   let w_px' = style [ width (Px 1.0) ]
@@ -230,7 +230,7 @@ module Handler = struct
 
   (* Int-based width function for Tailwind scale (n * 0.25rem) *)
 
-  let h' size =
+  let h' ?theme size =
     match size with
     | `None -> style [ height (Px 0.) ]
     | `Xs -> style [ height (Rem 0.5) ]
@@ -241,7 +241,7 @@ module Handler = struct
     | `Xl_2 -> style [ height (Rem 4.0) ]
     | `Xl_3 -> style [ height (Rem 6.0) ]
     | `Full -> style [ height (Pct 100.0) ]
-    | `Rem n -> spacing_utility height n
+    | `Rem n -> spacing_utility ?theme height n
 
   let h_auto' = style [ height Auto ]
   let h_px' = style [ height (Px 1.0) ]
@@ -253,7 +253,7 @@ module Handler = struct
 
   (* Int-based height function for Tailwind scale (n * 0.25rem) *)
 
-  let min_w' size =
+  let min_w' ?theme size =
     match size with
     | `None -> style [ min_width (Px 0.) ]
     | `Xs -> style [ min_width (Rem 0.5) ]
@@ -264,7 +264,7 @@ module Handler = struct
     | `Xl_2 -> style [ min_width (Rem 4.0) ]
     | `Xl_3 -> style [ min_width (Rem 6.0) ]
     | `Full -> style [ min_width (Pct 100.0) ]
-    | `Rem n -> spacing_utility min_width n
+    | `Rem n -> spacing_utility ?theme min_width n
 
   let min_w_0' = style [ min_width (Px 0.) ]
   let min_w_full' = style [ min_width (Pct 100.0) ]
@@ -274,7 +274,7 @@ module Handler = struct
 
   (* Int-based min-width function for Tailwind scale (n * 0.25rem) *)
 
-  let max_w' size =
+  let max_w' ?theme size =
     match size with
     | `None -> style [ max_width None ]
     | `Xs -> style [ max_width (Rem 20.0) ]
@@ -285,7 +285,7 @@ module Handler = struct
     | `Xl_2 -> style [ max_width (Rem 42.0) ]
     | `Xl_3 -> style [ max_width (Rem 48.0) ]
     | `Full -> style [ max_width (Pct 100.0) ]
-    | `Rem n -> spacing_utility max_width n
+    | `Rem n -> spacing_utility ?theme max_width n
 
   (* Named width theme variable *)
   let width_xl = Var.theme Css.Length "width-xl" ~order:(5, 20)
@@ -377,7 +377,7 @@ module Handler = struct
 
   (* Int-based max-width function for Tailwind scale (n * 0.25rem) *)
 
-  let min_h' size =
+  let min_h' ?theme size =
     match size with
     | `None -> style [ min_height (Px 0.) ]
     | `Xs -> style [ min_height (Rem 0.5) ]
@@ -388,7 +388,7 @@ module Handler = struct
     | `Xl_2 -> style [ min_height (Rem 4.0) ]
     | `Xl_3 -> style [ min_height (Rem 6.0) ]
     | `Full -> style [ min_height (Pct 100.0) ]
-    | `Rem n -> spacing_utility min_height n
+    | `Rem n -> spacing_utility ?theme min_height n
 
   let min_h_0' = style [ min_height (Px 0.) ]
   let min_h_full' = style [ min_height (Pct 100.0) ]
@@ -399,7 +399,7 @@ module Handler = struct
 
   (* Int-based min-height function for Tailwind scale (n * 0.25rem) *)
 
-  let max_h' size =
+  let max_h' ?theme size =
     match size with
     | `None -> style [ max_height None ]
     | `Xs -> style [ max_height (Rem 0.5) ]
@@ -410,7 +410,7 @@ module Handler = struct
     | `Xl_2 -> style [ max_height (Rem 4.0) ]
     | `Xl_3 -> style [ max_height (Rem 6.0) ]
     | `Full -> style [ max_height (Pct 100.0) ]
-    | `Rem n -> spacing_utility max_height n
+    | `Rem n -> spacing_utility ?theme max_height n
 
   let max_h_none' = style [ max_height None ]
   let max_h_full' = style [ max_height (Pct 100.0) ]
@@ -455,6 +455,12 @@ module Handler = struct
 
   let to_style theme =
     let spacing_utility css_prop n = spacing_utility ~theme css_prop n in
+    let w' size = w' ~theme size in
+    let h' size = h' ~theme size in
+    let min_w' size = min_w' ~theme size in
+    let max_w' size = max_w' ~theme size in
+    let min_h' size = min_h' ~theme size in
+    let max_h' size = max_h' ~theme size in
     function
     (* Width utilities *)
     | W_auto -> w_auto'

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -453,7 +453,7 @@ module Handler = struct
 
   let aspect_ratio' w h = style [ Css.aspect_ratio (Ratio (w, h)) ]
 
-  let to_style = function
+  let to_style _theme = function
     (* Width utilities *)
     | W_auto -> w_auto'
     | W_px -> w_px'

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -992,7 +992,7 @@ module Handler = struct
         | _ -> err_not_utility)
     | _ -> err_not_utility
 
-  let of_class class_name =
+  let of_class _theme class_name =
     match Parse.split_class class_name with
     | [ "w"; value ] -> parse_w value
     | [ "h"; value ] -> parse_h value

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -203,8 +203,8 @@ module Handler = struct
       in rem units (e.g., 16.0 for w-64). We convert to class units by
       multiplying by 4, since --spacing is 0.25rem. Uses calc(var(--spacing) *
       n) for Tailwind v4 compatibility. *)
-  let spacing_utility css_prop n =
-    let decl, spacing_value = Theme.spacing_calc_float (n *. 4.) in
+  let spacing_utility ?theme css_prop n =
+    let decl, spacing_value = Theme.spacing_calc_float ?theme (n *. 4.) in
     style (decl :: [ css_prop spacing_value ])
 
   let w' size =
@@ -453,7 +453,9 @@ module Handler = struct
 
   let aspect_ratio' w h = style [ Css.aspect_ratio (Ratio (w, h)) ]
 
-  let to_style _theme = function
+  let to_style theme =
+    let spacing_utility css_prop n = spacing_utility ~theme css_prop n in
+    function
     (* Width utilities *)
     | W_auto -> w_auto'
     | W_px -> w_px'
@@ -563,7 +565,7 @@ module Handler = struct
     | Size_max -> style [ width Max_content; height Max_content ]
     | Size_fit -> style [ width Fit_content; height Fit_content ]
     | Size_spacing n ->
-        let decl, spacing_value = Theme.spacing_calc_float (n *. 4.) in
+        let decl, spacing_value = Theme.spacing_calc_float ~theme (n *. 4.) in
         style (decl :: [ width spacing_value; height spacing_value ])
     | Size_fraction f -> (
         match

--- a/lib/spacing.ml
+++ b/lib/spacing.ml
@@ -40,9 +40,9 @@ let pp_margin_suffix : margin -> string = function
 let named_spacing_ref name : Css.length =
   Css.Var (Var.bracket ("spacing-" ^ name))
 
-let named_spacing_binding name : Css.declaration option * Css.length =
+let named_spacing_binding ?theme name : Css.declaration option * Css.length =
   let prop_name = "spacing-" ^ name in
-  match Var.theme_value prop_name with
+  match Scheme.theme_value theme prop_name with
   | Some value_str ->
       let decl =
         Css.custom_property ~layer:"theme" ("--" ^ prop_name) value_str

--- a/lib/spacing.mli
+++ b/lib/spacing.mli
@@ -78,10 +78,11 @@ val named_spacing_ref : string -> Css.length
     [var(--spacing-name)] for a named spacing value (e.g., "big" ->
     [var(--spacing-big)]). *)
 
-val named_spacing_binding : string -> Css.declaration option * Css.length
-(** [named_spacing_binding name] creates a theme variable binding for a named
-    spacing value, returning both the theme declaration (if theme value is set)
-    and a var reference. *)
+val named_spacing_binding :
+  ?theme:Scheme.t -> string -> Css.declaration option * Css.length
+(** [named_spacing_binding ?theme name] creates a theme variable binding for a
+    named spacing value, returning both the theme declaration (if theme value is
+    set) and a var reference. *)
 
 val is_named_spacing : string -> bool
 (** [is_named_spacing value] checks if a string is a valid named spacing

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -69,7 +69,7 @@ module Handler = struct
       style [ Css.fill (Css.Color css_color) ]
     else
       let color_var =
-        Color.property_color_var ~property_prefix:"fill" color shade
+        Color.property_color_var ?theme ~property_prefix:"fill" color shade
       in
       let color_value =
         Color.property_color_value ?theme ~property_prefix:"fill" color shade
@@ -84,7 +84,7 @@ module Handler = struct
       style [ Css.stroke (Css.Color css_color) ]
     else
       let color_var =
-        Color.property_color_var ~property_prefix:"stroke" color shade
+        Color.property_color_var ?theme ~property_prefix:"stroke" color shade
       in
       let color_value =
         Color.property_color_value ?theme ~property_prefix:"stroke" color shade

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -396,7 +396,7 @@ module Handler = struct
       Ok (Stroke_width_bracket inner)
     else err_not_utility
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "fill"; "none" ] -> Ok Fill_none

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -63,7 +63,7 @@ module Handler = struct
     | Color.Opacity_var v -> "/[" ^ v ^ "]"
 
   (* Fill color style with scheme support *)
-  let fill_color_style color shade =
+  let fill_color_style ?theme color shade =
     if Color.is_custom_color color then
       let css_color = Color.to_css color shade in
       style [ Css.fill (Css.Color css_color) ]
@@ -72,13 +72,13 @@ module Handler = struct
         Color.property_color_var ~property_prefix:"fill" color shade
       in
       let color_value =
-        Color.property_color_value ~property_prefix:"fill" color shade
+        Color.property_color_value ?theme ~property_prefix:"fill" color shade
       in
       let theme_decl, color_ref = Var.binding color_var color_value in
       style [ theme_decl; Css.fill (Css.Color (Css.Var color_ref)) ]
 
   (* Stroke color style with scheme support *)
-  let stroke_color_style color shade =
+  let stroke_color_style ?theme color shade =
     if Color.is_custom_color color then
       let css_color = Color.to_css color shade in
       style [ Css.stroke (Css.Color css_color) ]
@@ -87,7 +87,7 @@ module Handler = struct
         Color.property_color_var ~property_prefix:"stroke" color shade
       in
       let color_value =
-        Color.property_color_value ~property_prefix:"stroke" color shade
+        Color.property_color_value ?theme ~property_prefix:"stroke" color shade
       in
       let theme_decl, color_ref = Var.binding color_var color_value in
       style [ theme_decl; Css.stroke (Css.Color (Css.Var color_ref)) ]
@@ -163,7 +163,12 @@ module Handler = struct
       match float_of_string_opt num_str with Some f -> Pct f | None -> Pct 0.
     else match float_of_string_opt inner with Some f -> Px f | None -> Px 0.
 
-  let to_style _theme = function
+  let to_style theme =
+    let fill_color_style color shade = fill_color_style ~theme color shade in
+    let stroke_color_style color shade =
+      stroke_color_style ~theme color shade
+    in
+    function
     | Fill_none -> style Css.[ fill None ]
     | Fill_inherit -> style Css.[ fill Inherit ]
     | Fill_transparent -> style Css.[ fill (Color (Css.hex "0000")) ]
@@ -171,7 +176,7 @@ module Handler = struct
     | Fill_current_opacity opacity -> Color.fill_current_with_opacity opacity
     | Fill_color (color, shade) -> fill_color_style color shade
     | Fill_color_opacity (color, shade, opacity) ->
-        Color.fill_with_opacity color shade opacity
+        Color.fill_with_opacity ~theme color shade opacity
     | Fill_bracket_color (_, css_color) ->
         bracket_color_style ~property:Css.fill css_color
     | Fill_bracket_color_opacity (_, css_color, opacity) ->
@@ -191,7 +196,7 @@ module Handler = struct
         Color.stroke_current_with_opacity opacity
     | Stroke_color (color, shade) -> stroke_color_style color shade
     | Stroke_color_opacity (color, shade, opacity) ->
-        Color.stroke_with_opacity color shade opacity
+        Color.stroke_with_opacity ~theme color shade opacity
     | Stroke_bracket_color (_, css_color) ->
         bracket_color_style ~property:Css.stroke css_color
     | Stroke_bracket_color_opacity (_, css_color, opacity) ->

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -396,7 +396,7 @@ module Handler = struct
       Ok (Stroke_width_bracket inner)
     else err_not_utility
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "fill"; "none" ] -> Ok Fill_none
@@ -404,17 +404,18 @@ module Handler = struct
     | [ "fill"; "transparent" ] -> Ok Fill_transparent
     | [ "fill"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let _, opacity = Color.parse_opacity_modifier current_str in
+        let _, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity -> Ok Fill_current
         | _ -> Ok (Fill_current_opacity opacity))
     | [ "fill"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
+           && Parse.is_bracket_value
+                (fst (Color.parse_opacity_modifier ~theme v)) ->
         parse_bracket_fill v
     | "fill" :: color_parts when List.exists has_opacity color_parts -> (
-        match Color.shade_and_opacity_of_strings color_parts with
+        match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Fill_color_opacity (color, shade, opacity))
         | Error e -> Error e)
@@ -427,16 +428,17 @@ module Handler = struct
     | [ "stroke"; "transparent" ] -> Ok Stroke_transparent
     | [ "stroke"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
-        let _, opacity = Color.parse_opacity_modifier current_str in
+        let _, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
         | Color.No_opacity -> Ok Stroke_current
         | _ -> Ok (Stroke_current_opacity opacity))
     | [ "stroke"; v ]
       when String.length v > 0
            && v.[0] = '['
-           && Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
+           && Parse.is_bracket_value
+                (fst (Color.parse_opacity_modifier ~theme v)) ->
         (* Bracket value: could be color or width *)
-        let base_str, _ = Color.parse_opacity_modifier v in
+        let base_str, _ = Color.parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
         let normalized =
           String.map (fun c -> if c = '_' then ' ' else c) base_inner
@@ -455,7 +457,7 @@ module Handler = struct
         | Some width -> Ok (Stroke_width width)
         | None -> err_not_utility)
     | "stroke" :: color_parts when List.exists has_opacity color_parts -> (
-        match Color.shade_and_opacity_of_strings color_parts with
+        match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Stroke_color_opacity (color, shade, opacity))
         | Error e -> Error e)

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -163,7 +163,7 @@ module Handler = struct
       match float_of_string_opt num_str with Some f -> Pct f | None -> Pct 0.
     else match float_of_string_opt inner with Some f -> Px f | None -> Px 0.
 
-  let to_style = function
+  let to_style _theme = function
     | Fill_none -> style Css.[ fill None ]
     | Fill_inherit -> style Css.[ fill Inherit ]
     | Fill_transparent -> style Css.[ fill (Color (Css.hex "0000")) ]

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -36,7 +36,7 @@ module Handler = struct
           | None -> None)
     else None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     match Parse.split_class class_name with
     | [ "tab"; n ] -> (
         match int_of_string_opt n with

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -16,7 +16,7 @@ module Handler = struct
     | Tab n -> "tab-" ^ string_of_int n
     | Tab_arbitrary (raw, _) -> "tab-" ^ raw
 
-  let to_style = function
+  let to_style _theme = function
     | Tab n -> style [ Css.tab_size n ]
     | Tab_arbitrary (_, v) -> style [ Css.tab_size_value v ]
 

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -55,14 +55,14 @@ module Handler = struct
       "tw-border-spacing-y"
 
   (** Get spacing value - uses theme variable var(--spacing-N) *)
-  let spacing_value n =
-    let decl, len = Theme.spacing_calc_float n in
+  let spacing_value ?theme n =
+    let decl, len = Theme.spacing_calc_float ?theme n in
     (decl, len)
 
   (** border-spacing: sets both x and y variables and outputs two-value
       border-spacing *)
-  let border_spacing_style n =
-    let spacing_decl, spacing_len = spacing_value n in
+  let border_spacing_style ?theme n =
+    let spacing_decl, spacing_len = spacing_value ?theme n in
     (* Set --tw-border-spacing-x and --tw-border-spacing-y to the spacing
        value *)
     let decl_x, x_ref = Var.binding border_spacing_x_var spacing_len in
@@ -84,8 +84,8 @@ module Handler = struct
       ]
 
   (** border-spacing-x: sets only x variable *)
-  let border_spacing_x_style n =
-    let spacing_decl, spacing_len = spacing_value n in
+  let border_spacing_x_style ?theme n =
+    let spacing_decl, spacing_len = spacing_value ?theme n in
     let decl_x, x_ref = Var.binding border_spacing_x_var spacing_len in
     let _, y_ref = Var.binding border_spacing_y_var Zero in
     let property_rules =
@@ -104,8 +104,8 @@ module Handler = struct
       ]
 
   (** border-spacing-y: sets only y variable *)
-  let border_spacing_y_style n =
-    let spacing_decl, spacing_len = spacing_value n in
+  let border_spacing_y_style ?theme n =
+    let spacing_decl, spacing_len = spacing_value ?theme n in
     let _, x_ref = Var.binding border_spacing_x_var Zero in
     let decl_y, y_ref = Var.binding border_spacing_y_var spacing_len in
     let property_rules =
@@ -165,7 +165,11 @@ module Handler = struct
       ~property_rules:(Css.concat property_rules)
       [ decl_y; Css.border_spacing (Lengths [ Var x_ref; Var y_ref ]) ]
 
-  let to_style _theme = function
+  let to_style theme =
+    let border_spacing_style n = border_spacing_style ~theme n in
+    let border_spacing_x_style n = border_spacing_x_style ~theme n in
+    let border_spacing_y_style n = border_spacing_y_style ~theme n in
+    function
     | Border_collapse -> style [ Css.border_collapse Collapse ]
     | Border_separate -> style [ Css.border_collapse Separate ]
     | Border_spacing n -> border_spacing_style n

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -200,7 +200,7 @@ module Handler = struct
     | Border_spacing_y n -> 2032 + int_of_float (n *. 10.)
     | Border_spacing_y_arb _ -> 3000
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "border"; "collapse" ] -> Ok Border_collapse

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -165,7 +165,7 @@ module Handler = struct
       ~property_rules:(Css.concat property_rules)
       [ decl_y; Css.border_spacing (Lengths [ Var x_ref; Var y_ref ]) ]
 
-  let to_style = function
+  let to_style _theme = function
     | Border_collapse -> style [ Css.border_collapse Collapse ]
     | Border_separate -> style [ Css.border_collapse Separate ]
     | Border_spacing n -> border_spacing_style n

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -438,7 +438,7 @@ module Handler = struct
 
   (* ============ Style dispatch ============ *)
 
-  let to_style = function
+  let to_style _theme = function
     | Text_shadow_none ->
         style ~property_rules:text_shadow_property_rules
           [ Css.text_shadow Css.None ]

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -185,7 +185,7 @@ module Handler = struct
 
   let color_hex ?theme c shade =
     let color_name = Color.scheme_color_name c shade in
-    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     match Scheme.hex_color scheme color_name with
     | Some h -> h
     | Stdlib.Option.None -> (

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -189,7 +189,7 @@ module Handler = struct
     match Scheme.hex_color scheme color_name with
     | Some h -> h
     | Stdlib.Option.None -> (
-        match Var.theme_value ("color-" ^ color_name) with
+        match Scheme.theme_value theme ("color-" ^ color_name) with
         | Some h -> h
         | Stdlib.Option.None ->
             let oklch = Color.to_oklch c shade in

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -625,7 +625,7 @@ module Handler = struct
     in
     has_length_unit inner && not has_typed_prefix
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "text"; "shadow"; "none" ] -> Ok Text_shadow_none
@@ -633,7 +633,7 @@ module Handler = struct
        named scale is `text-shadow-{2xs,xs,sm,md,lg}`. *)
     | [ "text"; "shadow" ] -> err_not_utility
     | [ "text"; "shadow"; size_str ] -> (
-        let base, opacity = Color.parse_opacity_modifier size_str in
+        let base, opacity = Color.parse_opacity_modifier ~theme size_str in
         let shape_opt =
           match base with
           | "2xs" -> Some S_2xs
@@ -678,7 +678,7 @@ module Handler = struct
         | _ -> err_not_utility)
     | "text" :: "shadow" :: color_parts when List.exists has_opacity color_parts
       -> (
-        match Color.shade_and_opacity_of_strings color_parts with
+        match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
             Ok (Text_shadow_color_opacity (color, shade, opacity))
         | Error e -> Error e)

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -183,9 +183,10 @@ module Handler = struct
 
   (* ============ Color-setting styles ============ *)
 
-  let color_hex c shade =
+  let color_hex ?theme c shade =
     let color_name = Color.scheme_color_name c shade in
-    match Scheme.hex_color (Color.scheme ()) color_name with
+    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    match Scheme.hex_color scheme color_name with
     | Some h -> h
     | Stdlib.Option.None -> (
         match Var.theme_value ("color-" ^ color_name) with
@@ -195,8 +196,8 @@ module Handler = struct
             let rgb = Color.oklch_to_rgb oklch in
             Color.rgb_to_hex rgb)
 
-  let set_color c shade =
-    let hex_value = color_hex c shade in
+  let set_color ?theme c shade =
+    let hex_value = color_hex ?theme c shade in
     let base_decl, _ = Var.binding text_shadow_color_var (Css.hex hex_value) in
     let theme_color_var = Color.color_var c shade in
     let theme_decl, color_ref =
@@ -211,9 +212,9 @@ module Handler = struct
     style ~rules:(Some [ supports_block ])
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
-  let set_color_opacity c shade opacity =
+  let set_color_opacity ?theme c shade opacity =
     let percent = Color.opacity_to_percent opacity in
-    let hex_value = color_hex c shade in
+    let hex_value = color_hex ?theme c shade in
     let hex_with_alpha = Color.hex_with_alpha hex_value percent in
     let base_decl, _ =
       Var.binding text_shadow_color_var (Css.hex hex_with_alpha)
@@ -438,7 +439,12 @@ module Handler = struct
 
   (* ============ Style dispatch ============ *)
 
-  let to_style _theme = function
+  let to_style theme =
+    let set_color c shade = set_color ~theme c shade in
+    let set_color_opacity c shade opacity =
+      set_color_opacity ~theme c shade opacity
+    in
+    function
     | Text_shadow_none ->
         style ~property_rules:text_shadow_property_rules
           [ Css.text_shadow Css.None ]

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -625,7 +625,7 @@ module Handler = struct
     in
     has_length_unit inner && not has_typed_prefix
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "text"; "shadow"; "none" ] -> Ok Text_shadow_none

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -5,6 +5,7 @@ module Css = Cascade.Css
 (* Capture project Pp helpers before open Css shadows Pp with Css.Pp. *)
 let pp_float = Pp.float
 let pp_str = Pp.str
+let pp_hex_byte = Pp.hex_byte
 
 module Handler = struct
   open Style
@@ -128,21 +129,119 @@ module Handler = struct
 
   (* ============ Shape definitions ============ *)
 
+  (* v4.3.1 default text-shadow scale (the values the bare CLI emits). 2xs/xs
+     are single shadows; sm/md/lg are 3-shadow stacks. *)
   let shape_shadows (shape : shape) :
       (length * length * length option * string) list =
     match shape with
-    | S_2xs -> [ ((Px 0. : length), Px 1., Some (Px 0.), "#0000001a") ]
-    | S_xs -> [ ((Px 0. : length), Px 1., Some (Px 1.), "#0000001a") ]
+    | S_2xs -> [ ((Px 0. : length), Px 1., Some (Px 0.), "#00000026") ]
+    | S_xs -> [ ((Px 0. : length), Px 1., Some (Px 1.), "#00000033") ]
     | S_sm ->
         [
-          ((Px 0. : length), Px 1., Some (Px 2.), "#0000000f");
-          (Px 0., Px 2., Some (Px 2.), "#0000000f");
+          ((Px 0. : length), Px 1., Some (Px 0.), "#00000013");
+          (Px 0., Px 1., Some (Px 1.), "#00000013");
+          (Px 0., Px 2., Some (Px 2.), "#00000013");
         ]
-    | S_md -> [ ((Px 0. : length), Px 2., Some (Px 4.), "#0000001a") ]
-    | S_lg -> [ ((Px 0. : length), Px 4., Some (Px 8.), "#0000001a") ]
+    | S_md ->
+        [
+          ((Px 0. : length), Px 1., Some (Px 1.), "#0000001a");
+          (Px 0., Px 1., Some (Px 2.), "#0000001a");
+          (Px 0., Px 2., Some (Px 4.), "#0000001a");
+        ]
+    | S_lg ->
+        [
+          ((Px 0. : length), Px 1., Some (Px 2.), "#0000001a");
+          (Px 0., Px 3., Some (Px 2.), "#0000001a");
+          (Px 0., Px 4., Some (Px 8.), "#0000001a");
+        ]
 
-  let shape_text_shadow shape =
-    let shadows = shape_shadows shape in
+  (* Theme token name for a shape's scale value (matches the @theme keys, e.g.
+     --text-shadow-2xs). *)
+  let shape_token = function
+    | S_2xs -> "text-shadow-2xs"
+    | S_xs -> "text-shadow-xs"
+    | S_sm -> "text-shadow-sm"
+    | S_md -> "text-shadow-md"
+    | S_lg -> "text-shadow-lg"
+
+  (* Parse a theme shadow-list override (e.g. "0px 1px 0px rgb(0 0 0 / 0.1), 0px
+     2px 2px rgb(0 0 0 / 0.06)") into the same (h, v, blur, hex) tuples
+     [shape_shadows] returns. Splits on top-level commas, then for each shadow
+     takes the leading length tokens and converts the trailing colour to a hex
+     string. *)
+  let hex_string_of_color (s : string) : string =
+    match Css.parse_color s with
+    | Some c -> (
+        match Color.css_color_to_hex c with
+        | Some (Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ }) ->
+            let bh = pp_hex_byte in
+            "#" ^ bh r ^ bh g ^ bh b ^ if a = 255 then "" else bh a
+        | _ -> s)
+    | None -> s
+
+  let parse_shadow_list (s : string) :
+      (length * length * length option * string) list =
+    let split_top_level str =
+      let buf = Buffer.create 32 and acc = ref [] and depth = ref 0 in
+      String.iter
+        (fun c ->
+          if c = '(' then (
+            incr depth;
+            Buffer.add_char buf c)
+          else if c = ')' then (
+            decr depth;
+            Buffer.add_char buf c)
+          else if c = ',' && !depth = 0 then (
+            acc := Buffer.contents buf :: !acc;
+            Buffer.clear buf)
+          else Buffer.add_char buf c)
+        str;
+      acc := Buffer.contents buf :: !acc;
+      List.rev_map String.trim !acc
+    in
+    let parse_len str : length option =
+      match str with
+      | "0" -> Some (Zero : length)
+      | _ ->
+          let n = String.length str in
+          let cut suf = String.sub str 0 (n - String.length suf) in
+          if Filename.check_suffix str "px" then
+            Option.map
+              (fun f -> (Px f : length))
+              (float_of_string_opt (cut "px"))
+          else if Filename.check_suffix str "rem" then
+            Option.map
+              (fun f -> (Rem f : length))
+              (float_of_string_opt (cut "rem"))
+          else None
+    in
+    let parse_one shadow =
+      let toks = String.split_on_char ' ' shadow |> List.filter (( <> ) "") in
+      let rec take_lengths acc = function
+        | t :: rest -> (
+            match parse_len t with
+            | Some l -> take_lengths (l :: acc) rest
+            | None -> (List.rev acc, t :: rest))
+        | [] -> (List.rev acc, [])
+      in
+      let lengths, color_toks = take_lengths [] toks in
+      let color = hex_string_of_color (String.concat " " color_toks) in
+      match lengths with
+      | [ h; v ] -> Some (h, v, Stdlib.Option.None, color)
+      | [ h; v; blur ] -> Some (h, v, Some blur, color)
+      | _ -> Stdlib.Option.None
+    in
+    List.filter_map parse_one (split_top_level s)
+
+  (* Shadows for a shape: a threaded [@theme] override if present, else the
+     v4.3.1 default scale. *)
+  let shadows_for ?theme shape =
+    match Scheme.theme_value theme (shape_token shape) with
+    | Some override -> parse_shadow_list override
+    | None -> shape_shadows shape
+
+  let shape_text_shadow ?theme shape =
+    let shadows = shadows_for ?theme shape in
     let text_shadows =
       List.map
         (fun (h, v, blur, fallback_hex) ->
@@ -158,8 +257,8 @@ module Handler = struct
     | [ single ] -> Css.text_shadow single
     | multiple -> Css.text_shadows multiple
 
-  let shape_text_shadow_opacity shape opacity =
-    let shadows = shape_shadows shape in
+  let shape_text_shadow_opacity ?theme shape opacity =
+    let shadows = shadows_for ?theme shape in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
     let text_shadows =
@@ -443,6 +542,10 @@ module Handler = struct
     let set_color c shade = set_color ~theme c shade in
     let set_color_opacity c shade opacity =
       set_color_opacity ~theme c shade opacity
+    in
+    let shape_text_shadow shape = shape_text_shadow ~theme shape in
+    let shape_text_shadow_opacity shape opacity =
+      shape_text_shadow_opacity ~theme shape opacity
     in
     function
     | Text_shadow_none ->

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -11,16 +11,8 @@ module Css = Cascade.Css
 
 (** {1 Spacing Variables} *)
 
-(* Current scheme for spacing overrides *)
-let current_scheme : Scheme.t ref = ref Scheme.default
-
-(* Set the current scheme for spacing generation *)
-let set_scheme scheme = current_scheme := scheme
-
-(* Resolve the scheme to read from: the threaded [theme] when given, else the
-   global. Migration scaffold while spacing callers move onto the threaded
-   scheme. *)
-let resolve_scheme = function Some s -> s | None -> !current_scheme
+(* Resolve the optionally-threaded theme, defaulting to the base scheme. *)
+let resolve_scheme = function Some s -> s | None -> Scheme.default
 
 (* Shared spacing variable used across padding, margin, positioning, etc.
    Tailwind v4 uses a single --spacing: 0.25rem variable and calc() for

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -17,6 +17,11 @@ let current_scheme : Scheme.t ref = ref Scheme.default
 (* Set the current scheme for spacing generation *)
 let set_scheme scheme = current_scheme := scheme
 
+(* Resolve the scheme to read from: the threaded [theme] when given, else the
+   global. Migration scaffold while spacing callers move onto the threaded
+   scheme. *)
+let resolve_scheme = function Some s -> s | None -> !current_scheme
+
 (* Shared spacing variable used across padding, margin, positioning, etc.
    Tailwind v4 uses a single --spacing: 0.25rem variable and calc() for
    values. *)
@@ -32,10 +37,10 @@ let spacing_n_var n = Var.theme Css.Length ("spacing-" ^ Pp.int n) ~order:(3, n)
    returns var(--spacing-|n|) or calc(var(--spacing-|n|) * -1) for negatives.
    Otherwise returns calc(var(--spacing) * n). Returns the theme declaration and
    the length. *)
-let spacing_calc n : Css.declaration * Css.length =
+let spacing_calc ?theme n : Css.declaration * Css.length =
   let abs_n = abs n in
   let is_negative = n < 0 in
-  match Scheme.spacing !current_scheme abs_n with
+  match Scheme.spacing (resolve_scheme theme) abs_n with
   | Some explicit_length ->
       (* Scheme has explicit spacing: use var(--spacing-|n|) *)
       let spacing_n = spacing_n_var abs_n in
@@ -81,14 +86,14 @@ let spacing_calc n : Css.declaration * Css.length =
 (* Create a spacing length value for float multipliers like 2.5. For integer
    values, checks scheme for explicit spacing. Otherwise uses calc. This handles
    cases like my-2.5 which need calc(var(--spacing) * 2.5). *)
-let spacing_calc_float (n : float) : Css.declaration * Css.length =
+let spacing_calc_float ?theme (n : float) : Css.declaration * Css.length =
   let abs_n = Float.abs n in
   let is_negative = n < 0.0 in
   (* Check if this is an integer value that might have explicit spacing *)
   let is_integer = Float.is_integer abs_n in
   if is_integer then
     (* Use integer version which checks scheme *)
-    spacing_calc (int_of_float n)
+    spacing_calc ?theme (int_of_float n)
   else
     (* Fractional value: always use calc *)
     let decl, spacing_ref = Var.binding spacing_var spacing_base in

--- a/lib/theme.mli
+++ b/lib/theme.mli
@@ -2,9 +2,6 @@
 
 module Css = Cascade.Css
 
-val set_scheme : Scheme.t -> unit
-(** [set_scheme s] sets the current scheme used by spacing calculations. *)
-
 val spacing_var : Css.length Var.theme
 (** [spacing_var] is the shared [--spacing] variable used across padding,
     margin, positioning, etc. *)

--- a/lib/theme.mli
+++ b/lib/theme.mli
@@ -16,13 +16,15 @@ val spacing_n_var : int -> Css.length Var.theme
 (** [spacing_n_var n] creates the [--spacing-n] variable for explicit spacing
     values. *)
 
-val spacing_calc : int -> Css.declaration * Css.length
-(** [spacing_calc n] returns the theme declaration and a length for [n].
+val spacing_calc : ?theme:Scheme.t -> int -> Css.declaration * Css.length
+(** [spacing_calc ?theme n] returns the theme declaration and a length for [n].
 
-    When the current scheme has an explicit spacing for [|n|], returns
-    [var(--spacing-|n|)] (or [calc(var(--spacing-|n|) * -1)] for negatives).
-    Otherwise returns [calc(var(--spacing) * n)]. *)
+    When the scheme ([theme] when given, else the global) has an explicit
+    spacing for [|n|], returns [var(--spacing-|n|)] (or
+    [calc(var(--spacing-|n|) * -1)] for negatives). Otherwise returns
+    [calc(var(--spacing) * n)]. *)
 
-val spacing_calc_float : float -> Css.declaration * Css.length
-(** [spacing_calc_float n] is like {!spacing_calc} but accepts float multipliers
-    such as [2.5] for classes like [my-2.5]. *)
+val spacing_calc_float :
+  ?theme:Scheme.t -> float -> Css.declaration * Css.length
+(** [spacing_calc_float ?theme n] is like {!spacing_calc} but accepts float
+    multipliers such as [2.5] for classes like [my-2.5]. *)

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -97,7 +97,7 @@ module Handler = struct
   let to_style _theme t = (List.assoc t to_style_map) ()
   let suborder t = List.assoc t suborder_map
 
-  let of_class cls =
+  let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not a touch-action utility")

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -94,7 +94,7 @@ module Handler = struct
 
   (* Handler functions derived from maps *)
   let to_class t = List.assoc t to_class_map
-  let to_style t = (List.assoc t to_style_map) ()
+  let to_style _theme t = (List.assoc t to_style_map) ()
   let suborder t = List.assoc t suborder_map
 
   let of_class cls =

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1347,7 +1347,7 @@ module Handler = struct
         | _ -> None)
     | _ -> None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "rotate"; n ] when Parse.is_bare_var n ->

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -795,8 +795,8 @@ module Handler = struct
     style ~property_rules:props
       [ Css.scale (XYZ (Var scale_x_ref, Var scale_y_ref, Var scale_z_ref)) ]
 
-  let perspective_none () =
-    match Var.theme_value "perspective-none" with
+  let perspective_none ?theme () =
+    match Scheme.theme_value theme "perspective-none" with
     | Some value_str ->
         let len : Css.length =
           if String.ends_with ~suffix:"px" value_str then
@@ -818,8 +818,9 @@ module Handler = struct
 
   let perspective_arbitrary len = style [ Css.perspective len ]
 
-  let po_with_ref name (default : Css.perspective_origin) default_css () =
-    match Var.theme_value name with
+  let po_with_ref ?theme name (default : Css.perspective_origin) default_css ()
+      =
+    match Scheme.theme_value theme name with
     | Some value_str ->
         let decl = Css.custom_property ~layer:"theme" ("--" ^ name) value_str in
         let ref : Css.perspective_origin =
@@ -844,34 +845,36 @@ module Handler = struct
             Css.theme_guarded ~var_name:name (Css.perspective perspective_ref);
           ]
 
-  let perspective_origin_center () =
-    po_with_ref "perspective-origin-center" Center "center" ()
+  let perspective_origin_center ?theme () =
+    po_with_ref ?theme "perspective-origin-center" Center "center" ()
 
-  let perspective_origin_top () =
-    po_with_ref "perspective-origin-top" Top "top" ()
+  let perspective_origin_top ?theme () =
+    po_with_ref ?theme "perspective-origin-top" Top "top" ()
 
-  let perspective_origin_bottom () =
-    po_with_ref "perspective-origin-bottom" Bottom "bottom" ()
+  let perspective_origin_bottom ?theme () =
+    po_with_ref ?theme "perspective-origin-bottom" Bottom "bottom" ()
 
-  let perspective_origin_left () =
-    po_with_ref "perspective-origin-left" (Single Zero) "0" ()
+  let perspective_origin_left ?theme () =
+    po_with_ref ?theme "perspective-origin-left" (Single Zero) "0" ()
 
-  let perspective_origin_right () =
-    po_with_ref "perspective-origin-right" (Single (Pct 100.)) "100%" ()
+  let perspective_origin_right ?theme () =
+    po_with_ref ?theme "perspective-origin-right" (Single (Pct 100.)) "100%" ()
 
-  let perspective_origin_top_left () =
-    po_with_ref "perspective-origin-top-left" (XY (Zero, Zero)) "0 0" ()
+  let perspective_origin_top_left ?theme () =
+    po_with_ref ?theme "perspective-origin-top-left" (XY (Zero, Zero)) "0 0" ()
 
-  let perspective_origin_top_right () =
-    po_with_ref "perspective-origin-top-right" (XY (Pct 100., Zero)) "100% 0" ()
+  let perspective_origin_top_right ?theme () =
+    po_with_ref ?theme "perspective-origin-top-right"
+      (XY (Pct 100., Zero))
+      "100% 0" ()
 
-  let perspective_origin_bottom_left () =
-    po_with_ref "perspective-origin-bottom-left"
+  let perspective_origin_bottom_left ?theme () =
+    po_with_ref ?theme "perspective-origin-bottom-left"
       (XY (Zero, Pct 100.))
       "0 100%" ()
 
-  let perspective_origin_bottom_right () =
-    po_with_ref "perspective-origin-bottom-right"
+  let perspective_origin_bottom_right ?theme () =
+    po_with_ref ?theme "perspective-origin-bottom-right"
       (XY (Pct 100., Pct 100.))
       "100% 100%" ()
 
@@ -903,8 +906,9 @@ module Handler = struct
       Tailwind v4 uses theme variable references for origin utilities when theme
       variables are defined. *)
 
-  let origin_with_ref name (default : Css.transform_origin) default_css () =
-    match Var.theme_value name with
+  let origin_with_ref ?theme name (default : Css.transform_origin) default_css
+      () =
+    match Scheme.theme_value theme name with
     | Some value_str ->
         let decl = Css.custom_property ~layer:"theme" ("--" ^ name) value_str in
         let ref : Css.transform_origin Css.var =
@@ -917,34 +921,38 @@ module Handler = struct
         in
         style [ transform_origin v ]
 
-  let origin_center () =
-    origin_with_ref "transform-origin-center" Center "center" ()
+  let origin_center ?theme () =
+    origin_with_ref ?theme "transform-origin-center" Center "center" ()
 
-  let origin_top () = origin_with_ref "transform-origin-top" Top "top" ()
+  let origin_top ?theme () =
+    origin_with_ref ?theme "transform-origin-top" Top "top" ()
 
-  let origin_bottom () =
-    origin_with_ref "transform-origin-bottom" Bottom "bottom" ()
+  let origin_bottom ?theme () =
+    origin_with_ref ?theme "transform-origin-bottom" Bottom "bottom" ()
 
-  let origin_left () = origin_with_ref "transform-origin-left" (X Zero) "0" ()
+  let origin_left ?theme () =
+    origin_with_ref ?theme "transform-origin-left" (X Zero) "0" ()
 
-  let origin_right () =
-    origin_with_ref "transform-origin-right" (X (Pct 100.)) "100%" ()
+  let origin_right ?theme () =
+    origin_with_ref ?theme "transform-origin-right" (X (Pct 100.)) "100%" ()
 
-  let origin_top_left () =
-    origin_with_ref "transform-origin-top-left" (XY (Zero, Zero)) "0 0" ()
+  let origin_top_left ?theme () =
+    origin_with_ref ?theme "transform-origin-top-left"
+      (XY (Zero, Zero))
+      "0 0" ()
 
-  let origin_top_right () =
-    origin_with_ref "transform-origin-top-right"
+  let origin_top_right ?theme () =
+    origin_with_ref ?theme "transform-origin-top-right"
       (XY (Pct 100., Zero))
       "100% 0" ()
 
-  let origin_bottom_left () =
-    origin_with_ref "transform-origin-bottom-left"
+  let origin_bottom_left ?theme () =
+    origin_with_ref ?theme "transform-origin-bottom-left"
       (XY (Zero, Pct 100.))
       "0 100%" ()
 
-  let origin_bottom_right () =
-    origin_with_ref "transform-origin-bottom-right"
+  let origin_bottom_right ?theme () =
+    origin_with_ref ?theme "transform-origin-bottom-right"
       (XY (Pct 100., Pct 100.))
       "100% 100%" ()
 
@@ -1064,7 +1072,35 @@ module Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style _theme = function
+  let to_style theme =
+    let perspective_none () = perspective_none ~theme () in
+    let perspective_origin_center () = perspective_origin_center ~theme () in
+    let perspective_origin_top () = perspective_origin_top ~theme () in
+    let perspective_origin_bottom () = perspective_origin_bottom ~theme () in
+    let perspective_origin_left () = perspective_origin_left ~theme () in
+    let perspective_origin_right () = perspective_origin_right ~theme () in
+    let perspective_origin_top_left () =
+      perspective_origin_top_left ~theme ()
+    in
+    let perspective_origin_top_right () =
+      perspective_origin_top_right ~theme ()
+    in
+    let perspective_origin_bottom_left () =
+      perspective_origin_bottom_left ~theme ()
+    in
+    let perspective_origin_bottom_right () =
+      perspective_origin_bottom_right ~theme ()
+    in
+    let origin_center () = origin_center ~theme () in
+    let origin_top () = origin_top ~theme () in
+    let origin_bottom () = origin_bottom ~theme () in
+    let origin_left () = origin_left ~theme () in
+    let origin_right () = origin_right ~theme () in
+    let origin_top_left () = origin_top_left ~theme () in
+    let origin_top_right () = origin_top_right ~theme () in
+    let origin_bottom_left () = origin_bottom_left ~theme () in
+    let origin_bottom_right () = origin_bottom_right ~theme () in
+    function
     | Rotate n -> rotate n
     | Rotate_arbitrary a -> rotate_arbitrary a
     | Rotate_3d_arbitrary (x, y, z, a) -> rotate_3d_arbitrary x y z a

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1064,7 +1064,7 @@ module Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style = function
+  let to_style _theme = function
     | Rotate n -> rotate n
     | Rotate_arbitrary a -> rotate_arbitrary a
     | Rotate_3d_arbitrary (x, y, z, a) -> rotate_3d_arbitrary x y z a

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -460,7 +460,7 @@ module Handler = struct
     in
     style ~property_rules [ tw_duration_decl; Css.transition_duration d ]
 
-  let to_style = function
+  let to_style _theme = function
     | Transition_none -> transition_none
     | Transition_all -> transition_all ()
     | Transition_colors -> transition_colors ()

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -525,7 +525,7 @@ module Handler = struct
 
   let ( >|= ) = Parse.( >|= )
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "transition"; "none" ] -> Ok Transition_none

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -90,11 +90,13 @@ module Handler = struct
   (* Theme declarations for the default transition vars. These go into :root,
      :host when transition utilities are used. Only included when theme values
      are set, so @config none tests don't get the :root, :host block. *)
-  let default_theme_decls () =
+  let default_theme_decls ?theme () =
     let has_timing =
-      Var.theme_value "default-transition-timing-function" <> None
+      Scheme.theme_value theme "default-transition-timing-function" <> None
     in
-    let has_duration = Var.theme_value "default-transition-duration" <> None in
+    let has_duration =
+      Scheme.theme_value theme "default-transition-duration" <> None
+    in
     let timing =
       if has_timing then
         let d, _ =
@@ -111,7 +113,7 @@ module Handler = struct
     in
     timing @ duration
 
-  let transition () =
+  let transition ?theme () =
     (* Use typed variable names for gradient properties *)
     let gradient_from_name =
       Var.css_name Backgrounds.Handler.gradient_from_var
@@ -119,7 +121,7 @@ module Handler = struct
     let gradient_via_name = Var.css_name Backgrounds.Handler.gradient_via_var in
     let gradient_to_name = Var.css_name Backgrounds.Handler.gradient_to_var in
     style
-      (default_theme_decls ()
+      (default_theme_decls ?theme ()
       @ [
           Css.transition_property
             [
@@ -151,9 +153,9 @@ module Handler = struct
           Css.transition_duration (Css.Var duration_ref);
         ])
 
-  let transition_all () =
+  let transition_all ?theme () =
     style
-      (default_theme_decls ()
+      (default_theme_decls ?theme ()
       @ [
           Css.transition_property [ Css.All ];
           Css.transition_timing_function (Css.Var ease_ref);
@@ -165,7 +167,7 @@ module Handler = struct
     Var.theme Css.Transition_property_value "transition-property-colors"
       ~order:(8, 3)
 
-  let transition_colors () =
+  let transition_colors ?theme () =
     let gradient_from_name =
       Var.css_name Backgrounds.Handler.gradient_from_var
     in
@@ -173,7 +175,9 @@ module Handler = struct
     let gradient_to_name = Var.css_name Backgrounds.Handler.gradient_to_var in
     (* When --transition-property-colors is set in theme, use the var reference;
        otherwise inline the full property list *)
-    let has_theme_var = Var.theme_value "transition-property-colors" <> None in
+    let has_theme_var =
+      Scheme.theme_value theme "transition-property-colors" <> None
+    in
     let extra_decls, (transition_props : Css.transition_property_value list) =
       if has_theme_var then
         let colors_decl, colors_ref =
@@ -210,15 +214,18 @@ module Handler = struct
           ] )
     in
     style
-      (default_theme_decls () @ extra_decls
+      (default_theme_decls ?theme ()
+      @ extra_decls
       @ [
           Css.transition_property transition_props;
           Css.transition_timing_function (Css.Var ease_ref);
           Css.transition_duration (Css.Var duration_ref);
         ])
 
-  let transition_opacity () =
-    let has_theme_var = Var.theme_value "transition-property-opacity" <> None in
+  let transition_opacity ?theme () =
+    let has_theme_var =
+      Scheme.theme_value theme "transition-property-opacity" <> None
+    in
     let extra_decls, (transition_props : Css.transition_property_value list) =
       if has_theme_var then
         let opacity_decl, opacity_ref =
@@ -228,25 +235,26 @@ module Handler = struct
       else ([], [ Css.Property "opacity" ])
     in
     style
-      (default_theme_decls () @ extra_decls
+      (default_theme_decls ?theme ()
+      @ extra_decls
       @ [
           Css.transition_property transition_props;
           Css.transition_timing_function (Css.Var ease_ref);
           Css.transition_duration (Css.Var duration_ref);
         ])
 
-  let transition_shadow () =
+  let transition_shadow ?theme () =
     style
-      (default_theme_decls ()
+      (default_theme_decls ?theme ()
       @ [
           Css.transition_property [ Css.Property "box-shadow" ];
           Css.transition_timing_function (Css.Var ease_ref);
           Css.transition_duration (Css.Var duration_ref);
         ])
 
-  let transition_transform () =
+  let transition_transform ?theme () =
     style
-      (default_theme_decls ()
+      (default_theme_decls ?theme ()
       @ [
           Css.transition_property
             [
@@ -259,14 +267,14 @@ module Handler = struct
           Css.transition_duration (Css.Var duration_ref);
         ])
 
-  let transition_arbitrary s =
+  let transition_arbitrary ?theme s =
     if Parse.is_var s then
       let bare_name = Parse.extract_var_name s in
       let ref_ : Css.transition_property_value Css.var =
         Var.bracket bare_name
       in
       style
-        (default_theme_decls ()
+        (default_theme_decls ?theme ()
         @ [
             Css.transition_property [ Css.Var ref_ ];
             Css.transition_timing_function (Css.Var ease_ref);
@@ -280,7 +288,7 @@ module Handler = struct
         |> List.map (fun p -> Css.Property (String.trim p))
       in
       style
-        (default_theme_decls ()
+        (default_theme_decls ?theme ()
         @ [
             Css.transition_property props;
             Css.transition_timing_function (Css.Var ease_ref);
@@ -314,10 +322,10 @@ module Handler = struct
   let ease_linear_var =
     Var.theme Css.Timing_function "ease-linear" ~order:(7, 12)
 
-  let ease_linear () =
+  let ease_linear ?theme () =
     (* Tailwind uses the raw 'linear' keyword by default, but uses
        var(--ease-linear) when the theme defines --ease-linear. *)
-    match Var.theme_value "ease-linear" with
+    match Scheme.theme_value theme "ease-linear" with
     | Some _ ->
         let theme_decl, ease_linear_ref =
           Var.binding ease_linear_var Css.Linear
@@ -460,7 +468,16 @@ module Handler = struct
     in
     style ~property_rules [ tw_duration_decl; Css.transition_duration d ]
 
-  let to_style _theme = function
+  let to_style theme =
+    let transition_all () = transition_all ~theme () in
+    let transition_colors () = transition_colors ~theme () in
+    let transition_opacity () = transition_opacity ~theme () in
+    let transition_shadow () = transition_shadow ~theme () in
+    let transition_transform () = transition_transform ~theme () in
+    let transition () = transition ~theme () in
+    let transition_arbitrary s = transition_arbitrary ~theme s in
+    let ease_linear () = ease_linear ~theme () in
+    function
     | Transition_none -> transition_none
     | Transition_all -> transition_all ()
     | Transition_colors -> transition_colors ()

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -95,7 +95,7 @@ let split_whitespace s =
   List.rev !tokens
 
 (* Parse a single class string into a Tw.t *)
-let of_string class_str =
+let of_string ?(theme = Scheme.default) class_str =
   let modifiers, base_class = modifiers_of_string class_str in
   (* The [!] important marker sits right next to the utility: the v3 prefix
      ([!flex], [md:!flex]) or the v4 trailing form ([flex!]). Each keeps its
@@ -108,7 +108,7 @@ let of_string class_str =
       (`Suffix, String.sub base_class 0 (n - 1))
     else (`None, base_class)
   in
-  match Utility.base_of_class base_class with
+  match Utility.base_of_class theme base_class with
   | Error _ -> Error (`Msg ("Unknown class: " ^ class_str))
   | Ok base_utility -> (
       (* Wrap [important] around the base before applying modifiers, so a

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -64,11 +64,11 @@ include Contain
 include Scroll
 include Arbitrary
 
-let to_css ?(base = Build.default_config.base) ?forms
+let to_css ?theme ?(base = Build.default_config.base) ?forms
     ?(layers = Build.default_config.layers) utilities =
-  Build.to_css ~config:{ base; forms; layers } utilities
+  Build.to_css ?theme ~config:{ base; forms; layers } utilities
 
-let to_inline_style utilities = Build.to_inline_style utilities
+let to_inline_style ?theme utilities = Build.to_inline_style ?theme utilities
 let preflight = Preflight.stylesheet
 
 (* Class generation functions *)

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -94,16 +94,8 @@ let split_whitespace s =
   flush ();
   List.rev !tokens
 
-(* Default parse-time theme. Transitional bridge: callers that do not pass an
-   explicit [~theme] (e.g. parse-parity test runners that still seed the global
-   [Var] overrides) get a scheme built from those overrides, so custom-token
-   validation keeps working while they migrate to threading a theme. *)
-let default_parse_theme () =
-  Scheme.with_overrides Scheme.default (Var.theme_value_overrides_list ())
-
 (* Parse a single class string into a Tw.t *)
-let of_string ?theme class_str =
-  let theme = match theme with Some t -> t | None -> default_parse_theme () in
+let of_string ?(theme = Scheme.default) class_str =
   let modifiers, base_class = modifiers_of_string class_str in
   (* The [!] important marker sits right next to the utility: the v3 prefix
      ([!flex], [md:!flex]) or the v4 trailing form ([flex!]). Each keeps its

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -94,8 +94,16 @@ let split_whitespace s =
   flush ();
   List.rev !tokens
 
+(* Default parse-time theme. Transitional bridge: callers that do not pass an
+   explicit [~theme] (e.g. parse-parity test runners that still seed the global
+   [Var] overrides) get a scheme built from those overrides, so custom-token
+   validation keeps working while they migrate to threading a theme. *)
+let default_parse_theme () =
+  Scheme.with_overrides Scheme.default (Var.theme_value_overrides_list ())
+
 (* Parse a single class string into a Tw.t *)
-let of_string ?(theme = Scheme.default) class_str =
+let of_string ?theme class_str =
+  let theme = match theme with Some t -> t | None -> default_parse_theme () in
   let modifiers, base_class = modifiers_of_string class_str in
   (* The [!] important marker sits right next to the utility: the v3 prefix
      ([!flex], [md:!flex]) or the v4 trailing form ([flex!]). Each keeps its

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3624,8 +3624,9 @@ val str : string -> t list
     For dynamic styles that change at runtime, use [to_inline_style] to generate
     CSS properties directly for the style attribute. *)
 
-val to_inline_style : t list -> string
-(** [to_inline_style styles] generates inline CSS for the style attribute.
+val to_inline_style : ?theme:Scheme.t -> t list -> string
+(** [to_inline_style ?theme styles] generates inline CSS for the style
+    attribute.
 
     {b Note:} This generates {i only} the CSS properties for the given styles,
     without any Tailwind reset/prelude. The reset is only included in
@@ -3693,9 +3694,11 @@ module Var = Var
 
 (* Version module is now in the css library *)
 
-val to_css : ?base:bool -> ?forms:bool -> ?layers:bool -> t list -> Css.t
-(** [to_css ?base ?forms ?layers styles] generates a CSS stylesheet for the
-    given styles.
+val to_css :
+  ?theme:Scheme.t -> ?base:bool -> ?forms:bool -> ?layers:bool -> t list -> Css.t
+(** [to_css ?theme ?base ?forms ?layers styles] generates a CSS stylesheet for
+    the given styles. [theme] (default {!Scheme.default}) supplies the theme
+    values utilities read while generating CSS.
 
     The generated CSS follows Tailwind's layering and ordering conventions:
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3591,8 +3591,10 @@ val to_classes : t list -> string
 val pp : t -> string
 (** [pp style] generates a class name from a style. *)
 
-val of_string : string -> (t, [ `Msg of string ]) result
-(** [of_string class_str] parses a Tailwind class string into a style.
+val of_string : ?theme:Scheme.t -> string -> (t, [ `Msg of string ]) result
+(** [of_string ?theme class_str] parses a Tailwind class string into a style.
+    [theme] (default {!Scheme.default}) is consulted to validate custom tokens
+    such as named colors and opacities defined in an [@theme] block.
 
     Example:
     {[

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1079,7 +1079,7 @@ module Typography_early = struct
   (** Generate font-size-only style for bracket value. *)
   let bracket_font_size_style raw = style (bracket_font_size_decls raw)
 
-  let to_style = function
+  let to_style _theme = function
     | Text_xs -> text_xs ()
     | Text_sm -> text_sm ()
     | Text_base -> text_base ()
@@ -2640,7 +2640,7 @@ module Typography_late = struct
   let stacked_fractions =
     font_variant_numeric_utility `Fraction Stacked_fractions
 
-  let to_style = function
+  let to_style _theme = function
     | Decoration_color (color, None) -> decoration_color color
     | Decoration_color (color, Some shade) -> decoration_color ~shade color
     | Decoration_color_opacity (color, shade, opacity) ->

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -898,8 +898,8 @@ module Typography_early = struct
     style ~property_rules
       [ theme_decl; channel_decl; line_height (Css.Var theme_ref) ]
 
-  let leading_none () =
-    match Var.theme_value "leading-none" with
+  let leading_none ?theme () =
+    match Scheme.theme_value theme "leading-none" with
     | Some _ -> leading_with_theme_var leading_none_var (Num 1.0)
     | None ->
         (* Tailwind v4.3 ships no --leading-none token, so inline the literal
@@ -917,9 +917,9 @@ module Typography_early = struct
   let leading_relaxed = leading_with_theme_var leading_relaxed_var (Num 1.625)
   let leading_loose = leading_with_theme_var leading_loose_var (Num 2.0)
 
-  let leading n =
+  let leading ?theme n =
     let name = "leading-" ^ string_of_int n in
-    match Var.theme_value name with
+    match Scheme.theme_value theme name with
     | Some _ ->
         (* A theme overrides --leading-N: reference it like a named leading. *)
         let theme_var = Var.theme Css.Line_height name ~order:(6, 53) in
@@ -1079,7 +1079,10 @@ module Typography_early = struct
   (** Generate font-size-only style for bracket value. *)
   let bracket_font_size_style raw = style (bracket_font_size_decls raw)
 
-  let to_style _theme = function
+  let to_style theme =
+    let leading_none () = leading_none ~theme () in
+    let leading n = leading ~theme n in
+    function
     | Text_xs -> text_xs ()
     | Text_sm -> text_sm ()
     | Text_base -> text_base ()
@@ -2014,8 +2017,8 @@ module Typography_late = struct
         ]
     else
       let color_var =
-        Color.property_color_var ~property_prefix:"text-decoration-color" color
-          shade
+        Color.property_color_var ?theme ~property_prefix:"text-decoration-color"
+          color shade
       in
       let color_value =
         Color.property_color_value ?theme
@@ -2058,8 +2061,8 @@ module Typography_late = struct
     | None ->
         (* No scheme hex: use property-scoped variable *)
         let color_var =
-          Color.property_color_var ~property_prefix:"text-decoration-color"
-            color shade
+          Color.property_color_var ?theme
+            ~property_prefix:"text-decoration-color" color shade
         in
         let color_value =
           Color.property_color_value ~property_prefix:"text-decoration-color"
@@ -2293,8 +2296,8 @@ module Typography_late = struct
     in
     style ~property_rules [ channel_decl; letter_spacing direct_neg ]
 
-  let underline_offset_auto () =
-    match Var.theme_value "text-underline-offset-auto" with
+  let underline_offset_auto ?theme () =
+    match Scheme.theme_value theme "text-underline-offset-auto" with
     | Some _ ->
         let decl, ref_ =
           Var.binding underline_offset_auto_var (Auto : Css.length)
@@ -2375,8 +2378,8 @@ module Typography_late = struct
         overflow Hidden;
       ]
 
-  let line_clamp_none_style () =
-    match Var.theme_value "line-clamp-none" with
+  let line_clamp_none_style ?theme () =
+    match Scheme.theme_value theme "line-clamp-none" with
     | Some value_str -> (
         match int_of_string_opt value_str with
         | Some n ->
@@ -2442,10 +2445,10 @@ module Typography_late = struct
     let c : Css.content = Css.Var content_ref in
     style ~property_rules [ content_decl; Css.content c ]
 
-  let content_named name =
+  let content_named ?theme name =
     let var_name = "content-" ^ name in
     let content_decl, content_ref =
-      match Var.theme_value var_name with
+      match Scheme.theme_value theme var_name with
       | Some _ ->
           let tv = Var.theme Css.Content var_name ~order:(6, 60) in
           let theme_decl, theme_ref = Var.binding tv (String "") in
@@ -2473,14 +2476,14 @@ module Typography_late = struct
   let align_sub = style [ vertical_align Sub ]
   let align_super = style [ vertical_align Super ]
 
-  let list_none () =
+  let list_none ?theme () =
     let var_name = "list-style-type-none" in
     let ref =
       Var.theme_ref var_name
         ~default:(None : Css.list_style_type)
         ~default_css:"none"
     in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value ->
         let theme_decl =
           Css.custom_property ~layer:"theme" ("--" ^ var_name) value
@@ -2503,14 +2506,14 @@ module Typography_late = struct
     let ref : Css.list_style_image Css.var = Var.bracket inner in
     style [ list_style_image (Var ref) ]
 
-  let list_image_none () =
+  let list_image_none ?theme () =
     let var_name = "list-style-image-none" in
     let ref =
       Var.theme_ref var_name
         ~default:(None : Css.list_style_image)
         ~default_css:"none"
     in
-    match Var.theme_value var_name with
+    match Scheme.theme_value theme var_name with
     | Some value ->
         let theme_decl =
           Css.custom_property ~layer:"theme" ("--" ^ var_name) value
@@ -2645,6 +2648,11 @@ module Typography_late = struct
     let decoration_color_with_opacity color shade opacity =
       decoration_color_with_opacity ~theme color shade opacity
     in
+    let underline_offset_auto () = underline_offset_auto ~theme () in
+    let line_clamp_none_style () = line_clamp_none_style ~theme () in
+    let content_named name = content_named ~theme name in
+    let list_none () = list_none ~theme () in
+    let list_image_none () = list_image_none ~theme () in
     function
     | Decoration_color (color, None) -> decoration_color color
     | Decoration_color (color, Some shade) -> decoration_color ~shade color

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1406,7 +1406,7 @@ module Typography_late = struct
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not a late typography utility")
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "underline" ] -> Ok Underline
@@ -1424,7 +1424,7 @@ module Typography_late = struct
     | [ "decoration"; "inherit" ] -> Ok Decoration_inherit
     | [ "decoration"; n ] -> (
         (* Parse opacity modifier first *)
-        let base_str, opacity = Color.parse_opacity_modifier n in
+        let base_str, opacity = Color.parse_opacity_modifier ~theme n in
         (* Check for "current" with optional opacity *)
         match (base_str, opacity) with
         | "current", Color.No_opacity -> Ok Decoration_current
@@ -1494,7 +1494,7 @@ module Typography_late = struct
     | [ "decoration"; color; shade ] -> (
         (* Check for opacity modifier in shade (e.g., "500/50" or
            "500/[0.5]") *)
-        let shade_str, opacity = Color.parse_opacity_modifier shade in
+        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
         match (Color.of_string color, Parse.int_any shade_str) with
         | Ok c, Ok s -> (
             match opacity with

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -485,7 +485,7 @@ module Typography_early = struct
           if List.mem s known_leading_names then Stdlib.Option.Some (Lh_named s)
           else Stdlib.Option.None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "text"; "xs" ] -> Ok Text_xs
@@ -1406,7 +1406,7 @@ module Typography_late = struct
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not a late typography utility")
 
-  let of_class class_name =
+  let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "underline" ] -> Ok Underline

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2004,7 +2004,7 @@ module Typography_late = struct
     let var_ref : Css.length Css.var = Var.bracket bare_name in
     style [ text_decoration_thickness (Var var_ref) ]
 
-  let decoration_color ?(shade = 500) (color : Color.color) =
+  let decoration_color ?theme ?(shade = 500) (color : Color.color) =
     if Color.is_custom_color color then
       let css_color = Color.to_css color shade in
       style
@@ -2018,8 +2018,8 @@ module Typography_late = struct
           shade
       in
       let color_value =
-        Color.property_color_value ~property_prefix:"text-decoration-color"
-          color shade
+        Color.property_color_value ?theme
+          ~property_prefix:"text-decoration-color" color shade
       in
       let color_decl, color_ref = Var.binding color_var color_value in
       style
@@ -2029,9 +2029,9 @@ module Typography_late = struct
           text_decoration_color (Css.Var color_ref);
         ]
 
-  let decoration_color_with_opacity (color : Color.color) shade opacity =
+  let decoration_color_with_opacity ?theme (color : Color.color) shade opacity =
     let percent = Color.opacity_to_percent opacity in
-    let scheme = Color.scheme () in
+    let scheme = match theme with Some t -> t | None -> Color.scheme () in
     let color_name = Color.scheme_color_name color shade in
     match Scheme.hex_color scheme color_name with
     | Some hex_value ->
@@ -2640,7 +2640,12 @@ module Typography_late = struct
   let stacked_fractions =
     font_variant_numeric_utility `Fraction Stacked_fractions
 
-  let to_style _theme = function
+  let to_style theme =
+    let decoration_color ?shade color = decoration_color ~theme ?shade color in
+    let decoration_color_with_opacity color shade opacity =
+      decoration_color_with_opacity ~theme color shade opacity
+    in
+    function
     | Decoration_color (color, None) -> decoration_color color
     | Decoration_color (color, Some shade) -> decoration_color ~shade color
     | Decoration_color_opacity (color, shade, opacity) ->

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2031,7 +2031,7 @@ module Typography_late = struct
 
   let decoration_color_with_opacity ?theme (color : Color.color) shade opacity =
     let percent = Color.opacity_to_percent opacity in
-    let scheme = match theme with Some t -> t | None -> Color.scheme () in
+    let scheme = match theme with Some t -> t | None -> Scheme.default in
     let color_name = Color.scheme_color_name color shade in
     match Scheme.hex_color scheme color_name with
     | Some hex_value ->

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -16,7 +16,7 @@ module type Handler = sig
   type base += Self of t
 
   val name : string
-  val to_style : t -> Style.t
+  val to_style : Scheme.t -> t -> Style.t
   val priority : int
   val suborder : t -> int
   val of_class : string -> (t, [ `Msg of string ]) result
@@ -66,7 +66,7 @@ let base_of_strings parts =
   let class_name = String.concat "-" parts in
   base_of_class class_name
 
-let base_to_style u =
+let base_to_style theme u =
   let rec try_handlers = function
     | [] ->
         prerr_endline
@@ -75,15 +75,15 @@ let base_to_style u =
           "Unknown utility type - handler not registered. This is a bug in the \
            utility system."
     | H (module M) :: rest -> (
-        match u with M.Self x -> M.to_style x | _ -> try_handlers rest)
+        match u with M.Self x -> M.to_style theme x | _ -> try_handlers rest)
   in
   try_handlers !handlers
 
-let rec to_style = function
-  | Base u -> base_to_style u
-  | Modified (m, u) -> Style.Modified (m, to_style u)
-  | Group us -> Style.Group (List.map to_style us)
-  | Important (_, u) -> Style.map_important (to_style u)
+let rec to_style theme = function
+  | Base u -> base_to_style theme u
+  | Modified (m, u) -> Style.Modified (m, to_style theme u)
+  | Group us -> Style.Group (List.map (to_style theme) us)
+  | Important (_, u) -> Style.map_important (to_style theme u)
 
 let rec to_class = function
   | Base u -> class_of_base u

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -19,7 +19,7 @@ module type Handler = sig
   val to_style : Scheme.t -> t -> Style.t
   val priority : int
   val suborder : t -> int
-  val of_class : string -> (t, [ `Msg of string ]) result
+  val of_class : Scheme.t -> string -> (t, [ `Msg of string ]) result
   val to_class : t -> string
 end
 
@@ -51,20 +51,20 @@ let class_of_base u =
   | Some class_name -> class_name
   | None -> failwith "name_of_base"
 
-let base_of_class class_name =
+let base_of_class theme class_name =
   let rec try_handlers = function
     | [] -> Error (`Msg "Unknown utility")
     | H (module M) :: rest -> (
-        match M.of_class class_name with
+        match M.of_class theme class_name with
         | Ok x -> Ok (M.Self x)
         | Error _ -> try_handlers rest)
   in
   try_handlers !handlers
 
 (* Keep for backward compatibility with tests *)
-let base_of_strings parts =
+let base_of_strings theme parts =
   let class_name = String.concat "-" parts in
-  base_of_class class_name
+  base_of_class theme class_name
 
 let base_to_style theme u =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -83,8 +83,9 @@ module type Handler = sig
   val name : string
   (** Name of this utility handler. *)
 
-  val to_style : t -> Style.t
-  (** [to_style u] converts utility [u] to a style. *)
+  val to_style : Scheme.t -> t -> Style.t
+  (** [to_style theme u] converts utility [u] to a style, reading any theme
+      values it needs from [theme]. *)
 
   val priority : int
   (** Priority for ordering utilities. *)
@@ -110,8 +111,9 @@ val base_of_strings : string list -> (base, [ `Msg of string ]) result
 (** [base_of_strings parts] parses a list of string parts into a base utility.
     Deprecated: use base_of_class. For backward compatibility with tests. *)
 
-val base_to_style : base -> Style.t
-(** [base_to_style u] converts a base utility (without modifiers) to Style.t. *)
+val base_to_style : Scheme.t -> base -> Style.t
+(** [base_to_style theme u] converts a base utility (without modifiers) to
+    Style.t, reading theme values from [theme]. *)
 
 val name_of_base : base -> string
 (** [name_of_base u] returns the utility name. *)
@@ -119,8 +121,9 @@ val name_of_base : base -> string
 val class_of_base : base -> string
 (** [class_of_base u] returns the CSS class name for a base utility. *)
 
-val to_style : t -> Style.t
-(** [to_style u] converts Utility.t (with modifiers) to Style.t. *)
+val to_style : Scheme.t -> t -> Style.t
+(** [to_style theme u] converts Utility.t (with modifiers) to Style.t, reading
+    theme values from [theme]. *)
 
 val to_class : t -> string
 (** [to_class u] converts Utility.t (with modifiers) to class name string. *)

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -93,8 +93,9 @@ module type Handler = sig
   val suborder : t -> int
   (** [suborder u] is the suborder within the same priority. *)
 
-  val of_class : string -> (t, [ `Msg of string ]) result
-  (** [of_class name] parses class [name] into a utility. *)
+  val of_class : Scheme.t -> string -> (t, [ `Msg of string ]) result
+  (** [of_class theme name] parses class [name] into a utility, consulting
+      [theme] for custom token validation (e.g. named colors and opacities). *)
 
   val to_class : t -> string
   (** [to_class u] is the CSS class name for utility [u]. *)
@@ -103,13 +104,15 @@ end
 val register : (module Handler with type t = 'a) -> unit
 (** [register h] registers a utility handler module. *)
 
-val base_of_class : string -> (base, [ `Msg of string ]) result
-(** [base_of_class class_name] parses a class name into a base utility (without
-    modifiers). For internal use by the Tw module. *)
+val base_of_class : Scheme.t -> string -> (base, [ `Msg of string ]) result
+(** [base_of_class theme class_name] parses a class name into a base utility
+    (without modifiers). For internal use by the Tw module. *)
 
-val base_of_strings : string list -> (base, [ `Msg of string ]) result
-(** [base_of_strings parts] parses a list of string parts into a base utility.
-    Deprecated: use base_of_class. For backward compatibility with tests. *)
+val base_of_strings :
+  Scheme.t -> string list -> (base, [ `Msg of string ]) result
+(** [base_of_strings theme parts] parses a list of string parts into a base
+    utility. Deprecated: use base_of_class. For backward compatibility with
+    tests. *)
 
 val base_to_style : Scheme.t -> base -> Style.t
 (** [base_to_style theme u] converts a base utility (without modifiers) to

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -18,10 +18,13 @@
 
         let name = "example"
         let priority = 4
-        let to_style = function Block -> Style.style [ Css.display Css.Block ]
+
+        let to_style _theme = function
+          | Block -> Style.style [ Css.display Css.Block ]
+
         let suborder = function Block -> 0
 
-        let of_class = function
+        let of_class _theme = function
           | "example-block" -> Ok Block
           | _ -> Error (`Msg "Not an example utility")
 

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -167,20 +167,6 @@ let (meta_of_info : info -> Css.meta), (info_of_meta : Css.meta -> info option)
 
 let layer_name = function (Theme : layer) -> "theme" | Utility -> "utilities"
 
-(* Theme value overrides: maps var name -> CSS string value. When set,
-   theme-backed utilities emit the override in the theme layer while still using
-   typed variable references in utility declarations. *)
-let theme_value_overrides : (string, string) Hashtbl.t = Hashtbl.create 16
-
-let set_theme_value name value =
-  Hashtbl.replace theme_value_overrides name value
-
-let theme_value name = Hashtbl.find_opt theme_value_overrides name
-let clear_theme_values () = Hashtbl.clear theme_value_overrides
-
-let theme_value_overrides_list () =
-  Hashtbl.fold (fun k v acc -> (k, v) :: acc) theme_value_overrides []
-
 (* Convert a [Css.kind] witness to the matching [Css.Properties.kind]. *)
 let properties_kind_of_kind : type a. a Css.kind -> a Css.Properties.kind =
   let open Css in

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -178,6 +178,9 @@ let set_theme_value name value =
 let theme_value name = Hashtbl.find_opt theme_value_overrides name
 let clear_theme_values () = Hashtbl.clear theme_value_overrides
 
+let theme_value_overrides_list () =
+  Hashtbl.fold (fun k v acc -> (k, v) :: acc) theme_value_overrides []
+
 (* Convert a [Css.kind] witness to the matching [Css.Properties.kind]. *)
 let properties_kind_of_kind : type a. a Css.kind -> a Css.Properties.kind =
   let open Css in

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -278,14 +278,8 @@ let v : type a r.
       | _, _, Some f -> f (* Use provided fallback *)
       | _ -> Css.None (* No fallback *)
     in
-    let decl, var =
-      Css.var ~default:value ~fallback:actual_fallback ?layer:layer_name ~meta
-        ?runtime name kind value
-    in
-    match ((role : r role), Hashtbl.find_opt theme_value_overrides name) with
-    | Theme, Some css ->
-        (Css.custom_property ?layer:layer_name ("--" ^ name) css, var)
-    | _ -> (decl, var)
+    Css.var ~default:value ~fallback:actual_fallback ?layer:layer_name ~meta
+      ?runtime name kind value
   in
   { kind; name; role; binding; property; fallback }
 

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -520,6 +520,12 @@ val theme_value : string -> string option
 val clear_theme_values : unit -> unit
 (** [clear_theme_values ()] removes all theme value overrides. *)
 
+val theme_value_overrides_list : unit -> (string * string) list
+(** [theme_value_overrides_list ()] returns all registered theme value overrides
+    as (name, value) pairs. Transitional bridge: lets {!Tw.of_string} build a
+    default {!Scheme.t} from the global overrides while parse-time callers
+    migrate to passing a threaded theme explicitly. *)
+
 val binding :
   ('a, [< `Theme | `Property_default | `Channel ]) t ->
   ?fallback:'a Css.fallback ->

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -508,24 +508,6 @@ val resolve_theme_refs : string -> string option
     {!val-theme_ref} variable. Used as [theme_defaults] in [Pp.ctx] when theme
     variables don't exist and should be replaced by their concrete defaults. *)
 
-val set_theme_value : string -> string -> unit
-(** [set_theme_value name value] registers a theme value override. When set,
-    utilities using {!val-theme_ref} for this name will produce custom
-    declarations in the theme layer (e.g., [--z-index-auto: 42] in
-    [:root, :host]). *)
-
-val theme_value : string -> string option
-(** [theme_value name] returns the overridden theme value, if any. *)
-
-val clear_theme_values : unit -> unit
-(** [clear_theme_values ()] removes all theme value overrides. *)
-
-val theme_value_overrides_list : unit -> (string * string) list
-(** [theme_value_overrides_list ()] returns all registered theme value overrides
-    as (name, value) pairs. Transitional bridge: lets {!Tw.of_string} build a
-    default {!Scheme.t} from the global overrides while parse-time callers
-    migrate to passing a threaded theme explicitly. *)
-
 val binding :
   ('a, [< `Theme | `Property_default | `Channel ]) t ->
   ?fallback:'a Css.fallback ->

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -19,7 +19,7 @@ module Handler = struct
     | Zoom_pct n -> "zoom-" ^ num_to_string n
     | Zoom_arbitrary (raw, _) -> "zoom-" ^ raw
 
-  let to_style = function
+  let to_style _theme = function
     | Zoom_pct n -> style [ Css.zoom (Pct n) ]
     | Zoom_arbitrary (_, v) -> style [ Css.zoom v ]
 

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -40,7 +40,7 @@ module Handler = struct
         | None -> None
     else None
 
-  let of_class class_name =
+  let of_class _theme class_name =
     match Parse.split_class class_name with
     | [ "zoom"; n ] -> (
         match int_of_string_opt n with

--- a/test/dune
+++ b/test/dune
@@ -12,4 +12,7 @@
   tw_tools
   cascade
   cascade.diff
-  test_helpers))
+  test_helpers)
+ (deps
+  upstream/utilities.txt
+  upstream/variants.txt))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -321,7 +321,6 @@ module type Handler = sig
 
   val of_class : string -> (t, [ `Msg of string ]) result
   val to_class : t -> string
-  val to_style : t -> Tw.Style.t
 end
 
 (** Generic handler test - checks that parsing and pretty-printing round-trip

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -319,7 +319,7 @@ let shuffle lst =
 module type Handler = sig
   type t
 
-  val of_class : string -> (t, [ `Msg of string ]) result
+  val of_class : Tw.Scheme.t -> string -> (t, [ `Msg of string ]) result
   val to_class : t -> string
 end
 
@@ -328,7 +328,7 @@ end
     with to_class, and verifies they match. *)
 let check_handler_roundtrip (module H : Handler) class_name =
   (* Test of_class -> to_class roundtrip *)
-  match H.of_class class_name with
+  match H.of_class Tw.Scheme.default class_name with
   | Ok result ->
       let class_name2 = H.to_class result in
       Alcotest.(check string)
@@ -338,7 +338,7 @@ let check_handler_roundtrip (module H : Handler) class_name =
 
 (** Generic test for invalid inputs - expects parsing to fail *)
 let check_invalid_input (module H : Handler) input =
-  match H.of_class input with
+  match H.of_class Tw.Scheme.default input with
   | Ok _ -> Alcotest.fail ("Expected error for: " ^ input)
   | Error _ -> ()
 

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -134,9 +134,6 @@ module type Handler = sig
 
   val to_class : t -> string
   (** [to_class v] converts to a class name. *)
-
-  val to_style : t -> Tw.Style.t
-  (** [to_style v] converts to a style. *)
 end
 
 val check_handler_roundtrip : (module Handler) -> string -> unit

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -129,8 +129,8 @@ val shuffle : 'a list -> 'a list
 module type Handler = sig
   type t
 
-  val of_class : string -> (t, [ `Msg of string ]) result
-  (** [of_class s] parses a class name. *)
+  val of_class : Tw.Scheme.t -> string -> (t, [ `Msg of string ]) result
+  (** [of_class theme s] parses a class name. *)
 
   val to_class : t -> string
   (** [to_class v] converts to a class name. *)

--- a/test/test_alignment.ml
+++ b/test/test_alignment.ml
@@ -73,7 +73,7 @@ let of_string_valid () =
 let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Alignment.Handler.of_class class_name with
+    match Tw.Alignment.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ class_name)
     | Error _ -> ()
   in

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -2,7 +2,7 @@ open Alcotest
 open Tw.Arbitrary.Handler
 
 let check input =
-  match of_class input with
+  match of_class Tw.Scheme.default input with
   | Ok result ->
       Alcotest.check string "arbitrary class name" input (to_class result)
   | Error (`Msg msg) -> fail msg
@@ -14,7 +14,7 @@ let of_string_valid () =
 
 let of_string_invalid () =
   let fail_maybe input =
-    match of_class input with
+    match of_class Tw.Scheme.default input with
     | Ok _ -> fail ("Expected error for: " ^ input)
     | Error _ -> ()
   in

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -680,7 +680,7 @@ let test_style_rules_props () =
     let to_class _t = "test"
     let to_style _theme _t = style
     let suborder _t = 0
-    let of_class _ = Error (`Msg "test utility")
+    let of_class _ _ = Error (`Msg "test utility")
   end in
   let () = Tw.Utility.register (module TestHandler) in
   let test_utility = Tw.Utility.base (TestHandler.Self TestHandler.Test) in

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -678,7 +678,7 @@ let test_style_rules_props () =
     let name = "test"
     let priority = 0
     let to_class _t = "test"
-    let to_style _t = style
+    let to_style _theme _t = style
     let suborder _t = 0
     let of_class _ = Error (`Msg "test utility")
   end in

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 let check class_name =
-  match Tw.Containers.Handler.of_class class_name with
+  match Tw.Containers.Handler.of_class Tw.Scheme.default class_name with
   | Ok t ->
       check string "containers class" class_name
         (Tw.Containers.Handler.to_class t)
@@ -30,7 +30,7 @@ let test_of_string_invalid () =
   (* Invalid container utilities *)
   let test_invalid input =
     let class_name = String.concat "-" input in
-    match Tw.Containers.Handler.of_class class_name with
+    match Tw.Containers.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ class_name)
     | Error _ -> ()
   in

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -3,7 +3,7 @@ open Tw.Cursor.Handler
 
 let check parts =
   let expected = String.concat "-" parts in
-  match of_class expected with
+  match of_class Tw.Scheme.default expected with
   | Ok result ->
       Alcotest.check string "cursor class name" expected (to_class result)
   | Error (`Msg msg) -> fail msg
@@ -24,7 +24,7 @@ let of_string_valid () =
 let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match of_class class_name with
+    match of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ class_name)
     | Error _ -> ()
   in

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -62,7 +62,7 @@ let of_string_invalid () =
   (* Invalid effects values *)
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Effects.Handler.of_class class_name with
+    match Tw.Effects.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ class_name)
     | Error _ -> ()
   in

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 let check class_name =
-  match Tw.Filters.Handler.of_class class_name with
+  match Tw.Filters.Handler.of_class Tw.Scheme.default class_name with
   | Ok u ->
       check string "filters class" class_name (Tw.Filters.Handler.to_class u)
   | Error (`Msg msg) -> fail msg

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -38,7 +38,7 @@ let of_string_valid () =
 let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Flex_props.Handler.of_class class_name with
+    match Tw.Flex_props.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in

--- a/test/test_forms.ml
+++ b/test/test_forms.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 let check class_name =
-  match Tw.Forms.Handler.of_class class_name with
+  match Tw.Forms.Handler.of_class Tw.Scheme.default class_name with
   | Ok u -> check string "forms class" class_name (Tw.Forms.Handler.to_class u)
   | Error (`Msg msg) -> fail msg
 
@@ -13,7 +13,7 @@ let test_of_string_invalid () =
   (* Invalid form utilities *)
   let test_invalid input =
     let class_name = String.concat "-" input in
-    match Tw.Forms.Handler.of_class class_name with
+    match Tw.Forms.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ class_name)
     | Error _ -> ()
   in

--- a/test/test_grid.ml
+++ b/test/test_grid.ml
@@ -10,7 +10,7 @@ let of_string_valid () =
 let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Grid.Handler.of_class class_name with
+    match Tw.Grid.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in

--- a/test/test_grid_item.ml
+++ b/test/test_grid_item.ml
@@ -36,7 +36,7 @@ let of_string_valid () =
 let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Grid_item.Handler.of_class class_name with
+    match Tw.Grid_item.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in

--- a/test/test_grid_template.ml
+++ b/test/test_grid_template.ml
@@ -64,7 +64,7 @@ let of_string_valid () =
 let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Grid_template.Handler.of_class class_name with
+    match Tw.Grid_template.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in
@@ -99,7 +99,7 @@ let of_string_invalid () =
   (* Arbitrary values with unparseable contents: should reject, not crash.
      Regression: grid-cols-[1fr_40%] used to raise Invalid_argument mid-run. *)
   let bad input =
-    match Tw.Grid_template.Handler.of_class input with
+    match Tw.Grid_template.Handler.of_class Tw.Scheme.default input with
     | Ok _ -> fail ("Expected error for: " ^ input)
     | Error _ -> ()
   in

--- a/test/test_interactivity.ml
+++ b/test/test_interactivity.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 let check class_name =
-  match Tw.Interactivity.Handler.of_class class_name with
+  match Tw.Interactivity.Handler.of_class Tw.Scheme.default class_name with
   | Ok u ->
       check string "interactivity class" class_name
         (Tw.Interactivity.Handler.to_class u)
@@ -17,7 +17,7 @@ let test_of_string_invalid () =
   (* Invalid interactivity utilities *)
   let test_invalid input =
     let class_name = String.concat "-" input in
-    match Tw.Interactivity.Handler.of_class class_name with
+    match Tw.Interactivity.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -40,7 +40,7 @@ let of_string_invalid () =
   (* Invalid layout values *)
   let fail_maybe input =
     let class_name = String.concat "-" input in
-    match Tw.Layout.Handler.of_class class_name with
+    match Tw.Layout.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 let check class_name =
-  match Tw.Position.Handler.of_class class_name with
+  match Tw.Position.Handler.of_class Tw.Scheme.default class_name with
   | Ok util ->
       check string "positioning class" class_name
         (Tw.Position.Handler.to_class util)

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -16,7 +16,41 @@ let test_invalid () =
      named scale `text-shadow-{2xs,xs,sm,md,lg}` is valid. *)
   Test_helpers.check_invalid_input (module Tw.Text_shadow.Handler) "text-shadow"
 
+let parse s = Result.get_ok (Tw.of_string s)
+
+(* The v4.3.1 default text-shadow scale: text-shadow-2xs uses alpha .15
+   (#00000026), not the .1 (#0000001a) tw emitted before theme-threading. *)
+let test_default_scale () =
+  let css =
+    Tw.to_css ~base:false [ parse "text-shadow-2xs" ]
+    |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "text-shadow-2xs default is #00000026 (alpha .15)" true
+    (Astring.String.is_infix ~affix:"#00000026" css)
+
+(* A threaded @theme override for the text-shadow token flows through to the
+   inlined value (here .1 = #0000001a), which is impossible without
+   threading. *)
+let test_theme_override () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("text-shadow-2xs", "0px 1px 0px rgb(0 0 0 / 0.1)") ]
+  in
+  let css =
+    Tw.to_css ~theme ~base:false [ parse "text-shadow-2xs" ]
+    |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "text-shadow-2xs @theme override flows to #0000001a" true
+    (Astring.String.is_infix ~affix:"#0000001a" css)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "default scale (v4.3.1)" `Quick test_default_scale;
+      Alcotest.test_case "@theme override threads through" `Quick
+        test_theme_override;
+    ]
 
 let suite = ("text_shadow", tests)

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 let check class_name =
-  match Tw.Transforms.Handler.of_class class_name with
+  match Tw.Transforms.Handler.of_class Tw.Scheme.default class_name with
   | Ok t ->
       check string "transforms class" class_name
         (Tw.Transforms.Handler.to_class t)
@@ -15,7 +15,7 @@ let test_of_string_invalid () =
   (* Invalid transform utilities *)
   let test_invalid input =
     let class_name = String.concat "-" input in
-    match Tw.Transforms.Handler.of_class class_name with
+    match Tw.Transforms.Handler.of_class Tw.Scheme.default class_name with
     | Ok _ -> fail ("Expected error for: " ^ String.concat "-" input)
     | Error _ -> ()
   in

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -202,6 +202,270 @@ let check_exact_match tw_styles =
 let check tw_style = check_exact_match [ tw_style ]
 let check_list tw_styles = check_exact_match tw_styles
 
+(* ===== UPSTREAM PARSE PARITY ============================================= *)
+
+type upstream_case = {
+  source : string;
+  name : string;
+  config : upstream_config;
+  variants : string list;
+  classes : string list;
+  expected : string;
+}
+
+and upstream_config =
+  | Theme
+  | Theme_inline
+  | Theme_reference
+  | Theme_inline_reference
+  | No_theme
+  | Run
+
+let upstream_config_of_string = function
+  | "theme" -> Theme
+  | "theme-inline" -> Theme_inline
+  | "theme-reference" -> Theme_reference
+  | "theme-inline-reference" -> Theme_inline_reference
+  | "none" -> No_theme
+  | "run" -> Run
+  | _ -> No_theme
+
+let split_classes line =
+  let len = String.length line in
+  let buf = Buffer.create 64 in
+  let acc = ref [] in
+  let depth = ref 0 in
+  for i = 0 to len - 1 do
+    let c = line.[i] in
+    if c = '[' then (
+      incr depth;
+      Buffer.add_char buf c)
+    else if c = ']' then (
+      decr depth;
+      Buffer.add_char buf c)
+    else if c = ' ' && !depth = 0 then (
+      let s = Buffer.contents buf in
+      if s <> "" then acc := s :: !acc;
+      Buffer.clear buf)
+    else Buffer.add_char buf c
+  done;
+  let s = Buffer.contents buf in
+  if s <> "" then acc := s :: !acc;
+  List.rev !acc
+
+let fixture_path filename =
+  (* Found at [upstream/<f>] under the dune sandbox (see the test/dune deps), or
+     [test/upstream/<f>] when run from the repo root. *)
+  [
+    filename;
+    Filename.concat "upstream" filename;
+    Filename.concat "test/upstream" filename;
+  ]
+  |> List.find_opt Sys.file_exists
+  |> Option.value ~default:filename
+
+let find_separator lines =
+  let rec go before = function
+    | [] -> None
+    | line :: rest ->
+        if String.trim line = "---" then Some (List.rev before, rest)
+        else go (line :: before) rest
+  in
+  go [] lines
+
+let parse_upstream_block source block =
+  let lines = String.split_on_char '\n' block in
+  match find_separator lines with
+  | None -> None
+  | Some (before, after) ->
+      let before = List.map String.trim before in
+      let name =
+        before
+        |> List.find_opt (String.starts_with ~prefix:"# ")
+        |> Option.map (fun s -> String.sub s 2 (String.length s - 2))
+        |> Option.value ~default:"<unnamed>"
+      in
+      let variants =
+        before
+        |> List.filter_map (fun s ->
+            if String.starts_with ~prefix:"@variant " s then
+              Some (String.sub s 9 (String.length s - 9))
+            else None)
+      in
+      let config =
+        before
+        |> List.find_opt (String.starts_with ~prefix:"@config ")
+        |> Option.map (fun s ->
+            String.sub s 8 (String.length s - 8) |> upstream_config_of_string)
+        |> Option.value ~default:No_theme
+      in
+      let class_line =
+        before
+        |> List.filter (fun s ->
+            s <> ""
+            && (not (String.starts_with ~prefix:"# " s))
+            && (not (String.starts_with ~prefix:"@config " s))
+            && not (String.starts_with ~prefix:"@variant " s))
+        |> List.rev
+        |> List.find_opt (fun _ -> true)
+      in
+      let classes = Option.value ~default:"" class_line |> split_classes in
+      let expected = after |> String.concat "\n" |> String.trim in
+      Some { source; name; config; variants; classes; expected }
+
+let read_upstream_cases filename =
+  let path = fixture_path filename in
+  let ic = open_in path in
+  let content = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  content
+  |> Astring.String.cuts ~sep:"<<<>>>"
+  |> List.filter_map (parse_upstream_block filename)
+
+let register_upstream_variant_directives directives =
+  let parse_variant_directive d =
+    match String.split_on_char ' ' d with
+    | "container" :: _ -> None
+    | name :: template :: pairs ->
+        let values =
+          List.filter_map
+            (fun kv ->
+              match String.index_opt kv '=' with
+              | Some i ->
+                  let k = String.sub kv 0 i in
+                  let v = String.sub kv (i + 1) (String.length kv - i - 1) in
+                  Some ((if k = "DEFAULT" then "" else k), v)
+              | None -> None)
+            pairs
+        in
+        Some (name, Tw.Modifiers.{ values; template })
+    | _ -> None
+  in
+  let parse_container_directive d =
+    let container_of_header header =
+      match String.index_opt header ' ' with
+      | Some i ->
+          let first = String.sub header 0 i in
+          let rest = String.sub header (i + 1) (String.length header - i - 1) in
+          if first <> "not" && not (String.contains first '(') then
+            Css.Container.Named (first, Css.Container.of_string rest)
+          else Css.Container.of_string header
+      | None -> Css.Container.of_string header
+    in
+    match String.split_on_char ' ' d with
+    | "container" :: name :: (_ :: _ as rest) -> (
+        let header = String.concat " " rest in
+        try Some (name, container_of_header header) with _ -> None)
+    | _ -> None
+  in
+  Tw.Modifiers.register_custom_variants
+    (List.filter_map parse_variant_directive directives);
+  Tw.Modifiers.register_container_variants
+    (List.filter_map parse_container_directive directives)
+
+let upstream_positive_cases filename =
+  read_upstream_cases filename
+  |> List.filter (fun c -> c.expected <> "" && c.classes <> [])
+
+let extract_root_vars expected =
+  let pattern = Re.Pcre.regexp {|--([a-zA-Z0-9_-]+):\s*([^;}]+)|} in
+  Re.all pattern expected
+  |> List.filter_map (fun m ->
+      try
+        let name = Re.Group.get m 1 in
+        let value = String.trim (Re.Group.get m 2) in
+        Some (name, value)
+      with Not_found | Failure _ -> None)
+
+let extract_var_fallbacks expected =
+  let pattern =
+    Re.Pcre.regexp
+      {|var\(--([a-zA-Z0-9_-]+),\s*(var\(--[a-zA-Z0-9_-]+\)|[^)]+)\)|}
+  in
+  Re.all pattern expected
+  |> List.filter_map (fun m ->
+      try
+        let name = Re.Group.get m 1 in
+        let fallback = String.trim (Re.Group.get m 2) in
+        Some (name, fallback)
+      with Not_found | Failure _ -> None)
+
+(* Vars whose value the typed [Scheme.t] fields own (the spacing scale and
+   runtime [--tw-*] vars); they must not become token overrides. *)
+let is_scheme_typed_var name =
+  let is_numbered_spacing =
+    String.length name > 8
+    && String.sub name 0 8 = "spacing-"
+    &&
+    let rest = String.sub name 8 (String.length name - 8) in
+    match int_of_string_opt rest with Some _ -> true | None -> false
+  in
+  let is_bare_spacing = name = "spacing" in
+  let is_tw_var = String.length name > 3 && String.sub name 0 3 = "tw-" in
+  is_numbered_spacing || is_bare_spacing || is_tw_var
+
+(* Build the per-test scheme from the @theme tokens in the expected CSS, so
+   of_string validates custom tokens against the threaded theme. *)
+let upstream_scheme config expected =
+  let overrides =
+    match config with
+    | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
+        let base =
+          extract_root_vars expected
+          |> List.filter (fun (name, _) -> not (is_scheme_typed_var name))
+        in
+        if config = Theme_reference || config = Theme_inline_reference then
+          let extra =
+            extract_var_fallbacks expected
+            |> List.filter (fun (name, _) -> not (List.mem_assoc name base))
+          in
+          base @ extra
+        else base
+    | No_theme -> []
+  in
+  Tw.Scheme.with_overrides Tw.Scheme.default overrides
+
+let class_is_emitted expected cls =
+  String.contains expected '.'
+  && Astring.String.is_infix
+       ~affix:("." ^ Tw.Rule.escape_class_name cls)
+       expected
+
+let check_upstream_positive_fixture_parse filename () =
+  let cases = upstream_positive_cases filename in
+  Tw.Modifiers.register_custom_breakpoints
+    [ ("xs", 320.); ("10xl", 1600.); ("lg-sm-potato", 1600.) ];
+  let rejected =
+    cases
+    |> List.concat_map (fun c ->
+        register_upstream_variant_directives c.variants;
+        let theme = upstream_scheme c.config c.expected in
+        c.classes
+        |> List.filter (class_is_emitted c.expected)
+        |> List.filter_map (fun cls ->
+            match Tw.of_string ~theme cls with
+            | Ok _ -> None
+            | Error (`Msg msg) -> Some (c, cls, msg)))
+  in
+  match rejected with
+  | [] -> ()
+  | _ ->
+      let rec take n xs =
+        match (n, xs) with
+        | 0, _ | _, [] -> []
+        | n, x :: rest -> x :: take (n - 1) rest
+      in
+      let sample =
+        rejected |> take 30
+        |> List.map (fun (c, cls, msg) ->
+            Fmt.str "%s / %s / %s: %s" c.source c.name cls msg)
+        |> String.concat "\n"
+      in
+      Alcotest.fail
+        (Fmt.str
+           "Unparsed upstream classes that Tailwind emitted (%d rejected).\n%s"
+           (List.length rejected) sample)
+
 (* ===== CORE TESTS (renamed to shorter names) ===== *)
 
 let empty_test () =
@@ -877,6 +1141,10 @@ let property_order_duration_first () =
 let core_tests =
   [
     test_case "empty test" `Quick empty_test;
+    test_case "upstream utilities parse parity" `Quick
+      (check_upstream_positive_fixture_parse "utilities.txt");
+    test_case "upstream variants parse parity" `Quick
+      (check_upstream_positive_fixture_parse "variants.txt");
     test_case "responsive classes" `Slow responsive_classes;
     test_case "states" `Slow states;
     test_case "negative spacing" `Slow negative_spacing;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -8,7 +8,9 @@ let check_late = check_handler_roundtrip (module Tw.Typography.Typography_late)
 
 (* Try both handlers - the utility could be in either *)
 let check class_name =
-  match Tw.Typography.Typography_early.of_class class_name with
+  match
+    Tw.Typography.Typography_early.of_class Tw.Scheme.default class_name
+  with
   | Ok _ -> check_early class_name
   | Error _ -> check_late class_name
 
@@ -197,10 +199,12 @@ let test_text_bracket_size_valid () =
 
 let test_text_bracket_size_invalid () =
   let bad input =
-    match Tw.Typography.Typography_early.of_class input with
+    match Tw.Typography.Typography_early.of_class Tw.Scheme.default input with
     | Ok _ -> Alcotest.fail ("Expected early handler to reject: " ^ input)
     | Error _ -> (
-        match Tw.Typography.Typography_late.of_class input with
+        match
+          Tw.Typography.Typography_late.of_class Tw.Scheme.default input
+        with
         | Ok _ -> Alcotest.fail ("Expected late handler to reject: " ^ input)
         | Error _ -> ())
   in
@@ -216,13 +220,17 @@ let of_string_invalid () =
   let fail_maybe input =
     let class_name = String.concat "-" input in
     (* Both handlers should reject the input *)
-    (match Tw.Typography.Typography_early.of_class class_name with
+    (match
+       Tw.Typography.Typography_early.of_class Tw.Scheme.default class_name
+     with
     | Error _ -> ()
     | Ok _ ->
         Alcotest.fail
           (String.concat ""
              [ "Expected early handler to reject: "; class_name ]));
-    match Tw.Typography.Typography_late.of_class class_name with
+    match
+      Tw.Typography.Typography_late.of_class Tw.Scheme.default class_name
+    with
     | Error _ -> ()
     | Ok _ ->
         Alcotest.fail

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -317,14 +317,15 @@ let test_leading_none_inline () =
 (* A text size must honor a --text-N--line-height theme override at use time,
    not bake in the spacing-derived default at module load. *)
 let test_text_line_height_override () =
-  Tw.Var.clear_theme_values ();
-  Tw.Var.set_theme_value "text-sm--line-height" "1.25rem";
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("text-sm--line-height", "1.25rem") ]
+  in
   let css =
     match Tw.of_string "text-sm" with
-    | Ok u -> Tw.to_css [ u ] |> Tw.Css.to_string ~minify:true
+    | Ok u -> Tw.to_css ~theme [ u ] |> Tw.Css.to_string ~minify:true
     | Error _ -> Alcotest.fail "could not parse text-sm"
   in
-  Tw.Var.clear_theme_values ();
   Alcotest.(check bool)
     "text-sm honors --text-sm--line-height override" true
     (Astring.String.is_infix ~affix:"--text-sm--line-height:1.25rem" css)

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -3,14 +3,14 @@ open Alcotest
 (* Test parsing valid class strings and converting to CSS *)
 let test_base_of_class_valid () =
   let open Tw.Utility in
-  match base_of_class "p-4" with
+  match base_of_class Tw.Scheme.default "p-4" with
   | Ok base -> check string "parsed class name" "p-4" (to_class (Base base))
   | Error _ -> fail "Failed to parse p-4"
 
 (* Test parsing invalid class strings returns error *)
 let test_base_of_class_invalid () =
   let open Tw.Utility in
-  match base_of_class "invalid-class" with
+  match base_of_class Tw.Scheme.default "invalid-class" with
   | Ok base ->
       let name = to_class (Base base) in
       fail ("Should not parse invalid class, got: " ^ name)
@@ -22,17 +22,17 @@ let test_deduplicate () =
   let open Tw.Utility in
   (* Parse some utilities *)
   let u1 =
-    match base_of_class "p-0" with
+    match base_of_class Tw.Scheme.default "p-0" with
     | Ok u -> Base u
     | Error _ -> failwith "parse failed"
   in
   let u2 =
-    match base_of_class "p-1" with
+    match base_of_class Tw.Scheme.default "p-1" with
     | Ok u -> Base u
     | Error _ -> failwith "parse failed"
   in
   let u3 =
-    match base_of_class "p-0" with
+    match base_of_class Tw.Scheme.default "p-0" with
     | Ok u -> Base u
     | Error _ -> failwith "parse failed"
   in
@@ -65,7 +65,7 @@ let test_order_priorities () =
   (* Test various utilities - using actual module assignments, not ideal
      priorities *)
   let parse_and_order class_name =
-    match base_of_class class_name with
+    match base_of_class Tw.Scheme.default class_name with
     | Ok u -> order u
     | Error _ -> failwith ("Failed to parse: " ^ class_name)
   in
@@ -87,7 +87,7 @@ let test_order_priorities () =
 let test_order_suborders () =
   let open Tw.Utility in
   let parse_and_order class_name =
-    match base_of_class class_name with
+    match base_of_class Tw.Scheme.default class_name with
     | Ok u -> order u
     | Error _ -> failwith ("Failed to parse: " ^ class_name)
   in
@@ -107,7 +107,7 @@ let test_order_suborders () =
 let test_order_consistency () =
   let open Tw.Utility in
   let parse_and_order class_name =
-    match base_of_class class_name with
+    match base_of_class Tw.Scheme.default class_name with
     | Ok u -> order u
     | Error _ -> failwith ("Failed to parse: " ^ class_name)
   in

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -118,6 +118,11 @@ type test_case = {
   expected : string option;
   variants : string list;
       (** [matchVariant] directives, e.g. ["is-data ..."]. *)
+  theme_vars : (string * string) list;
+      (** [@theme] token declarations ([--name: value]) from the test's CSS
+          template. Captures tokens (e.g. [text-shadow-2xs]) that Tailwind
+          inlines into utilities rather than emitting to [:root], so the runner
+          can reconstruct the test's theme as token overrides. *)
 }
 
 (* Parse [matchVariant('name', (value) => `template`, { values: {...} })] calls
@@ -214,6 +219,14 @@ let parse_file filename =
   let match_variant_use = Re.Pcre.regexp {|matchVariant\(\s*'([^']+)'|} in
   let custom_variant_use = Re.Pcre.regexp {|@custom-variant\s+([A-Za-z0-9_-]+)|} in
   let current_variant_names = ref [] in
+  (* Capture [@theme] token declarations [--name: value;]. [in_theme]/[theme_depth]
+     track the brace nesting of the active [@theme {...}] block within a
+     compileCss template. *)
+  let current_theme_vars = ref [] in
+  let in_theme = ref false in
+  let theme_depth = ref 0 in
+  let theme_open_re = Re.Pcre.regexp {|@theme\b[^{]*\{|} in
+  let theme_var_re = Re.Pcre.regexp {|^\s*--([A-Za-z0-9-]+)\s*:\s*(.+?)\s*;\s*$|} in
 
   let flush_test name expected =
     let classes =
@@ -226,10 +239,20 @@ let parse_file filename =
     in
     if classes <> [] then
       tests :=
-        { name; config = !current_config; classes; expected; variants }
+        {
+          name;
+          config = !current_config;
+          classes;
+          expected;
+          variants;
+          theme_vars = List.rev !current_theme_vars;
+        }
         :: !tests;
     current_classes := [];
-    current_variant_names := []
+    current_variant_names := [];
+    current_theme_vars := [];
+    in_theme := false;
+    theme_depth := 0
   in
 
   List.iter
@@ -272,6 +295,24 @@ let parse_file filename =
           else if Re.execp theme_ref_re line then
             current_config := Theme_reference
           else if Re.execp theme_re line then current_config := Theme;
+
+          (* Capture [@theme] token declarations. Enter on the opener line,
+             capture [--name: value;] lines, exit when braces balance. *)
+          if (not !in_theme) && Re.execp theme_open_re line then (
+            in_theme := true;
+            theme_depth := 0);
+          if !in_theme then (
+            (match Re.exec_opt theme_var_re line with
+            | Some g ->
+                current_theme_vars :=
+                  (Re.Group.get g 1, Re.Group.get g 2) :: !current_theme_vars
+            | None -> ());
+            String.iter
+              (fun c ->
+                if c = '{' then incr theme_depth
+                else if c = '}' then decr theme_depth)
+              line;
+            if !theme_depth <= 0 then in_theme := false);
 
           (* Check for run([...]) *)
           (match Re.exec_opt run_pattern line with
@@ -367,6 +408,9 @@ let () =
       Fmt.pr "# %s@." test.name;
       Fmt.pr "@config %s@." (config_to_string test.config);
       List.iter (fun v -> Fmt.pr "@variant %s@." v) test.variants;
+      List.iter
+        (fun (n, v) -> Fmt.pr "@theme-var %s %s@." n v)
+        test.theme_vars;
       Fmt.pr "%s@." (String.concat " " test.classes);
       (match test.expected with
       | Some css ->

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -70,7 +70,8 @@ type case = {
   variants : string list;  (** [matchVariant] directive lines for this test. *)
   theme_vars : (string * string) list;
       (** [@theme] token overrides (name, value) captured from the test's CSS
-          template by the extractor (e.g. text-shadow sizes Tailwind inlines). *)
+          template by the extractor (e.g. text-shadow sizes Tailwind inlines).
+      *)
 }
 
 (** Split a class line by spaces, but don't split inside brackets. *)
@@ -140,7 +141,8 @@ let read_test_cases filename =
             current_variants :=
               String.sub tl 9 (String.length tl - 9) :: !current_variants;
             parse_variants name config rest)
-          else if String.length tl >= 11 && String.sub tl 0 11 = "@theme-var " then (
+          else if String.length tl >= 11 && String.sub tl 0 11 = "@theme-var "
+          then (
             (* "@theme-var <name> <value>" -- split on the first space. *)
             let rest_str = String.sub tl 11 (String.length tl - 11) in
             (match String.index_opt rest_str ' ' with
@@ -550,31 +552,33 @@ let extract_var_fallbacks expected =
       with Not_found | Failure _ -> None)
     matches
 
+(* Vars whose value the typed [Scheme.t] fields own (the spacing scale and
+   runtime [--tw-*] vars). These must NOT become token overrides: doing so would
+   emit them verbatim as raw custom properties instead of through their typed
+   binding (e.g. [--spacing: 0.25rem] instead of the normalized [.25rem]). Named
+   spacings like [spacing-big] are passed through. *)
+
 (** Set theme value overrides for non-spacing root vars from expected CSS. This
     enables utilities like z-auto and order-first to produce custom declarations
     in the :root, :host block when [@config] theme is used. *)
+let is_scheme_typed_var name =
+  let is_numbered_spacing =
+    String.length name > 8
+    && String.sub name 0 8 = "spacing-"
+    &&
+    let rest = String.sub name 8 (String.length name - 8) in
+    match int_of_string_opt rest with Some _ -> true | None -> false
+  in
+  let is_bare_spacing = name = "spacing" in
+  let is_tw_var = String.length name > 3 && String.sub name 0 3 = "tw-" in
+  is_numbered_spacing || is_bare_spacing || is_tw_var
+
 let theme_overrides_of config expected =
   match config with
   | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
       let root_vars = extract_root_vars expected in
       let base =
-        List.filter
-          (fun (name, _) ->
-            (* Skip numbered spacing (spacing-N) and tw- vars handled via
-               scheme. Named spacings like spacing-big are passed through. *)
-            let is_numbered_spacing =
-              String.length name > 8
-              && String.sub name 0 8 = "spacing-"
-              &&
-              let rest = String.sub name 8 (String.length name - 8) in
-              match int_of_string_opt rest with Some _ -> true | None -> false
-            in
-            let is_bare_spacing = name = "spacing" in
-            let is_tw_var =
-              String.length name > 3 && String.sub name 0 3 = "tw-"
-            in
-            not (is_numbered_spacing || is_bare_spacing || is_tw_var))
-          root_vars
+        List.filter (fun (name, _) -> not (is_scheme_typed_var name)) root_vars
       in
       (* For theme-reference mode, also extract var(--name, fallback) patterns
          from expected CSS. This provides fallback values for opacity modifiers
@@ -764,7 +768,7 @@ let stat_expected_empty_cases = ref 0
 
 let run_test_case test () =
   if test.classes = [] then ()
-  else (
+  else
     let base_scheme = setup_scheme_for_test test.expected in
     (* Register any matchVariant custom variants for this test. Directive form:
        "name <template> KEY=value ...", DEFAULT mapped to the default slot. *)
@@ -818,7 +822,7 @@ let run_test_case test () =
     let custom_bps = extract_custom_breakpoints test.classes test.expected in
     let scheme =
       if custom_bps = [] then base_scheme
-      else (
+      else
         let updated_scheme =
           {
             base_scheme with
@@ -826,14 +830,24 @@ let run_test_case test () =
           }
         in
         Tw.Modifiers.register_custom_breakpoints custom_bps;
-        updated_scheme)
+        updated_scheme
     in
     setup_theme_overrides test.config test.expected;
     (* Thread the same @theme token overrides into the scheme so utilities read
        them from ~theme rather than the Var global. *)
     let scheme =
+      (* [theme_overrides_of] derives values from the expected [:root] (already
+         normalized as Tailwind emits them), so it must win over the raw
+         [@theme-var] source values for theme-layer emission; [test.theme_vars]
+         is the fallback for tokens not present in the expected [:root] (e.g.
+         inlined [@theme] blocks like text-shadow). *)
+      let theme_vars =
+        List.filter
+          (fun (name, _) -> not (is_scheme_typed_var name))
+          test.theme_vars
+      in
       Tw.Scheme.with_overrides scheme
-        (test.theme_vars @ theme_overrides_of test.config test.expected)
+        (theme_overrides_of test.config test.expected @ theme_vars)
     in
     let theme, theme_defaults = theme_config test.config test.expected in
     let parsed, rejected =

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -594,18 +594,6 @@ let theme_overrides_of config expected =
       else base
   | No_theme -> []
 
-(* Set theme value overrides for non-spacing root vars from expected CSS. This
-   enables utilities like z-auto and order-first to produce custom declarations
-   in the :root, :host block when [@config] theme is used. The same overrides
-   are threaded into the scheme's token_overrides (see run_test_case); the
-   global hashtbl remains only for the [Var.binding] theme-layer emission until
-   that seam is migrated. *)
-let setup_theme_overrides config expected =
-  Tw.Var.clear_theme_values ();
-  List.iter
-    (fun (name, value) -> Tw.Var.set_theme_value name value)
-    (theme_overrides_of config expected)
-
 (** Extract custom breakpoints by matching input class modifiers with px values
     from expected CSS. Handles bare custom names (e.g. "10xl:flex"), and names
     within min-/max- prefixes (e.g. "min-xs:max-sm:flex"). *)
@@ -832,9 +820,8 @@ let run_test_case test () =
         Tw.Modifiers.register_custom_breakpoints custom_bps;
         updated_scheme
     in
-    setup_theme_overrides test.config test.expected;
-    (* Thread the same @theme token overrides into the scheme so utilities read
-       them from ~theme rather than the Var global. *)
+    (* Thread the @theme token overrides into the scheme so utilities read them
+       from ~theme (parse and render); the Var global is no longer consulted. *)
     let scheme =
       (* [theme_overrides_of] derives values from the expected [:root] (already
          normalized as Tailwind emits them), so it must win over the raw

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -331,7 +331,8 @@ let setup_scheme_for_test expected =
       (fun (name, _) -> not (List.mem name standard_names))
       scheme.breakpoints
   in
-  Tw.Modifiers.register_custom_breakpoints custom_bps
+  Tw.Modifiers.register_custom_breakpoints custom_bps;
+  scheme
 
 (** Extract all CSS variable names referenced in expected CSS text. *)
 let extract_var_names expected =
@@ -734,7 +735,7 @@ let stat_expected_empty_cases = ref 0
 let run_test_case test () =
   if test.classes = [] then ()
   else (
-    setup_scheme_for_test test.expected;
+    let base_scheme = setup_scheme_for_test test.expected in
     (* Register any matchVariant custom variants for this test. Directive form:
        "name <template> KEY=value ...", DEFAULT mapped to the default slot. *)
     let parse_variant_directive d =
@@ -781,15 +782,23 @@ let run_test_case test () =
       (List.filter_map parse_variant_directive test.variants);
     Tw.Modifiers.register_container_variants
       (List.filter_map parse_container_directive test.variants);
-    (* Register custom breakpoints before parsing classes *)
+    (* Register custom breakpoints before parsing classes. The resulting scheme
+       (base plus any custom breakpoints) is the one threaded to [Tw.to_css]
+       below via [~theme]. *)
     let custom_bps = extract_custom_breakpoints test.classes test.expected in
-    if custom_bps <> [] then (
-      let scheme = scheme_from_expected_css test.expected in
-      let updated_scheme =
-        { scheme with breakpoints = scheme.breakpoints @ custom_bps }
-      in
-      Tw.Rule.set_scheme updated_scheme;
-      Tw.Modifiers.register_custom_breakpoints custom_bps);
+    let scheme =
+      if custom_bps = [] then base_scheme
+      else (
+        let updated_scheme =
+          {
+            base_scheme with
+            breakpoints = base_scheme.breakpoints @ custom_bps;
+          }
+        in
+        Tw.Rule.set_scheme updated_scheme;
+        Tw.Modifiers.register_custom_breakpoints custom_bps;
+        updated_scheme)
+    in
     setup_theme_overrides test.config test.expected;
     let theme, theme_defaults = theme_config test.config test.expected in
     let parsed, rejected =
@@ -808,7 +817,7 @@ let run_test_case test () =
     if test.expected = "" then incr stat_expected_empty_cases;
     let our_stylesheet =
       if utilities = [] then None
-      else Some (Tw.to_css ~base:false ~layers:false utilities)
+      else Some (Tw.to_css ~theme:scheme ~base:false ~layers:false utilities)
     in
     let our_css =
       match our_stylesheet with

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -904,7 +904,7 @@ let run_test_case test () =
         Alcotest.fail
           (Fmt.str "CSS mismatch for: %s\n\n%s\n\nExpected:\n%s\n\nGot:\n%s%s"
              (String.concat " " test.classes)
-             (Buffer.contents buf) expected got rejected_note))
+             (Buffer.contents buf) expected got rejected_note)
 
 (* Guards [colors_close]: a documented stale fixture pair is accepted, but a
    near-miss the previous [abs (x - y) <= 2] blanket would have wrongly accepted

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -853,7 +853,7 @@ let run_test_case test () =
     let parsed, rejected =
       List.fold_left
         (fun (ok, bad) cls ->
-          match Tw.of_string cls with
+          match Tw.of_string ~theme:scheme cls with
           | Ok u -> (u :: ok, bad)
           | Error (`Msg m) -> (ok, (cls, m) :: bad))
         ([], []) test.classes

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -68,6 +68,9 @@ type case = {
   classes : string list;
   expected : string;
   variants : string list;  (** [matchVariant] directive lines for this test. *)
+  theme_vars : (string * string) list;
+      (** [@theme] token overrides (name, value) captured from the test's CSS
+          template by the extractor (e.g. text-shadow sizes Tailwind inlines). *)
 }
 
 (** Split a class line by spaces, but don't split inside brackets. *)
@@ -102,6 +105,7 @@ let read_test_cases filename =
     close_in ic;
     let tests = ref [] in
     let current_variants = ref [] in
+    let current_theme_vars = ref [] in
     let lines = String.split_on_char '\n' content in
     let parse_config_line line =
       let line = String.trim line in
@@ -117,6 +121,7 @@ let read_test_cases filename =
           if String.length line > 2 && line.[0] = '#' && line.[1] = ' ' then (
             let name = String.sub line 2 (String.length line - 2) in
             current_variants := [];
+            current_theme_vars := [];
             parse_config name No_theme rest)
           else parse rest
     and parse_config name default_config lines =
@@ -135,6 +140,18 @@ let read_test_cases filename =
             current_variants :=
               String.sub tl 9 (String.length tl - 9) :: !current_variants;
             parse_variants name config rest)
+          else if String.length tl >= 11 && String.sub tl 0 11 = "@theme-var " then (
+            (* "@theme-var <name> <value>" -- split on the first space. *)
+            let rest_str = String.sub tl 11 (String.length tl - 11) in
+            (match String.index_opt rest_str ' ' with
+            | Some i ->
+                let n = String.sub rest_str 0 i in
+                let v =
+                  String.sub rest_str (i + 1) (String.length rest_str - i - 1)
+                in
+                current_theme_vars := (n, v) :: !current_theme_vars
+            | None -> ());
+            parse_variants name config rest)
           else parse_classes name config (line :: rest)
     and parse_classes name config lines =
       match lines with
@@ -150,6 +167,7 @@ let read_test_cases filename =
             (* New test without classes *)
             let new_name = String.sub line 2 (String.length line - 2) in
             current_variants := [];
+            current_theme_vars := [];
             parse_config new_name No_theme rest)
           else
             let classes = split_classes line in
@@ -177,6 +195,7 @@ let read_test_cases filename =
                 classes;
                 expected;
                 variants = List.rev !current_variants;
+                theme_vars = List.rev !current_theme_vars;
               }
               :: !tests
       | line :: rest ->
@@ -190,6 +209,7 @@ let read_test_cases filename =
                   classes;
                   expected;
                   variants = List.rev !current_variants;
+                  theme_vars = List.rev !current_theme_vars;
                 }
                 :: !tests;
             parse rest)
@@ -813,7 +833,7 @@ let run_test_case test () =
        them from ~theme rather than the Var global. *)
     let scheme =
       Tw.Scheme.with_overrides scheme
-        (theme_overrides_of test.config test.expected)
+        (test.theme_vars @ theme_overrides_of test.config test.expected)
     in
     let theme, theme_defaults = theme_config test.config test.expected in
     let parsed, rejected =

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -533,40 +533,54 @@ let extract_var_fallbacks expected =
 (** Set theme value overrides for non-spacing root vars from expected CSS. This
     enables utilities like z-auto and order-first to produce custom declarations
     in the :root, :host block when [@config] theme is used. *)
-let setup_theme_overrides config expected =
-  Tw.Var.clear_theme_values ();
+let theme_overrides_of config expected =
   match config with
   | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
       let root_vars = extract_root_vars expected in
-      List.iter
-        (fun (name, value) ->
-          (* Skip numbered spacing (spacing-N) and tw- vars handled via scheme.
-             Named spacings like spacing-big are passed through. *)
-          let is_numbered_spacing =
-            String.length name > 8
-            && String.sub name 0 8 = "spacing-"
-            &&
-            let rest = String.sub name 8 (String.length name - 8) in
-            match int_of_string_opt rest with Some _ -> true | None -> false
-          in
-          let is_bare_spacing = name = "spacing" in
-          let is_tw_var =
-            String.length name > 3 && String.sub name 0 3 = "tw-"
-          in
-          if not (is_numbered_spacing || is_bare_spacing || is_tw_var) then
-            Tw.Var.set_theme_value name value)
-        root_vars;
+      let base =
+        List.filter
+          (fun (name, _) ->
+            (* Skip numbered spacing (spacing-N) and tw- vars handled via
+               scheme. Named spacings like spacing-big are passed through. *)
+            let is_numbered_spacing =
+              String.length name > 8
+              && String.sub name 0 8 = "spacing-"
+              &&
+              let rest = String.sub name 8 (String.length name - 8) in
+              match int_of_string_opt rest with Some _ -> true | None -> false
+            in
+            let is_bare_spacing = name = "spacing" in
+            let is_tw_var =
+              String.length name > 3 && String.sub name 0 3 = "tw-"
+            in
+            not (is_numbered_spacing || is_bare_spacing || is_tw_var))
+          root_vars
+      in
       (* For theme-reference mode, also extract var(--name, fallback) patterns
          from expected CSS. This provides fallback values for opacity modifiers
          and other cases where the @theme block isn't in our test format. *)
       if config = Theme_reference || config = Theme_inline_reference then
         let var_fallbacks = extract_var_fallbacks expected in
-        List.iter
-          (fun (name, fallback) ->
-            if Tw.Var.theme_value name = None then
-              Tw.Var.set_theme_value name fallback)
-          var_fallbacks
-  | No_theme -> ()
+        let extra =
+          List.filter
+            (fun (name, _) -> not (List.mem_assoc name base))
+            var_fallbacks
+        in
+        base @ extra
+      else base
+  | No_theme -> []
+
+(* Set theme value overrides for non-spacing root vars from expected CSS. This
+   enables utilities like z-auto and order-first to produce custom declarations
+   in the :root, :host block when [@config] theme is used. The same overrides
+   are threaded into the scheme's token_overrides (see run_test_case); the
+   global hashtbl remains only for the [Var.binding] theme-layer emission until
+   that seam is migrated. *)
+let setup_theme_overrides config expected =
+  Tw.Var.clear_theme_values ();
+  List.iter
+    (fun (name, value) -> Tw.Var.set_theme_value name value)
+    (theme_overrides_of config expected)
 
 (** Extract custom breakpoints by matching input class modifiers with px values
     from expected CSS. Handles bare custom names (e.g. "10xl:flex"), and names
@@ -795,6 +809,12 @@ let run_test_case test () =
         updated_scheme)
     in
     setup_theme_overrides test.config test.expected;
+    (* Thread the same @theme token overrides into the scheme so utilities read
+       them from ~theme rather than the Var global. *)
+    let scheme =
+      Tw.Scheme.with_overrides scheme
+        (theme_overrides_of test.config test.expected)
+    in
     let theme, theme_defaults = theme_config test.config test.expected in
     let parsed, rejected =
       List.fold_left

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -313,6 +313,7 @@ let scheme_from_expected_css expected : Tw.Scheme.t =
     default_border_width;
     default_outline_width;
     breakpoints;
+    token_overrides = [];
   }
 
 let setup_scheme_for_test expected =

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -318,12 +318,8 @@ let scheme_from_expected_css expected : Tw.Scheme.t =
 
 let setup_scheme_for_test expected =
   let scheme = scheme_from_expected_css expected in
-  Tw.Color.Handler.set_scheme scheme;
-  Tw.Theme.set_scheme scheme;
-  Tw.Borders.set_scheme scheme;
-  Tw.Effects.set_scheme scheme;
-  Tw.Divide.set_scheme scheme;
-  Tw.Rule.set_scheme scheme;
+  (* The scheme is threaded into Tw.to_css via ~theme below; the per-module
+     set_scheme globals are no longer used for rendering. *)
   (* Register custom breakpoints for modifier parsing *)
   let standard_names = [ "sm"; "md"; "lg"; "xl"; "2xl" ] in
   let custom_bps =
@@ -795,7 +791,6 @@ let run_test_case test () =
             breakpoints = base_scheme.breakpoints @ custom_bps;
           }
         in
-        Tw.Rule.set_scheme updated_scheme;
         Tw.Modifiers.register_custom_breakpoints custom_bps;
         updated_scheme)
     in

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -123,6 +123,9 @@ absolute fixed relative static sticky
 <<<>>>
 # inset
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-var inset-shadowned 1940px
 -inset-4 -inset-full inset-3/4 inset-4 inset-[4px] inset-auto inset-full inset-shadow-sm inset-shadowned
 ---
 
@@ -277,6 +280,8 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-x
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -inset-x-4 -inset-x-full inset-x-3/4 inset-x-4 inset-x-[4px] inset-x-auto inset-x-full inset-x-shadowned
 ---
 
@@ -320,12 +325,16 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-x
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px #0000000d
 -inset-x-4/foo -inset-x-full/foo inset-x inset-x--1 inset-x--1/-2 inset-x--1/2 inset-x-1/-2 inset-x-3/4/foo inset-x-4/foo inset-x-[4px]/foo inset-x-auto/foo inset-x-full/foo inset-x-shadow-sm
 ---
 
 <<<>>>
 # inset-y
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -inset-y-4 -inset-y-full inset-y-3/4 inset-y-4 inset-y-[4px] inset-y-auto inset-y-full inset-y-shadowned
 ---
 
@@ -369,12 +378,16 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-y
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -inset-y-4/foo -inset-y-full/foo inset-1/-2 inset-y inset-y--1 inset-y--1/-2 inset-y--1/2 inset-y-3/4/foo inset-y-4/foo inset-y-[4px]/foo inset-y-auto/foo inset-y-full/foo inset-y-shadow-sm
 ---
 
 <<<>>>
 # inset-s
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -inset-s-4 -inset-s-full inset-s-3/4 inset-s-4 inset-s-[4px] inset-s-auto inset-s-full inset-s-shadowned
 ---
 
@@ -418,12 +431,16 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-s
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -inset-s-4/foo -inset-s-full/foo inset-s inset-s--1 inset-s--1/-2 inset-s--1/2 inset-s-1/-2 inset-s-3/4/foo inset-s-4/foo inset-s-[4px]/foo inset-s-auto/foo inset-s-full/foo inset-s-shadow-sm
 ---
 
 <<<>>>
 # inset-e
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -inset-e-4 -inset-e-full inset-e-3/4 inset-e-4 inset-e-[4px] inset-e-auto inset-e-full inset-e-shadowned
 ---
 
@@ -467,12 +484,16 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-e
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -inset-e-4/foo -inset-e-full/foo inset-e inset-e--1 inset-e--1/-2 inset-e--1/2 inset-e-1/-2 inset-e-3/4/foo inset-e-4/foo inset-e-[4px]/foo inset-e-auto/foo inset-e-full/foo inset-e-shadow-sm
 ---
 
 <<<>>>
 # inset-bs
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -inset-bs-4 -inset-bs-full inset-bs-3/4 inset-bs-4 inset-bs-[4px] inset-bs-auto inset-bs-full inset-bs-shadowned
 ---
 
@@ -516,12 +537,16 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-bs
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -inset-bs-4/foo -inset-bs-full/foo inset-bs inset-bs--1 inset-bs--1/-2 inset-bs--1/2 inset-bs-1/-2 inset-bs-3/4/foo inset-bs-4/foo inset-bs-[4px]/foo inset-bs-auto/foo inset-bs-full/foo inset-bs-shadow-sm
 ---
 
 <<<>>>
 # inset-be
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -inset-be-4 -inset-be-full inset-be-3/4 inset-be-4 inset-be-[4px] inset-be-auto inset-be-full inset-be-shadowned
 ---
 
@@ -565,12 +590,16 @@ absolute fixed relative static sticky
 <<<>>>
 # inset-be
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -inset-be-4/foo -inset-be-full/foo inset-be inset-be--1 inset-be--1/-2 inset-be--1/2 inset-be-1/-2 inset-be-3/4/foo inset-be-4/foo inset-be-[4px]/foo inset-be-auto/foo inset-be-full/foo inset-be-shadow-sm
 ---
 
 <<<>>>
 # top
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -top-4 -top-full top-3/4 top-4 top-[4px] top-auto top-full top-shadowned
 ---
 
@@ -614,12 +643,16 @@ absolute fixed relative static sticky
 <<<>>>
 # top
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -top-4/foo -top-full/foo top top--1 top--1/-2 top--1/2 top-1/-2 top-3/4/foo top-4/foo top-[4px]/foo top-auto/foo top-full/foo top-shadow-sm
 ---
 
 <<<>>>
 # right
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -right-4 -right-full right-3/4 right-4 right-[4px] right-auto right-full right-shadowned
 ---
 
@@ -663,12 +696,16 @@ absolute fixed relative static sticky
 <<<>>>
 # right
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -right-4/foo -right-full/foo right right--1 right--1/-2 right--1/2 right-1/-2 right-3/4/foo right-4/foo right-[4px]/foo right-auto/foo right-full/foo right-shadow-sm
 ---
 
 <<<>>>
 # bottom
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -bottom-4 -bottom-full bottom-3/4 bottom-4 bottom-[4px] bottom-auto bottom-full bottom-shadowned
 ---
 
@@ -712,12 +749,16 @@ absolute fixed relative static sticky
 <<<>>>
 # bottom
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -bottom-4/foo -bottom-full/foo bottom bottom--1 bottom--1/-2 bottom--1/2 bottom-1/-2 bottom-3/4/foo bottom-4/foo bottom-[4px]/foo bottom-auto/foo bottom-full/foo bottom-shadow-sm
 ---
 
 <<<>>>
 # left
 @config theme
+@theme-var spacing-4 1rem
+@theme-var inset-shadowned 1940px
 -left-4 -left-[(var(--my-var1)+var(--my-var2))] -left-full left-3/4 left-4 left-[4px] left-auto left-full left-shadowned
 ---
 
@@ -765,6 +806,8 @@ absolute fixed relative static sticky
 <<<>>>
 # left
 @config theme-reference
+@theme-var spacing-4 1rem
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 -left-4/foo -left-full/foo left left--1 left--1/-2 left--1/2 left-1/-2 left-3/4/foo left-4/foo left-[4px]/foo left-auto/foo left-full/foo left-shadow-sm
 ---
 
@@ -821,6 +864,7 @@ isolate isolation-auto
 <<<>>>
 # z-index
 @config theme
+@theme-var z-index-auto 42
 z-auto
 ---
 
@@ -875,6 +919,7 @@ z-auto
 <<<>>>
 # order
 @config theme
+@theme-var order-first 1
 order-first
 ---
 
@@ -889,6 +934,7 @@ order-first
 <<<>>>
 # order
 @config theme
+@theme-var order-last -1
 order-last
 ---
 
@@ -947,6 +993,7 @@ order-last
 <<<>>>
 # col
 @config theme
+@theme-var grid-column-auto 5
 col-auto
 ---
 
@@ -961,6 +1008,7 @@ col-auto
 <<<>>>
 # col-start
 @config theme
+@theme-var grid-column-start-custom 1 column-start
 -col-start-4 col-start-4 col-start-99 col-start-[123] col-start-auto col-start-custom
 ---
 
@@ -1001,6 +1049,7 @@ col-auto
 <<<>>>
 # col-start
 @config theme
+@theme-var grid-column-start-auto 7
 col-start-auto
 ---
 
@@ -1015,6 +1064,7 @@ col-start-auto
 <<<>>>
 # col-end
 @config theme
+@theme-var grid-column-end-custom 1 column-end
 -col-end-4 col-end-4 col-end-99 col-end-[123] col-end-auto col-end-custom
 ---
 
@@ -1055,6 +1105,7 @@ col-start-auto
 <<<>>>
 # col-end
 @config theme
+@theme-var grid-column-end-auto 3
 col-end-auto
 ---
 
@@ -1113,6 +1164,7 @@ col-end-auto
 <<<>>>
 # row
 @config theme
+@theme-var grid-row-auto 9
 row-auto
 ---
 
@@ -1127,6 +1179,7 @@ row-auto
 <<<>>>
 # row-start
 @config theme
+@theme-var grid-row-start-custom 1 row-start
 -row-start-4 row-start-4 row-start-99 row-start-[123] row-start-auto row-start-custom
 ---
 
@@ -1167,6 +1220,7 @@ row-auto
 <<<>>>
 # row-start
 @config theme
+@theme-var grid-row-start-auto 11
 row-start-auto
 ---
 
@@ -1181,6 +1235,7 @@ row-start-auto
 <<<>>>
 # row-end
 @config theme
+@theme-var grid-row-end-custom 1 row-end
 -row-end-4 row-end-4 row-end-99 row-end-[123] row-end-auto row-end-custom
 ---
 
@@ -1221,6 +1276,7 @@ row-start-auto
 <<<>>>
 # row-end
 @config theme
+@theme-var grid-row-end-auto 13
 row-end-auto
 ---
 
@@ -1303,6 +1359,7 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # margin
 @config theme
+@theme-var spacing-4 1rem
 -m-4 -m-[var(--value)] m-4 m-[4px] m-auto
 ---
 
@@ -1339,6 +1396,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # mx
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -mx-4 -mx-[4px] -mx-[var(--my-var)] -mx-big mx-1 mx-4 mx-99 mx-[4px] mx-[var(--my-var)] mx-auto mx-big
 ---
 
@@ -1400,6 +1459,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # my
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -my-2.5 -my-4 -my-[4px] -my-[var(--my-var)] -my-big my-1 my-2.5 my-99 my-[4px] my-[var(--my-var)] my-big
 ---
 
@@ -1461,6 +1522,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # mt
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -mt-2.5 -mt-4 -mt-[4px] -mt-[var(--my-var)] -mt-big mt-1 mt-2.5 mt-99 mt-[4px] mt-[var(--my-var)] mt-big
 ---
 
@@ -1522,6 +1585,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # ms
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -ms-2.5 -ms-4 -ms-[4px] -ms-[var(--my-var)] -ms-big ms-1 ms-2.5 ms-99 ms-[4px] ms-[var(--my-var)] ms-big
 ---
 
@@ -1583,6 +1648,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # me
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -me-2.5 -me-4 -me-[4px] -me-[var(--my-var)] -me-big me-1 me-2.5 me-99 me-[4px] me-[var(--my-var)] me-big
 ---
 
@@ -1644,6 +1711,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # mbs
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -mbs-2.5 -mbs-4 -mbs-[4px] -mbs-[var(--my-var)] -mbs-big mbs-1 mbs-2.5 mbs-99 mbs-[4px] mbs-[var(--my-var)] mbs-big
 ---
 
@@ -1705,6 +1774,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # mbe
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -mbe-2.5 -mbe-4 -mbe-[4px] -mbe-[var(--my-var)] -mbe-big mbe-1 mbe-2.5 mbe-99 mbe-[4px] mbe-[var(--my-var)] mbe-big
 ---
 
@@ -1766,6 +1837,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # mr
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -mr-2.5 -mr-4 -mr-[4px] -mr-[var(--my-var)] -mr-big mr-1 mr-2.5 mr-99 mr-[4px] mr-[var(--my-var)] mr-big
 ---
 
@@ -1827,6 +1900,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # mb
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -mb-2.5 -mb-4 -mb-[4px] -mb-[var(--my-var)] -mb-big mb-1 mb-2.5 mb-99 mb-[4px] mb-[var(--my-var)] mb-big
 ---
 
@@ -1888,6 +1963,8 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # ml
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 -ml-2.5 -ml-4 -ml-[4px] -ml-[var(--my-var)] -ml-big ml-1 ml-2.5 ml-99 ml-[4px] ml-[var(--my-var)] ml-big
 ---
 
@@ -1949,6 +2026,7 @@ clear-both clear-end clear-left clear-none clear-right clear-start
 <<<>>>
 # margin sort order
 @config theme
+@theme-var spacing-4 1rem
 m-4 mb-4 me-4 ml-4 mr-4 ms-4 mt-4 mx-4 my-4
 ---
 
@@ -2061,6 +2139,7 @@ line-clamp-4 line-clamp-99 line-clamp-[123] line-clamp-none
 <<<>>>
 # line-clamp
 @config theme
+@theme-var line-clamp-none 0
 line-clamp-none
 ---
 
@@ -2194,6 +2273,7 @@ field-sizing-content field-sizing-fixed
 <<<>>>
 # aspect-ratio
 @config theme
+@theme-var aspect-video 16 / 9
 aspect-4/3 aspect-8.5/11 aspect-[10/9] aspect-video
 ---
 
@@ -2226,6 +2306,7 @@ aspect-4/3 aspect-8.5/11 aspect-[10/9] aspect-video
 <<<>>>
 # size
 @config theme
+@theme-var spacing-4 1rem
 size-1/2 size-4 size-[4px] size-auto size-fit size-full size-max size-min
 ---
 
@@ -2282,6 +2363,8 @@ size-1/2 size-4 size-[4px] size-auto size-fit size-full size-max size-min
 <<<>>>
 # width
 @config theme
+@theme-var spacing-4 1rem
+@theme-var width-xl 36rem
 w-1/2 w-4 w-[4px] w-auto w-dvw w-fit w-full w-lvw w-max w-min w-screen w-svw w-xl
 ---
 
@@ -2351,6 +2434,8 @@ w-1/2 w-4 w-[4px] w-auto w-dvw w-fit w-full w-lvw w-max w-min w-screen w-svw w-x
 <<<>>>
 # min-width
 @config theme
+@theme-var spacing-4 1rem
+@theme-var container-xl 36rem
 min-w-4 min-w-[4px] min-w-auto min-w-fit min-w-full min-w-max min-w-min min-w-xl
 ---
 
@@ -2400,6 +2485,8 @@ min-w-4 min-w-[4px] min-w-auto min-w-fit min-w-full min-w-max min-w-min min-w-xl
 <<<>>>
 # max-width
 @config theme
+@theme-var spacing-4 1rem
+@theme-var container-xl 36rem
 max-w-4 max-w-[4px] max-w-fit max-w-full max-w-max max-w-none max-w-xl
 ---
 
@@ -2445,6 +2532,7 @@ max-w-4 max-w-[4px] max-w-fit max-w-full max-w-max max-w-none max-w-xl
 <<<>>>
 # height
 @config theme
+@theme-var spacing-4 1rem
 h-1/2 h-4 h-[4px] h-auto h-dvh h-fit h-full h-lh h-lvh h-max h-min h-screen h-svh
 ---
 
@@ -2513,6 +2601,7 @@ h-1/2 h-4 h-[4px] h-auto h-dvh h-fit h-full h-lh h-lvh h-max h-min h-screen h-sv
 <<<>>>
 # min-height
 @config theme
+@theme-var spacing-4 1rem
 min-h-4 min-h-[4px] min-h-auto min-h-dvh min-h-fit min-h-full min-h-lh min-h-lvh min-h-max min-h-min min-h-screen min-h-svh
 ---
 
@@ -2577,6 +2666,7 @@ min-h-4 min-h-[4px] min-h-auto min-h-dvh min-h-fit min-h-full min-h-lh min-h-lvh
 <<<>>>
 # max-height
 @config theme
+@theme-var spacing-4 1rem
 max-h-4 max-h-[4px] max-h-dvh max-h-fit max-h-full max-h-lh max-h-lvh max-h-max max-h-min max-h-none max-h-screen max-h-svh
 ---
 
@@ -2641,6 +2731,8 @@ max-h-4 max-h-[4px] max-h-dvh max-h-fit max-h-full max-h-lh max-h-lvh max-h-max 
 <<<>>>
 # inline-size
 @config theme
+@theme-var spacing-4 1rem
+@theme-var container-xl 36rem
 inline-1/2 inline-4 inline-[4px] inline-auto inline-dvw inline-fit inline-full inline-lvw inline-max inline-min inline-screen inline-svw inline-xl
 ---
 
@@ -2710,6 +2802,8 @@ inline-1/2 inline-4 inline-[4px] inline-auto inline-dvw inline-fit inline-full i
 <<<>>>
 # min-inline-size
 @config theme
+@theme-var spacing-4 1rem
+@theme-var container-xl 36rem
 min-inline-4 min-inline-[4px] min-inline-auto min-inline-fit min-inline-full min-inline-max min-inline-min min-inline-xl
 ---
 
@@ -2759,6 +2853,8 @@ min-inline-4 min-inline-[4px] min-inline-auto min-inline-fit min-inline-full min
 <<<>>>
 # max-inline-size
 @config theme
+@theme-var spacing-4 1rem
+@theme-var container-xl 36rem
 max-inline-4 max-inline-[4px] max-inline-fit max-inline-full max-inline-max max-inline-none max-inline-xl
 ---
 
@@ -2804,6 +2900,7 @@ max-inline-4 max-inline-[4px] max-inline-fit max-inline-full max-inline-max max-
 <<<>>>
 # block-size
 @config theme
+@theme-var spacing-4 1rem
 block-1/2 block-4 block-[4px] block-auto block-dvh block-fit block-full block-lh block-lvh block-max block-min block-screen block-svh
 ---
 
@@ -2872,6 +2969,7 @@ block-1/2 block-4 block-[4px] block-auto block-dvh block-fit block-full block-lh
 <<<>>>
 # min-block-size
 @config theme
+@theme-var spacing-4 1rem
 min-block-4 min-block-[4px] min-block-auto min-block-dvh min-block-fit min-block-full min-block-lh min-block-lvh min-block-max min-block-min min-block-screen min-block-svh
 ---
 
@@ -2936,6 +3034,7 @@ min-block-4 min-block-[4px] min-block-auto min-block-dvh min-block-fit min-block
 <<<>>>
 # max-block-size
 @config theme
+@theme-var spacing-4 1rem
 max-block-4 max-block-[4px] max-block-dvh max-block-fit max-block-full max-block-lh max-block-lvh max-block-max max-block-min max-block-none max-block-screen max-block-svh
 ---
 
@@ -3088,6 +3187,7 @@ grow grow-0 grow-[123]
 <<<>>>
 # flex-basis
 @config theme
+@theme-var container-xl 36rem
 basis-11/12 basis-[123px] basis-auto basis-full basis-xl
 ---
 
@@ -3182,6 +3282,7 @@ border-collapse border-separate
 <<<>>>
 # border-spacing
 @config theme
+@theme-var spacing-1 0.25rem
 border-spacing-1 border-spacing-[123px]
 ---
 
@@ -3231,6 +3332,7 @@ border-spacing-1 border-spacing-[123px]
 <<<>>>
 # border-spacing-x
 @config theme
+@theme-var spacing-1 0.25rem
 border-spacing-x-1 border-spacing-x-[123px]
 ---
 
@@ -3278,6 +3380,7 @@ border-spacing-x-1 border-spacing-x-[123px]
 <<<>>>
 # border-spacing-y
 @config theme
+@theme-var spacing-1 0.25rem
 border-spacing-y-1 border-spacing-y-[123px]
 ---
 
@@ -3381,6 +3484,7 @@ origin-[50px_100px] origin-[var(--value)] origin-bottom origin-bottom-left origi
 <<<>>>
 # origin
 @config theme
+@theme-var transform-origin-top 10px 20px
 origin-top
 ---
 
@@ -3451,6 +3555,7 @@ perspective-origin-[50px_100px] perspective-origin-[var(--value)] perspective-or
 <<<>>>
 # perspective-origin
 @config theme
+@theme-var perspective-origin-top 10px 20px
 perspective-origin-top
 ---
 
@@ -3596,6 +3701,7 @@ perspective-origin-top
 <<<>>>
 # translate-x
 @config theme
+@theme-var spacing 0.25rem
 -translate-x-[var(--value)] -translate-x-full translate-x-full translate-x-px
 ---
 
@@ -3716,6 +3822,7 @@ perspective-origin-top
 <<<>>>
 # translate-y
 @config theme
+@theme-var spacing 0.25rem
 -translate-y-[var(--value)] -translate-y-full translate-y-full translate-y-px
 ---
 
@@ -4794,6 +4901,8 @@ zoom-100 zoom-50 zoom-[var(--zoom)]
 <<<>>>
 # perspective
 @config theme
+@theme-var perspective-dramatic 100px
+@theme-var perspective-normal 500px
 perspective-[456px] perspective-dramatic perspective-none perspective-normal
 ---
 
@@ -4827,6 +4936,7 @@ perspective-[456px] perspective-dramatic perspective-none perspective-normal
 <<<>>>
 # perspective
 @config theme
+@theme-var perspective-none 400px
 perspective-none
 ---
 
@@ -4841,6 +4951,7 @@ perspective-none
 <<<>>>
 # cursor
 @config theme
+@theme-var cursor-custom url(/my-cursor.png)
 cursor-[var(--value)] cursor-alias cursor-all-scroll cursor-auto cursor-cell cursor-col-resize cursor-context-menu cursor-copy cursor-crosshair cursor-custom cursor-default cursor-e-resize cursor-ew-resize cursor-grab cursor-grabbing cursor-help cursor-move cursor-n-resize cursor-ne-resize cursor-nesw-resize cursor-no-drop cursor-none cursor-not-allowed cursor-ns-resize cursor-nw-resize cursor-nwse-resize cursor-pointer cursor-progress cursor-row-resize cursor-s-resize cursor-se-resize cursor-sw-resize cursor-text cursor-vertical-text cursor-w-resize cursor-wait cursor-zoom-in cursor-zoom-out
 ---
 
@@ -5324,6 +5435,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-m
 @config theme
+@theme-var spacing-4 1rem
 -scroll-m-4 -scroll-m-[var(--value)] scroll-m-4 scroll-m-[4px]
 ---
 
@@ -5356,6 +5468,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-mx
 @config theme
+@theme-var spacing-4 1rem
 -scroll-mx-4 -scroll-mx-[var(--value)] scroll-mx-4 scroll-mx-[4px]
 ---
 
@@ -5388,6 +5501,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-my
 @config theme
+@theme-var spacing-4 1rem
 -scroll-my-4 -scroll-my-[var(--value)] scroll-my-4 scroll-my-[4px]
 ---
 
@@ -5420,6 +5534,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-ms
 @config theme
+@theme-var spacing-4 1rem
 -scroll-ms-4 -scroll-ms-[var(--value)] scroll-ms-4 scroll-ms-[4px]
 ---
 
@@ -5452,6 +5567,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-me
 @config theme
+@theme-var spacing-4 1rem
 -scroll-me-4 -scroll-me-[var(--value)] scroll-me-4 scroll-me-[4px]
 ---
 
@@ -5484,6 +5600,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-mbs
 @config theme
+@theme-var spacing-4 1rem
 -scroll-mbs-4 -scroll-mbs-[var(--value)] scroll-mbs-4 scroll-mbs-[4px]
 ---
 
@@ -5516,6 +5633,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-mbe
 @config theme
+@theme-var spacing-4 1rem
 -scroll-mbe-4 -scroll-mbe-[var(--value)] scroll-mbe-4 scroll-mbe-[4px]
 ---
 
@@ -5548,6 +5666,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-mt
 @config theme
+@theme-var spacing-4 1rem
 -scroll-mt-4 -scroll-mt-[var(--value)] scroll-mt-4 scroll-mt-[4px]
 ---
 
@@ -5580,6 +5699,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-mr
 @config theme
+@theme-var spacing-4 1rem
 -scroll-mr-4 -scroll-mr-[var(--value)] scroll-mr-4 scroll-mr-[4px]
 ---
 
@@ -5612,6 +5732,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-mb
 @config theme
+@theme-var spacing-4 1rem
 -scroll-mb-4 -scroll-mb-[var(--value)] scroll-mb-4 scroll-mb-[4px]
 ---
 
@@ -5644,6 +5765,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-ml
 @config theme
+@theme-var spacing-4 1rem
 -scroll-ml-4 -scroll-ml-[var(--value)] scroll-ml-4 scroll-ml-[4px]
 ---
 
@@ -5676,6 +5798,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-p
 @config theme
+@theme-var spacing-4 1rem
 -scroll-p-4 -scroll-p-[var(--value)] scroll-p-4 scroll-p-[4px]
 ---
 
@@ -5700,6 +5823,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-px
 @config theme
+@theme-var spacing-4 1rem
 -scroll-px-4 -scroll-px-[var(--value)] scroll-px-4 scroll-px-[4px]
 ---
 
@@ -5724,6 +5848,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-py
 @config theme
+@theme-var spacing-4 1rem
 -scroll-py-4 -scroll-py-[var(--value)] scroll-py-4 scroll-py-[4px]
 ---
 
@@ -5748,6 +5873,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-ps
 @config theme
+@theme-var spacing-4 1rem
 -scroll-ps-4 -scroll-ps-[var(--value)] scroll-ps-4 scroll-ps-[4px]
 ---
 
@@ -5772,6 +5898,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-pe
 @config theme
+@theme-var spacing-4 1rem
 -scroll-pe-4 -scroll-pe-[var(--value)] scroll-pe-4 scroll-pe-[4px]
 ---
 
@@ -5796,6 +5923,7 @@ snap-always snap-normal
 <<<>>>
 # scroll-pbs
 @config theme
+@theme-var spacing-4 1rem
 scroll-pbs-4 scroll-pbs-[4px]
 ---
 
@@ -5820,6 +5948,7 @@ scroll-pbs-4 scroll-pbs-[4px]
 <<<>>>
 # scroll-pbe
 @config theme
+@theme-var spacing-4 1rem
 scroll-pbe-4 scroll-pbe-[4px]
 ---
 
@@ -5844,6 +5973,7 @@ scroll-pbe-4 scroll-pbe-[4px]
 <<<>>>
 # scroll-pt
 @config theme
+@theme-var spacing-4 1rem
 -scroll-pt-4 -scroll-pt-[var(--value)] scroll-pt-4 scroll-pt-[4px]
 ---
 
@@ -5868,6 +5998,7 @@ scroll-pbe-4 scroll-pbe-[4px]
 <<<>>>
 # scroll-pr
 @config theme
+@theme-var spacing-4 1rem
 -scroll-pr-4 -scroll-pr-[var(--value)] scroll-pr-4 scroll-pr-[4px]
 ---
 
@@ -5892,6 +6023,7 @@ scroll-pbe-4 scroll-pbe-[4px]
 <<<>>>
 # scroll-pb
 @config theme
+@theme-var spacing-4 1rem
 -scroll-pb-4 -scroll-pb-[var(--value)] scroll-pb-4 scroll-pb-[4px]
 ---
 
@@ -5916,6 +6048,7 @@ scroll-pbe-4 scroll-pbe-[4px]
 <<<>>>
 # scroll-pl
 @config theme
+@theme-var spacing-4 1rem
 -scroll-pl-4 -scroll-pl-[var(--value)] scroll-pl-4 scroll-pl-[4px]
 ---
 
@@ -5988,6 +6121,7 @@ list-[var(--value)] list-decimal list-disc list-none
 <<<>>>
 # list
 @config theme
+@theme-var list-style-type-none disc
 list-none
 ---
 
@@ -6022,6 +6156,7 @@ list-image-[var(--value)] list-image-none
 <<<>>>
 # list-image
 @config theme
+@theme-var list-style-image-none url(../foo.png)
 list-image-none
 ---
 
@@ -6092,6 +6227,8 @@ scheme-dark scheme-light scheme-light-dark scheme-normal scheme-only-dark scheme
 <<<>>>
 # columns
 @config theme
+@theme-var container-3xs 16rem
+@theme-var container-7xl 80rem
 columns-3xs columns-4 columns-7xl columns-99 columns-[123] columns-[var(--value)] columns-auto
 ---
 
@@ -6137,6 +6274,7 @@ columns-3xs columns-4 columns-7xl columns-99 columns-[123] columns-[var(--value)
 <<<>>>
 # columns
 @config theme
+@theme-var columns-auto 3
 columns-auto
 ---
 
@@ -6267,6 +6405,7 @@ break-after-all break-after-auto break-after-avoid break-after-avoid-page break-
 <<<>>>
 # auto-cols
 @config theme
+@theme-var spacing 0.25rem
 auto-cols-12 auto-cols-[2fr] auto-cols-auto auto-cols-fr auto-cols-max auto-cols-min
 ---
 
@@ -6307,6 +6446,7 @@ auto-cols-12 auto-cols-[2fr] auto-cols-auto auto-cols-fr auto-cols-max auto-cols
 <<<>>>
 # auto-cols
 @config theme
+@theme-var grid-auto-columns-auto 2fr
 auto-cols-auto
 ---
 
@@ -6353,6 +6493,7 @@ grid-flow-col grid-flow-col-dense grid-flow-dense grid-flow-row grid-flow-row-de
 <<<>>>
 # auto-rows
 @config theme
+@theme-var spacing 0.25rem
 auto-rows-12 auto-rows-[2fr] auto-rows-auto auto-rows-fr auto-rows-max auto-rows-min
 ---
 
@@ -6393,6 +6534,7 @@ auto-rows-12 auto-rows-[2fr] auto-rows-auto auto-rows-fr auto-rows-max auto-rows
 <<<>>>
 # auto-rows
 @config theme
+@theme-var grid-auto-rows-auto 2fr
 auto-rows-auto
 ---
 
@@ -6439,6 +6581,7 @@ grid-cols-12 grid-cols-99 grid-cols-[123] grid-cols-none grid-cols-subgrid
 <<<>>>
 # grid-cols
 @config theme
+@theme-var grid-template-columns-none 200px 1fr
 grid-cols-none
 ---
 
@@ -6485,6 +6628,7 @@ grid-rows-12 grid-rows-99 grid-rows-[123] grid-rows-none grid-rows-subgrid
 <<<>>>
 # grid-rows
 @config theme
+@theme-var grid-template-rows-none 200px 1fr
 grid-rows-none
 ---
 
@@ -6831,6 +6975,7 @@ justify-items-center justify-items-center-safe justify-items-end justify-items-e
 <<<>>>
 # gap
 @config theme
+@theme-var spacing-4 1rem
 gap-4 gap-[4px]
 ---
 
@@ -6855,6 +7000,7 @@ gap-4 gap-[4px]
 <<<>>>
 # gap-x
 @config theme
+@theme-var spacing-4 1rem
 gap-x-4 gap-x-[4px]
 ---
 
@@ -6879,6 +7025,7 @@ gap-x-4 gap-x-[4px]
 <<<>>>
 # gap-y
 @config theme
+@theme-var spacing-4 1rem
 gap-y-4 gap-y-[4px]
 ---
 
@@ -6903,6 +7050,8 @@ gap-y-4 gap-y-[4px]
 <<<>>>
 # space-x
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-4 1rem
 -space-x-0 -space-x-1 -space-x-4 space-x-0 space-x-1 space-x-4 space-x-[-0] space-x-[-0px] space-x-[0] space-x-[0px] space-x-[4px]
 ---
 
@@ -6979,6 +7128,8 @@ gap-y-4 gap-y-[4px]
 <<<>>>
 # space-y
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-4 1rem
 -space-y-0 -space-y-1 -space-y-4 space-y-0 space-y-1 space-y-4 space-y-[-0] space-y-[-0px] space-y-[0] space-y-[0px] space-y-[4px]
 ---
 
@@ -7183,6 +7334,7 @@ divide-x divide-x-0 divide-x-123 divide-x-4 divide-x-[4px]
 <<<>>>
 # divide-x with custom default border width
 @config theme
+@theme-var default-border-width 2px
 divide-x
 ---
 
@@ -7296,6 +7448,7 @@ divide-y divide-y-0 divide-y-123 divide-y-4 divide-y-[4px]
 <<<>>>
 # divide-y with custom default border width
 @config theme
+@theme-var default-border-width 2px
 divide-y
 ---
 
@@ -7434,6 +7587,8 @@ divide-dashed divide-dotted divide-double divide-none divide-solid
 <<<>>>
 # accent
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var accent-color-blue-500 #3b82f6
 accent-[#0088cc] accent-[#0088cc]/50 accent-[#0088cc]/[0.5] accent-[#0088cc]/[50%] accent-blue-500 accent-current accent-current/50 accent-current/[0.5] accent-current/[50%] accent-inherit accent-red-500 accent-red-500/2.25 accent-red-500/2.5 accent-red-500/2.75 accent-red-500/50 accent-red-500/[0.5] accent-red-500/[50%] accent-transparent
 ---
 
@@ -7565,6 +7720,8 @@ accent-[#0088cc] accent-[#0088cc]/50 accent-[#0088cc]/[0.5] accent-[#0088cc]/[50
 <<<>>>
 # caret
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var caret-color-blue-500 #3b82f6
 caret-[#0088cc] caret-[#0088cc]/50 caret-[#0088cc]/[0.5] caret-[#0088cc]/[50%] caret-blue-500 caret-current caret-current/50 caret-current/[0.5] caret-current/[50%] caret-inherit caret-red-500 caret-red-500/2.25 caret-red-500/2.5 caret-red-500/2.75 caret-red-500/50 caret-red-500/[0.5] caret-red-500/[50%] caret-transparent
 ---
 
@@ -7696,6 +7853,8 @@ caret-[#0088cc] caret-[#0088cc]/50 caret-[#0088cc]/[0.5] caret-[#0088cc]/[50%] c
 <<<>>>
 # divide-color
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var border-color-best-blue #6495ed
 divide-[#0088cc] divide-[#0088cc]/50 divide-[#0088cc]/[0.5] divide-[#0088cc]/[50%] divide-best-blue divide-current divide-current/50 divide-current/[0.5] divide-current/[50%] divide-inherit divide-red-500 divide-red-500/2.25 divide-red-500/2.5 divide-red-500/2.75 divide-red-500/50 divide-red-500/[0.5] divide-red-500/[50%] divide-transparent
 ---
 
@@ -8191,6 +8350,7 @@ scrollbar-gutter-auto scrollbar-gutter-both scrollbar-gutter-stable
 <<<>>>
 # scrollbar-thumb
 @config theme
+@theme-var color-red-500 #ef4444
 scrollbar-thumb-[#0088cc] scrollbar-thumb-[#0088cc]/50 scrollbar-thumb-current scrollbar-thumb-inherit scrollbar-thumb-red-500 scrollbar-thumb-red-500/50 scrollbar-thumb-red-500/[0.5] scrollbar-thumb-transparent
 ---
 
@@ -8286,6 +8446,7 @@ scrollbar-thumb-[#0088cc] scrollbar-thumb-[#0088cc]/50 scrollbar-thumb-current s
 <<<>>>
 # scrollbar-track
 @config theme
+@theme-var color-red-500 #ef4444
 scrollbar-track-[#0088cc] scrollbar-track-[#0088cc]/50 scrollbar-track-current scrollbar-track-inherit scrollbar-track-red-500 scrollbar-track-red-500/50 scrollbar-track-red-500/[0.5] scrollbar-track-transparent
 ---
 
@@ -8589,6 +8750,8 @@ wrap-anywhere wrap-break-word wrap-normal
 <<<>>>
 # rounded
 @config theme
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded rounded-[4px] rounded-full rounded-none rounded-sm
 ---
 
@@ -8620,6 +8783,7 @@ rounded rounded-[4px] rounded-full rounded-none rounded-sm
 <<<>>>
 # rounded
 @config theme
+@theme-var radius-full 99999px
 rounded-full
 ---
 
@@ -8640,6 +8804,10 @@ rounded-full
 <<<>>>
 # rounded-s
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-s rounded-s-[4px] rounded-s-full rounded-s-none rounded-s-sm
 ---
 
@@ -8684,6 +8852,10 @@ rounded-s rounded-s-[4px] rounded-s-full rounded-s-none rounded-s-sm
 <<<>>>
 # rounded-e
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-e rounded-e-[4px] rounded-e-full rounded-e-none rounded-e-sm
 ---
 
@@ -8728,6 +8900,10 @@ rounded-e rounded-e-[4px] rounded-e-full rounded-e-none rounded-e-sm
 <<<>>>
 # rounded-t
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-t rounded-t-[4px] rounded-t-full rounded-t-none rounded-t-sm
 ---
 
@@ -8772,6 +8948,10 @@ rounded-t rounded-t-[4px] rounded-t-full rounded-t-none rounded-t-sm
 <<<>>>
 # rounded-r
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-r rounded-r-[4px] rounded-r-full rounded-r-none rounded-r-sm
 ---
 
@@ -8816,6 +8996,10 @@ rounded-r rounded-r-[4px] rounded-r-full rounded-r-none rounded-r-sm
 <<<>>>
 # rounded-b
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-b rounded-b-[4px] rounded-b-full rounded-b-none rounded-b-sm
 ---
 
@@ -8860,6 +9044,10 @@ rounded-b rounded-b-[4px] rounded-b-full rounded-b-none rounded-b-sm
 <<<>>>
 # rounded-l
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-l rounded-l-[4px] rounded-l-full rounded-l-none rounded-l-sm
 ---
 
@@ -8904,6 +9092,10 @@ rounded-l rounded-l-[4px] rounded-l-full rounded-l-none rounded-l-sm
 <<<>>>
 # rounded-ss
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-ss rounded-ss-[4px] rounded-ss-full rounded-ss-none rounded-ss-sm
 ---
 
@@ -8943,6 +9135,10 @@ rounded-ss rounded-ss-[4px] rounded-ss-full rounded-ss-none rounded-ss-sm
 <<<>>>
 # rounded-se
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-se rounded-se-[4px] rounded-se-full rounded-se-none rounded-se-sm
 ---
 
@@ -8982,6 +9178,10 @@ rounded-se rounded-se-[4px] rounded-se-full rounded-se-none rounded-se-sm
 <<<>>>
 # rounded-ee
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-ee rounded-ee-[4px] rounded-ee-full rounded-ee-none rounded-ee-sm
 ---
 
@@ -9021,6 +9221,10 @@ rounded-ee rounded-ee-[4px] rounded-ee-full rounded-ee-none rounded-ee-sm
 <<<>>>
 # rounded-es
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-es rounded-es-[4px] rounded-es-full rounded-es-none rounded-es-sm
 ---
 
@@ -9060,6 +9264,10 @@ rounded-es rounded-es-[4px] rounded-es-full rounded-es-none rounded-es-sm
 <<<>>>
 # rounded-tl
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-tl rounded-tl-[4px] rounded-tl-full rounded-tl-none rounded-tl-sm
 ---
 
@@ -9099,6 +9307,10 @@ rounded-tl rounded-tl-[4px] rounded-tl-full rounded-tl-none rounded-tl-sm
 <<<>>>
 # rounded-tr
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-tr rounded-tr-[4px] rounded-tr-full rounded-tr-none rounded-tr-sm
 ---
 
@@ -9138,6 +9350,10 @@ rounded-tr rounded-tr-[4px] rounded-tr-full rounded-tr-none rounded-tr-sm
 <<<>>>
 # rounded-br
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-br rounded-br-[4px] rounded-br-full rounded-br-none rounded-br-sm
 ---
 
@@ -9177,6 +9393,10 @@ rounded-br rounded-br-[4px] rounded-br-full rounded-br-none rounded-br-sm
 <<<>>>
 # rounded-bl
 @config theme
+@theme-var radius-none 0px
+@theme-var radius-full 9999px
+@theme-var radius-sm 0.125rem
+@theme-var radius 0.25rem
 rounded-bl rounded-bl-[4px] rounded-bl-full rounded-bl-none rounded-bl-sm
 ---
 
@@ -9258,6 +9478,7 @@ border-dashed border-dotted border-double border-hidden border-none border-solid
 <<<>>>
 # border with custom default border width
 @config theme
+@theme-var default-border-width 2px
 border
 ---
 
@@ -9289,6 +9510,8 @@ border
 <<<>>>
 # bg
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var background-color-blue-500 #3b82f6
 -bg-conic-45/oklab -bg-linear-45 -bg-linear-45/oklab -bg-linear-[1.3rad] -bg-linear-[125deg] bg-[#0088cc] bg-[#0088cc]/50 bg-[#0088cc]/[0.5] bg-[#0088cc]/[50%] bg-[120px] bg-[120px_120px] bg-[50%] bg-[color:var(--some-var)] bg-[color:var(--some-var)]/50 bg-[color:var(--some-var)]/[0.5] bg-[color:var(--some-var)]/[50%] bg-[contain] bg-[cover] bg-[image:var(--my-gradient)] bg-[length:120px_120px] bg-[linear-gradient(to_bottom,red,blue)] bg-[position:120px_120px] bg-[size:120px_120px] bg-[url(/image.png)] bg-[url:var(--my-url)] bg-[var(--some-var)] bg-[var(--some-var)]/50 bg-[var(--some-var)]/[0.5] bg-[var(--some-var)]/[50%] bg-auto bg-blue-500 bg-bottom bg-bottom-left bg-bottom-right bg-center bg-conic-45/[in_hsl_longer_hue] bg-conic-45/oklab bg-conic-45/shorter bg-conic/[in_hsl_longer_hue] bg-conic/decreasing bg-conic/hsl bg-conic/increasing bg-conic/longer bg-conic/oklab bg-conic/oklch bg-conic/shorter bg-conic/srgb bg-contain bg-cover bg-current bg-current/50 bg-current/[0.5] bg-current/[50%] bg-current/[var(--bg-opacity)] bg-fixed bg-inherit bg-left bg-left-bottom bg-left-top bg-linear-45 bg-linear-45/[in_hsl_longer_hue] bg-linear-45/oklab bg-linear-45/shorter bg-linear-[1.3rad] bg-linear-[125deg] bg-linear-[to_bottom] bg-linear-to-b bg-linear-to-bl bg-linear-to-br bg-linear-to-l bg-linear-to-r bg-linear-to-r/[in_hsl_longer_hue] bg-linear-to-r/[longer] bg-linear-to-r/decreasing bg-linear-to-r/hsl bg-linear-to-r/increasing bg-linear-to-r/longer bg-linear-to-r/oklab bg-linear-to-r/oklch bg-linear-to-r/shorter bg-linear-to-r/srgb bg-linear-to-t bg-linear-to-tl bg-linear-to-tr bg-local bg-no-repeat bg-none bg-radial-[circle_at_center] bg-radial/[in_hsl_longer_hue] bg-radial/decreasing bg-radial/hsl bg-radial/increasing bg-radial/longer bg-radial/oklab bg-radial/oklch bg-radial/shorter bg-radial/srgb bg-red-500 bg-red-500/100 bg-red-500/2.25 bg-red-500/2.5 bg-red-500/2.75 bg-red-500/50 bg-red-500/[0.5] bg-red-500/[100%] bg-red-500/[50%] bg-repeat bg-repeat-round bg-repeat-space bg-repeat-x bg-repeat-y bg-right bg-right-bottom bg-right-top bg-scroll bg-top bg-top-left bg-top-right bg-transparent
 ---
 
@@ -10118,6 +10341,8 @@ border
 <<<>>>
 # bg
 @config theme-reference
+@theme-var opacity-half 0.5
+@theme-var opacity-custom var(--custom-opacity)
 [color:red]/half bg-current/custom bg-current/half
 ---
 
@@ -10154,6 +10379,7 @@ border
 <<<>>>
 # bg-position
 @config theme
+@theme-var color-red-500 #ef4444
 bg-position-[120px] bg-position-[120px_120px] bg-position-[var(--some-var)]
 ---
 
@@ -10178,6 +10404,7 @@ bg-position-[120px] bg-position-[120px_120px] bg-position-[var(--some-var)]
 <<<>>>
 # bg-size
 @config theme
+@theme-var color-red-500 #ef4444
 bg-size-[120px] bg-size-[120px_120px] bg-size-[var(--some-var)]
 ---
 
@@ -10202,6 +10429,7 @@ bg-size-[120px] bg-size-[120px_120px] bg-size-[var(--some-var)]
 <<<>>>
 # from
 @config theme
+@theme-var color-red-500 #ef4444
 from-0% from-100% from-5% from-[#0088cc] from-[#0088cc]/50 from-[#0088cc]/[0.5] from-[#0088cc]/[50%] from-[50%] from-[50px] from-[color:var(--my-color)] from-[color:var(--my-color)]/50 from-[color:var(--my-color)]/[0.5] from-[color:var(--my-color)]/[50%] from-[length:var(--my-position)] from-[percentage:var(--my-position)] from-[var(--my-color)] from-[var(--my-color)]/50 from-[var(--my-color)]/[0.5] from-[var(--my-color)]/[50%] from-current from-current/50 from-current/[0.5] from-current/[50%] from-inherit from-red-500 from-red-500/50 from-red-500/[0.5] from-red-500/[50%] from-transparent
 ---
 
@@ -10517,6 +10745,7 @@ from-0% from-100% from-5% from-[#0088cc] from-[#0088cc]/50 from-[#0088cc]/[0.5] 
 <<<>>>
 # via
 @config theme
+@theme-var color-red-500 #ef4444
 via-0% via-100% via-5% via-[#0088cc] via-[#0088cc]/50 via-[#0088cc]/[0.5] via-[#0088cc]/[50%] via-[50%] via-[50px] via-[color:var(--my-color)] via-[color:var(--my-color)]/50 via-[color:var(--my-color)]/[0.5] via-[color:var(--my-color)]/[50%] via-[length:var(--my-position)] via-[percentage:var(--my-position)] via-[var(--my-color)] via-[var(--my-color)]/50 via-[var(--my-color)]/[0.5] via-[var(--my-color)]/[50%] via-current via-current/50 via-current/[0.5] via-current/[50%] via-inherit via-red-500 via-red-500/50 via-red-500/[0.5] via-red-500/[50%] via-transparent
 ---
 
@@ -10852,6 +11081,7 @@ via-0% via-100% via-5% via-[#0088cc] via-[#0088cc]/50 via-[#0088cc]/[0.5] via-[#
 <<<>>>
 # to
 @config theme
+@theme-var color-red-500 #ef4444
 to-0% to-100% to-5% to-[#0088cc] to-[#0088cc]/50 to-[#0088cc]/[0.5] to-[#0088cc]/[50%] to-[50%] to-[50px] to-[color:var(--my-color)] to-[color:var(--my-color)]/50 to-[color:var(--my-color)]/[0.5] to-[color:var(--my-color)]/[50%] to-[length:var(--my-position)] to-[percentage:var(--my-position)] to-[var(--my-color)] to-[var(--my-color)]/50 to-[var(--my-color)]/[0.5] to-[var(--my-color)]/[50%] to-current to-current/50 to-current/[0.5] to-current/[50%] to-inherit to-red-500 to-red-500/50 to-red-500/[0.5] to-red-500/[50%] to-transparent
 ---
 
@@ -11167,6 +11397,7 @@ to-0% to-100% to-5% to-[#0088cc] to-[#0088cc]/50 to-[#0088cc]/[0.5] to-[#0088cc]
 <<<>>>
 # mask
 @config theme
+@theme-var color-red-500 #ef4444
 mask-[120px] mask-[120px_120px] mask-[50%] mask-[contain] mask-[cover] mask-[image:var(--some-var)] mask-[length:120px_120px] mask-[linear-gradient(#ffff,#0000)] mask-[position:120px_120px] mask-[size:120px_120px] mask-[url(http://example.com)] mask-[url:var(--some-var)] mask-[var(--some-var)] mask-add mask-alpha mask-auto mask-bottom mask-bottom-left mask-bottom-right mask-center mask-contain mask-cover mask-exclude mask-intersect mask-left mask-luminance mask-match mask-no-repeat mask-none mask-repeat mask-repeat-round mask-repeat-space mask-repeat-x mask-repeat-y mask-right mask-subtract mask-top mask-top-left mask-top-right mask-type-alpha mask-type-luminance
 ---
 
@@ -11376,6 +11607,8 @@ mask-[120px] mask-[120px_120px] mask-[50%] mask-[contain] mask-[cover] mask-[ima
 <<<>>>
 # mask
 @config theme-reference
+@theme-var opacity-half 0.5
+@theme-var opacity-custom var(--custom-opacity)
 [color:red]/half mask-current/custom mask-current/half
 ---
 
@@ -11392,6 +11625,7 @@ mask-[120px] mask-[120px_120px] mask-[50%] mask-[contain] mask-[cover] mask-[ima
 <<<>>>
 # mask-position
 @config theme
+@theme-var color-red-500 #ef4444
 mask-position-[120px] mask-position-[120px_120px] mask-position-[var(--some-var)]
 ---
 
@@ -11420,6 +11654,7 @@ mask-position-[120px] mask-position-[120px_120px] mask-position-[var(--some-var)
 <<<>>>
 # mask-size
 @config theme
+@theme-var color-red-500 #ef4444
 mask-size-[120px] mask-size-[120px_120px] mask-size-[var(--some-var)]
 ---
 
@@ -11448,6 +11683,7 @@ mask-size-[120px] mask-size-[120px_120px] mask-size-[var(--some-var)]
 <<<>>>
 # mask-t-from
 @config run
+@theme-var spacing 0.25rem
 mask-t-from-(--my-var) mask-t-from-(color:--my-var) mask-t-from-(length:--my-var) mask-t-from-0 mask-t-from-0% mask-t-from-1.5 mask-t-from-2 mask-t-from-2% mask-t-from-[0%] mask-t-from-[0px]
 ---
 
@@ -11656,6 +11892,7 @@ mask-t-from-(--my-var) mask-t-from-(color:--my-var) mask-t-from-(length:--my-var
 <<<>>>
 # mask-t-to
 @config run
+@theme-var spacing 0.25rem
 mask-t-to-(--my-var) mask-t-to-(color:--my-var) mask-t-to-(length:--my-var) mask-t-to-0 mask-t-to-0% mask-t-to-1.5 mask-t-to-2 mask-t-to-2% mask-t-to-[0%] mask-t-to-[0px]
 ---
 
@@ -11864,6 +12101,7 @@ mask-t-to-(--my-var) mask-t-to-(color:--my-var) mask-t-to-(length:--my-var) mask
 <<<>>>
 # mask-r-from
 @config run
+@theme-var spacing 0.25rem
 mask-r-from-(--my-var) mask-r-from-(color:--my-var) mask-r-from-(length:--my-var) mask-r-from-0 mask-r-from-0% mask-r-from-1.5 mask-r-from-2 mask-r-from-2% mask-r-from-[0%] mask-r-from-[0px]
 ---
 
@@ -12072,6 +12310,7 @@ mask-r-from-(--my-var) mask-r-from-(color:--my-var) mask-r-from-(length:--my-var
 <<<>>>
 # mask-r-to
 @config run
+@theme-var spacing 0.25rem
 mask-r-to-(--my-var) mask-r-to-(color:--my-var) mask-r-to-(length:--my-var) mask-r-to-0 mask-r-to-0% mask-r-to-1.5 mask-r-to-2 mask-r-to-2% mask-r-to-[0%] mask-r-to-[0px]
 ---
 
@@ -12280,6 +12519,7 @@ mask-r-to-(--my-var) mask-r-to-(color:--my-var) mask-r-to-(length:--my-var) mask
 <<<>>>
 # mask-b-from
 @config run
+@theme-var spacing 0.25rem
 mask-b-from-(--my-var) mask-b-from-(color:--my-var) mask-b-from-(length:--my-var) mask-b-from-0 mask-b-from-0% mask-b-from-1.5 mask-b-from-2 mask-b-from-2% mask-b-from-[0%] mask-b-from-[0px]
 ---
 
@@ -12488,6 +12728,7 @@ mask-b-from-(--my-var) mask-b-from-(color:--my-var) mask-b-from-(length:--my-var
 <<<>>>
 # mask-b-to
 @config run
+@theme-var spacing 0.25rem
 mask-b-to-(--my-var) mask-b-to-(color:--my-var) mask-b-to-(length:--my-var) mask-b-to-0 mask-b-to-0% mask-b-to-1.5 mask-b-to-2 mask-b-to-2% mask-b-to-[0%] mask-b-to-[0px]
 ---
 
@@ -12696,6 +12937,7 @@ mask-b-to-(--my-var) mask-b-to-(color:--my-var) mask-b-to-(length:--my-var) mask
 <<<>>>
 # mask-l-from
 @config run
+@theme-var spacing 0.25rem
 mask-l-from-(--my-var) mask-l-from-(color:--my-var) mask-l-from-(length:--my-var) mask-l-from-0 mask-l-from-0% mask-l-from-1.5 mask-l-from-2 mask-l-from-2% mask-l-from-[0%] mask-l-from-[0px]
 ---
 
@@ -12904,6 +13146,7 @@ mask-l-from-(--my-var) mask-l-from-(color:--my-var) mask-l-from-(length:--my-var
 <<<>>>
 # mask-l-to
 @config run
+@theme-var spacing 0.25rem
 mask-l-to-(--my-var) mask-l-to-(color:--my-var) mask-l-to-(length:--my-var) mask-l-to-0 mask-l-to-0% mask-l-to-1.5 mask-l-to-2 mask-l-to-2% mask-l-to-[0%] mask-l-to-[0px]
 ---
 
@@ -13112,6 +13355,7 @@ mask-l-to-(--my-var) mask-l-to-(color:--my-var) mask-l-to-(length:--my-var) mask
 <<<>>>
 # mask-x-from
 @config run
+@theme-var spacing 0.25rem
 mask-x-from-(--my-var) mask-x-from-(color:--my-var) mask-x-from-(length:--my-var) mask-x-from-0 mask-x-from-0% mask-x-from-1.5 mask-x-from-2 mask-x-from-2% mask-x-from-[0%] mask-x-from-[0px]
 ---
 
@@ -13366,6 +13610,7 @@ mask-x-from-(--my-var) mask-x-from-(color:--my-var) mask-x-from-(length:--my-var
 <<<>>>
 # mask-x-to
 @config run
+@theme-var spacing 0.25rem
 mask-x-to-(--my-var) mask-x-to-(color:--my-var) mask-x-to-(length:--my-var) mask-x-to-0 mask-x-to-0% mask-x-to-1.5 mask-x-to-2 mask-x-to-2% mask-x-to-[0%] mask-x-to-[0px]
 ---
 
@@ -13620,6 +13865,7 @@ mask-x-to-(--my-var) mask-x-to-(color:--my-var) mask-x-to-(length:--my-var) mask
 <<<>>>
 # mask-y-from
 @config run
+@theme-var spacing 0.25rem
 mask-y-from-(--my-var) mask-y-from-(color:--my-var) mask-y-from-(length:--my-var) mask-y-from-0 mask-y-from-0% mask-y-from-1.5 mask-y-from-2 mask-y-from-2% mask-y-from-[0%] mask-y-from-[0px]
 ---
 
@@ -13874,6 +14120,7 @@ mask-y-from-(--my-var) mask-y-from-(color:--my-var) mask-y-from-(length:--my-var
 <<<>>>
 # mask-y-to
 @config run
+@theme-var spacing 0.25rem
 mask-y-to-(--my-var) mask-y-to-(color:--my-var) mask-y-to-(length:--my-var) mask-y-to-0 mask-y-to-0% mask-y-to-1.5 mask-y-to-2 mask-y-to-2% mask-y-to-[0%] mask-y-to-[0px]
 ---
 
@@ -14269,6 +14516,7 @@ mask-y-to-(--my-var) mask-y-to-(color:--my-var) mask-y-to-(length:--my-var) mask
 <<<>>>
 # mask-linear-from
 @config run
+@theme-var spacing 0.25rem
 mask-linear-from-(--my-var) mask-linear-from-(color:--my-var) mask-linear-from-(length:--my-var) mask-linear-from-0 mask-linear-from-0% mask-linear-from-1.5 mask-linear-from-2 mask-linear-from-2% mask-linear-from-[0%] mask-linear-from-[0px]
 ---
 
@@ -14456,6 +14704,7 @@ mask-linear-from-(--my-var) mask-linear-from-(color:--my-var) mask-linear-from-(
 <<<>>>
 # mask-linear-to
 @config run
+@theme-var spacing 0.25rem
 mask-linear-to-(--my-var) mask-linear-to-(color:--my-var) mask-linear-to-(length:--my-var) mask-linear-to-0 mask-linear-to-0% mask-linear-to-1.5 mask-linear-to-2 mask-linear-to-2% mask-linear-to-[0%] mask-linear-to-[0px]
 ---
 
@@ -14767,6 +15016,7 @@ mask-circle mask-ellipse mask-radial-[25%_25%] mask-radial-closest-corner mask-r
 <<<>>>
 # mask-radial-at
 @config theme
+@theme-var spacing 0.25rem
 mask-radial-at-[25%] mask-radial-at-bottom mask-radial-at-bottom-left mask-radial-at-bottom-right mask-radial-at-left mask-radial-at-right mask-radial-at-top mask-radial-at-top-left mask-radial-at-top-right
 ---
 
@@ -14815,6 +15065,7 @@ mask-radial-at-[25%] mask-radial-at-bottom mask-radial-at-bottom-left mask-radia
 <<<>>>
 # mask-radial-from
 @config run
+@theme-var spacing 0.25rem
 mask-radial-from-(--my-var) mask-radial-from-(color:--my-var) mask-radial-from-(length:--my-var) mask-radial-from-0 mask-radial-from-0% mask-radial-from-1.5 mask-radial-from-2 mask-radial-from-2% mask-radial-from-[0%] mask-radial-from-[0px]
 ---
 
@@ -15016,6 +15267,7 @@ mask-radial-from-(--my-var) mask-radial-from-(color:--my-var) mask-radial-from-(
 <<<>>>
 # mask-radial-to
 @config run
+@theme-var spacing 0.25rem
 mask-radial-to-(--my-var) mask-radial-to-(color:--my-var) mask-radial-to-(length:--my-var) mask-radial-to-0 mask-radial-to-0% mask-radial-to-1.5 mask-radial-to-2 mask-radial-to-2% mask-radial-to-[0%] mask-radial-to-[0px]
 ---
 
@@ -15358,6 +15610,7 @@ mask-radial-to-(--my-var) mask-radial-to-(color:--my-var) mask-radial-to-(length
 <<<>>>
 # mask-conic-from
 @config run
+@theme-var spacing 0.25rem
 mask-conic-from-(--my-var) mask-conic-from-(color:--my-var) mask-conic-from-(length:--my-var) mask-conic-from-0 mask-conic-from-0% mask-conic-from-1.5 mask-conic-from-2 mask-conic-from-2% mask-conic-from-[0%] mask-conic-from-[0px]
 ---
 
@@ -15545,6 +15798,7 @@ mask-conic-from-(--my-var) mask-conic-from-(color:--my-var) mask-conic-from-(len
 <<<>>>
 # mask-conic-to
 @config run
+@theme-var spacing 0.25rem
 mask-conic-to-(--my-var) mask-conic-to-(color:--my-var) mask-conic-to-(length:--my-var) mask-conic-to-0 mask-conic-to-0% mask-conic-to-1.5 mask-conic-to-2 mask-conic-to-2% mask-conic-to-[0%] mask-conic-to-[0px]
 ---
 
@@ -16056,6 +16310,8 @@ mix-blend-color mix-blend-color-burn mix-blend-color-dodge mix-blend-darken mix-
 <<<>>>
 # fill
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var fill-blue-500 #3b82f6
 fill-[#0088cc] fill-[#0088cc]/50 fill-[#0088cc]/[0.5] fill-[#0088cc]/[50%] fill-blue-500 fill-current fill-current/50 fill-current/[0.5] fill-current/[50%] fill-inherit fill-red-500 fill-red-500/2.25 fill-red-500/2.5 fill-red-500/2.75 fill-red-500/50 fill-red-500/[0.5] fill-red-500/[50%] fill-transparent
 ---
 
@@ -16187,6 +16443,8 @@ fill-[#0088cc] fill-[#0088cc]/50 fill-[#0088cc]/[0.5] fill-[#0088cc]/[50%] fill-
 <<<>>>
 # stroke
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var stroke-blue-500 #3b82f6
 stroke-0 stroke-1 stroke-2 stroke-[#0088cc] stroke-[#0088cc]/50 stroke-[#0088cc]/[0.5] stroke-[#0088cc]/[50%] stroke-[1.5] stroke-[12px] stroke-[50%] stroke-[color:var(--my-color)] stroke-[color:var(--my-color)]/50 stroke-[color:var(--my-color)]/[0.5] stroke-[color:var(--my-color)]/[50%] stroke-[length:var(--my-width)] stroke-[number:var(--my-width)] stroke-[percentage:var(--my-width)] stroke-[var(--my-color)] stroke-[var(--my-color)]/50 stroke-[var(--my-color)]/[0.5] stroke-[var(--my-color)]/[50%] stroke-blue-500 stroke-current stroke-current/50 stroke-current/[0.5] stroke-current/[50%] stroke-inherit stroke-none stroke-red-500 stroke-red-500/2.25 stroke-red-500/2.5 stroke-red-500/2.75 stroke-red-500/50 stroke-red-500/[0.5] stroke-red-500/[50%] stroke-transparent
 ---
 
@@ -16498,6 +16756,7 @@ object-[var(--value)] object-bottom object-bottom-left object-bottom-right objec
 <<<>>>
 # object
 @config theme
+@theme-var object-position-center top left
 object-center
 ---
 
@@ -16512,6 +16771,8 @@ object-center
 <<<>>>
 # p
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 p-1 p-4 p-99 p-[4px] p-big
 ---
 
@@ -16549,6 +16810,8 @@ p-1 p-4 p-99 p-[4px] p-big
 <<<>>>
 # px
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 px-1 px-2.5 px-99 px-[4px] px-big
 ---
 
@@ -16586,6 +16849,8 @@ px-1 px-2.5 px-99 px-[4px] px-big
 <<<>>>
 # py
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 py-1 py-4 py-99 py-[4px] py-big
 ---
 
@@ -16623,6 +16888,8 @@ py-1 py-4 py-99 py-[4px] py-big
 <<<>>>
 # pt
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pt-1 pt-4 pt-99 pt-[4px] pt-big
 ---
 
@@ -16660,6 +16927,8 @@ pt-1 pt-4 pt-99 pt-[4px] pt-big
 <<<>>>
 # ps
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 ps-1 ps-4 ps-99 ps-[4px] ps-big
 ---
 
@@ -16697,6 +16966,8 @@ ps-1 ps-4 ps-99 ps-[4px] ps-big
 <<<>>>
 # pe
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pe-1 pe-4 pe-99 pe-[4px] pe-big
 ---
 
@@ -16734,6 +17005,8 @@ pe-1 pe-4 pe-99 pe-[4px] pe-big
 <<<>>>
 # pbs
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pbs-1 pbs-4 pbs-99 pbs-[4px] pbs-big
 ---
 
@@ -16771,6 +17044,8 @@ pbs-1 pbs-4 pbs-99 pbs-[4px] pbs-big
 <<<>>>
 # pbe
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pbe-1 pbe-4 pbe-99 pbe-[4px] pbe-big
 ---
 
@@ -16808,6 +17083,8 @@ pbe-1 pbe-4 pbe-99 pbe-[4px] pbe-big
 <<<>>>
 # pr
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pr-1 pr-4 pr-99 pr-[4px] pr-big
 ---
 
@@ -16845,6 +17122,8 @@ pr-1 pr-4 pr-99 pr-[4px] pr-big
 <<<>>>
 # pb
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pb-1 pb-4 pb-99 pb-[4px] pb-big
 ---
 
@@ -16882,6 +17161,8 @@ pb-1 pb-4 pb-99 pb-[4px] pb-big
 <<<>>>
 # pl
 @config theme
+@theme-var spacing 0.25rem
+@theme-var spacing-big 100rem
 pl-1 pl-4 pl-99 pl-[4px] pl-big
 ---
 
@@ -17023,6 +17304,7 @@ align-[var(--value)] align-baseline align-bottom align-middle align-sub align-su
 <<<>>>
 # font
 @config theme
+@theme-var font-weight-bold 650
 font-["arial_rounded"] font-[100] font-[family-name:var(--my-family)] font-[generic-name:var(--my-family)] font-[number:var(--my-weight)] font-[ui-sans-serif] font-[var(--my-family)] font-bold font-sans
 ---
 
@@ -17084,6 +17366,7 @@ font-["arial_rounded"] font-[100] font-[family-name:var(--my-family)] font-[gene
 <<<>>>
 # font
 @config theme-reference
+@theme-var font-weight-bold 650
 -font-bold -font-sans font font-["arial_rounded"]/foo font-[100]/foo font-[family-name:var(--my-family)]/foo font-[generic-name:var(--my-family)]/foo font-[number:var(--my-weight)]/foo font-[ui-sans-serif]/foo font-[var(--my-family)]/foo font-bold/foo font-sans/foo font-weight-bold
 ---
 
@@ -17218,6 +17501,7 @@ line-through no-underline overline underline
 <<<>>>
 # placeholder
 @config theme
+@theme-var color-red-500 #ef4444
 placeholder-[#0088cc] placeholder-[#0088cc]/50 placeholder-[#0088cc]/[0.5] placeholder-[#0088cc]/[50%] placeholder-current placeholder-current/50 placeholder-current/[0.5] placeholder-current/[50%] placeholder-inherit placeholder-red-500 placeholder-red-500/2.25 placeholder-red-500/2.5 placeholder-red-500/2.75 placeholder-red-500/50 placeholder-red-500/[0.5] placeholder-red-500/[50%] placeholder-transparent
 ---
 
@@ -17344,6 +17628,8 @@ placeholder-[#0088cc] placeholder-[#0088cc]/50 placeholder-[#0088cc]/[0.5] place
 <<<>>>
 # decoration
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var text-decoration-color-blue-500 #3b82f6
 decoration-0 decoration-1 decoration-123 decoration-2 decoration-4 decoration-[#0088cc] decoration-[#0088cc]/50 decoration-[#0088cc]/[0.5] decoration-[#0088cc]/[50%] decoration-[12px] decoration-[50%] decoration-[color:var(--my-color)] decoration-[color:var(--my-color)]/50 decoration-[color:var(--my-color)]/[0.5] decoration-[color:var(--my-color)]/[50%] decoration-[length:var(--my-thickness)] decoration-[percentage:var(--my-thickness)] decoration-[var(--my-color)] decoration-[var(--my-color)]/50 decoration-[var(--my-color)]/[0.5] decoration-[var(--my-color)]/[50%] decoration-auto decoration-blue-500 decoration-current decoration-current/50 decoration-current/[0.5] decoration-current/[50%] decoration-dashed decoration-dotted decoration-double decoration-from-font decoration-inherit decoration-red-500 decoration-red-500/50 decoration-red-500/[0.5] decoration-red-500/[50%] decoration-solid decoration-transparent decoration-wavy
 ---
 
@@ -17607,6 +17893,7 @@ decoration-0 decoration-1 decoration-123 decoration-2 decoration-4 decoration-[#
 <<<>>>
 # animate
 @config theme
+@theme-var animate-spin spin 1s linear infinite
 animate-[bounce_1s_infinite] animate-none animate-not-found animate-spin
 ---
 
@@ -17635,6 +17922,7 @@ animate-[bounce_1s_infinite] animate-none animate-not-found animate-spin
 <<<>>>
 # animate
 @config theme
+@theme-var animate-none bounce 1s infinite
 animate-none
 ---
 
@@ -17649,6 +17937,13 @@ animate-none
 <<<>>>
 # filter
 @config theme-inline
+@theme-var spacing 0.25rem
+@theme-var blur-xl 24px
+@theme-var color-red-500 #ef4444
+@theme-var drop-shadow 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-var drop-shadow-xl 0 9px 7px rgb(0 0 0 / 0.1)
+@theme-var drop-shadow-calc 0 0 calc(1 * var(--spacing)) black
+@theme-var drop-shadow-multi 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1)
 -hue-rotate-15 -hue-rotate-[45deg] blur-[4px] blur-none blur-xl brightness-50 brightness-[1.23] contrast-50 contrast-[1.23] drop-shadow drop-shadow-[0_0_red] drop-shadow-calc drop-shadow-inherit drop-shadow-multi drop-shadow-none drop-shadow-red-500 drop-shadow-red-500/50 drop-shadow-xl drop-shadow/25 filter filter-[var(--value)] filter-none grayscale grayscale-0 grayscale-[var(--value)] hue-rotate-15 hue-rotate-[45deg] invert invert-0 invert-[var(--value)] saturate-0 saturate-[1.75] saturate-[var(--value)] sepia sepia-0 sepia-[50%] sepia-[var(--value)]
 ---
 
@@ -17963,6 +18258,7 @@ animate-none
 <<<>>>
 # filter
 @config theme
+@theme-var blur-none 2px
 blur-none
 ---
 
@@ -18064,6 +18360,7 @@ blur-none
 <<<>>>
 # backdrop-filter
 @config theme
+@theme-var blur-xl 24px
 -backdrop-hue-rotate-15 -backdrop-hue-rotate-[45deg] backdrop-blur-[4px] backdrop-blur-none backdrop-blur-xl backdrop-brightness-50 backdrop-brightness-[1.23] backdrop-contrast-50 backdrop-contrast-[1.23] backdrop-filter backdrop-filter-[var(--value)] backdrop-filter-none backdrop-grayscale backdrop-grayscale-0 backdrop-grayscale-[var(--value)] backdrop-hue-rotate-15 backdrop-hue-rotate-[45deg] backdrop-invert backdrop-invert-0 backdrop-invert-[var(--value)] backdrop-opacity-1.25 backdrop-opacity-2.5 backdrop-opacity-3.75 backdrop-opacity-50 backdrop-opacity-71 backdrop-opacity-[0.5] backdrop-saturate-0 backdrop-saturate-[1.75] backdrop-saturate-[var(--value)] backdrop-sepia backdrop-sepia-0 backdrop-sepia-[50%] backdrop-sepia-[var(--value)]
 ---
 
@@ -18336,6 +18633,7 @@ blur-none
 <<<>>>
 # backdrop-filter
 @config theme
+@theme-var backdrop-blur-none 2px
 backdrop-blur-none
 ---
 
@@ -18413,6 +18711,9 @@ backdrop-blur-none
 <<<>>>
 # transition
 @config theme
+@theme-var default-transition-timing-function ease
+@theme-var default-transition-duration 100ms
+@theme-var transition-property-opacity opacity
 transition transition-[var(--value)] transition-all transition-colors transition-none transition-opacity transition-shadow transition-transform
 ---
 
@@ -18471,6 +18772,8 @@ transition transition-[var(--value)] transition-all transition-colors transition
 <<<>>>
 # transition
 @config theme-inline
+@theme-var default-transition-timing-function ease
+@theme-var default-transition-duration 100ms
 transition transition-all transition-colors
 ---
 
@@ -18513,6 +18816,7 @@ transition-all
 <<<>>>
 # transition
 @config theme
+@theme-var transition-property-colors transform
 transition-colors
 ---
 
@@ -18613,6 +18917,8 @@ duration-123 duration-200 duration-[300ms]
 <<<>>>
 # ease
 @config theme
+@theme-var ease-in cubic-bezier(0.4, 0, 1, 1)
+@theme-var ease-out cubic-bezier(0, 0, 0.2, 1)
 ease-[var(--value)] ease-in ease-out
 ---
 
@@ -18658,6 +18964,7 @@ ease-[var(--value)] ease-in ease-out
 <<<>>>
 # ease
 @config theme
+@theme-var ease-linear steps(4)
 ease-linear
 ---
 
@@ -18802,6 +19109,7 @@ contain-[unset]/foo contain-content/foo contain-inline-size/foo contain-layout/f
 <<<>>>
 # content
 @config theme
+@theme-var content-slash '/'
 content-["hello_world"] content-slash
 ---
 
@@ -18860,6 +19168,8 @@ forced-color-adjust-auto forced-color-adjust-none
 <<<>>>
 # leading
 @config theme
+@theme-var leading-tight 1.25
+@theme-var leading-6 1.5rem
 leading-6 leading-[var(--value)] leading-tight
 ---
 
@@ -18905,6 +19215,7 @@ leading-6 leading-[var(--value)] leading-tight
 <<<>>>
 # leading
 @config theme
+@theme-var leading-none 2
 leading-none
 ---
 
@@ -18933,6 +19244,8 @@ leading-none
 <<<>>>
 # tracking
 @config theme
+@theme-var tracking-normal 0em
+@theme-var tracking-wide 0.025em
 -tracking-[var(--value)] tracking-[var(--value)] tracking-normal tracking-wide
 ---
 
@@ -19098,6 +19411,8 @@ diagonal-fractions lining-nums normal-nums oldstyle-nums ordinal proportional-nu
 <<<>>>
 # outline
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var outline-color-blue-500 #3b82f6
 outline outline-0 outline-[#0088cc] outline-[#0088cc]/50 outline-[#0088cc]/[0.5] outline-[#0088cc]/[50%] outline-[1.5] outline-[12px] outline-[50%] outline-[black] outline-[black]/50 outline-[black]/[0.5] outline-[black]/[50%] outline-[color:var(--value)] outline-[color:var(--value)]/50 outline-[color:var(--value)]/[0.5] outline-[color:var(--value)]/[50%] outline-[length:var(--my-width)] outline-[number:var(--my-width)] outline-[percentage:var(--my-width)] outline-[var(--value)] outline-[var(--value)]/50 outline-[var(--value)]/[0.5] outline-[var(--value)]/[50%] outline-blue-500 outline-current outline-current/50 outline-current/[0.5] outline-current/[50%] outline-dashed outline-dotted outline-double outline-hidden outline-inherit outline-none outline-red-500 outline-red-500/50 outline-red-500/[0.5] outline-red-500/[50%] outline-solid outline-transparent
 ---
 
@@ -19350,6 +19665,7 @@ outline outline-0 outline-[#0088cc] outline-[#0088cc]/50 outline-[#0088cc]/[0.5]
 <<<>>>
 # outline
 @config theme
+@theme-var default-outline-width 2px
 outline
 ---
 
@@ -19481,6 +19797,7 @@ opacity-15 opacity-2.5 opacity-3.25 opacity-4.75 opacity-[var(--value)]
 <<<>>>
 # underline-offset
 @config theme
+@theme-var text-underline-offset-auto 4px
 underline-offset-auto
 ---
 
@@ -19495,6 +19812,12 @@ underline-offset-auto
 <<<>>>
 # text
 @config theme
+@theme-var spacing 0.25rem
+@theme-var color-red-500 #ef4444
+@theme-var text-color-blue-500 #3b82f6
+@theme-var text-sm 0.875rem
+@theme-var text-sm--line-height 1.25rem
+@theme-var leading-snug 1.375
 text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-[10px]/none text-[12px] text-[12px]/0 text-[12px]/6 text-[50%] text-[50%]/6 text-[absolute-size:var(--my-size)] text-[clamp(1rem,2rem,3rem)] text-[clamp(1rem,var(--size),3rem)] text-[clamp(1rem,var(--size),3rem)]/9 text-[color:var(--my-color)] text-[color:var(--my-color)]/50 text-[color:var(--my-color)]/[0.5] text-[color:var(--my-color)]/[50%] text-[larger] text-[larger]/6 text-[length:var(--my-size)] text-[percentage:var(--my-size)] text-[relative-size:var(--my-size)] text-[var(--my-color)] text-[var(--my-color)]/50 text-[var(--my-color)]/[0.5] text-[var(--my-color)]/[50%] text-[xx-large] text-[xx-large]/6 text-blue-500 text-current text-current/50 text-current/[0.5] text-current/[50%] text-inherit text-red-500 text-red-500/2.25 text-red-500/2.5 text-red-500/2.75 text-red-500/50 text-red-500/[0.5] text-red-500/[50%] text-sm text-sm/0 text-sm/6 text-sm/[4px] text-sm/none text-sm/snug text-transparent
 ---
 
@@ -19781,12 +20104,16 @@ text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-
 <<<>>>
 # text
 @config theme-inline-reference
+@theme-var text-sm 0.875rem
 -text-[#0088cc] -text-[#0088cc]/50 -text-[#0088cc]/[0.5] -text-[#0088cc]/[50%] -text-current -text-current/50 -text-current/[0.5] -text-current/[50%] -text-inherit -text-red-500 -text-red-500/50 -text-red-500/[0.5] -text-red-500/[50%] -text-sm -text-sm/6 -text-sm/[4px] -text-transparent text text-[10px]/foo text-sm/foo
 ---
 
 <<<>>>
 # text-shadow
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var text-shadow-2xs 0px 1px 0px rgb(0 0 0 / 0.1)
+@theme-var text-shadow-sm 0px 1px 2px rgb(0 0 0 / 0.06), 0px 2px 2px rgb(0 0 0 / 0.06)
 text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#0088cc]/[0.5] text-shadow-[#0088cc]/[50%] text-shadow-[10px_10px] text-shadow-[10px_10px]/25 text-shadow-[12px_12px_#0088cc] text-shadow-[12px_12px_#0088cc]/25 text-shadow-[12px_12px_var(--value)] text-shadow-[12px_12px_var(--value)]/25 text-shadow-[color:var(--value)] text-shadow-[color:var(--value)]/50 text-shadow-[color:var(--value)]/[0.5] text-shadow-[color:var(--value)]/[50%] text-shadow-[shadow:var(--value)] text-shadow-[var(--value)] text-shadow-current text-shadow-current/50 text-shadow-current/[0.5] text-shadow-current/[50%] text-shadow-inherit text-shadow-none text-shadow-red-500 text-shadow-red-500/2.25 text-shadow-red-500/2.5 text-shadow-red-500/2.75 text-shadow-red-500/50 text-shadow-red-500/[0.5] text-shadow-red-500/[50%] text-shadow-sm text-shadow-sm/25 text-shadow-transparent
 ---
 
@@ -20087,6 +20414,10 @@ text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#008
 <<<>>>
 # shadow
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var box-shadow-color-blue-500 #3b82f6
+@theme-var shadow-sm 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)
+@theme-var shadow-xl 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)
 shadow-[#0088cc] shadow-[#0088cc]/50 shadow-[#0088cc]/[0.5] shadow-[#0088cc]/[50%] shadow-[10px_10px] shadow-[10px_10px]/25 shadow-[12px_12px_#0088cc] shadow-[12px_12px_#0088cc]/25 shadow-[12px_12px_var(--value)] shadow-[12px_12px_var(--value)]/25 shadow-[color:var(--value)] shadow-[color:var(--value)]/50 shadow-[color:var(--value)]/[0.5] shadow-[color:var(--value)]/[50%] shadow-[shadow:var(--value)] shadow-[var(--value)] shadow-blue-500 shadow-current shadow-current/50 shadow-current/[0.5] shadow-current/[50%] shadow-inherit shadow-none shadow-red-500 shadow-red-500/2.25 shadow-red-500/2.5 shadow-red-500/2.75 shadow-red-500/50 shadow-red-500/[0.5] shadow-red-500/[50%] shadow-sm shadow-sm/25 shadow-transparent shadow-xl
 ---
 
@@ -20495,6 +20826,9 @@ shadow-[#0088cc] shadow-[#0088cc]/50 shadow-[#0088cc]/[0.5] shadow-[#0088cc]/[50
 <<<>>>
 # inset-shadow
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var inset-shadow inset 0 2px 4px rgb(0 0 0 / 0.05)
+@theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
 inset-shadow inset-shadow-[#0088cc] inset-shadow-[#0088cc]/50 inset-shadow-[#0088cc]/[0.5] inset-shadow-[#0088cc]/[50%] inset-shadow-[10px_10px] inset-shadow-[10px_10px]/25 inset-shadow-[12px_12px_#0088cc,12px_12px_var(--value,#0088cc)] inset-shadow-[12px_12px_#0088cc,12px_12px_var(--value,#0088cc)]/25 inset-shadow-[12px_12px_#0088cc] inset-shadow-[12px_12px_#0088cc]/25 inset-shadow-[12px_12px_var(--value)] inset-shadow-[12px_12px_var(--value)]/25 inset-shadow-[color:var(--value)] inset-shadow-[color:var(--value)]/50 inset-shadow-[color:var(--value)]/[0.5] inset-shadow-[color:var(--value)]/[50%] inset-shadow-[shadow:var(--value)] inset-shadow-[var(--value)] inset-shadow-current inset-shadow-current/50 inset-shadow-current/[0.5] inset-shadow-current/[50%] inset-shadow-inherit inset-shadow-none inset-shadow-red-500 inset-shadow-red-500/2.25 inset-shadow-red-500/2.5 inset-shadow-red-500/2.75 inset-shadow-red-500/50 inset-shadow-red-500/[0.5] inset-shadow-red-500/[50%] inset-shadow-sm inset-shadow-sm/25 inset-shadow-transparent
 ---
 
@@ -20912,6 +21246,8 @@ inset-shadow inset-shadow-[#0088cc] inset-shadow-[#0088cc]/50 inset-shadow-[#008
 <<<>>>
 # ring
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var ring-color-blue-500 #3b82f6
 ring ring-0 ring-1 ring-2 ring-4 ring-[#0088cc] ring-[#0088cc]/50 ring-[#0088cc]/[0.5] ring-[#0088cc]/[50%] ring-[12px] ring-[color:var(--my-color)] ring-[color:var(--my-color)]/50 ring-[color:var(--my-color)]/[0.5] ring-[color:var(--my-color)]/[50%] ring-[length:var(--my-width)] ring-[var(--my-color)] ring-[var(--my-color)]/50 ring-[var(--my-color)]/[0.5] ring-[var(--my-color)]/[50%] ring-blue-500 ring-current ring-current/50 ring-current/[0.5] ring-current/[50%] ring-inherit ring-inset ring-red-500 ring-red-500/2.25 ring-red-500/2.5 ring-red-500/2.75 ring-red-500/50 ring-red-500/[0.5] ring-red-500/[50%] ring-transparent
 ---
 
@@ -21236,6 +21572,7 @@ ring ring-0 ring-1 ring-2 ring-4 ring-[#0088cc] ring-[#0088cc]/50 ring-[#0088cc]
 <<<>>>
 # ring
 @config theme
+@theme-var default-ring-width 2px
 ring
 ---
 
@@ -21353,6 +21690,7 @@ ring
 <<<>>>
 # inset-ring
 @config theme
+@theme-var color-red-500 #ef4444
 inset-ring inset-ring-0 inset-ring-1 inset-ring-2 inset-ring-4 inset-ring-[#0088cc] inset-ring-[#0088cc]/50 inset-ring-[#0088cc]/[0.5] inset-ring-[#0088cc]/[50%] inset-ring-[12px] inset-ring-[color:var(--my-color)] inset-ring-[color:var(--my-color)]/50 inset-ring-[color:var(--my-color)]/[0.5] inset-ring-[color:var(--my-color)]/[50%] inset-ring-[length:var(--my-width)] inset-ring-[var(--my-color)] inset-ring-[var(--my-color)]/50 inset-ring-[var(--my-color)]/[0.5] inset-ring-[var(--my-color)]/[50%] inset-ring-current inset-ring-current/50 inset-ring-current/[0.5] inset-ring-current/[50%] inset-ring-inherit inset-ring-red-500 inset-ring-red-500/2.25 inset-ring-red-500/2.5 inset-ring-red-500/2.75 inset-ring-red-500/50 inset-ring-red-500/[0.5] inset-ring-red-500/[50%] inset-ring-transparent
 ---
 
@@ -21674,6 +22012,8 @@ inset-ring inset-ring-0 inset-ring-1 inset-ring-2 inset-ring-4 inset-ring-[#0088
 <<<>>>
 # ring-offset
 @config theme
+@theme-var color-red-500 #ef4444
+@theme-var ring-offset-color-blue-500 #3b82f6
 ring-offset-0 ring-offset-1 ring-offset-2 ring-offset-4 ring-offset-[#0088cc] ring-offset-[#0088cc]/50 ring-offset-[#0088cc]/[0.5] ring-offset-[#0088cc]/[50%] ring-offset-[12px] ring-offset-[color:var(--my-color)] ring-offset-[color:var(--my-color)]/50 ring-offset-[color:var(--my-color)]/[0.5] ring-offset-[color:var(--my-color)]/[50%] ring-offset-[length:var(--my-width)] ring-offset-[var(--my-color)] ring-offset-[var(--my-color)]/50 ring-offset-[var(--my-color)]/[0.5] ring-offset-[var(--my-color)]/[50%] ring-offset-blue-500 ring-offset-current ring-offset-current/50 ring-offset-current/[0.5] ring-offset-current/[50%] ring-offset-inherit ring-offset-inset ring-offset-red-500 ring-offset-red-500/50 ring-offset-red-500/[0.5] ring-offset-red-500/[50%] ring-offset-transparent
 ---
 

--- a/test/upstream/variants.txt
+++ b/test/upstream/variants.txt
@@ -1064,6 +1064,11 @@ print/foo:flex
 <<<>>>
 # default breakpoints
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-md 768px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-xl 1280px
+@theme-var breakpoint-2xl 1536px
 2xl:flex lg:flex md:flex sm:flex xl:flex
 ---
 
@@ -1100,12 +1105,18 @@ print/foo:flex
 <<<>>>
 # default breakpoints
 @config theme-reference
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-md 768px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-xl 1280px
+@theme-var breakpoint-2xl 1536px
 2xl/foo:flex lg/foo:flex md/foo:flex sm/foo:flex xl/foo:flex
 ---
 
 <<<>>>
 # custom breakpoint
 @config theme
+@theme-var breakpoint-10xl 5000px
 10xl:flex
 ---
 
@@ -1118,6 +1129,9 @@ print/foo:flex
 <<<>>>
 # max-*
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
 max-lg:flex max-md:flex max-sm:flex
 ---
 
@@ -1142,12 +1156,18 @@ max-lg:flex max-md:flex max-sm:flex
 <<<>>>
 # max-*
 @config theme-reference
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
 max-lg/foo:flex max-md/foo:flex max-sm/foo:flex
 ---
 
 <<<>>>
 # min-*
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
 min-lg:flex min-md:flex min-sm:flex
 ---
 
@@ -1172,12 +1192,20 @@ min-lg:flex min-md:flex min-sm:flex
 <<<>>>
 # min-*
 @config theme-reference
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
 min-lg/foo:flex min-md/foo:flex min-sm/foo:flex
 ---
 
 <<<>>>
 # sorting stacked min-* and max-* variants
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
+@theme-var breakpoint-xl 1280px
+@theme-var breakpoint-xs 280px
 min-md:max-lg:flex min-sm:max-lg:flex min-sm:max-xl:flex min-xs:max-sm:flex
 ---
 
@@ -1214,6 +1242,9 @@ min-md:max-lg:flex min-sm:max-lg:flex min-sm:max-xl:flex min-xs:max-sm:flex
 <<<>>>
 # stacked min-* and max-* variants should come after unprefixed variants
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
 md:flex min-md:max-lg:flex min-sm:max-lg:flex sm:flex
 ---
 
@@ -1244,6 +1275,9 @@ md:flex min-md:max-lg:flex min-sm:max-lg:flex sm:flex
 <<<>>>
 # min, max and unprefixed breakpoints
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-md 768px
 lg-sm-potato:flex lg:flex max-[1000px]:flex max-lg-sm-potato:flex max-lg:flex max-md:flex max-sm:flex md:flex min-[700px]:flex min-lg-sm-potato:flex min-lg:flex min-md:flex min-sm:flex sm:flex
 ---
 
@@ -1484,6 +1518,7 @@ supports-[(display:grid)_and_font-format(opentype)]/foo:grid supports-[display:g
 <<<>>>
 # not
 @config theme
+@theme-var breakpoint-sm 640px
 group-not-[:checked]/parent-name:flex group-not-[:checked]:flex group-not-checked:flex group-not-device-hocus:flex group-not-hocus/parent-name:flex group-not-hocus:flex group-not-hover:flex not-[:checked]:flex not-[@media(orientation:portrait)]:flex not-[@media_(orientation:landscape)]:flex not-[@media_not_(orientation:portrait)]:flex not-[@media_print]:flex not-active:flex not-aria-selected:flex not-autofill:flex not-checked:flex not-contrast-less:flex not-contrast-more:flex not-dark:flex not-data-foo:flex not-default:flex not-device-hocus:flex not-disabled:flex not-empty:flex not-enabled:flex not-even:flex not-first-of-type:flex not-first:flex not-focus-visible:flex not-focus-within:flex not-focus:flex not-forced-colors:flex not-has-checked:flex not-hocus:flex not-hover:flex not-in-range:flex not-indeterminate:flex not-inert:flex not-invalid:flex not-landscape:flex not-last-of-type:flex not-last:flex not-ltr:flex not-max-[130px]:flex not-max-sm:flex not-min-[130px]:flex not-min-sm:flex not-motion-reduce:flex not-motion-safe:flex not-noscript:flex not-nth-2:flex not-odd:flex not-only-of-type:flex not-only:flex not-open:flex not-optional:flex not-out-of-range:flex not-placeholder-shown:flex not-portrait:flex not-print:flex not-read-only:flex not-required:flex not-rtl:flex not-sm:flex not-supports-grid:flex not-target:flex not-valid:flex not-visited:flex peer-not-[:checked]/sibling-name:flex peer-not-[:checked]:flex peer-not-checked:flex peer-not-hocus/sibling-name:flex peer-not-hocus:flex
 ---
 
@@ -1960,6 +1995,11 @@ nth--3:flex nth-3/foo:flex nth-[2n+1]/foo:flex nth-[2n+1_of_.foo]/foo:flex nth-l
 <<<>>>
 # variant order
 @config theme
+@theme-var breakpoint-sm 640px
+@theme-var breakpoint-md 768px
+@theme-var breakpoint-lg 1024px
+@theme-var breakpoint-xl 1280px
+@theme-var breakpoint-2xl 1536px
 2xl:flex [&_p]:flex active:flex after:flex aria-[custom=true]:flex aria-busy:flex aria-checked:flex aria-disabled:flex aria-expanded:flex aria-hidden:flex aria-pressed:flex aria-readonly:flex aria-required:flex aria-selected:flex autofill:flex backdrop:flex before:flex checked:flex contrast-less:flex contrast-more:flex dark:flex data-[custom=true]:flex data-custom:flex default:flex details-content:flex disabled:flex empty:flex enabled:flex even:flex file:flex first-letter:flex first-line:flex first-of-type:flex first:flex focus-visible:flex focus-within:flex focus:flex forced-colors:flex group-hover:flex has-[:hover]:flex hover:flex in-range:flex indeterminate:flex invalid:flex landscape:flex last-of-type:flex last:flex lg:flex ltr:flex marker:flex md:flex motion-reduce:flex motion-safe:flex odd:flex only-of-type:flex only:flex open:flex optional:flex out-of-range:flex peer-hover:flex placeholder-shown:flex placeholder:flex portrait:flex print:flex read-only:flex required:flex rtl:flex selection:flex sm:flex supports-[display:flex]:flex target:flex valid:flex visited:flex xl:flex
 ---
 


### PR DESCRIPTION
Replaces the global theme state — the per-module `set_scheme` refs and the `Var.theme_value_overrides` hashtbl — with a `Scheme.t` threaded through `to_style`, `of_class`, and `Rule.outputs`.

Also fixes `text-shadow`: its sizes were hardcoded, so they could neither match the v4.3.1 scale nor pick up a custom `@theme`.