### PR TITLE
tw: --diff mode selection and --input-css project theme

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3,11 +3,11 @@ open Cascade_diff
 open Cmdliner
 
 (* Parse a whitespace-separated string of classes *)
-let parse_classes ?(warn = true) classes_str =
+let parse_classes ?(warn = true) ?(theme = Tw.Scheme.default) classes_str =
   let class_names = Tw_tools.Source_scan.split_whitespace classes_str in
   List.filter_map
     (fun cls ->
-      match Tw.of_string cls with
+      match Tw.of_string ~theme cls with
       | Ok style -> Some style
       | Error _ ->
           if warn then Fmt.epr "Warning: Unknown class '%s'@." cls;
@@ -39,7 +39,90 @@ type gen_opts = {
   quiet : bool;
   css_mode : Tw.Css.mode;
   backend : backend;
+  theme : Tw.Scheme.t;
+      (** Theme used by tw's renderer, built from the project's --input-css so a
+          --diff over a real repo compares against the same [@theme] Tailwind
+          uses. Defaults to {!Tw.Scheme.default}. *)
+  input_css : string option;
+      (** Path to the project's CSS entrypoint, fed verbatim to the real
+          Tailwind backend so both sides share the project config. *)
+  diff_mode : Cascade_diff.Css_compare.mode;
+      (** Comparison mode for --diff. [`Canonical] (semantic) ignores selector
+          regrouping/reordering and is right for real-world parity sweeps;
+          [`Auto] (structural) reports regrouping, for tests that target it. *)
 }
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+(* Extract @theme token overrides ([(bare-name, value)]) from a project CSS
+   entrypoint, so tw renders with the same tokens Tailwind reads from it. This
+   reads name->value strings from the config (consumed by
+   Scheme.with_overrides); it does not synthesise CSS values. Handles [@theme],
+   [@theme inline], etc. *)
+let theme_overrides_of_css css =
+  let len = String.length css in
+  let acc = ref [] in
+  (* Parse "--name: value;" declarations inside [s.[lo .. hi)] (one @theme
+     body). *)
+  let parse_block lo hi =
+    let i = ref lo in
+    while !i < hi do
+      (* Skip to the next custom-property declaration. *)
+      if !i + 1 < hi && css.[!i] = '-' && css.[!i + 1] = '-' then begin
+        let name_start = !i in
+        while !i < hi && css.[!i] <> ':' && css.[!i] <> '}' do
+          incr i
+        done;
+        if !i < hi && css.[!i] = ':' then begin
+          let name =
+            String.trim (String.sub css name_start (!i - name_start))
+          in
+          incr i;
+          let val_start = !i in
+          while !i < hi && css.[!i] <> ';' && css.[!i] <> '}' do
+            incr i
+          done;
+          let value = String.trim (String.sub css val_start (!i - val_start)) in
+          (* Drop the leading "--" for the Scheme override key. *)
+          if String.length name > 2 then
+            acc := (String.sub name 2 (String.length name - 2), value) :: !acc
+        end
+      end
+      else incr i
+    done
+  in
+  (* Walk @theme blocks, matching braces to find each body. *)
+  let i = ref 0 in
+  while !i < len do
+    if !i + 6 <= len && String.sub css !i 6 = "@theme" then begin
+      (* Advance to the block's opening brace. *)
+      let j = ref (!i + 6) in
+      while !j < len && css.[!j] <> '{' && css.[!j] <> ';' do
+        incr j
+      done;
+      if !j < len && css.[!j] = '{' then begin
+        let body_start = !j + 1 in
+        let depth = ref 1 in
+        let k = ref body_start in
+        while !k < len && !depth > 0 do
+          (match css.[!k] with
+          | '{' -> incr depth
+          | '}' -> decr depth
+          | _ -> ());
+          if !depth > 0 then incr k
+        done;
+        parse_block body_start !k;
+        i := !k + 1
+      end
+      else i := !j + 1
+    end
+    else incr i
+  done;
+  List.rev !acc
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default
@@ -81,14 +164,14 @@ let diff_single_class class_str ~(opts : gen_opts) =
   try
     let legacy_css =
       Tw_tools.Tailwind_gen.generate ~minify:opts.minify ~optimize:opts.optimize
-        ~forms:true [ class_str ]
+        ~forms:true ?input_css:opts.input_css [ class_str ]
     in
-    let tw_styles = parse_classes ~warn:false class_str in
+    let tw_styles = parse_classes ~warn:false ~theme:opts.theme class_str in
     let styles = match tw_styles with [] -> [] | s -> s in
-    let stylesheet = Tw.to_css ~base:true styles in
+    let stylesheet = Tw.to_css ~theme:opts.theme ~base:true styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
-      Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+      Css_compare.diff ~mode:opts.diff_mode ~prune_unused_custom_props:true
         legacy_css our_css
     in
     match tw_styles with
@@ -148,10 +231,10 @@ let print_stats ~quiet ~candidate_count ~known_count =
     Fmt.epr "Candidate tokens scanned: %d@." candidate_count;
     Fmt.epr "Successfully parsed: %d@." known_count)
 
-let parse_known_candidates candidates =
+let parse_known_candidates ?(theme = Tw.Scheme.default) candidates =
   List.filter_map
     (fun cls ->
-      match Tw.of_string cls with
+      match Tw.of_string ~theme cls with
       | Ok style -> Some (cls, style)
       | Error _ -> None)
     candidates
@@ -165,13 +248,15 @@ let diff_files paths ~(opts : gen_opts) =
     in
     let legacy_css =
       Tw_tools.Tailwind_gen.generate ~minify:opts.minify ~optimize:opts.optimize
-        ~forms:true all_classes
+        ~forms:true ?input_css:opts.input_css all_classes
     in
-    let tw_styles = parse_known_candidates all_classes |> List.map snd in
-    let stylesheet = Tw.to_css ~base:true tw_styles in
+    let tw_styles =
+      parse_known_candidates ~theme:opts.theme all_classes |> List.map snd
+    in
+    let stylesheet = Tw.to_css ~theme:opts.theme ~base:true tw_styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
-      Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+      Css_compare.diff ~mode:opts.diff_mode ~prune_unused_custom_props:true
         legacy_css our_css
     in
     print_diff_result "" diff;
@@ -220,7 +305,7 @@ let process_files paths flag ~(opts : gen_opts) =
   | Native -> native_files paths flag ~opts
 
 let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
-    paths =
+    ~input_css ~diff_mode paths =
   (* Resolve default CSS mode based on operation kind when not provided *)
   let resolved_css_mode : Css.mode =
     match (single_class, backend, css_mode) with
@@ -233,6 +318,16 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
   (* Diff mode forces minified output; Cascade handles semantic comparison. *)
   let resolved_minify = match backend with Diff -> true | _ -> minify in
   let resolved_optimize = optimize in
+  (* Build the renderer theme from the project's CSS entrypoint (its @theme), so
+     a --diff over a real repo compares against the same tokens Tailwind
+     uses. *)
+  let css_content = Option.map read_file input_css in
+  let theme =
+    match css_content with
+    | None -> Tw.Scheme.default
+    | Some css ->
+        Tw.Scheme.with_overrides Tw.Scheme.default (theme_overrides_of_css css)
+  in
   let opts : gen_opts =
     {
       minify = resolved_minify;
@@ -240,6 +335,9 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
       quiet;
       css_mode = resolved_css_mode;
       backend;
+      theme;
+      input_css = css_content;
+      diff_mode;
     }
   in
   match single_class with
@@ -283,19 +381,39 @@ let quiet_flag =
   let doc = "Suppress warnings about unknown classes" in
   Arg.(value & flag & info [ "q"; "quiet" ] ~doc)
 
-let backend_vflag =
+let input_css_arg =
+  let doc =
+    "Project CSS entrypoint to feed to Tailwind during --diff. @theme blocks \
+     are also used to configure tw's renderer."
+  in
+  Arg.(value & opt (some file) None & info [ "input-css" ] ~docv:"CSS" ~doc)
+
+let tailwind_flag =
   let doc_tailwind = "Use the real tailwindcss tool to generate CSS" in
-  let doc_diff =
-    "Compare tw output with real Tailwind CSS (shows differences). Forces \
-     --variables --base --minify for comparison."
+  Arg.(value & flag & info [ "tailwind" ] ~doc:doc_tailwind)
+
+let diff_flag =
+  let doc = "Compare tw output with real Tailwind CSS." in
+  Arg.(value & flag & info [ "diff" ] ~doc)
+
+let diff_mode_arg =
+  let doc =
+    "CSS comparison mode for --diff: semantic (canonical compare; default), \
+     auto, tree/structural, or string."
+  in
+  let mode_conv =
+    Arg.enum
+      [
+        ("semantic", `Canonical);
+        ("canonical", `Canonical);
+        ("auto", `Auto);
+        ("tree", `Tree);
+        ("structural", `Tree);
+        ("string", `String);
+      ]
   in
   Arg.(
-    value
-    & vflag Native
-        [
-          (Tailwind, info [ "tailwind" ] ~doc:doc_tailwind);
-          (Diff, info [ "diff" ] ~doc:doc_diff);
-        ])
+    value & opt mode_conv `Canonical & info [ "diff-mode" ] ~docv:"MODE" ~doc)
 
 let css_mode_vflag =
   let doc_inline = "Inline mode: resolve values (no variables), no layers." in
@@ -341,8 +459,10 @@ let cmd =
       `Pre "  tw --minify --optimize index.html src/";
       `P "Use real Tailwind CSS:";
       `Pre "  tw -s bg-blue-500 --tailwind";
-      `P "Compare tw output with real Tailwind CSS (minified and optimized):";
-      `Pre "  tw -s prose-sm --diff";
+      `P "Compare tw output with real Tailwind CSS:";
+      `Pre "  tw -s prose-sm --diff --diff-mode=semantic";
+      `P "Use structural diff output when regrouping/order is relevant:";
+      `Pre "  tw -s prose-sm --diff --diff-mode=tree";
       `S Manpage.s_see_also;
       `P "https://tailwindcss.com";
     ]
