### PR TITLE
modifiers: support the full container-query size scale

### DIFF
--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -117,21 +117,37 @@ let at_container_named name = utility (Container_named name)
 
 (** Convert a container query modifier to a structured Container.t condition *)
 let container_query_to_condition = function
+  | Style.Container_3xs -> Css.Container.Min_width_rem 16.
+  | Style.Container_2xs -> Css.Container.Min_width_rem 18.
+  | Style.Container_xs -> Css.Container.Min_width_rem 20.
   | Style.Container_sm -> Css.Container.Min_width_rem 24.
   | Style.Container_md -> Css.Container.Min_width_rem 28.
   | Style.Container_lg -> Css.Container.Min_width_rem 32.
   | Style.Container_xl -> Css.Container.Min_width_rem 36.
   | Style.Container_2xl -> Css.Container.Min_width_rem 42.
+  | Style.Container_3xl -> Css.Container.Min_width_rem 48.
+  | Style.Container_4xl -> Css.Container.Min_width_rem 56.
+  | Style.Container_5xl -> Css.Container.Min_width_rem 64.
+  | Style.Container_6xl -> Css.Container.Min_width_rem 72.
+  | Style.Container_7xl -> Css.Container.Min_width_rem 80.
   | Style.Container_named ("", width) -> Css.Container.Min_width_px width
   | Style.Container_named (name, width) ->
       Css.Container.Named (name, Min_width_px width)
 
 let container_query_to_class_prefix = function
+  | Style.Container_3xs -> "@3xs"
+  | Style.Container_2xs -> "@2xs"
+  | Style.Container_xs -> "@xs"
   | Style.Container_sm -> "@sm"
   | Style.Container_md -> "@md"
   | Style.Container_lg -> "@lg"
   | Style.Container_xl -> "@xl"
   | Style.Container_2xl -> "@2xl"
+  | Style.Container_3xl -> "@3xl"
+  | Style.Container_4xl -> "@4xl"
+  | Style.Container_5xl -> "@5xl"
+  | Style.Container_6xl -> "@6xl"
+  | Style.Container_7xl -> "@7xl"
   | Style.Container_named ("", width) -> "@" ^ string_of_int width ^ "px"
   | Style.Container_named (name, width) ->
       "@" ^ name ^ "/" ^ string_of_int width

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1565,11 +1565,19 @@ let simple_modifiers =
     ("hocus", Hocus);
     ("device-hocus", Device_hocus);
     (* Container queries *)
+    ("@3xs", Container Container_3xs);
+    ("@2xs", Container Container_2xs);
+    ("@xs", Container Container_xs);
     ("@sm", Container Container_sm);
     ("@md", Container Container_md);
     ("@lg", Container Container_lg);
     ("@xl", Container Container_xl);
     ("@2xl", Container Container_2xl);
+    ("@3xl", Container Container_3xl);
+    ("@4xl", Container Container_4xl);
+    ("@5xl", Container Container_5xl);
+    ("@6xl", Container Container_6xl);
+    ("@7xl", Container Container_7xl);
   ]
 
 (* Try looking up a custom breakpoint (e.g., "10xl", "min-10xl", "max-10xl") *)

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -5,11 +5,19 @@ module Css = Cascade.Css
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
 
 type container_query =
+  | Container_3xs
+  | Container_2xs
+  | Container_xs
   | Container_sm
   | Container_md
   | Container_lg
   | Container_xl
   | Container_2xl
+  | Container_3xl
+  | Container_4xl
+  | Container_5xl
+  | Container_6xl
+  | Container_7xl
   | Container_named of string * int
 
 type modifier =
@@ -333,11 +341,19 @@ let rec pp_modifier = function
       "min-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
   | Max_arbitrary_length l ->
       "max-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
+  | Container Container_3xs -> "@3xs"
+  | Container Container_2xs -> "@2xs"
+  | Container Container_xs -> "@xs"
   | Container Container_sm -> "@sm"
   | Container Container_md -> "@md"
   | Container Container_lg -> "@lg"
   | Container Container_xl -> "@xl"
   | Container Container_2xl -> "@2xl"
+  | Container Container_3xl -> "@3xl"
+  | Container Container_4xl -> "@4xl"
+  | Container Container_5xl -> "@5xl"
+  | Container Container_6xl -> "@6xl"
+  | Container Container_7xl -> "@7xl"
   | Container (Container_named (n, size)) ->
       String.concat "" [ "@"; n; "/"; string_of_int size ]
   | Group_hover -> "group-hover"

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -5,11 +5,19 @@ open Cascade
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
 
 type container_query =
+  | Container_3xs
+  | Container_2xs
+  | Container_xs
   | Container_sm
   | Container_md
   | Container_lg
   | Container_xl
   | Container_2xl
+  | Container_3xl
+  | Container_4xl
+  | Container_5xl
+  | Container_6xl
+  | Container_7xl
   | Container_named of string * int
 
 type modifier =

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -386,6 +386,23 @@ let test_pp_modifier_strings () =
   check string "pp before" "before" (pp_modifier Pseudo_before);
   check string "pp not-hover" "not-hover" (pp_modifier (Not Hover))
 
+(* The full container-query size scale (@3xs .. @7xl) emits a container query at
+   the right min-width; @xs and @3xl+ used to be unknown modifiers. *)
+let test_container_query_scale () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check bool "@xs:flex is a 20rem container query" true
+    (Astring.String.is_infix ~affix:"@container (min-width: 20rem)"
+       (css "@xs:flex"));
+  check bool "@3xl:flex is a 48rem container query" true
+    (Astring.String.is_infix ~affix:"@container (min-width: 48rem)"
+       (css "@3xl:flex"));
+  check string "@xs round-trips" "@xs:p-4"
+    (Tw.Utility.to_class (Option.get (apply [ "@xs" ] (p 4))))
+
 (* Test apply with bracketed has/group-has/peer-has modifiers *)
 let test_apply_bracketed_has () =
   let u1 = apply [ "has-[.x]" ] (p 4) in
@@ -507,6 +524,7 @@ let tests =
       test_case "is_hover flags" `Quick test_is_hover;
       test_case "of_string parsing" `Quick test_of_string_parsing;
       test_case "pp_modifier strings" `Quick test_pp_modifier_strings;
+      test_case "container query scale" `Quick test_container_query_scale;
       test_case "apply bracketed has variants" `Quick test_apply_bracketed_has;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "before/after modifiers" `Quick test_before_after_modifiers;


### PR DESCRIPTION
Only the `@sm`–`@2xl` container variants were known; `@xs`, `@3xl`–`@7xl`, `@2xs` and `@3xs` were unknown modifiers. This extends the `container_query` scale to the full v4 set with the right `min-width` rems (`@xs` = 20rem, `@3xl` = 48rem, ...). The `@max-*` and arbitrary `@min-[...]`/`@max-[...]` container variants remain a follow-up. Surfaced by a parity sweep over real source.