### PR TITLE
effects: register the @property family for ring-inset

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -16,16 +16,7 @@ module Handler = struct
     let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
     if a = 255 then rgb else rgb ^ hex_byte a
 
-  type shadow_shape =
-    | Two_xs
-    | Xs
-    | Sm
-    | Default
-    | Md
-    | Lg
-    | Xl
-    | Two_xl
-
+  type shadow_shape = Two_xs | Xs | Sm | Default | Md | Lg | Xl | Two_xl
   type inset_shadow_shape = Ish_2xs | Ish_xs | Ish_sm
 
   (* Color in an arbitrary shadow value *)
@@ -663,7 +654,8 @@ module Handler = struct
     in
     let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_value) in
     let theme_color_var =
-      Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c
+        shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -685,7 +677,8 @@ module Handler = struct
     let hex_with_alpha = Color.hex_with_alpha hex_value percent in
     let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_with_alpha) in
     let theme_color_var =
-      Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c
+        shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -1219,7 +1212,8 @@ module Handler = struct
     in
     let base_decl, _ = Var.binding inset_shadow_color_var (Css.hex hex_value) in
     let theme_color_var =
-      Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color"
+        c shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -1244,7 +1238,8 @@ module Handler = struct
       Var.binding inset_shadow_color_var (Css.hex hex_with_alpha)
     in
     let theme_color_var =
-      Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color" c shade
+      Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color"
+        c shade
     in
     let theme_decl, color_ref =
       Var.binding theme_color_var (Css.hex hex_value)
@@ -1509,7 +1504,9 @@ module Handler = struct
     let decl, _var_ref =
       Var.binding ring_inset_var (Css.Variables.custom_value_ident "inset")
     in
-    style [ decl ]
+    (* Register the ring/shadow @property family, like the other ring utilities;
+       Tailwind emits it for ring-inset too. *)
+    style ~property_rules:shadow_property_rules [ decl ]
 
   let ring_color ?theme color shade =
     let cvar =
@@ -1528,7 +1525,8 @@ module Handler = struct
     | Some hex_alpha ->
         let fallback, _ = Var.binding ring_color_var (Css.hex hex_alpha) in
         let cvar =
-          Color.property_color_var ?theme ~property_prefix:"ring-color" color shade
+          Color.property_color_var ?theme ~property_prefix:"ring-color" color
+            shade
         in
         let color_value =
           Color.property_color_value ~property_prefix:"ring-color" color shade
@@ -1568,7 +1566,8 @@ module Handler = struct
     (* Sets --tw-ring-offset-color to reference theme color variable. Uses
        property-scoped variable: --ring-offset-color-blue-500 *)
     let color_theme_var =
-      Color.property_color_var ?theme ~property_prefix:"ring-offset-color" color shade
+      Color.property_color_var ?theme ~property_prefix:"ring-offset-color" color
+        shade
     in
     let color_value =
       Color.property_color_value ~property_prefix:"ring-offset-color" color
@@ -1630,8 +1629,8 @@ module Handler = struct
           Var.binding ring_offset_color_var (Css.hex hex_alpha)
         in
         let cvar =
-          Color.property_color_var ?theme ~property_prefix:"ring-offset-color" color
-            shade
+          Color.property_color_var ?theme ~property_prefix:"ring-offset-color"
+            color shade
         in
         let color_value =
           Color.property_color_value ~property_prefix:"ring-offset-color" color
@@ -1759,7 +1758,8 @@ module Handler = struct
   (* Inset-ring utilities *)
   let inset_ring_color ?theme color shade =
     let cvar =
-      Color.property_color_var ?theme ~property_prefix:"inset-ring-color" color shade
+      Color.property_color_var ?theme ~property_prefix:"inset-ring-color" color
+        shade
     in
     let color_value =
       Color.property_color_value ~property_prefix:"inset-ring-color" color shade
@@ -1776,8 +1776,8 @@ module Handler = struct
           Var.binding inset_ring_color_var (Css.hex hex_alpha)
         in
         let cvar =
-          Color.property_color_var ?theme ~property_prefix:"inset-ring-color" color
-            shade
+          Color.property_color_var ?theme ~property_prefix:"inset-ring-color"
+            color shade
         in
         let color_value =
           Color.property_color_value ~property_prefix:"inset-ring-color" color
@@ -2568,7 +2568,7 @@ module Handler = struct
     | [ "ring"; "4" ] -> Ok Ring_lg
     | [ "ring"; "8" ] -> Ok Ring_xl
     | [ "ring"; n ]
-      when (match int_of_string_opt n with Some w -> w > 0 | None -> false) ->
+      when match int_of_string_opt n with Some w -> w > 0 | None -> false ->
         Ok (Ring_width (int_of_string n))
     | [ "ring"; "inset" ] -> Ok Ring_inset
     | [ "ring"; "transparent" ] -> Ok Ring_transparent

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -62,6 +62,20 @@ let test_filters_css_generation () =
   Alcotest.check bool "has backdrop-filter property" true
     (Astring.String.is_infix ~affix:"backdrop-filter:" css)
 
+(* ring-inset registers the ring/shadow @property family, like the other ring
+   utilities; it used to emit only the --tw-ring-inset declaration. *)
+let test_ring_inset_property_rules () =
+  let open Tw in
+  let css =
+    match of_string "ring-inset" with
+    | Ok u -> to_css ~base:false [ u ] |> Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "ring-inset: %s" m
+  in
+  Alcotest.check bool "ring-inset sets --tw-ring-inset" true
+    (Astring.String.is_infix ~affix:"--tw-ring-inset: inset" css);
+  Alcotest.check bool "ring-inset registers @property --tw-ring-shadow" true
+    (Astring.String.is_infix ~affix:"@property --tw-ring-shadow" css)
+
 let of_string_invalid () =
   (* Invalid effects values *)
   let fail_maybe input =
@@ -190,6 +204,8 @@ let tests =
     test_case "effects of_string - valid values" `Quick of_string_valid;
     test_case "effects of_string - invalid values" `Quick of_string_invalid;
     test_case "ring of_string - valid values" `Quick test_ring_of_string_valid;
+    test_case "ring-inset @property family" `Quick
+      test_ring_inset_property_rules;
     test_case "filters css generation" `Quick test_filters_css_generation;
     test_case "effects suborder matches Tailwind" `Quick
       suborder_matches_tailwind;


### PR DESCRIPTION
`ring-inset` set `--tw-ring-inset` but did not register the ring/shadow `@property` family, so the 14 `@property` rules the other ring utilities emit were missing from its output. It now passes `shadow_property_rules` like `ring` and `ring-N` do. Surfaced by a parity sweep over Headless UI source.