### PR TITLE
tw: feed the project's --input-css theme to --diff

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3,11 +3,11 @@ open Cascade_diff
 open Cmdliner
 
 (* Parse a whitespace-separated string of classes *)
-let parse_classes ?(warn = true) classes_str =
+let parse_classes ?(warn = true) ?(theme = Tw.Scheme.default) classes_str =
   let class_names = Tw_tools.Source_scan.split_whitespace classes_str in
   List.filter_map
     (fun cls ->
-      match Tw.of_string cls with
+      match Tw.of_string ~theme cls with
       | Ok style -> Some style
       | Error _ ->
           if warn then Fmt.epr "Warning: Unknown class '%s'@." cls;
@@ -39,12 +39,76 @@ type gen_opts = {
   quiet : bool;
   css_mode : Tw.Css.mode;
   backend : backend;
+  theme : Tw.Scheme.t;
+      (** Theme used by tw's renderer, built from the project's --input-css so a
+          --diff over a real repo compares against the same [@theme] Tailwind
+          uses. Defaults to {!Tw.Scheme.default}. *)
+  input_css : string option;
+      (** Path to the project's CSS entrypoint, fed verbatim to the real
+          Tailwind backend so both sides share the project config. *)
   diff_mode : Cascade_diff.Css_compare.mode;
       (** Comparison mode for --diff. [`Canonical] (default) ignores selector
           regrouping/reordering and is right for real-world parity sweeps;
           [`Auto]/[`Tree] (structural) reports regrouping, for tests that target
           it. *)
 }
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+(* Rewrite each Tailwind [@theme [modifiers] {] header to a [:root {] rule.
+   Cascade's parser accepts [@theme] but drops its body (it is not a standard
+   at-rule), so this swaps only the at-rule keyword and its modifiers up to the
+   opening brace; the declarations themselves are left for the real parser. *)
+let theme_blocks_as_root css =
+  let len = String.length css in
+  let buf = Buffer.create len in
+  let i = ref 0 in
+  while !i < len do
+    if !i + 6 <= len && String.sub css !i 6 = "@theme" then begin
+      (* Skip the header up to the block's opening brace. *)
+      let j = ref (!i + 6) in
+      while !j < len && css.[!j] <> '{' && css.[!j] <> ';' do
+        incr j
+      done;
+      if !j < len && css.[!j] = '{' then begin
+        Buffer.add_string buf ":root ";
+        i := !j (* keep the '{' and the body verbatim *)
+      end
+      else begin
+        Buffer.add_char buf css.[!i];
+        incr i
+      end
+    end
+    else begin
+      Buffer.add_char buf css.[!i];
+      incr i
+    end
+  done;
+  Buffer.contents buf
+
+(* Extract @theme token overrides ([(bare-name, value)]) from a project CSS
+   entrypoint, so tw renders with the same tokens Tailwind reads from it. The
+   declarations are parsed by cascade (after the @theme -> :root header swap);
+   the resulting name/value strings feed Scheme.with_overrides. *)
+let theme_overrides_of_css css =
+  match Css.of_string (theme_blocks_as_root css) with
+  | Error _ -> []
+  | Ok parse ->
+      Css.rules_of_statements (Css.statements parse.Css.stylesheet)
+      |> List.concat_map (fun (_sel, decls) ->
+          List.filter_map
+            (fun d ->
+              match Css.custom_declaration_name d with
+              | Some n when String.length n > 2 && String.sub n 0 2 = "--" ->
+                  Some
+                    ( String.sub n 2 (String.length n - 2),
+                      Css.declaration_value d )
+              | _ -> None)
+            decls)
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default
@@ -86,11 +150,11 @@ let diff_single_class class_str ~(opts : gen_opts) =
   try
     let legacy_css =
       Tw_tools.Tailwind_gen.generate ~minify:opts.minify ~optimize:opts.optimize
-        ~forms:true [ class_str ]
+        ~forms:true ?input_css:opts.input_css [ class_str ]
     in
-    let tw_styles = parse_classes ~warn:false class_str in
+    let tw_styles = parse_classes ~warn:false ~theme:opts.theme class_str in
     let styles = match tw_styles with [] -> [] | s -> s in
-    let stylesheet = Tw.to_css ~base:true styles in
+    let stylesheet = Tw.to_css ~theme:opts.theme ~base:true styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
       Css_compare.diff ~mode:opts.diff_mode ~prune_unused_custom_props:true
@@ -153,10 +217,10 @@ let print_stats ~quiet ~candidate_count ~known_count =
     Fmt.epr "Candidate tokens scanned: %d@." candidate_count;
     Fmt.epr "Successfully parsed: %d@." known_count)
 
-let parse_known_candidates candidates =
+let parse_known_candidates ?(theme = Tw.Scheme.default) candidates =
   List.filter_map
     (fun cls ->
-      match Tw.of_string cls with
+      match Tw.of_string ~theme cls with
       | Ok style -> Some (cls, style)
       | Error _ -> None)
     candidates
@@ -170,10 +234,12 @@ let diff_files paths ~(opts : gen_opts) =
     in
     let legacy_css =
       Tw_tools.Tailwind_gen.generate ~minify:opts.minify ~optimize:opts.optimize
-        ~forms:true all_classes
+        ~forms:true ?input_css:opts.input_css all_classes
     in
-    let tw_styles = parse_known_candidates all_classes |> List.map snd in
-    let stylesheet = Tw.to_css ~base:true tw_styles in
+    let tw_styles =
+      parse_known_candidates ~theme:opts.theme all_classes |> List.map snd
+    in
+    let stylesheet = Tw.to_css ~theme:opts.theme ~base:true tw_styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
       Css_compare.diff ~mode:opts.diff_mode ~prune_unused_custom_props:true
@@ -225,7 +291,7 @@ let process_files paths flag ~(opts : gen_opts) =
   | Native -> native_files paths flag ~opts
 
 let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
-    ~diff_mode paths =
+    ~input_css ~diff_mode paths =
   (* Resolve default CSS mode based on operation kind when not provided *)
   let resolved_css_mode : Css.mode =
     match (single_class, backend, css_mode) with
@@ -238,6 +304,16 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
   (* Diff mode forces minified output; Cascade handles semantic comparison. *)
   let resolved_minify = match backend with Diff -> true | _ -> minify in
   let resolved_optimize = optimize in
+  (* Build the renderer theme from the project's CSS entrypoint (its @theme), so
+     a --diff over a real repo compares against the same tokens Tailwind
+     uses. *)
+  let css_content = Option.map read_file input_css in
+  let theme =
+    match css_content with
+    | None -> Tw.Scheme.default
+    | Some css ->
+        Tw.Scheme.with_overrides Tw.Scheme.default (theme_overrides_of_css css)
+  in
   let opts : gen_opts =
     {
       minify = resolved_minify;
@@ -245,6 +321,8 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
       quiet;
       css_mode = resolved_css_mode;
       backend;
+      theme;
+      input_css = css_content;
       diff_mode;
     }
   in
@@ -288,6 +366,13 @@ let optimize_flag =
 let quiet_flag =
   let doc = "Suppress warnings about unknown classes" in
   Arg.(value & flag & info [ "q"; "quiet" ] ~doc)
+
+let input_css_arg =
+  let doc =
+    "Project CSS entrypoint to feed to Tailwind during --diff. @theme blocks \
+     are also used to configure tw's renderer."
+  in
+  Arg.(value & opt (some file) None & info [ "input-css" ] ~docv:"CSS" ~doc)
 
 let tailwind_flag =
   let doc_tailwind = "Use the real tailwindcss tool to generate CSS" in
@@ -372,7 +457,7 @@ let cmd =
   Cmd.v info
     Term.(
       ret
-        (const (fun s b css_m m o q tailwind diff diff_mode paths ->
+        (const (fun s b css_m m o q tailwind diff diff_mode input_css paths ->
              let backend, diff_mode =
                if diff then (Diff, diff_mode)
                else
@@ -380,9 +465,10 @@ let cmd =
                  (backend, `Canonical)
              in
              tw_main s b ~css_mode:css_m ~minify:m ~optimize:o ~quiet:q ~backend
-               ~diff_mode paths)
+               ~diff_mode ~input_css paths)
         $ single_flag $ base_flag $ css_mode_vflag $ minify_flag $ optimize_flag
-        $ quiet_flag $ tailwind_flag $ diff_flag $ diff_mode_arg $ paths_arg))
+        $ quiet_flag $ tailwind_flag $ diff_flag $ diff_mode_arg $ input_css_arg
+        $ paths_arg))
 
 let normalize_argv argv =
   argv |> Array.to_list

