### PR TITLE
rule: apply state modifiers to a utility's own media block

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1580,13 +1580,20 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
           in
           wrap_in_media outer_condition
       | _ ->
+          (* State/pseudo modifiers (focus, hover, ...) don't add an outer media
+             condition; they rewrite the inner rule's selector so a utility
+             whose own output is a media block (e.g. outline-hidden's
+             forced-colors reset) gets the modified selector inside the block.
+             The base_class is updated to the modified class so this media stays
+             grouped with the utility's regular rule (same-utility order),
+             rather than being treated as a different utility and reordered. *)
           [
             Media_query
               {
                 condition = inner_condition;
-                selector;
+                selector = new_selector;
                 props;
-                base_class;
+                base_class = Some modified_class;
                 nested;
                 not_order = 0;
               };

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -182,6 +182,24 @@ let test_outline_offset_arbitrary () =
     (Astring.String.is_infix ~affix:"outline-offset: 3px"
        (css "outline-offset-[3px]"))
 
+(* outline-hidden's forced-colors reset is its own @media block; under a state
+   modifier (focus, focus-within) the block must use the modified selector, not
+   the bare .outline-hidden, and stay grouped with the regular rule. It used to
+   keep the bare selector and reorder before the regular rule. *)
+let test_outline_hidden_modifier_forced_colors () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let out = css "focus:outline-hidden" in
+  Alcotest.(check bool)
+    "forced-colors block uses the focus-modified selector" true
+    (Astring.String.is_infix ~affix:".focus\\:outline-hidden:focus" out);
+  Alcotest.(check bool)
+    "forced-colors block is not the bare .outline-hidden" false
+    (Astring.String.is_infix ~affix:" .outline-hidden " out)
+
 (* Arbitrary per-side border widths (border-t-[1px], ...) emit the side width
    plus the side border-style var; they used to be unknown classes. *)
 let test_border_side_arbitrary_width () =
@@ -209,6 +227,8 @@ let tests =
     test_case "outline numeric widths" `Quick test_outline_widths;
     test_case "outline-offset arbitrary length" `Quick
       test_outline_offset_arbitrary;
+    test_case "outline-hidden modifier forced-colors" `Quick
+      test_outline_hidden_modifier_forced_colors;
     test_case "border side arbitrary widths" `Quick
       test_border_side_arbitrary_width;
     test_case "borders of_string - valid values" `Quick of_string_valid;


### PR DESCRIPTION
A utility whose own output is a media block — `outline-hidden`'s forced-colors reset — kept the bare `.outline-hidden` selector and reordered before the regular rule when a state modifier wrapped it. So `focus:outline-hidden` emitted `@media (forced-colors: active) { .outline-hidden { ... } }` ahead of the regular rule, instead of `.focus\:outline-hidden:focus` after it.

The state-modifier branch of `apply_modifier_to_media_query` now rewrites the inner selector to the modified class and tags the media with the modified `base_class`, so it uses the right selector and stays grouped with the regular rule (same-utility order). Fixes `focus:`/`focus-within:`; `hover:outline-hidden` (which also needs nesting under `@media (hover:hover)`) remains a follow-up. Surfaced by a parity sweep over shadcn/ui.