### PR TITLE
tw: support typed paren-var shorthand prop-(<type>:--x)

### DIFF
--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -95,22 +95,32 @@ let split_whitespace s =
   List.rev !tokens
 
 (* The v4 [prop-(--x)] shorthand is [prop-[var(--x)]] in value but keeps its own
-   class name. Rewrite the trailing [(--x)] to [[var(--x)]] for parsing; the
-   original spelling is restored via [Utility.alias]. Returns [None] when there
-   is no paren shorthand. *)
+   class name. Rewrite the trailing [(...)] to its bracket form for parsing; the
+   original spelling is restored via [Utility.alias]. Handles the bare var
+   [(--x)] / [(--x,fallback)] -> [[var(--x...)]] and the typed
+   [(family-name:--x)] -> [[family-name:var(--x)]] forms. Returns [None] when
+   there is no paren shorthand. *)
 let normalize_paren_var base_class =
   let n = String.length base_class in
   if n > 4 && base_class.[n - 1] = ')' then
     match String.rindex_opt base_class '(' with
-    | Some lp
-      when lp > 0
-           && base_class.[lp - 1] = '-'
-           && lp + 2 < n
-           && base_class.[lp + 1] = '-'
-           && base_class.[lp + 2] = '-' ->
+    | Some lp when lp > 0 && base_class.[lp - 1] = '-' -> (
         let prefix = String.sub base_class 0 lp in
         let inner = String.sub base_class (lp + 1) (n - lp - 2) in
-        Some (prefix ^ "[var(" ^ inner ^ ")]")
+        let ilen = String.length inner in
+        if ilen > 1 && inner.[0] = '-' && inner.[1] = '-' then
+          (* bare var (with optional ,fallback) *)
+          Some (prefix ^ "[var(" ^ inner ^ ")]")
+        else
+          (* typed hint: <type>:--name[,fallback] *)
+          match String.index_opt inner ':' with
+          | Some ci
+            when ci + 2 < ilen && inner.[ci + 1] = '-' && inner.[ci + 2] = '-'
+            ->
+              let typ = String.sub inner 0 ci in
+              let v = String.sub inner (ci + 1) (ilen - ci - 1) in
+              Some (prefix ^ "[" ^ typ ^ ":var(" ^ v ^ ")]")
+          | _ -> None)
     | _ -> None
   else None
 

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -1052,6 +1052,15 @@ let paren_var_shorthand () =
   Alcotest.(check bool)
     "selector is not the bracket form" false
     (Astring.String.is_infix ~affix:"var\\(--w\\)\\]" out);
+  (* fallback form keeps the default inside var() *)
+  Alcotest.(check bool)
+    "top-(--top,0) keeps the fallback" true
+    (Astring.String.is_infix ~affix:"top: var(--top,0)" (css "top-(--top,0)"));
+  (* typed hint maps to the bracket typed form *)
+  Alcotest.(check bool)
+    "font-(family-name:--font-x) sets font-family: var(--font-x)" true
+    (Astring.String.is_infix ~affix:"font-family: var(--font-x)"
+       (css "font-(family-name:--font-x)"));
   (* round-trips the class name through of_string -> to_class *)
   match Tw.of_string "p-(--p)" with
   | Ok u ->


### PR DESCRIPTION
The `prop-(--x)` shorthand normaliser handled the bare var and the `,fallback` form but rejected the typed hint, so `font-(family-name:--font-x)` was an unknown class. It now rewrites `(<type>:--x[,fallback])` to its bracket form `[<type>:var(--x[,fallback])]`, matching Tailwind (`font-family: var(--font-x)`). Surfaced by a parity sweep over shadcn/ui.