### PR TITLE
position: support arbitrary var() insets

### DIFF
--- a/lib/position.ml
+++ b/lib/position.ml
@@ -4,34 +4,37 @@ module Css = Cascade.Css
 
 (** {1 Helper Functions} *)
 
-(* Parse a bracket value like [4px] and return a Css.length *)
+(* Parse a bracket value like [4px] or [var(--x)] and return a Css.length *)
 let parse_bracket_length s : (Css.length, _) result =
   if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']' then (
     let inner = String.sub s 1 (String.length s - 2) in
-    let slen = String.length inner in
-    let i = ref 0 in
-    while
-      !i < slen
-      && (inner.[!i] = '-'
-         || inner.[!i] = '.'
-         || (inner.[!i] >= '0' && inner.[!i] <= '9'))
-    do
-      incr i
-    done;
-    let num_s = String.sub inner 0 !i in
-    let unit_s = String.sub inner !i (slen - !i) in
-    match Float.of_string_opt num_s with
-    | None -> Error (`Msg ("Invalid number: " ^ num_s))
-    | Some n -> (
-        let open Css in
-        match unit_s with
-        | "px" -> Ok (Px n)
-        | "rem" -> Ok (Rem n)
-        | "em" -> Ok (Em n)
-        | "%" -> Ok (Pct n)
-        | "vw" -> Ok (Vw n)
-        | "vh" -> Ok (Vh n)
-        | _ -> Error (`Msg ("Invalid length unit: " ^ unit_s))))
+    if Parse.is_var inner then
+      Ok (Css.Var (Var.bracket (Parse.extract_var_name inner)) : Css.length)
+    else
+      let slen = String.length inner in
+      let i = ref 0 in
+      while
+        !i < slen
+        && (inner.[!i] = '-'
+           || inner.[!i] = '.'
+           || (inner.[!i] >= '0' && inner.[!i] <= '9'))
+      do
+        incr i
+      done;
+      let num_s = String.sub inner 0 !i in
+      let unit_s = String.sub inner !i (slen - !i) in
+      match Float.of_string_opt num_s with
+      | None -> Error (`Msg ("Invalid number: " ^ num_s))
+      | Some n -> (
+          let open Css in
+          match unit_s with
+          | "px" -> Ok (Px n)
+          | "rem" -> Ok (Rem n)
+          | "em" -> Ok (Em n)
+          | "%" -> Ok (Pct n)
+          | "vw" -> Ok (Vw n)
+          | "vh" -> Ok (Vh n)
+          | _ -> Error (`Msg ("Invalid length unit: " ^ unit_s))))
   else Error (`Msg ("Not a bracket value: " ^ s))
 
 (* Negate an inset length: simple units flip sign directly; var()/calc() and

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -47,6 +47,25 @@ let named_inset_requires_theme_token () =
   | Ok _ -> ()
   | Error (`Msg m) -> Alcotest.failf "top-header with theme rejected: %s" m
 
+(* Arbitrary var() insets (top-[var(--t)], inset-[var(--i)]) reference the var
+   directly; they used to be unknown classes because the bracket parser only
+   accepted numeric lengths. *)
+let test_arbitrary_var () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "top-[var(--t)] sets top: var(--t)" true
+    (Astring.String.is_infix ~affix:"top: var(--t)" (css "top-[var(--t)]"));
+  Alcotest.(check bool)
+    "inset-[var(--i)] sets inset: var(--i)" true
+    (Astring.String.is_infix ~affix:"inset: var(--i)" (css "inset-[var(--i)]"));
+  (* round-trips the class name *)
+  check "top-[var(--t)]";
+  check "left-[var(--l)]"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -65,6 +84,7 @@ let tests =
     test_case "position utilities" `Quick test_position_utilities;
     test_case "named inset requires theme token" `Quick
       named_inset_requires_theme_token;
+    test_case "arbitrary var insets" `Quick test_arbitrary_var;
     test_case "position suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
   ]


### PR DESCRIPTION
`top-[var(--t)]`, `inset-[var(--i)]` and the other inset utilities rejected a `var()` bracket value: the bracket parser only accepted a numeric length with a unit. They now parse `[var(--x)]` to a var reference, which also unblocks the `top-(--x)` paren shorthand for these utilities (it normalises to the bracket form). Surfaced by a parity sweep over Headless UI source.