### PR TITLE
spacing: gate named spacing and inset on theme tokens

### DIFF
--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -317,10 +317,16 @@ module Handler = struct
     | "ms" | "me" | "mbs" | "mbe" -> true
     | _ -> false
 
+  (* A named margin (mx-big) is valid only when the theme actually defines the
+     [--spacing-<name>] token; otherwise a stray source token like [my-form]
+     would parse as a utility and emit a bogus var(). *)
+  let is_named_spacing theme name =
+    Scheme.theme_value theme ("spacing-" ^ name) <> None
+
   (** Parse value to standard or named margin *)
-  let parse_value ~is_negative value =
+  let parse_value ?theme ~is_negative value =
     let allow_auto = not is_negative in
-    match Spacing.parse_value_string ~allow_auto value with
+    match Spacing.parse_value_string ?theme ~allow_auto value with
     | Some (#spacing as spacing_val) ->
         Some
           {
@@ -330,13 +336,16 @@ module Handler = struct
           }
     | Some `Auto when not is_negative ->
         Some { negative = false; axis = `All; value = Standard `Auto }
-    | None when (not is_negative) && Parse.is_valid_theme_name value ->
+    | None
+      when (not is_negative)
+           && Parse.is_valid_theme_name value
+           && is_named_spacing theme value ->
         (* Try as a named spacing: mx-big *)
         Some { negative = false; axis = `All; value = Named value }
     | _ -> None
 
   (** Parse string parts to margin utility using shared logic *)
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* Handle arbitrary values: mx-[4px], mx-[var(--value)] *)
@@ -352,14 +361,15 @@ module Handler = struct
     (* Handle extended axes (ms, me, mbs, mbe) with values *)
     | [ prefix; value ] when is_extended_margin_prefix prefix -> (
         match
-          (axis_of_prefix_ext prefix, parse_value ~is_negative:false value)
+          ( axis_of_prefix_ext prefix,
+            parse_value ~theme ~is_negative:false value )
         with
         | Some axis, Some t -> Ok { t with axis }
         | _ -> Error (`Msg "Not a margin utility"))
     (* Handle negative extended axes: -ms-4 *)
     | [ ""; prefix; value ] when is_extended_margin_prefix prefix -> (
         match
-          (axis_of_prefix_ext prefix, parse_value ~is_negative:true value)
+          (axis_of_prefix_ext prefix, parse_value ~theme ~is_negative:true value)
         with
         | Some axis, Some t -> Ok { t with axis }
         | _ -> Error (`Msg "Not a margin utility"))
@@ -388,10 +398,13 @@ module Handler = struct
                     | `Be -> `Be
                   in
                   let allow_auto = not is_negative in
-                  match Spacing.parse_value_string ~allow_auto value with
+                  match Spacing.parse_value_string ~theme ~allow_auto value with
                   | None ->
                       (* Try as a named spacing: mx-big, -mx-big *)