@@ -351,10 +471,29 @@ let cmd =
   Cmd.v info
     Term.(
       ret
-        (const (fun s b css_m m o q backend paths ->
+        (const (fun s b css_m m o q tailwind diff diff_mode input_css paths ->
+             let backend, diff_mode =
+               if diff then (Diff, diff_mode)
+               else
+                 let backend = if tailwind then Tailwind else Native in
+                 (backend, `Canonical)
+             in
              tw_main s b ~css_mode:css_m ~minify:m ~optimize:o ~quiet:q ~backend
-               paths)
+               ~diff_mode ~input_css paths)
         $ single_flag $ base_flag $ css_mode_vflag $ minify_flag $ optimize_flag
-        $ quiet_flag $ backend_vflag $ paths_arg))
+        $ quiet_flag $ tailwind_flag $ diff_flag $ diff_mode_arg $ input_css_arg
+        $ paths_arg))
 
-let () = exit (Cmd.eval cmd)
+let normalize_argv argv =
+  argv |> Array.to_list
+  |> List.concat_map (fun arg ->
+      let prefix = "--diff=" in
+      let prefix_len = String.length prefix in
+      if String.length arg > prefix_len && String.sub arg 0 prefix_len = prefix
+      then
+        let mode = String.sub arg prefix_len (String.length arg - prefix_len) in
+        [ "--diff"; "--diff-mode=" ^ mode ]
+      else [ arg ])
+  |> Array.of_list
+
+let () = exit (Cmd.eval ~argv:(normalize_argv Sys.argv) cmd)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -47,9 +47,10 @@ type gen_opts = {
       (** Path to the project's CSS entrypoint, fed verbatim to the real
           Tailwind backend so both sides share the project config. *)
   diff_mode : Cascade_diff.Css_compare.mode;
-      (** Comparison mode for --diff. [`Canonical] (semantic) ignores selector
+      (** Comparison mode for --diff. [`Canonical] (default) ignores selector
           regrouping/reordering and is right for real-world parity sweeps;
-          [`Auto] (structural) reports regrouping, for tests that target it. *)
+          [`Auto]/[`Tree] (structural) reports regrouping, for tests that target
+          it. *)
 }
 
 let read_file path =
@@ -58,71 +59,56 @@ let read_file path =
     ~finally:(fun () -> close_in ic)
     (fun () -> really_input_string ic (in_channel_length ic))
 
-(* Extract @theme token overrides ([(bare-name, value)]) from a project CSS
-   entrypoint, so tw renders with the same tokens Tailwind reads from it. This
-   reads name->value strings from the config (consumed by
-   Scheme.with_overrides); it does not synthesise CSS values. Handles [@theme],
-   [@theme inline], etc. *)
-let theme_overrides_of_css css =
+(* Rewrite each Tailwind [@theme [modifiers] {] header to a [:root {] rule.
+   Cascade's parser accepts [@theme] but drops its body (it is not a standard
+   at-rule), so this swaps only the at-rule keyword and its modifiers up to the
+   opening brace; the declarations themselves are left for the real parser. *)
+let theme_blocks_as_root css =
   let len = String.length css in
-  let acc = ref [] in
-  (* Parse "--name: value;" declarations inside [s.[lo .. hi)] (one @theme
-     body). *)
-  let parse_block lo hi =
-    let i = ref lo in
-    while !i < hi do
-      (* Skip to the next custom-property declaration. *)
-      if !i + 1 < hi && css.[!i] = '-' && css.[!i + 1] = '-' then begin
-        let name_start = !i in
-        while !i < hi && css.[!i] <> ':' && css.[!i] <> '}' do
-          incr i
-        done;
-        if !i < hi && css.[!i] = ':' then begin
-          let name =
-            String.trim (String.sub css name_start (!i - name_start))
-          in
-          incr i;
-          let val_start = !i in
-          while !i < hi && css.[!i] <> ';' && css.[!i] <> '}' do
-            incr i
-          done;
-          let value = String.trim (String.sub css val_start (!i - val_start)) in
-          (* Drop the leading "--" for the Scheme override key. *)
-          if String.length name > 2 then
-            acc := (String.sub name 2 (String.length name - 2), value) :: !acc
-        end
-      end
-      else incr i
-    done
-  in
-  (* Walk @theme blocks, matching braces to find each body. *)
+  let buf = Buffer.create len in
   let i = ref 0 in
   while !i < len do
     if !i + 6 <= len && String.sub css !i 6 = "@theme" then begin
-      (* Advance to the block's opening brace. *)
+      (* Skip the header up to the block's opening brace. *)
       let j = ref (!i + 6) in
       while !j < len && css.[!j] <> '{' && css.[!j] <> ';' do
         incr j
       done;
       if !j < len && css.[!j] = '{' then begin
-        let body_start = !j + 1 in
-        let depth = ref 1 in
-        let k = ref body_start in
-        while !k < len && !depth > 0 do
-          (match css.[!k] with
-          | '{' -> incr depth
-          | '}' -> decr depth
-          | _ -> ());
-          if !depth > 0 then incr k
-        done;
-        parse_block body_start !k;
-        i := !k + 1
+        Buffer.add_string buf ":root ";
+        i := !j (* keep the '{' and the body verbatim *)
       end
-      else i := !j + 1
+      else begin
+        Buffer.add_char buf css.[!i];
+        incr i
+      end
     end
-    else incr i
+    else begin
+      Buffer.add_char buf css.[!i];
+      incr i
+    end
   done;
-  List.rev !acc
+  Buffer.contents buf
+
+(* Extract @theme token overrides ([(bare-name, value)]) from a project CSS
+   entrypoint, so tw renders with the same tokens Tailwind reads from it. The
+   declarations are parsed by cascade (after the @theme -> :root header swap);
+   the resulting name/value strings feed Scheme.with_overrides. *)
+let theme_overrides_of_css css =
+  match Css.of_string (theme_blocks_as_root css) with
+  | Error _ -> []
+  | Ok parse ->
+      Css.rules_of_statements (Css.statements parse.Css.stylesheet)
+      |> List.concat_map (fun (_sel, decls) ->
+          List.filter_map
+            (fun d ->
+              match Css.custom_declaration_name d with
+              | Some n when String.length n > 2 && String.sub n 0 2 = "--" ->
+                  Some
+                    ( String.sub n 2 (String.length n - 2),
+                      Css.declaration_value d )
+              | _ -> None)
+            decls)
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default
@@ -398,13 +384,13 @@ let diff_flag =
 
 let diff_mode_arg =
   let doc =
-    "CSS comparison mode for --diff: semantic (canonical compare; default), \
-     auto, tree/structural, or string."
+    "CSS comparison mode for --diff: canonical (default, ignores selector \
+     regrouping/reordering, right for real-world parity sweeps), auto, \
+     tree/structural (reports regrouping), or string."
   in
   let mode_conv =
     Arg.enum
       [
-        ("semantic", `Canonical);
         ("canonical", `Canonical);
         ("auto", `Auto);
         ("tree", `Tree);
@@ -460,7 +446,7 @@ let cmd =
       `P "Use real Tailwind CSS:";
       `Pre "  tw -s bg-blue-500 --tailwind";
       `P "Compare tw output with real Tailwind CSS:";
-      `Pre "  tw -s prose-sm --diff --diff-mode=semantic";
+      `Pre "  tw -s prose-sm --diff --diff-mode=canonical";
       `P "Use structural diff output when regrouping/order is relevant:";
       `Pre "  tw -s prose-sm --diff --diff-mode=tree";
       `S Manpage.s_see_also;

--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -5,7 +5,7 @@ let write_file path content =
   output_string oc content;
   close_out oc
 
-let tailwind_files ?(forms = false) temp_dir classnames =
+let tailwind_files ?(forms = false) ?input_css temp_dir classnames =
   (* Feed candidates to the extractor verbatim, space-separated, as raw file
      text rather than inside an HTML class attribute. An attribute forces
      escaping one quote style into an HTML entity, and Tailwind's extractor
@@ -14,16 +14,23 @@ let tailwind_files ?(forms = false) temp_dir classnames =
      preserves both single and double quotes exactly as a real source file
      would, so arbitrary url() and content-["..."] values round-trip. *)
   let html_content = String.concat " " classnames in
+  (* When the caller supplies a project CSS entrypoint, use it verbatim so the
+     real Tailwind reads the project's @theme/@plugin/@config; otherwise
+     synthesise the default import. *)
   let input_css_content =
-    if forms then
-      (* forms plugin with strategy: 'class' requires a config file *)
-      "@import \"tailwindcss\";\n\
-       @plugin \"@tailwindcss/typography\";\n\
-       @config \"./tailwind.config.js\";"
-    else "@import \"tailwindcss\";\n@plugin \"@tailwindcss/typography\";"
+    match input_css with
+    | Some content -> content
+    | None ->
+        if forms then
+          (* forms plugin with strategy: 'class' requires a config file *)
+          "@import \"tailwindcss\";\n\
+           @plugin \"@tailwindcss/typography\";\n\
+           @config \"./tailwind.config.js\";"
+        else "@import \"tailwindcss\";\n@plugin \"@tailwindcss/typography\";"
   in
-  (* Generate tailwind.config.js when forms plugin is needed *)
-  (if forms then
+  (* Generate tailwind.config.js when forms plugin is needed (only for the
+     synthesised input; a supplied entrypoint carries its own config). *)
+  (if forms && input_css = None then
      let config_content =
        {|import forms from '@tailwindcss/forms'
 
@@ -228,7 +235,7 @@ let has_forms_class classnames =
     (fun cls -> String.length cls >= 5 && String.sub cls 0 5 = "form-")
     classnames
 
-let generate ?(minify = false) ?(optimize = true) ?forms classnames =
+let generate ?(minify = false) ?(optimize = true) ?forms ?input_css classnames =
   check_tailwindcss_available ();
 
   let dir = temp_dir () in
@@ -243,7 +250,7 @@ let generate ?(minify = false) ?(optimize = true) ?forms classnames =
       | Some f -> f && classnames <> []
       | None -> has_forms_class classnames
     in
-    tailwind_files ~forms:use_forms dir classnames;
+    tailwind_files ~forms:use_forms ?input_css dir classnames;
 
     let minify_flag = if minify then " --minify" else "" in
     let optimize_flag = if optimize then " --optimize" else "" in

--- a/lib/tools/tailwind_gen.mli
+++ b/lib/tools/tailwind_gen.mli
@@ -1,13 +1,21 @@
 (** Tailwind CSS generation utilities for testing *)
 
 val generate :
-  ?minify:bool -> ?optimize:bool -> ?forms:bool -> string list -> string
-(** [generate ?minify ?optimize ?forms classnames] generates Tailwind CSS for
-    given class names.
+  ?minify:bool ->
+  ?optimize:bool ->
+  ?forms:bool ->
+  ?input_css:string ->
+  string list ->
+  string
+(** [generate ?minify ?optimize ?forms ?input_css classnames] generates Tailwind
+    CSS for given class names.
     @param minify Whether to minify the output (default: false)
     @param optimize Whether to optimize the output (default: true)
     @param forms
       Whether to include [@tailwindcss/forms] plugin (default: auto-detect)
+    @param input_css
+      The project's CSS entrypoint content, used verbatim as the Tailwind input
+      so its [@theme]/[@plugin]/[@config] apply (default: synthesised import)
     @param classnames List of Tailwind class names
     @return The generated CSS as a string
     @raise Failure if Tailwind CSS generation fails. *)


### PR DESCRIPTION
Adds `--diff-mode` (canonical by default; `tree`/`structural` to report selector regrouping) and `--input-css FILE`, whose `@theme` is parsed via cascade and fed to the real Tailwind so `--diff` over a real repo compares against the project's theme. Directory mode also scans more source extensions.