### PR TITLE
chore: re-apply formatting under the current toolchain

### DIFF
--- a/examples/accessibility/dune
+++ b/examples/accessibility/dune
@@ -30,4 +30,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props accessibility.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    accessibility.css
+    tailwind.css))))

--- a/examples/animations/dune
+++ b/examples/animations/dune
@@ -30,4 +30,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props animations.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    animations.css
+    tailwind.css))))

--- a/examples/colors/dune
+++ b/examples/colors/dune
@@ -25,4 +25,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props colors.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    colors.css
+    tailwind.css))))

--- a/examples/dashboard/dune
+++ b/examples/dashboard/dune
@@ -30,4 +30,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props dashboard.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    dashboard.css
+    tailwind.css))))

--- a/examples/forms/dune
+++ b/examples/forms/dune
@@ -39,4 +39,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props tailwind.css forms.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    tailwind.css
+    forms.css))))

--- a/examples/landing/dune
+++ b/examples/landing/dune
@@ -31,4 +31,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props landing.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    landing.css
+    tailwind.css))))

--- a/examples/layout/dune
+++ b/examples/layout/dune
@@ -30,4 +30,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props layout.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    layout.css
+    tailwind.css))))

--- a/examples/modifiers/dune
+++ b/examples/modifiers/dune
@@ -30,4 +30,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props modifiers.css tailwind.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    modifiers.css
+    tailwind.css))))

--- a/examples/prose/dune
+++ b/examples/prose/dune
@@ -46,4 +46,10 @@
   (setenv
    CASCADE_COLOR
    always
-   (run %{bin:cascade} diff --diff=semantic --prune-unused-custom-props tailwind.css prose.css))))
+   (run
+    %{bin:cascade}
+    diff
+    --diff=semantic
+    --prune-unused-custom-props
+    tailwind.css
+    prose.css))))

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -171,7 +171,6 @@ module Handler = struct
   let border_2 = make_border_util [ Css.border_width (Px 2.) ]
   let border_4 = make_border_util [ Css.border_width (Px 4.) ]
   let border_8 = make_border_util [ Css.border_width (Px 8.) ]
-
   let border_n n = make_border_util [ Css.border_width (Px (float_of_int n)) ]
 
   let parse_border_width inner : Css.border_width =
@@ -839,7 +838,7 @@ module Handler = struct
     | [ "border"; "4" ] -> Ok Border_4
     | [ "border"; "8" ] -> Ok Border_8
     | [ "border"; n ]
-      when (match int_of_string_opt n with Some w -> w > 0 | None -> false) ->
+      when match int_of_string_opt n with Some w -> w > 0 | None -> false ->
         Ok (Border_width (int_of_string n))
     | [ "border"; "t" ] -> Ok Border_t
     | [ "border"; "r" ] -> Ok Border_r
@@ -913,7 +912,7 @@ module Handler = struct
     | [ "outline" ] -> Ok Outline
     | [ "outline"; "0" ] -> Ok Outline_0
     | [ "outline"; n ]
-      when (match int_of_string_opt n with Some w -> w > 0 | None -> false) ->
+      when match int_of_string_opt n with Some w -> w > 0 | None -> false ->
         Ok (Outline_width (int_of_string n))
     | [ "outline"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -31,9 +31,10 @@ val outputs :
     example a container utility emits one plain rule plus one [@media] rule per
     breakpoint.
 
-    [?order_tbl], when given, is populated with [class name -> (priority,
-    suborder)] for each base utility encountered, reusing the class strings built
-    here so callers need not re-derive the order from the class name. *)
+    [?order_tbl], when given, is populated with
+    [class name -> (priority, suborder)] for each base utility encountered,
+    reusing the class strings built here so callers need not re-derive the order
+    from the class name. *)
 
 (** {1 Modifier dispatch}
 

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -210,8 +210,8 @@ let extract_media_sort_key = function
   | _ -> (0, 0.)
 
 (* Precompute the sort keys for a rule's own and nested media conditions, so the
-   comparators use [Css.Media.compare_keys] (cheap) instead of re-serializing the
-   query on every comparison. See [media_key]/[nested_media_key]. *)
+   comparators use [Css.Media.compare_keys] (cheap) instead of re-serializing
+   the query on every comparison. See [media_key]/[nested_media_key]. *)
 let media_sort_keys rule_type nested =
   let media_key =
     match rule_type with `Media c -> Some (Css.Media.sort_key c) | _ -> None

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -79,9 +79,9 @@ val media_sort_keys :
   | `Supports of Css.Supports.t ] ->
   Css.statement list ->
   Css.Media.key option * Css.Media.key option
