### PR TITLE
tw: support the prop-(--x) custom-property shorthand

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1139,6 +1139,7 @@ let has_pseudo_elements tw_classes =
     | Utility.Modified (modifier, u) -> has_pseudo modifier || check_utility u
     | Utility.Group us -> List.exists check_utility us
     | Utility.Important (_, u) -> check_utility u
+    | Utility.Aliased (_, u) -> check_utility u
   in
   List.exists check_utility tw_classes
 

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -681,6 +681,7 @@ let rec has_responsive_modifier = function
   | Utility.Modified (_, t) -> has_responsive_modifier t
   | Utility.Group styles -> List.exists has_responsive_modifier styles
   | Utility.Important (_, t) -> has_responsive_modifier t
+  | Utility.Aliased (_, t) -> has_responsive_modifier t
 
 (* Validate no nested responsive modifiers *)
 let validate_no_nested_responsive styles =

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -94,6 +94,26 @@ let split_whitespace s =
   flush ();
   List.rev !tokens
 
+(* The v4 [prop-(--x)] shorthand is [prop-[var(--x)]] in value but keeps its own
+   class name. Rewrite the trailing [(--x)] to [[var(--x)]] for parsing; the
+   original spelling is restored via [Utility.alias]. Returns [None] when there
+   is no paren shorthand. *)
+let normalize_paren_var base_class =
+  let n = String.length base_class in
+  if n > 4 && base_class.[n - 1] = ')' then
+    match String.rindex_opt base_class '(' with
+    | Some lp
+      when lp > 0
+           && base_class.[lp - 1] = '-'
+           && lp + 2 < n
+           && base_class.[lp + 1] = '-'
+           && base_class.[lp + 2] = '-' ->
+        let prefix = String.sub base_class 0 lp in
+        let inner = String.sub base_class (lp + 1) (n - lp - 2) in
+        Some (prefix ^ "[var(" ^ inner ^ ")]")
+    | _ -> None
+  else None
+
 (* Parse a single class string into a Tw.t *)
 let of_string ?(theme = Scheme.default) class_str =
   let modifiers, base_class = modifiers_of_string class_str in
@@ -108,36 +128,56 @@ let of_string ?(theme = Scheme.default) class_str =
       (`Suffix, String.sub base_class 0 (n - 1))
     else (`None, base_class)
   in
+  (* Wrap [important] around the base before applying modifiers, so a
+     responsive/state prefix stays outermost: md:!flex -> md:(!flex). An
+     optional [alias] sits inside importance so [w-(--w)!] keeps both forms. *)
+  let finish ?alias base_utility =
+    let base_util = Utility.base base_utility in
+    let base_util =
+      match alias with
+      | Some cls -> Utility.alias cls base_util
+      | None -> base_util
+    in
+    let base_util =
+      match importance with
+      | `Prefix -> Utility.important base_util
+      | `Suffix -> Utility.important ~suffix:true base_util
+      | `None -> base_util
+    in
+    match Modifiers.apply modifiers base_util with
+    | Some u -> Ok u
+    | None -> Error (`Msg ("Unknown modifier in: " ^ class_str))
+  in
   match Utility.base_of_class theme base_class with
