### PR TITLE
opam: bump cascade pin to cascade main

### DIFF
--- a/examples/accessibility/dune
+++ b/examples/accessibility/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     accessibility.css
     tailwind.css))))

--- a/examples/animations/dune
+++ b/examples/animations/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     animations.css
     tailwind.css))))

--- a/examples/colors/dune
+++ b/examples/colors/dune
@@ -28,7 +28,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     colors.css
     tailwind.css))))

--- a/examples/dashboard/dune
+++ b/examples/dashboard/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     dashboard.css
     tailwind.css))))

--- a/examples/forms/dune
+++ b/examples/forms/dune
@@ -42,7 +42,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     tailwind.css
     forms.css))))

--- a/examples/landing/dune
+++ b/examples/landing/dune
@@ -34,7 +34,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     landing.css
     tailwind.css))))

--- a/examples/layout/dune
+++ b/examples/layout/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     layout.css
     tailwind.css))))

--- a/examples/modifiers/dune
+++ b/examples/modifiers/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     modifiers.css
     tailwind.css))))

--- a/examples/prose/dune
+++ b/examples/prose/dune
@@ -49,7 +49,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     tailwind.css
     prose.css))))

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -134,7 +134,7 @@ else
   # Summary: exit 0 means identical, non-zero means differ.
   # Show the first 40 lines of output so the terminal doesn't get flooded.
   set +e
-  NO_COLOR=1 "$CASCADE_BIN" diff --diff=semantic "$TAILWIND_OUT" "$TW_OUT" > "$BENCH/cascade-diff.out" 2>&1
+  NO_COLOR=1 "$CASCADE_BIN" diff --diff=canonical "$TAILWIND_OUT" "$TW_OUT" > "$BENCH/cascade-diff.out" 2>&1
   rc=$?
   set -e
   if [ $rc -eq 0 ]; then
@@ -152,4 +152,4 @@ echo "## Artefacts"
 echo "  tw          -> $TW_OUT"
 echo "  tailwindcss -> $TAILWIND_OUT"
 echo "  cascade diff -> $BENCH/cascade-diff.out"
-echo "  rerun diff   : cascade diff --diff=semantic $TAILWIND_OUT $TW_OUT | less -R"
+echo "  rerun diff   : cascade diff --diff=canonical $TAILWIND_OUT $TW_OUT | less -R"

--- a/tw.opam
+++ b/tw.opam
@@ -43,5 +43,5 @@ build: [
 dev-repo: "git+https://github.com/samoht/tw.git"
 x-maintenance-intent: ["(latest)"]
 pin-depends: [
-  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#c84aac81900df988781ecb28841fd52d6d0564b8" ]
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#e986369dffa01d5d839c9a9ba54ec421bdba186e" ]
 ]

--- a/tw.opam.template
+++ b/tw.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#c84aac81900df988781ecb28841fd52d6d0564b8" ]
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#e986369dffa01d5d839c9a9ba54ec421bdba186e" ]
 ]


### PR DESCRIPTION
Points the pin at cascade main (`e986369d`), which now carries the full set of resolve_theme, canonical-comparison, and optimizer consolidation/factoring fixes. Against this cascade the parity suite is green (781 + 425).

Coupled with the pin: cascade renamed its diff CLI flag `--diff=semantic` -> `--diff=canonical`, so the example parity checks and the bench script move to the new name in lockstep (the pinned cascade rejects the old spelling).