### PR TITLE
containers: support @max-* and arbitrary container queries

### DIFF
--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -115,24 +115,67 @@ let at_container_named name = utility (Container_named name)
 
 (** Helper Functions *)
 
+(* Tailwind v4 container-query thresholds (rem) for the named size scale. *)
+let container_size_rem = function
+  | Style.Container_3xs -> Some 16.
+  | Style.Container_2xs -> Some 18.
+  | Style.Container_xs -> Some 20.
+  | Style.Container_sm -> Some 24.
+  | Style.Container_md -> Some 28.
+  | Style.Container_lg -> Some 32.
+  | Style.Container_xl -> Some 36.
+  | Style.Container_2xl -> Some 42.
+  | Style.Container_3xl -> Some 48.
+  | Style.Container_4xl -> Some 56.
+  | Style.Container_5xl -> Some 64.
+  | Style.Container_6xl -> Some 72.
+  | Style.Container_7xl -> Some 80.
+  | Style.Container_named _ | Style.Container_size _ | Style.Container_len _
+  | Style.Container_len_cmp _ ->
+      None
+
+(* A [(width <op> len)] container feature query, matching Tailwind v4's range
+   syntax: [(width >= 24rem)] for min, [(width < 28rem)] for max. *)
+let width_range op len =
+  Css.Container.Feature_query
+    (Css.Media.Cond
+       (Css.Media.Feature
+          (Css.Media.Range (Css.Media.Width, op, Css.Media.Length len))))
+
+(* Tailwind v4's max container query is the negated min: [@max-md] is [not
+   (width >= 28rem)], which Lightning CSS lowers to [not (min-width:28rem)].
+   Emitting the negated form keeps parity with Tailwind's optimized output. *)
+let width_cond cmp len =
+  match cmp with
+  | Style.Cq_min -> width_range Css.Media.Ge len
+  | Style.Cq_max -> Css.Container.Not (width_range Css.Media.Ge len)
+
 (** Convert a container query modifier to a structured Container.t condition *)
-let container_query_to_condition = function
-  | Style.Container_3xs -> Css.Container.Min_width_rem 16.
-  | Style.Container_2xs -> Css.Container.Min_width_rem 18.
-  | Style.Container_xs -> Css.Container.Min_width_rem 20.
-  | Style.Container_sm -> Css.Container.Min_width_rem 24.
-  | Style.Container_md -> Css.Container.Min_width_rem 28.
-  | Style.Container_lg -> Css.Container.Min_width_rem 32.
-  | Style.Container_xl -> Css.Container.Min_width_rem 36.
-  | Style.Container_2xl -> Css.Container.Min_width_rem 42.
-  | Style.Container_3xl -> Css.Container.Min_width_rem 48.
-  | Style.Container_4xl -> Css.Container.Min_width_rem 56.
-  | Style.Container_5xl -> Css.Container.Min_width_rem 64.
-  | Style.Container_6xl -> Css.Container.Min_width_rem 72.
-  | Style.Container_7xl -> Css.Container.Min_width_rem 80.
-  | Style.Container_named ("", width) -> Css.Container.Min_width_px width
+let container_query_to_condition q =
+  let geq len = width_range Css.Media.Ge len in
+  let rem r : Css.length = Css.Values.Rem r in
+  match q with
+  | Style.Container_3xs -> geq (rem 16.)
+  | Style.Container_2xs -> geq (rem 18.)
+  | Style.Container_xs -> geq (rem 20.)
+  | Style.Container_sm -> geq (rem 24.)
+  | Style.Container_md -> geq (rem 28.)
+  | Style.Container_lg -> geq (rem 32.)
+  | Style.Container_xl -> geq (rem 36.)
+  | Style.Container_2xl -> geq (rem 42.)
+  | Style.Container_3xl -> geq (rem 48.)
+  | Style.Container_4xl -> geq (rem 56.)
+  | Style.Container_5xl -> geq (rem 64.)
+  | Style.Container_6xl -> geq (rem 72.)
+  | Style.Container_7xl -> geq (rem 80.)
+  | Style.Container_named ("", width) ->
+      geq (Css.Values.Px (float_of_int width))
   | Style.Container_named (name, width) ->
