### PR TITLE
effects: fix inset-shadow default scale to v4.3.1

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -26,13 +26,7 @@ module Handler = struct
     | Xl
     | Two_xl
 
-  type inset_shadow_shape =
-    | Ish_sm
-    | Ish_default
-    | Ish_md
-    | Ish_lg
-    | Ish_xl
-    | Ish_2xl
+  type inset_shadow_shape = Ish_2xs | Ish_xs | Ish_sm
 
   (* Color in an arbitrary shadow value *)
   type arbitrary =
@@ -70,14 +64,14 @@ module Handler = struct
     | Shadow_bracket_color_var_opacity of string * Color.opacity_modifier
     | Shadow_bracket_shadow of string (* shadow-[shadow:...] type hint *)
     | Shadow_bracket_var of string
-    (* Inset shadows *)
+    (* Inset shadows. The named scale is inset-shadow-{2xs,xs,sm}; bare
+       `inset-shadow` is only valid when a threaded @theme defines the
+       --inset-shadow token (v4.3.1 has no default for it). *)
     | Inset_shadow_none
+    | Inset_shadow_2xs
+    | Inset_shadow_xs
     | Inset_shadow_sm
     | Inset_shadow
-    | Inset_shadow_md
-    | Inset_shadow_lg
-    | Inset_shadow_xl
-    | Inset_shadow_2xl
     | Inset_shadow_arbitrary of string (* For inset-shadow-[12px_12px_#color] *)
     | Inset_shadow_arbitrary_opacity of string * Color.opacity_modifier
     | Inset_shadow_shape_opacity of inset_shadow_shape * Color.opacity_modifier
@@ -822,53 +816,18 @@ module Handler = struct
 
   (* Inset shadow utilities - sets --tw-inset-shadow and composites
      box-shadow *)
-  type inset_shadow_size = [ `None | `Sm | `Default | `Md | `Lg | `Xl | `Xxl ]
 
-  let inset_shadow_internal (size : inset_shadow_size) =
-    (* Inset shadow sizes matching Tailwind v4: inset-shadow-none: 0 0 #0000
-       inset-shadow-sm: inset 0 1px 1px color inset-shadow: inset 0 2px 4px
-       color inset-shadow-md: inset 0 4px 6px color inset-shadow-lg: inset 0 4px
-       8px color inset-shadow-xl: inset 0 6px 10px color inset-shadow-2xl: inset
-       0 8px 25px color *)
-    let color_ref =
-      Var.reference_with_fallback inset_shadow_color_var (Css.hex "#0000000d")
-    in
-    let inset_value =
-      match size with
-      | `None ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:Zero
-            ~color:(Css.hex "#0000") ()
-      | `Sm ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:(Px 1.) ~blur:(Px 1.)
-            ~color:(Var color_ref) ()
-      | `Default ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:(Px 2.) ~blur:(Px 4.)
-            ~color:(Var color_ref) ()
-      | `Md ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:(Px 4.) ~blur:(Px 6.)
-            ~color:(Var color_ref) ()
-      | `Lg ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:(Px 4.) ~blur:(Px 8.)
-            ~color:(Var color_ref) ()
-      | `Xl ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:(Px 6.) ~blur:(Px 10.)
-            ~color:(Var color_ref) ()
-      | `Xxl ->
-          Css.shadow ~inset:true ~h_offset:Zero ~v_offset:(Px 8.) ~blur:(Px 25.)
-            ~color:(Var color_ref) ()
-    in
-
-    (* Set --tw-inset-shadow variable *)
+  (* Compose a built --tw-inset-shadow value into the full box-shadow stack.
+     Shared by the named scale, the bare themed utility and
+     inset-shadow-none. *)
+  let inset_shadow_compose inset_value =
     let d_inset_shadow, v_inset_shadow =
       Var.binding inset_shadow_var inset_value
     in
-
-    (* Reference other shadow variables through @property defaults *)
     let v_inset_ring = Var.reference inset_ring_shadow_var in
     let v_ring_offset = Var.reference ring_offset_shadow_var in
     let v_ring = Var.reference ring_shadow_var in
     let v_shadow = Var.reference shadow_var in
-
     let box_shadow_vars : Css.shadow list =
       [
         Css.Var v_inset_shadow;
@@ -878,39 +837,124 @@ module Handler = struct
         Css.Var v_shadow;
       ]
     in
-
-    (* Collect property rules *)
-    let property_rules =
-      [
-        Var.property_rule shadow_var;
-        Var.property_rule shadow_color_var;
-        Var.property_rule shadow_alpha_var;
-        Var.property_rule inset_shadow_var;
-        Var.property_rule inset_shadow_color_var;
-        Var.property_rule inset_shadow_alpha_var;
-        Var.property_rule ring_color_var;
-        Var.property_rule ring_shadow_var;
-        Var.property_rule inset_ring_color_var;
-        Var.property_rule inset_ring_shadow_var;
-        Var.property_rule ring_inset_var;
-        Var.property_rule ring_offset_width_var;
-        Var.property_rule ring_offset_color_var;
-        Var.property_rule ring_offset_shadow_var;
-      ]
-      |> List.filter_map (fun x -> x)
-    in
-
-    style
-      ~property_rules:(Css.concat property_rules)
+    style ~property_rules:shadow_property_rules
       [ d_inset_shadow; Css.box_shadows box_shadow_vars ]
 
-  let inset_shadow_none = inset_shadow_internal `None
-  let inset_shadow_sm = inset_shadow_internal `Sm
-  let inset_shadow = inset_shadow_internal `Default
-  let inset_shadow_md = inset_shadow_internal `Md
-  let inset_shadow_lg = inset_shadow_internal `Lg
-  let inset_shadow_xl = inset_shadow_internal `Xl
-  let inset_shadow_2xl = inset_shadow_internal `Xxl
+  (* v4.3.1 default inset-shadow scale (verified against the bare CLI). The
+     named utilities are inset-shadow-{2xs,xs,sm}; each is a single inset
+     shadow. The alpha is .05 (#0000000d). 2xs has no blur. *)
+  let inset_shadow_shape_data (shape : inset_shadow_shape) :
+      Css.length * Css.length * Css.length option * string =
+    match shape with
+    | Ish_2xs -> (Zero, Px 1., None, "#0000000d")
+    | Ish_xs -> (Zero, Px 1., Some (Px 1.), "#0000000d")
+    | Ish_sm -> (Zero, Px 2., Some (Px 4.), "#0000000d")
+
+  (* Theme token name for a shape's scale value (matches the @theme keys, e.g.
+     --inset-shadow-sm). *)
+  let inset_shadow_shape_token = function
+    | Ish_2xs -> "inset-shadow-2xs"
+    | Ish_xs -> "inset-shadow-xs"
+    | Ish_sm -> "inset-shadow-sm"
+
+  (* Parse a theme override for an inset-shadow token (e.g. "inset 0 2px 4px
+     rgb(0 0 0 / 0.05)") into the (h, v, blur, hex) tuple
+     [inset_shadow_shape_data] returns. Drops a leading "inset" keyword, takes
+     the leading length tokens, then converts the trailing colour to a hex
+     string. *)
+  let parse_inset_shadow_override (s : string) :
+      (Css.length * Css.length * Css.length option * string) option =
+    let hex_string_of_color (str : string) : string =
+      match Css.parse_color str with
+      | Some c -> (
+          match Color.css_color_to_hex c with
+          | Some (Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ })
+            ->
+              let bh = hex_byte in
+              "#" ^ bh r ^ bh g ^ bh b ^ if a = 255 then "" else bh a
+          | _ -> str)
+      | None -> str
+    in
+    let parse_len str : Css.length option =
+      match str with
+      | "0" -> Some (Zero : Css.length)
+      | _ ->
+          let n = String.length str in
+          let cut suf = String.sub str 0 (n - String.length suf) in
+          if Filename.check_suffix str "px" then
+            Option.map
+              (fun f -> (Px f : Css.length))
+              (float_of_string_opt (cut "px"))
+          else if Filename.check_suffix str "rem" then
+            Option.map
+              (fun f -> (Rem f : Css.length))
+              (float_of_string_opt (cut "rem"))
+          else None
+    in
+    let toks =
+      String.split_on_char ' ' s
+      |> List.filter (( <> ) "")
+      |> List.filter (( <> ) "inset")
+    in
+    let rec take_lengths acc = function
+      | t :: rest -> (
+          match parse_len t with
+          | Some l -> take_lengths (l :: acc) rest
+          | None -> (List.rev acc, t :: rest))
+      | [] -> (List.rev acc, [])
+    in
+    let lengths, color_toks = take_lengths [] toks in
+    let hex = hex_string_of_color (String.concat " " color_toks) in
+    match lengths with
+    | [ h; v ] -> Some (h, v, None, hex)
+    | [ h; v; blur ] -> Some (h, v, Some blur, hex)
+    | _ -> None
+
+  (* (h, v, blur, hex) for a named shape: a threaded @theme override if present,
+     else the v4.3.1 default scale. *)
+  let inset_shadow_data_for ?theme shape =
+    match Scheme.theme_value theme (inset_shadow_shape_token shape) with
+    | Some override -> (
+        match parse_inset_shadow_override override with
+        | Some data -> data
+        | None -> inset_shadow_shape_data shape)
+    | None -> inset_shadow_shape_data shape
+
+  let inset_shadow_shape_style ?theme shape =
+    let h_offset, v_offset, blur, fallback_hex =
+      inset_shadow_data_for ?theme shape
+    in
+    let color_ref =
+      Var.reference_with_fallback inset_shadow_color_var (Css.hex fallback_hex)
+    in
+    let inset_value =
+      Css.shadow ~inset:true ~h_offset ~v_offset ?blur ~color:(Var color_ref) ()
+    in
+    inset_shadow_compose inset_value
+
+  let inset_shadow_none =
+    inset_shadow_compose
+      (Css.shadow ~inset:true ~h_offset:Zero ~v_offset:Zero
+         ~color:(Css.hex "#0000") ())
+
+  (* Bare `inset-shadow` reads the threaded --inset-shadow token (it has no
+     v4.3.1 default; of_class only reaches here when the token is defined). *)
+  let inset_shadow_themed ?theme () =
+    let h_offset, v_offset, blur, fallback_hex =
+      match Scheme.theme_value theme "inset-shadow" with
+      | Some override -> (
+          match parse_inset_shadow_override override with
+          | Some data -> data
+          | None -> (Zero, Px 2., Some (Px 4.), "#0000000d"))
+      | None -> (Zero, Px 2., Some (Px 4.), "#0000000d")
+    in
+    let color_ref =
+      Var.reference_with_fallback inset_shadow_color_var (Css.hex fallback_hex)
+    in
+    let inset_value =
+      Css.shadow ~inset:true ~h_offset ~v_offset ?blur ~color:(Var color_ref) ()
+    in
+    inset_shadow_compose inset_value
 
   (* ============ Inset shadow helpers ============ *)
 
@@ -991,21 +1035,11 @@ module Handler = struct
           [ d_inset_shadow; inset_box_shadow_composition v_inset_shadow ]
     | Stdlib.Option.None -> inset_shadow_none
 
-  let inset_shadow_shape_data (shape : inset_shadow_shape) :
-      Css.length * Css.length * Css.length option * string =
-    match shape with
-    | Ish_sm -> (Zero, Px 1., Some (Px 1.), "#0000000d")
-    | Ish_default -> (Zero, Px 2., Some (Px 4.), "#0000000d")
-    | Ish_md -> (Zero, Px 4., Some (Px 6.), "#0000000d")
-    | Ish_lg -> (Zero, Px 4., Some (Px 8.), "#0000000d")
-    | Ish_xl -> (Zero, Px 6., Some (Px 10.), "#0000000d")
-    | Ish_2xl -> (Zero, Px 8., Some (Px 25.), "#0000000d")
-
-  let inset_shadow_shape_opacity_style shape opacity =
+  let inset_shadow_shape_opacity_style ?theme shape opacity =
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
     let h_offset, v_offset, blur, fallback_hex =
-      inset_shadow_shape_data shape
+      inset_shadow_data_for ?theme shape
     in
     let base_hex =
       if String.length fallback_hex = 9 then String.sub fallback_hex 0 7
@@ -2037,17 +2071,15 @@ module Handler = struct
     | Shadow_bracket_shadow s -> shadow_raw_var s
     | Shadow_bracket_var v -> shadow_raw_var v
     | Inset_shadow_none -> inset_shadow_none
-    | Inset_shadow_sm -> inset_shadow_sm
-    | Inset_shadow -> inset_shadow
-    | Inset_shadow_md -> inset_shadow_md
-    | Inset_shadow_lg -> inset_shadow_lg
-    | Inset_shadow_xl -> inset_shadow_xl
-    | Inset_shadow_2xl -> inset_shadow_2xl
+    | Inset_shadow_2xs -> inset_shadow_shape_style ~theme Ish_2xs
+    | Inset_shadow_xs -> inset_shadow_shape_style ~theme Ish_xs
+    | Inset_shadow_sm -> inset_shadow_shape_style ~theme Ish_sm
+    | Inset_shadow -> inset_shadow_themed ~theme ()
     | Inset_shadow_arbitrary arb -> inset_shadow_arbitrary arb
     | Inset_shadow_arbitrary_opacity (arb, op) ->
         inset_shadow_arbitrary_opacity arb op
     | Inset_shadow_shape_opacity (shape, op) ->
-        inset_shadow_shape_opacity_style shape op
+        inset_shadow_shape_opacity_style ~theme shape op
     | Inset_shadow_color (c, s) -> set_inset_shadow_color c s
     | Inset_shadow_color_opacity (c, s, op) ->
         set_inset_shadow_color_opacity c s op
@@ -2470,17 +2502,16 @@ module Handler = struct
             | _ -> Ok (Shadow_color_opacity (c, s, opacity)))
         | _ -> err_not_utility)
     | [ "inset"; "shadow"; "none" ] -> Ok Inset_shadow_none
+    | [ "inset"; "shadow"; "2xs" ] -> Ok Inset_shadow_2xs
+    | [ "inset"; "shadow"; "xs" ] -> Ok Inset_shadow_xs
     | [ "inset"; "shadow"; "sm" ] -> Ok Inset_shadow_sm
-    | [ "inset"; "shadow" ] -> Ok Inset_shadow
-    | [ base ] when String.starts_with ~prefix:"inset-shadow/" base -> (
-        let _, opacity = Color.parse_opacity_modifier ~theme base in
-        match opacity with
-        | Color.No_opacity -> err_not_utility
-        | op -> Ok (Inset_shadow_shape_opacity (Ish_default, op)))
-    | [ "inset"; "shadow"; "md" ] -> Ok Inset_shadow_md
-    | [ "inset"; "shadow"; "lg" ] -> Ok Inset_shadow_lg
-    | [ "inset"; "shadow"; "xl" ] -> Ok Inset_shadow_xl
-    | [ "inset"; "shadow"; "2xl" ] -> Ok Inset_shadow_2xl
+    (* Bare `inset-shadow` has no v4.3.1 default token; accept it only when a
+       threaded @theme defines --inset-shadow. inset-shadow-{md,lg,xl,2xl} do
+       not exist in v4.3.1 and fall through to err_not_utility. *)
+    | [ "inset"; "shadow" ]
+      when Scheme.theme_value (Some theme) "inset-shadow" <> None ->
+        Ok Inset_shadow
+    | [ "inset"; "shadow" ] -> err_not_utility
     | [ "inset"; "shadow"; "inherit" ] -> Ok Inset_shadow_inherit
     | [ "inset"; "shadow"; "transparent" ] -> Ok Inset_shadow_transparent
     | [ "inset"; "shadow"; current_str ]
@@ -2499,11 +2530,9 @@ module Handler = struct
         let base, opacity = Color.parse_opacity_modifier ~theme name in
         match (base, opacity) with
         | _, Color.No_opacity -> err_not_utility
+        | "2xs", op -> Ok (Inset_shadow_shape_opacity (Ish_2xs, op))
+        | "xs", op -> Ok (Inset_shadow_shape_opacity (Ish_xs, op))
         | "sm", op -> Ok (Inset_shadow_shape_opacity (Ish_sm, op))
-        | "md", op -> Ok (Inset_shadow_shape_opacity (Ish_md, op))
-        | "lg", op -> Ok (Inset_shadow_shape_opacity (Ish_lg, op))
-        | "xl", op -> Ok (Inset_shadow_shape_opacity (Ish_xl, op))
-        | "2xl", op -> Ok (Inset_shadow_shape_opacity (Ish_2xl, op))
         | _ -> err_not_utility)
     | [ "inset"; "shadow"; color; shade ] -> (
         let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
@@ -2692,23 +2721,18 @@ module Handler = struct
     | Shadow_bracket_shadow s -> "shadow-[shadow:" ^ s ^ "]"
     | Shadow_bracket_var v -> "shadow-[" ^ v ^ "]"
     | Inset_shadow_none -> "inset-shadow-none"
+    | Inset_shadow_2xs -> "inset-shadow-2xs"
+    | Inset_shadow_xs -> "inset-shadow-xs"
     | Inset_shadow_sm -> "inset-shadow-sm"
     | Inset_shadow -> "inset-shadow"
-    | Inset_shadow_md -> "inset-shadow-md"
-    | Inset_shadow_lg -> "inset-shadow-lg"
-    | Inset_shadow_xl -> "inset-shadow-xl"
-    | Inset_shadow_2xl -> "inset-shadow-2xl"
     | Inset_shadow_arbitrary arb -> "inset-shadow-[" ^ arb ^ "]"
     | Inset_shadow_arbitrary_opacity (arb, op) ->
         "inset-shadow-[" ^ arb ^ "]/" ^ Color.pp_opacity op
     | Inset_shadow_shape_opacity (shape, op) ->
         (match shape with
-          | Ish_sm -> "inset-shadow-sm"
-          | Ish_default -> "inset-shadow"
-          | Ish_md -> "inset-shadow-md"
-          | Ish_lg -> "inset-shadow-lg"
-          | Ish_xl -> "inset-shadow-xl"
-          | Ish_2xl -> "inset-shadow-2xl")
+          | Ish_2xs -> "inset-shadow-2xs"
+          | Ish_xs -> "inset-shadow-xs"
+          | Ish_sm -> "inset-shadow-sm")
         ^ "/" ^ Color.pp_opacity op
     | Inset_shadow_color (c, s) ->
         "inset-shadow-" ^ Color.pp c ^ "-" ^ string_of_int s
@@ -2890,9 +2914,8 @@ module Handler = struct
     | Inset_shadow_shape_opacity _ -> 30991
     (* Inset shadow shape utilities — all same suborder, natural_compare
        decides *)
-    | Inset_shadow | Inset_shadow_2xl | Inset_shadow_lg | Inset_shadow_md
-    | Inset_shadow_none | Inset_shadow_sm | Inset_shadow_xl
-    | Inset_shadow_arbitrary _ | Inset_shadow_bracket_shadow _
+    | Inset_shadow | Inset_shadow_2xs | Inset_shadow_xs | Inset_shadow_none
+    | Inset_shadow_sm | Inset_shadow_arbitrary _ | Inset_shadow_bracket_shadow _
     | Inset_shadow_bracket_var _ ->
         31000
     (* Inset shadow color utilities *)
@@ -2992,12 +3015,10 @@ let shadow_xl = utility Shadow_xl
 let shadow_2xl = utility Shadow_2xl
 let shadow_inner = utility Shadow_inner
 let inset_shadow_none = utility Inset_shadow_none
+let inset_shadow_2xs = utility Inset_shadow_2xs
+let inset_shadow_xs = utility Inset_shadow_xs
 let inset_shadow_sm = utility Inset_shadow_sm
 let inset_shadow = utility Inset_shadow
-let inset_shadow_md = utility Inset_shadow_md
-let inset_shadow_lg = utility Inset_shadow_lg
-let inset_shadow_xl = utility Inset_shadow_xl
-let inset_shadow_2xl = utility Inset_shadow_2xl
 let ring_inset = utility Ring_inset
 let ring_none = utility Ring_none
 let ring_xs = utility Ring_xs

--- a/lib/effects.mli
+++ b/lib/effects.mli
@@ -50,23 +50,20 @@ val shadow_inner : t
 val inset_shadow_none : t
 (** [inset_shadow_none] removes the inset shadow. *)
 
+val inset_shadow_2xs : t
+(** [inset_shadow_2xs] applies the smallest inset shadow ([inset 0 1px]). *)
+
+val inset_shadow_xs : t
+(** [inset_shadow_xs] applies an extra-small inset shadow ([inset 0 1px 1px]).
+*)
+
 val inset_shadow_sm : t
-(** [inset_shadow_sm] applies a small inset shadow. *)
+(** [inset_shadow_sm] applies a small inset shadow ([inset 0 2px 4px]). *)
 
 val inset_shadow : t
-(** [inset_shadow] applies the default inset shadow. *)
-
-val inset_shadow_md : t
-(** [inset_shadow_md] applies a medium inset shadow. *)
-
-val inset_shadow_lg : t
-(** [inset_shadow_lg] applies a large inset shadow. *)
-
-val inset_shadow_xl : t
-(** [inset_shadow_xl] applies an extra-large inset shadow. *)
-
-val inset_shadow_2xl : t
-(** [inset_shadow_2xl] applies a 2× extra-large inset shadow. *)
+(** [inset_shadow] applies the inset shadow defined by the [--inset-shadow]
+    theme token. It has no default value: it is only a valid class when the
+    active theme defines that token. *)
 
 val opacity : int -> t
 (** [opacity n] sets opacity to n%. *)

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -117,10 +117,72 @@ let test_shadow_small_sizes () =
     "shadow-xs has a 2px blur" true
     (Astring.String.is_infix ~affix:"1px 2px" (css Tw.shadow_xs))
 
+(* The v4.3.1 default inset-shadow scale is inset-shadow-{2xs,xs,sm} plus
+   inset-shadow-none. Bare inset-shadow and md/lg/xl/2xl do not exist. *)
+let test_inset_shadow_roundtrip () =
+  check "inset-shadow-none";
+  check "inset-shadow-2xs";
+  check "inset-shadow-xs";
+  check "inset-shadow-sm"
+
+let test_inset_shadow_invalid () =
+  (* Bare inset-shadow has no v4.3.1 default token, and md/lg/xl/2xl were
+     removed from the scale. *)
+  Test_helpers.check_invalid_input (module Tw.Effects.Handler) "inset-shadow";
+  Test_helpers.check_invalid_input (module Tw.Effects.Handler) "inset-shadow-md";
+  Test_helpers.check_invalid_input
+    (module Tw.Effects.Handler)
+    "inset-shadow-2xl"
+
+(* The default scale (alpha .05 = #0000000d): 2xs is a single inset shadow with
+   no blur ([inset 0 1px]); sm is [inset 0 2px 4px]. *)
+let test_inset_shadow_default_scale () =
+  let css cls =
+    Tw.to_css ~base:false [ Result.get_ok (Tw.of_string cls) ]
+    |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "inset-shadow-2xs uses #0000000d" true
+    (Astring.String.is_infix ~affix:"#0000000d" (css "inset-shadow-2xs"));
+  Alcotest.(check bool)
+    "inset-shadow-2xs has no blur ([inset 0 1px])" true
+    (Astring.String.is_infix ~affix:"inset 0 1px var(" (css "inset-shadow-2xs"));
+  Alcotest.(check bool)
+    "inset-shadow-sm is [inset 0 2px 4px]" true
+    (Astring.String.is_infix ~affix:"inset 0 2px 4px" (css "inset-shadow-sm"))
+
+(* A threaded @theme override for an inset-shadow token flows through to the
+   inlined value. The default inset-shadow-sm is [inset 0 2px 4px]; with the
+   override below it becomes [inset 0 1px 1px], which is impossible without
+   theme threading. *)
+let test_inset_shadow_theme_override () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("inset-shadow-sm", "inset 0 1px 1px rgb(0 0 0 / 0.05)") ]
+  in
+  let css =
+    Tw.to_css ~theme ~base:false
+      [ Result.get_ok (Tw.of_string ~theme "inset-shadow-sm") ]
+    |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "inset-shadow-sm @theme override flows to [inset 0 1px 1px]" true
+    (Astring.String.is_infix ~affix:"inset 0 1px 1px" css);
+  Alcotest.(check bool)
+    "inset-shadow-sm @theme override drops the default [inset 0 2px 4px]" false
+    (Astring.String.is_infix ~affix:"inset 0 2px 4px" css)
+
 let tests =
   [
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;
+    test_case "inset-shadow roundtrip" `Quick test_inset_shadow_roundtrip;
+    test_case "inset-shadow invalid (bare/md/2xl)" `Quick
+      test_inset_shadow_invalid;
+    test_case "inset-shadow default scale (v4.3.1)" `Quick
+      test_inset_shadow_default_scale;
+    test_case "inset-shadow @theme override threads through" `Quick
+      test_inset_shadow_theme_override;
     test_case "effects of_string - valid values" `Quick of_string_valid;
     test_case "effects of_string - invalid values" `Quick of_string_invalid;
     test_case "ring of_string - valid values" `Quick test_ring_of_string_valid;

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -209,6 +209,10 @@ type upstream_case = {
   name : string;
   config : upstream_config;
   variants : string list;
+  theme_vars : (string * string) list;
+      (** [@theme-var name value] token declarations captured from the fixture;
+          they must be threaded into the per-case scheme so custom tokens (e.g.
+          a themed [--inset-shadow]) validate. *)
   classes : string list;
   expected : string;
 }
@@ -292,6 +296,22 @@ let parse_upstream_block source block =
               Some (String.sub s 9 (String.length s - 9))
             else None)
       in
+      let theme_vars =
+        before
+        |> List.filter_map (fun s ->
+            if String.starts_with ~prefix:"@theme-var " s then
+              (* "@theme-var <name> <value>": split on the first space. *)
+              let rest = String.sub s 11 (String.length s - 11) in
+              match String.index_opt rest ' ' with
+              | Some i ->
+                  let n = String.sub rest 0 i in
+                  let v =
+                    String.sub rest (i + 1) (String.length rest - i - 1)
+                  in
+                  Some (n, v)
+              | None -> None
+            else None)
+      in
       let config =
         before
         |> List.find_opt (String.starts_with ~prefix:"@config ")
@@ -305,13 +325,14 @@ let parse_upstream_block source block =
             s <> ""
             && (not (String.starts_with ~prefix:"# " s))
             && (not (String.starts_with ~prefix:"@config " s))
-            && not (String.starts_with ~prefix:"@variant " s))
+            && (not (String.starts_with ~prefix:"@variant " s))
+            && not (String.starts_with ~prefix:"@theme-var " s))
         |> List.rev
         |> List.find_opt (fun _ -> true)
       in
       let classes = Option.value ~default:"" class_line |> split_classes in
       let expected = after |> String.concat "\n" |> String.trim in