--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -5,7 +5,7 @@ let write_file path content =
   output_string oc content;
   close_out oc
 
-let tailwind_files ?(forms = false) temp_dir classnames =
+let tailwind_files ?(forms = false) ?input_css temp_dir classnames =
   (* Feed candidates to the extractor verbatim, space-separated, as raw file
      text rather than inside an HTML class attribute. An attribute forces
      escaping one quote style into an HTML entity, and Tailwind's extractor
@@ -14,16 +14,23 @@ let tailwind_files ?(forms = false) temp_dir classnames =
      preserves both single and double quotes exactly as a real source file
      would, so arbitrary url() and content-["..."] values round-trip. *)
   let html_content = String.concat " " classnames in
+  (* When the caller supplies a project CSS entrypoint, use it verbatim so the
+     real Tailwind reads the project's @theme/@plugin/@config; otherwise
+     synthesise the default import. *)
   let input_css_content =
-    if forms then
-      (* forms plugin with strategy: 'class' requires a config file *)
-      "@import \"tailwindcss\";\n\
-       @plugin \"@tailwindcss/typography\";\n\
-       @config \"./tailwind.config.js\";"
-    else "@import \"tailwindcss\";\n@plugin \"@tailwindcss/typography\";"
+    match input_css with
+    | Some content -> content
+    | None ->
+        if forms then
+          (* forms plugin with strategy: 'class' requires a config file *)
+          "@import \"tailwindcss\";\n\
+           @plugin \"@tailwindcss/typography\";\n\
+           @config \"./tailwind.config.js\";"
+        else "@import \"tailwindcss\";\n@plugin \"@tailwindcss/typography\";"
   in