-      Css.Container.Named (name, Min_width_px width)
+      Css.Container.Named (name, geq (Css.Values.Px (float_of_int width)))
+  | Style.Container_size (cmp, inner) ->
+      width_cond cmp (rem (Option.value ~default:0. (container_size_rem inner)))
+  | Style.Container_len len -> geq len
+  | Style.Container_len_cmp (cmp, len) -> width_cond cmp len
 
 let container_query_to_class_prefix = function
   | Style.Container_3xs -> "@3xs"
@@ -151,3 +194,6 @@ let container_query_to_class_prefix = function
   | Style.Container_named ("", width) -> "@" ^ string_of_int width ^ "px"
   | Style.Container_named (name, width) ->
       "@" ^ name ^ "/" ^ string_of_int width
+  | (Style.Container_size _ | Style.Container_len _ | Style.Container_len_cmp _)
+    as q ->
+      "@" ^ Style.container_size_name q

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1944,11 +1944,73 @@ let try_prose_element s =
     if is_prose_element_name name then Some (Prose_element name) else None
   else None
 
+(* Parse the container-query modifier forms that are not plain table entries:
+   [@min-<size>], [@max-<size>], [@\[<len>\]], [@min-\[<len>\]], and
+   [@max-\[<len>\]]. The bare [@<size>] forms are in [simple_modifiers]. *)
+let container_size_of_string = function
+  | "3xs" -> Some Container_3xs
+  | "2xs" -> Some Container_2xs
+  | "xs" -> Some Container_xs
+  | "sm" -> Some Container_sm
+  | "md" -> Some Container_md
+  | "lg" -> Some Container_lg
+  | "xl" -> Some Container_xl
+  | "2xl" -> Some Container_2xl
+  | "3xl" -> Some Container_3xl
+  | "4xl" -> Some Container_4xl
+  | "5xl" -> Some Container_5xl
+  | "6xl" -> Some Container_6xl
+  | "7xl" -> Some Container_7xl
+  | _ -> None
+
+let try_container_query s =
+  (* Match ["<prefix>[<len>]"] and build a modifier from the parsed length. *)
+  let bracketed prefix mk =
+    let plen = String.length prefix and slen = String.length s in
+    if
+      slen > plen + 2
+      && String.sub s 0 plen = prefix
+      && s.[plen] = '['
+      && s.[slen - 1] = ']'
+    then
+      match Css.parse_length (String.sub s (plen + 1) (slen - plen - 2)) with
+      | Some len -> Some (mk len)
+      | None -> None
+    else None
+  in
+  (* Match ["<prefix><size>"] against the named size scale. *)
+  let sized prefix cmp =
+    let plen = String.length prefix in
+    if String.length s > plen && String.sub s 0 plen = prefix then
+      match
+        container_size_of_string (String.sub s plen (String.length s - plen))
+      with
+      | Some q -> Some (Container (Container_size (cmp, q)))
+      | None -> None
+    else None
+  in
+  if String.length s < 2 || s.[0] <> '@' then None
+  else
+    List.find_map
+      (fun f -> f ())
+      [
+        (fun () -> bracketed "@" (fun len -> Container (Container_len len)));
+        (fun () ->
+          bracketed "@min-" (fun len ->
+              Container (Container_len_cmp (Cq_min, len))));
+        (fun () ->
+          bracketed "@max-" (fun len ->
+              Container (Container_len_cmp (Cq_max, len))));
+        (fun () -> sized "@min-" Cq_min);
+        (fun () -> sized "@max-" Cq_max);
+      ]
+
 (* Parse a modifier string into a typed Style.modifier *)
 let parse_modifier s : modifier option =
   let fns =
     [
       (fun () -> List.assoc_opt s simple_modifiers);
+      (fun () -> try_container_query s);
       (fun () -> try_bracketed_modifier s);
       (fun () -> try_aria_shorthand s);
       (fun () -> try_has_shorthand s);

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -3,6 +3,7 @@
 module Css = Cascade.Css
 
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
+type container_cmp = Cq_min | Cq_max
 
 type container_query =
   | Container_3xs
@@ -19,6 +20,9 @@ type container_query =
   | Container_6xl
   | Container_7xl
   | Container_named of string * int
+  | Container_size of container_cmp * container_query
+  | Container_len of Css.length
+  | Container_len_cmp of container_cmp * Css.length
 
 type modifier =
   | Hover
@@ -303,6 +307,33 @@ let is_numeric s = s <> "" && String.for_all (fun c -> c >= '0' && c <= '9') s
 let pp_nth prefix expr =
   if is_numeric expr then prefix ^ "-" ^ expr else prefix ^ "-[" ^ expr ^ "]"
 
+let container_cmp_prefix = function Cq_min -> "min-" | Cq_max -> "max-"
+
+(* The class-name suffix (after the leading [@]) for a container query. *)
+let rec container_size_name = function
+  | Container_3xs -> "3xs"
+  | Container_2xs -> "2xs"
+  | Container_xs -> "xs"
+  | Container_sm -> "sm"
+  | Container_md -> "md"
+  | Container_lg -> "lg"
+  | Container_xl -> "xl"
+  | Container_2xl -> "2xl"
+  | Container_3xl -> "3xl"
+  | Container_4xl -> "4xl"
+  | Container_5xl -> "5xl"
+  | Container_6xl -> "6xl"
+  | Container_7xl -> "7xl"
+  | Container_named (n, size) -> n ^ "/" ^ string_of_int size
+  | Container_size (cmp, inner) ->
+      container_cmp_prefix cmp ^ container_size_name inner
+  | Container_len l ->
+      "[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
+  | Container_len_cmp (cmp, l) ->
+      container_cmp_prefix cmp ^ "["
+      ^ Css.Pp.to_string (Css.pp_length ~always:true) l
+      ^ "]"
+
 (* Convert modifier to string prefix *)
 let rec pp_modifier = function
   | Hover -> "hover"
@@ -341,21 +372,7 @@ let rec pp_modifier = function
       "min-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
   | Max_arbitrary_length l ->
       "max-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
-  | Container Container_3xs -> "@3xs"
-  | Container Container_2xs -> "@2xs"
-  | Container Container_xs -> "@xs"
-  | Container Container_sm -> "@sm"
-  | Container Container_md -> "@md"
-  | Container Container_lg -> "@lg"
-  | Container Container_xl -> "@xl"
-  | Container Container_2xl -> "@2xl"
-  | Container Container_3xl -> "@3xl"
-  | Container Container_4xl -> "@4xl"
-  | Container Container_5xl -> "@5xl"
-  | Container Container_6xl -> "@6xl"
-  | Container Container_7xl -> "@7xl"
-  | Container (Container_named (n, size)) ->
-      String.concat "" [ "@"; n; "/"; string_of_int size ]
+  | Container q -> "@" ^ container_size_name q
   | Group_hover -> "group-hover"
   | Group_focus -> "group-focus"
   | Peer_hover -> "peer-hover"

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -4,6 +4,12 @@ open Cascade
 
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
 
+type container_cmp =
+  | Cq_min
+  | Cq_max
+      (** Container-query direction: [Cq_min] is [width >= v], [Cq_max] is
+          [width < v]. *)
+
 type container_query =
   | Container_3xs
   | Container_2xs
@@ -19,6 +25,12 @@ type container_query =
   | Container_6xl
   | Container_7xl
   | Container_named of string * int
+  | Container_size of container_cmp * container_query
+      (** [@min-<size>] / [@max-<size>]; the inner query is a bare named size.
+      *)
+  | Container_len of Css.length  (** [@[<len>]]: [width >= len]. *)
+  | Container_len_cmp of container_cmp * Css.length
+      (** [@min-[<len>]] / [@max-[<len>]]. *)
 
 type modifier =
   | Hover
@@ -270,6 +282,10 @@ val pp_nth : string -> string -> string
 
 val pp_modifier : modifier -> string
 (** [pp_modifier m] converts a modifier to its string representation. *)
+
+val container_size_name : container_query -> string
+(** [container_size_name q] is the class-name suffix (after the leading [@]) for
+    a container query, e.g. ["md"], ["max-lg"], ["min-[20rem]"]. *)
 
 val style :
   ?rules:Css.statement list option ->

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -387,7 +387,8 @@ let test_pp_modifier_strings () =
   check string "pp not-hover" "not-hover" (pp_modifier (Not Hover))
 
 (* The full container-query size scale (@3xs .. @7xl) emits a container query at
-   the right min-width; @xs and @3xl+ used to be unknown modifiers. *)
+   the right threshold, using Tailwind v4's range syntax ([width >= 20rem]); @xs
+   and @3xl+ used to be unknown modifiers. *)
 let test_container_query_scale () =
   let css cls =
     match Tw.of_string cls with
