### PR TITLE
gap: support space-x-px and space-y-px

### DIFF
--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -157,6 +157,38 @@ module Handler = struct
     in
     style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
 
+  (* space-x-px / space-y-px: the gap is a literal 1px (not a spacing multiple),
+     so there is no --spacing declaration; the reverse mechanism wraps ±1px
+     directly, matching Tailwind. *)
+  let space_px ~axis ~negative
+      (reverse_var : Css.number_percentage Var.property_default)
+      ~margin_start_decl ~margin_end_decl =
+    let axis_str = match axis with `X -> "x" | `Y -> "y" in
+    let class_name =
+      (if negative then "-space-" else "space-") ^ axis_str ^ "-px"
+    in
+    let selector =
+      Css.Selector.(where [ class_ class_name >> not [ Last_child ] ])
+    in
+    let spacing_len : length = if negative then Px (-1.) else Px 1. in
+    let reverse_decl, reverse_ref = Var.binding reverse_var (Css.Num 0.0) in
+    let reverse_var_name = Css.var_name reverse_ref in
+    let margin_start, margin_end =
+      space_margin_calcs ~spacing_len ~reverse_var_name
+    in
+    let property_rules =
+      [ Var.property_rule reverse_var ] |> List.filter_map Fun.id
+    in
+    let rule =
+      Css.rule ~selector
+        [
+          reverse_decl;
+          margin_start_decl margin_start;
+          margin_end_decl margin_end;
+        ]
+    in
+    style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
+
   let space_y ?theme n =
     (* See [space_x]: negative zero ([-space-y-0]) must keep its sign. *)
     let negative = Float.sign_bit n in
@@ -293,6 +325,16 @@ module Handler = struct
     let space_y n = space_y ~theme n in
     match t with
     | Gap { axis; value } -> gap_value axis value
+    | Space { negative; axis; value = `Px } -> (
+        match axis with
+        | `X ->
+            space_px ~axis:`X ~negative space_x_reverse_var
+              ~margin_start_decl:margin_inline_start
+              ~margin_end_decl:margin_inline_end
+        | `Y ->
+            space_px ~axis:`Y ~negative space_y_reverse_var
+              ~margin_start_decl:margin_block_start
+              ~margin_end_decl:margin_block_end)
     | Space { negative; axis; value } -> (
         let n =
           match value with
@@ -422,6 +464,8 @@ module Handler = struct
           | None -> err_not_utility)
       | [ "space"; "x"; value ] -> (
           if value = "reverse" then Ok Space_x_reverse
+          else if value = "px" then
+            Ok (Space { negative = false; axis = `X; value = `Px })
           else
             match parse_gap_arbitrary value with
             | Some (Arbitrary len) ->
@@ -439,6 +483,8 @@ module Handler = struct
                 | Error _ -> err_not_utility))
       | [ "space"; "y"; value ] -> (
           if value = "reverse" then Ok Space_y_reverse
+          else if value = "px" then
+            Ok (Space { negative = false; axis = `Y; value = `Px })
           else
             match parse_gap_arbitrary value with
             | Some (Arbitrary len) ->
@@ -455,17 +501,25 @@ module Handler = struct
                          })
                 | Error _ -> err_not_utility))
       | [ ""; "space"; "x"; value ] -> (
-          match Parse.spacing_value ~name:"space-x" value with
-          | Ok n ->
-              Ok
-                (Space { negative = true; axis = `X; value = `Rem (n *. 0.25) })
-          | Error _ -> err_not_utility)
+          if value = "px" then
+            Ok (Space { negative = true; axis = `X; value = `Px })
+          else
+            match Parse.spacing_value ~name:"space-x" value with
+            | Ok n ->
+                Ok
+                  (Space
+                     { negative = true; axis = `X; value = `Rem (n *. 0.25) })
+            | Error _ -> err_not_utility)
       | [ ""; "space"; "y"; value ] -> (
-          match Parse.spacing_value ~name:"space-y" value with
-          | Ok n ->
-              Ok
-                (Space { negative = true; axis = `Y; value = `Rem (n *. 0.25) })
-          | Error _ -> err_not_utility)
+          if value = "px" then
+            Ok (Space { negative = true; axis = `Y; value = `Px })
+          else
+            match Parse.spacing_value ~name:"space-y" value with
+            | Ok n ->
+                Ok
+                  (Space
+                     { negative = true; axis = `Y; value = `Rem (n *. 0.25) })
+            | Error _ -> err_not_utility)
       | _ -> err_not_utility
     in
     parse_class parts

--- a/test/test_gap.ml
+++ b/test/test_gap.ml
@@ -29,7 +29,12 @@ let of_string_valid () =
   check "space-x-2";
   check "space-y-4";
   check "-space-x-1";
-  check "-space-y-2"
+  check "-space-y-2";
+  (* px-valued space, both signs *)
+  check "space-x-px";
+  check "space-y-px";
+  check "-space-x-px";
+  check "-space-y-px"
 
 let of_string_invalid () =
   let fail_maybe = Test_helpers.check_invalid_parts (module Tw.Gap.Handler) in
@@ -74,6 +79,23 @@ let mixed_gap_axis_arbitrary_order_matches_tailwind () =
   |> Test_helpers.check_ordering_matches
        ~test_name:"mixed gap axis arbitrary order matches Tailwind"
 
+(* space-x-px / -space-x-px use a literal +/-1px gap (no --spacing multiple),
+   wrapped in the reverse calc like the numeric variants. *)
+let test_space_px_values () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.check bool "space-x-px uses 1px gap" true
+    (Astring.String.is_infix ~affix:"calc(1px * var(--tw-space-x-reverse))"
+       (css "space-x-px"));
+  Alcotest.check bool "-space-x-px uses -1px gap" true
+    (Astring.String.is_infix ~affix:"calc(-1px * var(--tw-space-x-reverse))"
+       (css "-space-x-px"));
+  Alcotest.check bool "space-x-px sets no --spacing" false
+    (Astring.String.is_infix ~affix:"--spacing" (css "space-x-px"))
+
 (** Test that CSS values use the correct spacing multiplier. gap-64 should
     generate calc(var(--spacing)*64), not calc(var(--spacing)*16) *)
 let test_css_values () =
@@ -98,6 +120,7 @@ let tests =
       mixed_gap_space_order_matches_tailwind;
     test_case "mixed gap axis arbitrary order matches Tailwind" `Quick
       mixed_gap_axis_arbitrary_order_matches_tailwind;
+    test_case "space-px CSS values" `Quick test_space_px_values;
     test_case "gap CSS values" `Quick test_css_values;
   ]
 


### PR DESCRIPTION
`space-x-px`, `space-y-px` and their negatives were unknown classes: the space-between parser only produced rem values, so the `px` keyword fell through. They now render a literal `calc(±1px * var(--tw-space-*-reverse))` with no `--spacing` declaration, matching Tailwind. Surfaced by a parity sweep over Headless UI source.