### PR TITLE
arbitrary: stop crashing on var-valued and custom-property colours

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -70,6 +70,13 @@ let render_css ~(opts : gen_opts) stylesheet =
   in
   Tw.Css.to_string ~minify:opts.minify stylesheet
 
+(* Surface of_string's specific message (e.g. the actionable arbitrary-property
+   feedback) for a single unknown class; fall back to a generic message. *)
+let unknown_class_error class_str =
+  match Tw.of_string class_str with
+  | Error (`Msg m) -> Fmt.str "Error: %s" m
+  | Ok _ -> Fmt.str "Error: Unknown class: %s" class_str
+
 let diff_single_class class_str ~(opts : gen_opts) =
   try
     let legacy_css =
@@ -88,7 +95,7 @@ let diff_single_class class_str ~(opts : gen_opts) =
     | [] when class_str = "" ->
         print_diff_result " (empty/base only)" diff;
         `Ok ()
-    | [] -> `Error (false, Fmt.str "Error: Unknown class: %s" class_str)
+    | [] -> `Error (false, unknown_class_error class_str)
     | _ ->
         print_diff_result
           (Fmt.str " between Tailwind and tw for '%s'" class_str)
@@ -118,8 +125,7 @@ let process_single_class class_str flag ~(opts : gen_opts) =
       let tw_styles = parse_classes ~warn:false class_str in
       let styles = match tw_styles with [] -> [] | s -> s in
       match tw_styles with
-      | [] when class_str <> "" ->
-          `Error (false, Fmt.str "Error: Unknown class: %s" class_str)
+      | [] when class_str <> "" -> `Error (false, unknown_class_error class_str)
       | _ ->
           let stylesheet = Tw.to_css ~base:include_base styles in
           print_string (render_css ~opts stylesheet);

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -63,123 +63,182 @@ module Handler = struct
   let name = "arbitrary"
   let priority = 36
 
+  (* Render a known colour-property declaration ([color], [background-color],
+     ...) with a parsed colour value and an /opacity modifier. *)
+  let color_opacity_render theme prop color opacity =
+    match opacity with
+    | Color.Opacity_named name ->
+        let bare = Parse.extract_var_name name in
+        let var_name = "opacity-" ^ bare in
+        let fallback =
+          Color.opacity_fallback_for_theme_value ~theme var_name bare
+        in
+        (* srgb fallback: resolve the theme value to get the actual
+           percentage *)
+        let srgb_percent =
+          match Scheme.theme_value (Some theme) var_name with
+          | Some v -> (
+              match float_of_string_opt (String.trim v) with
+              | Some f -> f *. 100.0
+              | None -> 100.0)
+          | None -> 100.0
+        in
+        let srgb_fallback =
+          Css.color_mix ~in_space:Srgb ~percent1:srgb_percent color
+            Css.Transparent
+        in
+        let fallback_decl = prop srgb_fallback in
+        let oklab_color =
+          Css.color_mix_var_pct_fallback ~in_space:Oklab ~var_name ~fallback
+            color Css.Transparent
+        in
+        let oklab_decl = prop oklab_color in
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+        in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+    | Color.Opacity_percent p ->
+        let srgb_fallback =
+          Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
+        in
+        let fallback_decl = prop srgb_fallback in
+        let oklab_color =
+          Css.color_mix ~in_space:Oklab ~percent1:p color Css.Transparent
+        in
+        let oklab_decl = prop oklab_color in
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+        in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+    | Color.Opacity_arbitrary f ->
+        let p = f *. 100.0 in
+        let srgb_fallback =
+          Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
+        in
+        let fallback_decl = prop srgb_fallback in
+        let oklab_color =
+          Css.color_mix ~in_space:Oklab ~percent1:p color Css.Transparent
+        in
+        let oklab_decl = prop oklab_color in
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+        in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+    | Color.Opacity_bracket_percent p ->
+        let srgb_fallback =
+          Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
+        in
+        let fallback_decl = prop srgb_fallback in
+        let oklab_color =
+          Css.color_mix ~in_space:Oklab ~percent1:p color Css.Transparent
+        in
+        let oklab_decl = prop oklab_color in
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+        in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+    | Color.Opacity_var var_str ->
+        let bare = Parse.extract_var_name var_str in
+        let srgb_fallback =
+          Css.color_mix_var_percent ~in_space:Srgb ~var_name:bare color
+            Css.Transparent
+        in
+        let fallback_decl = prop srgb_fallback in
+        let oklab_color =
+          Css.color_mix_var_percent ~in_space:Oklab ~var_name:bare color
+            Css.Transparent
+        in
+        let oklab_decl = prop oklab_color in
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+        in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+    | Color.No_opacity -> style [ prop color ]
+
+  (* A var-valued colour with /opacity: oklab color-mix under @supports, with an
+     srgb fallback. The fallback resolves the var against the theme when known
+     (Tailwind inlines the resolved colour), else keeps the raw var (matching
+     Tailwind for non-theme vars). [emit] places the colour on the target
+     property ([prop] for a known property, [Css.var] for a custom one). *)
+  let color_var_opacity_style theme (emit : Css.color -> Css.declaration) value
+      opacity =
+    let bare = Parse.extract_var_name value in
+    let var_ref : Css.color Css.var = Var.bracket bare in
+    let percent = Color.opacity_to_percent opacity in
+    let oklab_decl =
+      emit
+        (Css.color_mix ~in_space:Oklab (Css.Var var_ref) Css.Transparent
+           ~percent1:percent)
+    in
+    (* The srgb fallback inlines the resolved theme colour when known (matching
+       Tailwind), else keeps the raw var. Emitting the referenced [--token] into
+       @layer theme needs the registering theme-var mechanism (see
+       [Color.color_var]); arbitrary references via [Var.bracket] don't trigger
+       it, so theme-var-referencing values still differ in the theme layer (the
+       same gap as [backgrounds.ml]'s bg-[color:var(--token)]). *)
+    let fallback =
+      match Scheme.theme_value (Some theme) bare with
+      | Some v -> (
+          match Css.parse_color (String.trim v) with
+          | Some c ->
+              emit
+                (Css.color_mix ~in_space:Srgb c Css.Transparent
+                   ~percent1:percent)
+          | None -> emit (Css.Var var_ref : Css.color))
+      | None -> emit (Css.Var var_ref : Css.color)
+    in
+    let supports =
+      Css.supports ~condition:Color.color_mix_supports_condition
+        [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+    in
+    style ~rules:(Some [ supports ]) [ fallback ]
+
+  (* Place a colour on the declaration's target property: a known colour
+     property uses its typed constructor; a custom property ([--name]) uses the
+     typed [Css.var] form (kept in the utilities layer), never a token
+     stream. *)
+  let color_emitter property : (Css.color -> Css.declaration) option =
+    match color_property_of_name property with
+    | Some prop -> Some prop
+    | None ->
+        if String.length property > 2 && String.sub property 0 2 = "--" then
+          let name = String.sub property 2 (String.length property - 2) in
+          Some (fun c -> fst (Css.var ~layer:"utilities" name Css.Color c))
+        else None
+
   let to_style theme (Color_opacity { property; value; opacity }) =
-    match (color_property_of_name property, parse_css_color value) with
-    | Some prop, Some color -> (
-        match opacity with
-        | Color.Opacity_named name ->
-            let bare = Parse.extract_var_name name in
-            let var_name = "opacity-" ^ bare in
-            let fallback =
-              Color.opacity_fallback_for_theme_value ~theme var_name bare
-            in
-            (* srgb fallback: resolve the theme value to get the actual
-               percentage *)
-            let srgb_percent =
-              match Scheme.theme_value (Some theme) var_name with
-              | Some v -> (
-                  match float_of_string_opt (String.trim v) with
-                  | Some f -> f *. 100.0
-                  | None -> 100.0)
-              | None -> 100.0
-            in
-            let srgb_fallback =
-              Css.color_mix ~in_space:Srgb ~percent1:srgb_percent color
-                Css.Transparent
-            in
-            let fallback_decl = prop srgb_fallback in
-            let oklab_color =
-              Css.color_mix_var_pct_fallback ~in_space:Oklab ~var_name ~fallback
-                color Css.Transparent
-            in
-            let oklab_decl = prop oklab_color in
-            let supports_block =
-              Css.supports ~condition:Color.color_mix_supports_condition
-                [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-            in
-            style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-        | Color.Opacity_percent p ->
-            let srgb_fallback =
-              Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
-            in
-            let fallback_decl = prop srgb_fallback in
-            let oklab_color =
-              Css.color_mix ~in_space:Oklab ~percent1:p color Css.Transparent
-            in
-            let oklab_decl = prop oklab_color in
-            let supports_block =
-              Css.supports ~condition:Color.color_mix_supports_condition
-                [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-            in
-            style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-        | Color.Opacity_arbitrary f ->
-            let p = f *. 100.0 in
-            let srgb_fallback =
-              Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
-            in
-            let fallback_decl = prop srgb_fallback in
-            let oklab_color =
-              Css.color_mix ~in_space:Oklab ~percent1:p color Css.Transparent
-            in
-            let oklab_decl = prop oklab_color in
-            let supports_block =
-              Css.supports ~condition:Color.color_mix_supports_condition
-                [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-            in
-            style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-        | Color.Opacity_bracket_percent p ->
-            let srgb_fallback =
-              Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
-            in
-            let fallback_decl = prop srgb_fallback in
-            let oklab_color =
-              Css.color_mix ~in_space:Oklab ~percent1:p color Css.Transparent
-            in
-            let oklab_decl = prop oklab_color in
-            let supports_block =
-              Css.supports ~condition:Color.color_mix_supports_condition
-                [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-            in
-            style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-        | Color.Opacity_var var_str ->
-            let bare = Parse.extract_var_name var_str in
-            let srgb_fallback =
-              Css.color_mix_var_percent ~in_space:Srgb ~var_name:bare color
-                Css.Transparent
-            in
-            let fallback_decl = prop srgb_fallback in
-            let oklab_color =
-              Css.color_mix_var_percent ~in_space:Oklab ~var_name:bare color
-                Css.Transparent
-            in
-            let oklab_decl = prop oklab_color in
-            let supports_block =
-              Css.supports ~condition:Color.color_mix_supports_condition
-                [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-            in
-            style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-        | Color.No_opacity -> style [ prop color ])
-    | _ ->
-        invalid_arg
-          ("Invalid arbitrary color property: " ^ property ^ ":" ^ value)
+    match color_emitter property with
+    (* of_class only accepts renderable colour declarations; defensive. *)
+    | None -> style []
+    | Some emit -> (
+        match parse_css_color value with
+        | Some color -> color_opacity_render theme emit color opacity
+        | None ->
+            if Parse.is_var value then
+              color_var_opacity_style theme emit value opacity
+            else style [])
 
   let suborder _ = 0
 
+  let opacity_suffix = function
+    | Color.No_opacity -> ""
+    | Color.Opacity_percent p ->
+        if Float.is_integer p then "/" ^ Pp.int (int_of_float p)
+        else "/" ^ Pp.float p
+    | Color.Opacity_bracket_percent p ->
+        if Float.is_integer p then "/[" ^ Pp.int (int_of_float p) ^ "%]"
+        else "/[" ^ Pp.float p ^ "%]"
+    | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
+    | Color.Opacity_named name -> "/" ^ name
+    | Color.Opacity_var v -> "/[" ^ v ^ "]"
+
   let to_class (Color_opacity { property; value; opacity }) =
-    let opacity_suffix =
-      match opacity with
-      | Color.No_opacity -> ""
-      | Color.Opacity_percent p ->
-          if Float.is_integer p then "/" ^ Pp.int (int_of_float p)
-          else "/" ^ Pp.float p
-      | Color.Opacity_bracket_percent p ->
-          if Float.is_integer p then "/[" ^ Pp.int (int_of_float p) ^ "%]"
-          else "/[" ^ Pp.float p ^ "%]"
-      | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
-      | Color.Opacity_named name -> "/" ^ name
-      | Color.Opacity_var v -> "/[" ^ v ^ "]"
-    in
-    "[" ^ property ^ ":" ^ value ^ "]" ^ opacity_suffix
+    "[" ^ property ^ ":" ^ value ^ "]" ^ opacity_suffix opacity
 
   let of_class theme class_name =
     (* Must start with [ and contain : *)
@@ -259,11 +318,24 @@ module Handler = struct
                         else Color.No_opacity
                 else Color.No_opacity
               in
-              if opacity = Color.No_opacity && opacity_str = "" then
+              let is_custom =
+                String.length property > 2 && String.sub property 0 2 = "--"
+              in
+              let is_colour_value =
+                Parse.is_var value || parse_css_color value <> None
+              in
+              if is_custom then
+                (* Custom property: only the color-mix /opacity form is rendered
+                   type-safely. The plain [--name:value] form (and non-colour
+                   values) need a cascade value parser and are deferred. *)
+                if opacity <> Color.No_opacity && is_colour_value then
+                  Ok (Color_opacity { property; value; opacity })
+                else err_not_utility
+              else if color_property_of_name property = None then
+                (* A non-colour standard property ([mask-type:...]) needs a
+                   typed arbitrary-declaration constructor; deferred. *)
                 err_not_utility
-              else if
-                opacity = Color.No_opacity && String.length opacity_str > 0
-              then err_not_utility
+              else if opacity = Color.No_opacity then err_not_utility
               else Ok (Color_opacity { property; value; opacity }))
 end
 

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -109,7 +109,22 @@ let of_string ?(theme = Scheme.default) class_str =
     else (`None, base_class)
   in
   match Utility.base_of_class theme base_class with
-  | Error _ -> Error (`Msg ("Unknown class: " ^ class_str))
+  | Error _ ->
+      (* An arbitrary-property class ([prop:value]) that no handler accepted
+         gets actionable feedback: only colour properties with an /opacity
+         modifier are emitted today. *)
+      if
+        String.length base_class > 2
+        && base_class.[0] = '['
+        && String.contains base_class ':'
+      then
+        Error
+          (`Msg
+             ("Unsupported arbitrary property '" ^ class_str
+            ^ "': only colour properties with an /opacity modifier are emitted \
+               (e.g. [color:var(--x)]/50); plain [--name:value] declarations \
+               and non-colour properties are not yet supported"))
+      else Error (`Msg ("Unknown class: " ^ class_str))
   | Ok base_utility -> (
       (* Wrap [important] around the base before applying modifiers, so a
          responsive/state prefix stays outermost: md:!flex -> md:(!flex). *)

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -9,8 +9,12 @@ let check input =
 
 let of_string_valid () =
   check "[color:red]/50";
-  check "[background:blue]/[50%]";
-  check "[border-color:#ff0000]/25"
+  check "[background-color:blue]/[50%]";
+  check "[border-color:#ff0000]/25";
+  (* var-valued colours and custom properties with /opacity round-trip *)
+  check "[color:var(--my-color)]/50";
+  check "[--x:#ff0000]/50";
+  check "[--gradient-bg:var(--color-black)]/15"
 
 let of_string_invalid () =
   let fail_maybe input =
@@ -23,12 +27,57 @@ let of_string_invalid () =
   fail_maybe "[invalid]";
   fail_maybe "[]";
   (* No opacity = not handled by this handler *)
-  fail_maybe "[color:red]"
+  fail_maybe "[color:red]";
+  (* Plain custom-property declarations and non-colour standard properties need
+     a typed cascade value parser; deferred (rejected, never crash). *)
+  fail_maybe "[--foo:bar]";
+  fail_maybe "[mask-type:luminance]"
+
+let css cls =
+  match Tw.of_string cls with
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+(* A var-valued colour with /opacity used to raise invalid_arg; it now emits an
+   oklab color-mix under @supports, with a fallback, type-safely. *)
+let test_var_color_opacity () =
+  let out = css "[color:var(--my-color)]/50" in
+  Alcotest.(check bool)
+    "oklab color-mix on the var" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, var(--my-color) 50%, transparent)" out)
+
+(* A custom property with /opacity sets the property to a color-mix via the
+   typed [Css.var] form (no token stream). *)
+let test_custom_prop_opacity () =
+  let out = css "[--x:#ff0000]/50" in
+  Alcotest.(check bool)
+    "custom property gets a color-mix value" true
+    (Astring.String.is_infix
+       ~affix:"--x: color-mix(in oklab, #ff0000 50%, transparent)" out)
+
+(* The previously-crashing inputs must never raise: they either render or are
+   rejected, but [to_css] must complete. *)
+let test_no_crash () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+      | Error _ -> ())
+    [
+      "[--gradient-bg:var(--color-black)]/15";
+      "[color:var(--color-red-500)]/40";
+      "[--foo:bar]";
+      "[mask-type:luminance]";
+    ]
 
 let tests =
   [
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
     test_case "arbitrary of_string - invalid values" `Quick of_string_invalid;
+    test_case "var-valued colour with opacity" `Quick test_var_color_opacity;
+    test_case "custom property with opacity" `Quick test_custom_prop_opacity;
+    test_case "deferred and var inputs never crash" `Quick test_no_crash;
   ]
 
 let suite = ("arbitrary", tests)


### PR DESCRIPTION
`[color:var(--x)]/50`, `[--gradient-bg:var(--color-black)]/15` and similar arbitrary-property classes raised `Invalid_argument` from `to_style`: the handler only understood named/hex colours on a fixed list of standard colour properties, so a `var()` value or a custom property fell through to a raising catch-all. These appear in real source (tailwindcss.com, shadcn/ui).

Var-valued colours and custom-property declarations now render through the typed `Css.color_mix` and `Css.var` forms (no token streams), resolving theme vars for the srgb fallback via `Css.parse_color`. `of_class` rejects the shapes that still need a typed cascade value parser (plain `[--name:value]`, non-colour standard properties like `[mask-type:...]`) rather than accepting and then crashing, and the CLI now prints an actionable message for those.