-                      if Parse.is_valid_theme_name value then
+                      if
+                        Parse.is_valid_theme_name value
+                        && is_named_spacing (Some theme) value
+                      then
                         Ok { negative = is_negative; axis; value = Named value }
                       else Error (`Msg "Not a margin utility")
                   | Some (#spacing as spacing_val) ->

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -178,7 +178,7 @@ module Handler = struct
     | "pbe" -> Some `Be
     | _ -> None
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* Handle arbitrary values: p-[4px], px-[var(--value)] *)
@@ -199,7 +199,9 @@ module Handler = struct
               match Spacing.axis_of_prefix prefix with
               | None -> Error (`Msg "Not a padding utility")
               | Some axis -> (
-                  match Spacing.parse_value_string ~allow_auto:false value with
+                  match
+                    Spacing.parse_value_string ~theme ~allow_auto:false value
+                  with
                   | None -> Error (`Msg "Not a padding utility")
                   | Some (#spacing as spacing_val) ->
                       Ok { axis; value = Standard spacing_val }

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -496,7 +496,15 @@ module Handler = struct
     | End_full -> 952
     | End n -> 1000 + n
 
-  let of_class _theme class_name =
+  (* A named inset (top-header) is valid only when the theme defines the token.
+     Tailwind resolves the name against the [--inset-*] namespace, then falls
+     back to [--spacing-*]; without this gate a stray source token like
+     [top-level] would parse as a utility and emit a bogus value. *)
+  let is_named_inset theme n =
+    Scheme.theme_value (Some theme) ("inset-" ^ n) <> None
+    || Scheme.theme_value (Some theme) ("spacing-" ^ n) <> None
+
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "static" ] -> Ok Position_static
@@ -525,7 +533,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_x_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_x_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_x_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "x"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_x (-x))
@@ -535,7 +545,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_y_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_y_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_y_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "y"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_y (-x))
@@ -550,7 +562,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_s_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_s_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_s_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "s"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_s (-x))
@@ -565,7 +579,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_e_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_e_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_e_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "e"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_e (-x))
@@ -580,7 +596,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_bs_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_bs_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_bs_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "bs"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_bs (-x))
@@ -595,7 +613,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_be_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_be_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_be_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; "be"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_be (-x))
@@ -607,7 +627,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Inset_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Inset_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Inset_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "inset"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset (-x))
@@ -622,7 +644,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Top_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Top_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Top_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "top"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Top (-x))
@@ -636,7 +660,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Right_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Right_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Right_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "right"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Right (-x))
@@ -650,7 +676,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Bottom_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Bottom_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Bottom_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "bottom"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Bottom (-x))
@@ -665,7 +693,9 @@ module Handler = struct
         | Error _ -> (
             match parse_bracket_length n with
             | Ok len -> Ok (Left_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n -> Ok (Left_named n)
+            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
+              ->
+                Ok (Left_named n)
             | Error _ -> Error (`Msg "invalid")))
     | [ ""; "left"; n ] -> (
         match int_of_string_with_sign n with

--- a/lib/spacing.ml
+++ b/lib/spacing.ml
@@ -106,14 +106,22 @@ let is_named_spacing value =
   c >= 'a' && c <= 'z'
 
 (** Parse a spacing value from a string, with optional support for auto *)
-let parse_value_string ~allow_auto value : margin option =
+let parse_value_string ?theme ~allow_auto value : margin option =
   if value = "px" then Some `Px
   else if value = "full" then Some `Full
   else if allow_auto && value = "auto" then Some `Auto
   else
     match Parse.spacing_value ~name:"spacing" value with
     | Ok f -> Some (`Rem (f *. 0.25))
-    | Error _ -> if is_named_spacing value then Some (`Named value) else None
+    | Error _ ->
+        (* A named spacing (mx-big) is valid only when the theme defines the
+           [--spacing-<name>] token; without that gate a stray source token like
+           [my-form] would parse as a utility. *)
+        if
+          is_named_spacing value
+          && Scheme.theme_value theme ("spacing-" ^ value) <> None
+        then Some (`Named value)
+        else None
 
 type axis = [ `All | `X | `Y | `T | `R | `B | `L | `S | `E | `Bs | `Be ]
 (** Parse axis from a prefix string *)

--- a/lib/spacing.mli
+++ b/lib/spacing.mli
@@ -92,12 +92,17 @@ type axis = [ `All | `X | `Y | `T | `R | `B | `L | `S | `E | `Bs | `Be ]
 (** Axis for spacing utilities (all, x, y, top, right, bottom, left,
     inline-start, inline-end, block-start, block-end) *)
 
-val parse_value_string : allow_auto:bool -> string -> Style.margin option
-(** [parse_value_string ~allow_auto value] parses a spacing value string (px,
-    full, auto, or numeric).
+val parse_value_string :
+  ?theme:Scheme.t -> allow_auto:bool -> string -> Style.margin option
+(** [parse_value_string ?theme ~allow_auto value] parses a spacing value string
+    (px, full, auto, numeric, or a named token).
 
+    @param theme
+      Theme used to validate a named spacing ([mx-big]): a name is accepted only
+      when [--spacing-<name>] is defined, so stray source tokens do not parse as
+      utilities.
     @param allow_auto Whether to accept "auto" as a valid value
-    @param value The string to parse ("px", "full", "auto", or a number)
+    @param value The string to parse ("px", "full", "auto", a number, or a name)
     @return Parsed margin value or None if invalid. *)
 
 val axis_of_prefix : string -> axis option

--- a/test/test_margin.ml
+++ b/test/test_margin.ml
@@ -43,9 +43,25 @@ let of_string_invalid () =
     check_invalid_input (module Tw.Margin.Handler) class_name
   in
 
-  fail_maybe [ "m" ]
-(* Missing value - note: m-<name> is valid in Tailwind v4 as named spacing
-   var *)
+  fail_maybe [ "m" ];
+  (* Named spacing is valid only when the theme defines --spacing-<name>; stray
+     source tokens like my-form / mt-big must not parse as utilities. *)
+  fail_maybe [ "my"; "form" ];
+  fail_maybe [ "mt"; "big" ];
+  fail_maybe [ "mx"; "foo" ]
+
+(* my-<name> parses only when the theme defines the spacing token, matching
+   Tailwind; without it the class is rejected (see [of_string_invalid]). *)
+let named_spacing_requires_theme_token () =
+  let themed =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("spacing-form", "1rem") ]
+  in
+  (match Tw.Margin.Handler.of_class themed "my-form" with
+  | Ok _ -> ()
+  | Error (`Msg m) -> Alcotest.failf "my-form with theme rejected: %s" m);
+  match Tw.Margin.Handler.of_class Tw.Scheme.default "my-form" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "my-form without theme token should be rejected"
 
 let suborder_matches_tailwind () =
   let open Tw in
@@ -81,6 +97,8 @@ let tests =
   [
     test_case "margin of_string - valid values" `Quick of_string_valid;
     test_case "margin of_string - invalid values" `Quick of_string_invalid;
+    test_case "named spacing requires theme token" `Quick
+      named_spacing_requires_theme_token;
     test_case "margin suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "margin CSS values" `Quick test_css_values;

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -28,6 +28,25 @@ let test_arbitrary_roundtrip () =
   check "inset-[0.25rem]";
   check "inset-x-[0.5rem]"
 
+(* A named inset (top-header) parses only when the theme defines --inset-<name>
+   or --spacing-<name>; stray source tokens like top-level / bottom-right must
+   be rejected rather than emitting a bogus placeholder value. *)
+let named_inset_requires_theme_token () =
+  let reject c =
+    match Tw.Position.Handler.of_class Tw.Scheme.default c with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s should be rejected without a theme token" c
+  in
+  reject "top-level";
+  reject "bottom-right";
+  reject "left-junk";
+  let themed =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("inset-header", "2rem") ]
+  in
+  match Tw.Position.Handler.of_class themed "top-header" with
+  | Ok _ -> ()
+  | Error (`Msg m) -> Alcotest.failf "top-header with theme rejected: %s" m
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -44,6 +63,8 @@ let tests =
     test_case "negative top" `Quick test_negative;
     test_case "arbitrary value roundtrip" `Quick test_arbitrary_roundtrip;
     test_case "position utilities" `Quick test_position_utilities;
+    test_case "named inset requires theme token" `Quick
+      named_inset_requires_theme_token;
     test_case "position suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
   ]


### PR DESCRIPTION
A named spacing (`mx-big`) or inset (`top-header`) was accepted for any identifier, so stray source tokens like `my-form`, `top-level` and `bottom-right` parsed as utilities and emitted bogus values (e.g. `top: 1940px`, `margin-block: var(--spacing-form)`) where Tailwind emits nothing.

The name is now validated against the threaded theme: margin and padding require `--spacing-<name>`; inset/top/right/bottom/left require `--inset-<name>` or `--spacing-<name>`, matching Tailwind's resolution namespaces. Tokens defined in a custom `@theme` still parse. Surfaced by a `tw --diff` parity sweep over Headless UI source.