-  | Error _ ->
-      (* An arbitrary-property class ([prop:value]) that no handler accepted
-         gets actionable feedback: only colour properties with an /opacity
-         modifier are emitted today. *)
-      if
-        String.length base_class > 2
-        && base_class.[0] = '['
-        && String.contains base_class ':'
-      then
-        Error
-          (`Msg
-             ("Unsupported arbitrary property '" ^ class_str
-            ^ "': only colour properties with an /opacity modifier are emitted \
-               (e.g. [color:var(--x)]/50); plain [--name:value] declarations \
-               and non-colour properties are not yet supported"))
-      else Error (`Msg ("Unknown class: " ^ class_str))
-  | Ok base_utility -> (
-      (* Wrap [important] around the base before applying modifiers, so a
-         responsive/state prefix stays outermost: md:!flex -> md:(!flex). *)
-      let base_util = Utility.base base_utility in
-      let base_util =
-        match importance with
-        | `Prefix -> Utility.important base_util
-        | `Suffix -> Utility.important ~suffix:true base_util
-        | `None -> base_util
-      in
-      match Modifiers.apply modifiers base_util with
-      | Some u -> Ok u
-      | None -> Error (`Msg ("Unknown modifier in: " ^ class_str)))
+  | Ok base_utility -> finish base_utility
+  | Error _ -> (
+      (* Fallback: the v4 [prop-(--x)] shorthand for handlers that accept the
+         [prop-[var(--x)]] form but not the paren spelling directly. Handlers
+         that support [(--x)] natively (e.g. rotate) already matched above, so
+         this never overrides them. The original spelling is kept via the
+         alias. *)
+      match normalize_paren_var base_class with
+      | Some normalized -> (
+          match Utility.base_of_class theme normalized with
+          | Ok base_utility -> finish ~alias:base_class base_utility
+          | Error _ -> Error (`Msg ("Unknown class: " ^ class_str)))
+      | None ->
+          (* An arbitrary-property class ([prop:value]) that no handler accepted
+             gets actionable feedback: only colour properties with an /opacity
+             modifier are emitted today. *)
+          if
+            String.length base_class > 2
+            && base_class.[0] = '['
+            && String.contains base_class ':'
+          then
+            Error
+              (`Msg
+                 ("Unsupported arbitrary property '" ^ class_str
+                ^ "': only colour properties with an /opacity modifier are \
+                   emitted (e.g. [color:var(--x)]/50); plain [--name:value] \
+                   declarations and non-colour properties are not yet \
+                   supported"))
+          else Error (`Msg ("Unknown class: " ^ class_str)))
 
 let str s =
   let classes = split_whitespace s in

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -7,9 +7,15 @@ type t =
   | Modified of Style.modifier * t
   | Group of t list
   | Important of bool * t  (** [bool] is [true] for the v4 trailing [!] form. *)
+  | Aliased of string * t
+      (** [Aliased (class_name, u)] renders as [u] but reports [class_name] from
+          {!to_class}, so the emitted selector matches the source spelling. Used
+          for the [prop-(--x)] shorthand, which is [prop-[var(--x)]] in value
+          but keeps its own class name. *)
 
 let base x = Base x
 let important ?(suffix = false) x = Important (suffix, x)
+let alias class_name u = Aliased (class_name, u)
 
 module type Handler = sig
   type t
@@ -84,6 +90,7 @@ let rec to_style theme = function
   | Modified (m, u) -> Style.Modified (m, to_style theme u)
   | Group us -> Style.Group (List.map (to_style theme) us)
   | Important (_, u) -> Style.map_important (to_style theme u)
+  | Aliased (_, u) -> to_style theme u
 
 let rec to_class = function
   | Base u -> class_of_base u
@@ -98,12 +105,14 @@ let rec to_class = function
   | Group us -> String.concat " " (List.map to_class us)
   | Important (suffix, u) ->
       if suffix then to_class u ^ "!" else "!" ^ to_class u
+  | Aliased (class_name, _) -> class_name
 
 let rec pp = function
   | Base u -> "Base " ^ class_of_base u
   | Modified (m, u) -> "Modified (" ^ Style.pp_modifier m ^ ", " ^ pp u ^ ")"
   | Group us -> "Group [" ^ String.concat "; " (List.map pp us) ^ "]"
   | Important (_, u) -> "Important (" ^ pp u ^ ")"
+  | Aliased (class_name, u) -> "Aliased (" ^ class_name ^ ", " ^ pp u ^ ")"
 
 let order (u : base) : int * int =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -65,9 +65,18 @@ type t =
   | Modified of Style.modifier * t
   | Group of t list
   | Important of bool * t  (** [bool] is [true] for the v4 trailing [!] form. *)
+  | Aliased of string * t
+      (** [Aliased (class_name, u)] renders as [u] but reports [class_name] from
+          {!to_class}, so the emitted selector matches the source spelling. Used
+          for the [prop-(--x)] shorthand, which is [prop-[var(--x)]] in value
+          but keeps its own class name. *)
 
 val base : base -> t
 (** [base u] wraps a base utility into a Utility.t. *)
+
+val alias : string -> t -> t
+(** [alias class_name u] is [u] with its class name overridden to [class_name]
+    (see {!constructor-Aliased}). *)
 
 val important : ?suffix:bool -> t -> t
 (** [important ?suffix u] marks every declaration [u] emits as [!important]: the

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -1031,6 +1031,34 @@ let style_combination () =
       then Alcotest.failf "Missing class %s in combined CSS" class_name)
     expected_classes
 
+(* The v4 [prop-(--x)] shorthand is [prop-[var(--x)]] in value but keeps its own
+   class name in the selector. It works for any utility that accepts the bracket
+   var form, and round-trips the paren spelling. *)
+let paren_var_shorthand () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  (* value is var(--x) *)
+  Alcotest.(check bool)
+    "w-(--w) sets width: var(--w)" true
+    (Astring.String.is_infix ~affix:"width: var(--w)" (css "w-(--w)"));
+  (* selector keeps the paren spelling, not the bracket form *)
+  let out = css "w-(--w)" in
+  Alcotest.(check bool)
+    "selector keeps (--w) spelling" true
+    (Astring.String.is_infix ~affix:{|.w-\(--w\)|} out);
+  Alcotest.(check bool)
+    "selector is not the bracket form" false
+    (Astring.String.is_infix ~affix:"var\\(--w\\)\\]" out);
+  (* round-trips the class name through of_string -> to_class *)
+  match Tw.of_string "p-(--p)" with
+  | Ok u ->
+      Alcotest.(check string)
+        "p-(--p) round-trips" "p-(--p)" (Tw.to_classes [ u ])
+  | Error (`Msg m) -> Alcotest.failf "p-(--p): %s" m
+
 let all_colors_grays () =
   check_list
     (bg_shades slate shades @ bg_shades gray shades @ bg_shades zinc shades
@@ -1240,6 +1268,7 @@ let core_tests =
     test_case "precedence states" `Slow precedence_states;
     test_case "inline styles" `Slow inline_styles;
     test_case "style combination" `Slow style_combination;
+    test_case "paren var shorthand" `Quick paren_var_shorthand;
     test_case "responsive classes" `Slow responsive_classes;
     test_case "multiple classes" `Slow multiple_classes;
     test_case "all colors same shade" `Slow all_colors_same_shade;


### PR DESCRIPTION
The v4 `prop-(--x)` shorthand (`w-(--button-width)`, `bg-(--c)`, `p-(--p)`) is `prop-[var(--x)]` in value but keeps its own class name in the selector. tw rejected it as an unknown class, even for utilities that accept the bracket form.

`of_string` now falls back to rewriting a trailing `(--x)` to `[var(--x)]` when the direct parse fails, wrapping the result in a new `Utility.alias` constructor so the emitted selector matches the source spelling. Handlers that already accept `(--x)` natively (rotate, content) keep matching directly and are untouched. Surfaced by a parity sweep over Headless UI source.