### PR TITLE
Upgrade to latest version of cascade (diff=semantic -> canonical)

### DIFF
--- a/examples/accessibility/dune
+++ b/examples/accessibility/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     accessibility.css
     tailwind.css))))

--- a/examples/animations/dune
+++ b/examples/animations/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     animations.css
     tailwind.css))))

--- a/examples/colors/dune
+++ b/examples/colors/dune
@@ -28,7 +28,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     colors.css
     tailwind.css))))

--- a/examples/dashboard/dune
+++ b/examples/dashboard/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     dashboard.css
     tailwind.css))))

--- a/examples/forms/dune
+++ b/examples/forms/dune
@@ -42,7 +42,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     tailwind.css
     forms.css))))

--- a/examples/landing/dune
+++ b/examples/landing/dune
@@ -34,7 +34,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     landing.css
     tailwind.css))))

--- a/examples/layout/dune
+++ b/examples/layout/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     layout.css
     tailwind.css))))

--- a/examples/modifiers/dune
+++ b/examples/modifiers/dune
@@ -33,7 +33,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     modifiers.css
     tailwind.css))))

--- a/examples/prose/dune
+++ b/examples/prose/dune
@@ -49,7 +49,7 @@
    (run
     %{bin:cascade}
     diff
-    --diff=semantic
+    --diff=canonical
     --prune-unused-custom-props
     tailwind.css
     prose.css))))

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -134,7 +134,7 @@ else
   # Summary: exit 0 means identical, non-zero means differ.
   # Show the first 40 lines of output so the terminal doesn't get flooded.
   set +e
-  NO_COLOR=1 "$CASCADE_BIN" diff --diff=semantic "$TAILWIND_OUT" "$TW_OUT" > "$BENCH/cascade-diff.out" 2>&1
+  NO_COLOR=1 "$CASCADE_BIN" diff --diff=canonical "$TAILWIND_OUT" "$TW_OUT" > "$BENCH/cascade-diff.out" 2>&1
   rc=$?
   set -e
   if [ $rc -eq 0 ]; then
@@ -152,4 +152,4 @@ echo "## Artefacts"
 echo "  tw          -> $TW_OUT"
 echo "  tailwindcss -> $TAILWIND_OUT"
 echo "  cascade diff -> $BENCH/cascade-diff.out"
-echo "  rerun diff   : cascade diff --diff=semantic $TAILWIND_OUT $TW_OUT | less -R"
+echo "  rerun diff   : cascade diff --diff=canonical $TAILWIND_OUT $TW_OUT | less -R"


### PR DESCRIPTION
Upgrade to latest version of cascade, which has a backwards-incompatible change from `--diff=semantic` to `--diff=canonical`.