### PR TITLE
build: emit theme tokens referenced via var() in @layer theme

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -646,12 +646,48 @@ let theme_layer_rule ~layers = function
       if layers then Css.v [ Css.layer ~name:"theme" [ rule ] ]
       else Css.v [ rule ]
 
+(* Every var() referenced anywhere in a utility's output (top-level props and
+   nested @media/@supports). *)
+let var_names_of_output = function
+  | Regular { props; nested; _ } | Media_query { props; nested; _ } ->
+      Css.vars_of_declarations props @ Css.vars_of_rules nested
+  | Container_query { props; _ }
+  | Starting_style { props; _ }
+  | Supports_query { props; _ } ->
+      Css.vars_of_declarations props
+
+(* Theme tokens referenced via var() (e.g. an arbitrary [color:var(--color-red-
+   500)]) must appear in @layer theme, but the extractor above only collects
+   tokens utilities SET. Emit the catalogued colour tokens those references name
+   (typed value + canonical order via [Color.Handler.theme_color_decl]). Other
+   token kinds need a general typed value parser and are left for now. [exclude]
+   holds the already-emitted (set) token names. *)
+let referenced_theme_decls ~theme ~exclude selector_props =
+  selector_props
+  |> List.concat_map var_names_of_output
+  |> List.map Css.any_var_name
+  |> List.sort_uniq String.compare
+  |> List.filter_map (fun full ->
+      if
+        String.length full <= 2
+        || String.sub full 0 2 <> "--"
+        || Strings.mem full exclude
+      then None
+      else
+        let bare = String.sub full 2 (String.length full - 2) in
+        Color.Handler.theme_color_decl ~theme bare)
+
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
 let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
     ?(default_decls = []) selector_props =
   let extracted =
     extract_non_tw_custom_declarations selector_props
     |> List.map (apply_token_override theme)
+  in
+  let extracted =
+    extracted
+    @ referenced_theme_decls ~theme ~exclude:(names_set_of extracted)
+        selector_props
   in
   let pre_defaults, post_defaults = split_defaults default_decls in
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1638,6 +1638,24 @@ module Handler = struct
     | Some hex -> Css.hex hex
     | None -> to_css c (if is_base_color c then 500 else shade)
 
+  (* The theme-layer declaration for a colour token named like "color-red-500",
+     or None when the name is not a catalogued colour token. [color_var]
+     registers the token's canonical order and [get_color_value] supplies the
+     typed value, so the result matches what a colour utility would emit. Used
+     to emit tokens that arbitrary values reference via var() but that no colour
+     utility set. *)
+  let theme_color_decl ?theme name =
+    if String.length name <= 6 || String.sub name 0 6 <> "color-" then None
+    else
+      let rest = String.sub name 6 (String.length name - 6) in
+      match shade_of_strings (String.split_on_char '-' rest) with
+      | Ok (c, shade) when not (is_custom_color c) ->
+          let decl, _ =
+            Var.binding (color_var c shade) (get_color_value ?theme c shade)
+          in
+          Some decl
+      | _ -> None
+
   (** Get a color variable for a property. Checks if a property-scoped theme
       value exists (e.g., [--accent-color-blue-500]) and if so creates a
       property-scoped variable. Otherwise falls back to the generic

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -348,6 +348,13 @@ val suborder_with_shade : string -> int
 
 module Handler : sig
   include Utility.Handler
+
+  val theme_color_decl : ?theme:Scheme.t -> string -> Css.declaration option
+  (** [theme_color_decl ?theme name] is the [\@layer theme] declaration for the
+      colour token [name] (e.g. ["color-red-500"]), or [None] when [name] is not
+      a catalogued colour token. Lets the build emit colour tokens that are only
+      referenced via [var()] (e.g. by an arbitrary [color:var(--color-red-500)])
+      rather than set by a colour utility. *)
 end
 
 (** {1 Color with Opacity Helpers}

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -759,8 +759,29 @@ let check_spacing_zero_prune () =
     "p-0 drops unused --spacing" false
     (Astring.String.is_infix ~affix:"--spacing" css)
 
+(* A utility that only REFERENCES a theme colour token via var() (here an
+   arbitrary bg-[color:var(--color-red-500)]) must still emit that token in
+   @layer theme; the build used to collect only tokens utilities set. A
+   non-theme var stays out. *)
+let test_referenced_theme_token () =
+  let css cls =
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "parse %s: %s" cls m
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+  in
+  (* The "--token:" form (a declaration) appears only when the token is SET in
+     @layer theme; the references are "var(--token)". *)
+  check bool "referenced --color-red-500 is emitted in theme" true
+    (Astring.String.is_infix ~affix:"--color-red-500:"
+       (css "bg-[color:var(--color-red-500)]/50"));
+  check bool "non-theme --my-color is not emitted" false
+    (Astring.String.is_infix ~affix:"--my-color:"
+       (css "bg-[color:var(--my-color)]/50"))
+
 let tests =
   [
+    test_case "referenced theme token emitted" `Quick
+      test_referenced_theme_token;
     test_case "spacing-0 prunes --spacing" `Quick check_spacing_zero_prune;
     test_case "theme layer - empty" `Quick check_theme_layer_empty;
     test_case "theme layer - with color" `Quick check_theme_layer_with_color;


### PR DESCRIPTION
A utility that only references a theme colour token through an arbitrary `var()` value — `bg-[color:var(--color-red-500)]/50`, or an arbitrary `[color:var(--color-red-500)]/40` — emitted the right rule but left `--color-red-500` out of `@layer theme`, because the theme-layer builder collected only tokens utilities *set*, never ones they *reference*.

The build now scans references with `Css.vars_of_declarations` and emits the catalogued colour tokens through a new `Color.Handler.theme_color_decl`, which produces the typed value and canonical order the same way a colour utility would. Non-theme vars (e.g. `var(--my-color)`) correctly stay out; other token kinds await a general value parser.