### PR TITLE
filters: resolve drop-shadow-<color> without a scheme hex

### DIFF
--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -700,69 +700,70 @@ module Handler = struct
   let drop_shadow_color ?theme c shade =
     let color_name = Color.scheme_color_name c shade in
     let scheme = match theme with Some t -> t | None -> Scheme.default in
-    match Scheme.hex_color scheme color_name with
-    | Option.Some hex ->
-        let color_ref : Css.color Css.var =
-          Var.bracket ("color-" ^ color_name)
-        in
-        let supports_decl =
-          bind_drop_shadow_color
-            (Css.color_mix_var_percent ~in_space:Oklab
-               ~var_name:"tw-drop-shadow-alpha" (Css.Var color_ref)
-               Css.Transparent)
-        in
-        let supports_block =
-          Css.supports ~condition:Color.color_mix_supports_condition
-            [ Css.rule ~selector:(Css.Selector.class_ "_") [ supports_decl ] ]
-        in
-        Group
-          [
-            style ~rules:(Option.Some [ supports_block ])
-              (theme_decl_if_set ?theme ("color-" ^ color_name)
-              @ [ bind_drop_shadow_color (Css.hex hex) ]);
-            style ~property_rules:filter_property_rules
-              [ bind_drop_shadow drop_shadow_size_ref ];
-          ]
-    | Option.None ->
-        invalid_arg
-          ("drop-shadow color not found in scheme: "
-          ^ Color.scheme_color_name c shade)
+    (* srgb fallback: the scheme hex when defined, else the colour resolved
+       directly (oklch), matching Tailwind. The default scheme has no hex
+       colours, so the old [Scheme.hex_color]-only path raised on every
+       drop-shadow-<color>. *)
+    let fallback_color =
+      match Scheme.hex_color scheme color_name with
+      | Option.Some hex -> Css.hex hex
+      | Option.None -> Color.to_css c shade
+    in
+    let color_ref : Css.color Css.var = Var.bracket ("color-" ^ color_name) in
+    let supports_decl =
+      bind_drop_shadow_color
+        (Css.color_mix_var_percent ~in_space:Oklab
+           ~var_name:"tw-drop-shadow-alpha" (Css.Var color_ref) Css.Transparent)
+    in
+    let supports_block =
+      Css.supports ~condition:Color.color_mix_supports_condition
+        [ Css.rule ~selector:(Css.Selector.class_ "_") [ supports_decl ] ]
+    in
+    Group
+      [
+        style ~rules:(Option.Some [ supports_block ])
+          (theme_decl_if_set ?theme ("color-" ^ color_name)
+          @ [ bind_drop_shadow_color fallback_color ]);
+        style ~property_rules:filter_property_rules
+          [ bind_drop_shadow drop_shadow_size_ref ];
+      ]
 
   let drop_shadow_color_opacity ?theme c shade opacity =
     let color_name = Color.scheme_color_name c shade in
     let scheme = match theme with Some t -> t | None -> Scheme.default in
-    match Scheme.hex_color scheme color_name with
-    | Option.Some hex ->
-        let percent = Color.opacity_to_percent opacity in
-        let hex_with_alpha = Color.hex_with_alpha hex percent in
-        let color_ref : Css.color Css.var =
-          Var.bracket ("color-" ^ color_name)
-        in
-        let supports_decl =
-          let inner =
-            Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-              ~percent1:percent
-          in
-          bind_drop_shadow_color
-            (Css.color_mix_var_percent ~in_space:Oklab
-               ~var_name:"tw-drop-shadow-alpha" inner Css.Transparent)
-        in
-        let supports_block =
-          Css.supports ~condition:Color.color_mix_supports_condition
-            [ Css.rule ~selector:(Css.Selector.class_ "_") [ supports_decl ] ]
-        in
-        Group
-          [
-            style ~rules:(Option.Some [ supports_block ])
-              (theme_decl_if_set ?theme ("color-" ^ color_name)
-              @ [ bind_drop_shadow_color (Css.hex hex_with_alpha) ]);
-            style ~property_rules:filter_property_rules
-              [ bind_drop_shadow drop_shadow_size_ref ];
-          ]
-    | Option.None ->
-        invalid_arg
-          ("drop-shadow color not found in scheme: "
-          ^ Color.scheme_color_name c shade)
+    let percent = Color.opacity_to_percent opacity in
+    (* srgb fallback: a scheme hex gets a hex+alpha; without one (the default
+       scheme) mix the resolved colour in srgb, matching Tailwind. The old path
+       raised when the scheme had no hex. *)
+    let fallback_color =
+      match Scheme.hex_color scheme color_name with
+      | Option.Some hex -> Css.hex (Color.hex_with_alpha hex percent)
+      | Option.None ->
+          Css.color_mix ~in_space:Srgb (Color.to_css c shade) Css.Transparent
+            ~percent1:percent
+    in
+    let color_ref : Css.color Css.var = Var.bracket ("color-" ^ color_name) in
+    let supports_decl =
+      let inner =
+        Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
+          ~percent1:percent
+      in
+      bind_drop_shadow_color
+        (Css.color_mix_var_percent ~in_space:Oklab
+           ~var_name:"tw-drop-shadow-alpha" inner Css.Transparent)
+    in
+    let supports_block =
+      Css.supports ~condition:Color.color_mix_supports_condition
+        [ Css.rule ~selector:(Css.Selector.class_ "_") [ supports_decl ] ]
+    in
+    Group
+      [
+        style ~rules:(Option.Some [ supports_block ])
+          (theme_decl_if_set ?theme ("color-" ^ color_name)
+          @ [ bind_drop_shadow_color fallback_color ]);
+        style ~property_rules:filter_property_rules
+          [ bind_drop_shadow drop_shadow_size_ref ];
+      ]
 
   let drop_shadow_opacity ?theme opacity =
     let alpha_str =

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -25,6 +25,23 @@ let test_drop_shadow_xs () =
     "emits --drop-shadow-xs default" true
     (Astring.String.is_infix ~affix:"--drop-shadow-xs:" css)
 
+(* drop-shadow-<color> resolves the colour itself (oklch) for the srgb fallback
+   instead of requiring a scheme hex; it used to raise on the default theme
+   (which has no hex colours). *)
+let test_drop_shadow_color () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "drop-shadow-red-500 sets the drop-shadow color" true
+    (Astring.String.is_infix ~affix:"--tw-drop-shadow-color"
+       (css "drop-shadow-red-500"));
+  Alcotest.(check bool)
+    "drop-shadow-red-500/50 uses color-mix" true
+    (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"))
+
 let test_backdrop () =
   check "backdrop-opacity-50";
   check "backdrop-invert"
@@ -54,6 +71,7 @@ let tests =
   [
     test_case "blur" `Quick test_blur;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;
+    test_case "drop-shadow color (default theme)" `Quick test_drop_shadow_color;
     test_case "backdrop" `Quick test_backdrop;
     test_case "backdrop-blur token" `Quick test_backdrop_blur_token;
     test_case "filters suborder matches Tailwind" `Quick


### PR DESCRIPTION
`drop-shadow-red-500` (and `drop-shadow-<color>/<opacity>`) raised `Invalid_argument "drop-shadow color not found in scheme"` on the default theme: the srgb fallback only handled colours the scheme carries a hex for, and the default scheme has none. The colour is now resolved directly — `oklch` via `Color.to_css`, a srgb `color-mix` for the opacity form — when the scheme has no hex, matching Tailwind, so every `drop-shadow-<color>` renders instead of crashing. A scheme-defined hex still takes precedence. Surfaced by a parity sweep over real source.