-      Some { source; name; config; variants; classes; expected }
+      Some { source; name; config; variants; theme_vars; classes; expected }
 
 let read_upstream_cases filename =
   let path = fixture_path filename in
@@ -406,7 +427,7 @@ let is_scheme_typed_var name =
 
 (* Build the per-test scheme from the @theme tokens in the expected CSS, so
    of_string validates custom tokens against the threaded theme. *)
-let upstream_scheme config expected =
+let upstream_scheme config theme_vars expected =
   let overrides =
     match config with
     | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
@@ -422,6 +443,18 @@ let upstream_scheme config expected =
           base @ extra
         else base
     | No_theme -> []
+  in
+  (* Thread the fixture's explicit [@theme-var] declarations too. Some tokens
+     (e.g. a themed [--inset-shadow]) are inlined by Tailwind and never appear
+     as [:root] vars, so they cannot be recovered from [expected] alone. *)
+  let overrides =
+    let extra =
+      theme_vars
+      |> List.filter (fun (name, _) ->
+          (not (is_scheme_typed_var name))
+          && not (List.mem_assoc name overrides))
+    in
+    overrides @ extra
   in
   Tw.Scheme.with_overrides Tw.Scheme.default overrides
 
@@ -439,7 +472,7 @@ let check_upstream_positive_fixture_parse filename () =
     cases
     |> List.concat_map (fun c ->
         register_upstream_variant_directives c.variants;
-        let theme = upstream_scheme c.config c.expected in
+        let theme = upstream_scheme c.config c.theme_vars c.expected in
         c.classes
         |> List.filter (class_is_emitted c.expected)
         |> List.filter_map (fun cls ->


### PR DESCRIPTION
tw's default inset-shadow scale was bare/sm, which only matched because the upstream test wraps it in a custom `@theme`. v4.3.1's real default is `2xs`/`xs`/`sm` (alpha .05), with bare `inset-shadow` and `md`/`lg`/`xl`/`2xl` rejected. inset-shadow now reads its tokens from the threaded `Scheme.t` (like text-shadow), so the default is correct and a custom `@theme` still flows through.