@@ -395,13 +396,36 @@ let test_container_query_scale () =
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   check bool "@xs:flex is a 20rem container query" true
-    (Astring.String.is_infix ~affix:"@container (min-width: 20rem)"
+    (Astring.String.is_infix ~affix:"@container (width >= 20rem)"
        (css "@xs:flex"));
   check bool "@3xl:flex is a 48rem container query" true
-    (Astring.String.is_infix ~affix:"@container (min-width: 48rem)"
+    (Astring.String.is_infix ~affix:"@container (width >= 48rem)"
        (css "@3xl:flex"));
   check string "@xs round-trips" "@xs:p-4"
     (Tw.Utility.to_class (Option.get (apply [ "@xs" ] (p 4))))
+
+(* @max-<size> negates the min query, and @min-/@max-[<len>] and bare @[<len>]
+   accept arbitrary lengths. All used to be unknown modifiers. *)
+let test_container_query_min_max () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "@min-md:flex" "@container (width >= 28rem)";
+  has "@max-md:flex" "@container (not (width >= 28rem))";
+  has "@min-[20rem]:flex" "@container (width >= 20rem)";
+  has "@max-[40rem]:flex" "@container (not (width >= 40rem))";
+  has "@[480px]:flex" "@container (width >= 480px)";
+  check string "@max-md round-trips" "@max-md:p-4"
+    (Tw.Utility.to_class (Option.get (apply [ "@max-md" ] (p 4))));
+  check string "@min-[20rem] round-trips" "@min-[20rem]:p-4"
+    (Tw.Utility.to_class (Option.get (apply [ "@min-[20rem]" ] (p 4))));
+  check string "@[480px] round-trips" "@[480px]:p-4"
+    (Tw.Utility.to_class (Option.get (apply [ "@[480px]" ] (p 4))))
 
 (* Test apply with bracketed has/group-has/peer-has modifiers *)
 let test_apply_bracketed_has () =
@@ -525,6 +549,7 @@ let tests =
       test_case "of_string parsing" `Quick test_of_string_parsing;
       test_case "pp_modifier strings" `Quick test_pp_modifier_strings;
       test_case "container query scale" `Quick test_container_query_scale;
+      test_case "container query min/max" `Quick test_container_query_min_max;
       test_case "apply bracketed has variants" `Quick test_apply_bracketed_has;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "before/after modifiers" `Quick test_before_after_modifiers;


### PR DESCRIPTION
tw rejected the `@max-<size>`, `@min-[<len>]`, `@max-[<len>]`, and bare `@[<len>]` container-query variants, and emitted the named scale as `(min-width: X)` rather than the range syntax Tailwind v4 uses.

Container queries now emit `(width >= X)` for min and `not (width >= X)` for max (which Lightning CSS lowers to `not (min-width: X)`, matching Tailwind's optimized output), and the previously-rejected min/max and arbitrary-length forms parse and round-trip.