### PR TITLE
effects: support ring/inset-ring shadeless colors with opacity

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2994,7 +2994,12 @@ let hex_alpha_color ?theme c shade opacity =
   let color_name = scheme_color_name c shade in
   match Scheme.hex_color (resolve_scheme theme) color_name with
   | Some hex_value -> Some (hex_with_alpha hex_value percent)
-  | None -> None
+  | None ->
+      (* Shadeless base colours (black/white) have no scheme entry but a known
+         hex, so an /opacity modifier still resolves to a colour. *)
+      if is_base_color c then
+        Some (hex_with_alpha (to_oklch_css c shade) percent)
+      else None
 
 let color_mix_supports_condition = Handler.color_mix_supports_condition
 

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2585,6 +2585,21 @@ module Handler = struct
            && v.[0] = '['
            && Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
         parse_ring_bracket `Ring v
+    (* Shadeless theme colours (ring-black, ring-white, with optional /opacity);
+       shaded colours like ring-red need an explicit shade and use the 3-part
+       arm below. *)
+    | [ "ring"; v ]
+      when let base, _ = Color.parse_opacity_modifier ~theme v in
+           match Color.of_string base with
+           | Ok c -> Color.is_shadeless c
+           | Error _ -> false -> (
+        let base, opacity = Color.parse_opacity_modifier ~theme v in
+        match Color.of_string base with
+        | Ok c -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_color (c, 500))
+            | _ -> Ok (Ring_color_opacity (c, 500, opacity)))
+        | Error _ -> err_not_utility)
     | [ "ring"; "offset"; "transparent" ] -> Ok Ring_offset_transparent
     | [ "ring"; "offset"; "inherit" ] -> Ok Ring_offset_inherit
     | [ "ring"; "offset"; current_str ]
@@ -2636,6 +2651,19 @@ module Handler = struct
            && v.[0] = '['
            && Parse.is_bracket_value (fst (Color.parse_opacity_modifier v)) ->
         parse_ring_bracket `Inset_ring v
+    (* Shadeless theme colours (inset-ring-black, with optional /opacity). *)
+    | [ "inset"; "ring"; v ]
+      when let base, _ = Color.parse_opacity_modifier ~theme v in
+           match Color.of_string base with
+           | Ok c -> Color.is_shadeless c
+           | Error _ -> false -> (
+        let base, opacity = Color.parse_opacity_modifier ~theme v in
+        match Color.of_string base with
+        | Ok c -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Inset_ring_color (c, 500))
+            | _ -> Ok (Inset_ring_color_opacity (c, 500, opacity)))
+        | Error _ -> err_not_utility)
     | [ "inset"; "ring"; n ] -> (
         match Parse.int_any n with
         | Ok width -> Ok (Inset_ring_width width)
@@ -2770,10 +2798,14 @@ module Handler = struct
     | Ring_width w -> "ring-" ^ string_of_int w
     | Ring_inset -> "ring-inset"
     | Ring_color (color, shade) ->
-        "ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
+        if Color.is_shadeless color then "ring-" ^ Color.pp color
+        else "ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
     | Ring_color_opacity (color, shade, opacity) ->
-        "ring-" ^ Color.pp color ^ "-" ^ string_of_int shade ^ "/"
-        ^ Color.pp_opacity opacity
+        let base =
+          if Color.is_shadeless color then "ring-" ^ Color.pp color
+          else "ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
+        in
+        base ^ "/" ^ Color.pp_opacity opacity
     | Ring_transparent -> "ring-transparent"
     | Ring_current -> "ring-current"
     | Ring_current_opacity o -> "ring-current/" ^ Color.pp_opacity o
@@ -2810,10 +2842,14 @@ module Handler = struct
     | Ring_offset_bracket_var_opacity (v, o) ->
         "ring-offset-[" ^ v ^ "]/" ^ Color.pp_opacity o
     | Inset_ring_color (color, shade) ->
-        "inset-ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
+        if Color.is_shadeless color then "inset-ring-" ^ Color.pp color
+        else "inset-ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
     | Inset_ring_color_opacity (color, shade, opacity) ->
-        "inset-ring-" ^ Color.pp color ^ "-" ^ string_of_int shade ^ "/"
-        ^ Color.pp_opacity opacity
+        let base =
+          if Color.is_shadeless color then "inset-ring-" ^ Color.pp color
+          else "inset-ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
+        in
+        base ^ "/" ^ Color.pp_opacity opacity
     | Inset_ring_transparent -> "inset-ring-transparent"
     | Inset_ring_current -> "inset-ring-current"
     | Inset_ring_current_opacity o -> "inset-ring-current/" ^ Color.pp_opacity o

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -42,7 +42,28 @@ let test_ring_of_string_valid () =
   check "ring-3";
   check "ring-5";
   check "ring-12";
-  check "ring-inset"
+  check "ring-inset";
+  (* shadeless theme colours, with and without /opacity *)
+  check "ring-black";
+  check "ring-white/10";
+  check "inset-ring-black";
+  check "inset-ring-white/10"
+
+(* ring-black / ring-white (shadeless theme colours) parse with an optional
+   /opacity; a shaded colour without a shade (ring-red) stays rejected. *)
+let test_ring_shadeless_color () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.check bool "ring-black sets ring color" true
+    (Astring.String.is_infix ~affix:"--tw-ring-color" (css "ring-black"));
+  Alcotest.check bool "ring-white/10 uses color-mix" true
+    (Astring.String.is_infix ~affix:"color-mix" (css "ring-white/10"));
+  match Tw.of_string "ring-red" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "ring-red (no shade) should be rejected"
 
 let test_filters_css_generation () =
   (* Spot-check a few filter/backdrop utilities *)
@@ -206,6 +227,7 @@ let tests =
     test_case "ring of_string - valid values" `Quick test_ring_of_string_valid;
     test_case "ring-inset @property family" `Quick
       test_ring_inset_property_rules;
+    test_case "ring shadeless color opacity" `Quick test_ring_shadeless_color;
     test_case "filters css generation" `Quick test_filters_css_generation;
     test_case "effects suborder matches Tailwind" `Quick
       suborder_matches_tailwind;


### PR DESCRIPTION
`ring-black`, `ring-white` and the `inset-ring` variants (with an optional `/opacity`) were rejected: the ring colour arms only matched shaded colours with an explicit shade. They now accept shadeless theme colours and render the class name without a shade. `hex_alpha_color` resolves the known hex for shadeless base colours so the `/opacity` color-mix applies — it returned `None` before, silently dropping the opacity. Shaded colours used without a shade (`ring-red`) stay rejected. Surfaced by a parity sweep over shadcn/ui.