-  (* Generate tailwind.config.js when forms plugin is needed *)
-  (if forms then
+  (* Generate tailwind.config.js when forms plugin is needed (only for the
+     synthesised input; a supplied entrypoint carries its own config). *)
+  (if forms && input_css = None then
      let config_content =
        {|import forms from '@tailwindcss/forms'
 
@@ -228,7 +235,7 @@ let has_forms_class classnames =
     (fun cls -> String.length cls >= 5 && String.sub cls 0 5 = "form-")
     classnames
 
-let generate ?(minify = false) ?(optimize = true) ?forms classnames =
+let generate ?(minify = false) ?(optimize = true) ?forms ?input_css classnames =
   check_tailwindcss_available ();
 
   let dir = temp_dir () in
@@ -243,7 +250,7 @@ let generate ?(minify = false) ?(optimize = true) ?forms classnames =
       | Some f -> f && classnames <> []
       | None -> has_forms_class classnames
     in
-    tailwind_files ~forms:use_forms dir classnames;
+    tailwind_files ~forms:use_forms ?input_css dir classnames;
 
     let minify_flag = if minify then " --minify" else "" in
     let optimize_flag = if optimize then " --optimize" else "" in

--- a/lib/tools/tailwind_gen.mli
+++ b/lib/tools/tailwind_gen.mli
@@ -1,13 +1,21 @@
 (** Tailwind CSS generation utilities for testing *)
 
 val generate :
-  ?minify:bool -> ?optimize:bool -> ?forms:bool -> string list -> string
-(** [generate ?minify ?optimize ?forms classnames] generates Tailwind CSS for
-    given class names.
+  ?minify:bool ->
+  ?optimize:bool ->
+  ?forms:bool ->
+  ?input_css:string ->
+  string list ->
+  string
+(** [generate ?minify ?optimize ?forms ?input_css classnames] generates Tailwind
+    CSS for given class names.
     @param minify Whether to minify the output (default: false)
     @param optimize Whether to optimize the output (default: true)
     @param forms
       Whether to include [@tailwindcss/forms] plugin (default: auto-detect)
+    @param input_css
+      The project's CSS entrypoint content, used verbatim as the Tailwind input
+      so its [@theme]/[@plugin]/[@config] apply (default: synthesised import)
     @param classnames List of Tailwind class names
     @return The generated CSS as a string
     @raise Failure if Tailwind CSS generation fails. *)


### PR DESCRIPTION
Splits #86 into focused PRs (2/2). Stacked on #93.

Adds `--input-css FILE`: its `@theme` is parsed via cascade into `Scheme` overrides so tw's renderer uses the project's tokens, and the file is passed verbatim to the real Tailwind backend. So `--diff` over a real repo compares both sides under the project's theme instead of the default one.