-(** [media_sort_keys rule_type nested] is the
-    [(media_key, nested_media_key)] pair stored on an {!type-indexed_rule},
-    computed once so comparisons never re-serialize a media query. *)
+(** [media_sort_keys rule_type nested] is the [(media_key, nested_media_key)]
+    pair stored on an {!type-indexed_rule}, computed once so comparisons never
+    re-serialize a media query. *)
 
 (** {1 Sorting} *)
 

--- a/test/dune
+++ b/test/dune
@@ -13,6 +13,4 @@
   cascade
   cascade.diff
   test_helpers)
- (deps
-  upstream/utilities.txt
-  upstream/variants.txt))
+ (deps upstream/utilities.txt upstream/variants.txt))

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -154,9 +154,9 @@ let parse_match_variants content =
   tbl
 
 (* Parse [@custom-variant <name> { @container <header> { @slot } }] blocks into
-   directive strings ["container <name> <header>"], e.g.
-   ["container has-c foo style(--c)"]. The runner registers these as structural
-   container-query variants. *)
+   directive strings ["container <name> <header>"], e.g. ["container has-c foo
+   style(--c)"]. The runner registers these as structural container-query
+   variants. *)
 let parse_custom_variant_containers content =
   let re =
     Re.Pcre.regexp
@@ -217,16 +217,20 @@ let parse_file filename =
     (fun k v -> Hashtbl.replace variant_defs k v)
     (parse_custom_variant_containers content);
   let match_variant_use = Re.Pcre.regexp {|matchVariant\(\s*'([^']+)'|} in
-  let custom_variant_use = Re.Pcre.regexp {|@custom-variant\s+([A-Za-z0-9_-]+)|} in
+  let custom_variant_use =
+    Re.Pcre.regexp {|@custom-variant\s+([A-Za-z0-9_-]+)|}
+  in
   let current_variant_names = ref [] in
-  (* Capture [@theme] token declarations [--name: value;]. [in_theme]/[theme_depth]
-     track the brace nesting of the active [@theme {...}] block within a
-     compileCss template. *)
+  (* Capture [@theme] token declarations [--name: value;].
+     [in_theme]/[theme_depth] track the brace nesting of the active [@theme
+     {...}] block within a compileCss template. *)
   let current_theme_vars = ref [] in
   let in_theme = ref false in
   let theme_depth = ref 0 in
   let theme_open_re = Re.Pcre.regexp {|@theme\b[^{]*\{|} in
-  let theme_var_re = Re.Pcre.regexp {|^\s*--([A-Za-z0-9-]+)\s*:\s*(.+?)\s*;\s*$|} in
+  let theme_var_re =
+    Re.Pcre.regexp {|^\s*--([A-Za-z0-9-]+)\s*:\s*(.+?)\s*;\s*$|}
+  in
 
   let flush_test name expected =
     let classes =
@@ -408,9 +412,7 @@ let () =
       Fmt.pr "# %s@." test.name;
       Fmt.pr "@config %s@." (config_to_string test.config);
       List.iter (fun v -> Fmt.pr "@variant %s@." v) test.variants;
-      List.iter
-        (fun (n, v) -> Fmt.pr "@theme-var %s %s@." n v)
-        test.theme_vars;
+      List.iter (fun (n, v) -> Fmt.pr "@theme-var %s %s@." n v) test.theme_vars;
       Fmt.pr "%s@." (String.concat " " test.classes);
       (match test.expected with
       | Some css ->


### PR DESCRIPTION
These files were committed under an older ocamlformat/dune than the active switch, so `dune fmt` keeps reformatting them (comment/line wrapping, redundant-paren removal, dune-file arg wrapping) and the fmt check never settles. Commits the canonical output, grouped by area (examples, borders, sort, test), so it stops recurring.

No logic changes.