### PR TITLE
test: keep the @theme config for cases mixing @theme and @theme inline

### DIFF
--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -212,6 +212,13 @@ let parse_file filename =
   let state = ref Outside in
   let current_classes = ref [] in
   let current_config = ref No_theme in
+  (* A single test can mix a keep [@theme { ... }] block with an inline [@theme
+     inline { ... }] block (e.g. filter: keep the sizes, inline
+     [--drop-shadow-multi]). The keep block wins the config so the runner keeps
+     those tokens (deriving the keep-set from the expected CSS) and inlines only
+     the ones the fixture actually inlined; tagging such a case [theme-inline]
+     would hand the runner an empty keep-set and inline everything. *)
+  let saw_keep_theme = ref false in
   let variant_defs = parse_match_variants content in
   Hashtbl.iter
     (fun k v -> Hashtbl.replace variant_defs k v)
@@ -266,13 +273,16 @@ let parse_file filename =
           match Re.exec_opt test_pattern line with
           | Some groups ->
               current_config := No_theme;
+              saw_keep_theme := false;
               state := In_test (Re.Group.get groups 1)
           | None -> ())
       | In_test name ->
           (* Detect compileCss/run calls to track theme configuration.
              compileCss() resets config (each call has its own @theme). run()
              uses built-in defaults. *)
-          if Re.execp compile_css_re line then current_config := No_theme
+          if Re.execp compile_css_re line then (
+            current_config := No_theme;
+            saw_keep_theme := false)
           else if Re.execp run_call_re line then current_config := Run;
 
           (* Record any matchVariant plugin used by this test so the runner can
@@ -292,13 +302,16 @@ let parse_file filename =
 
           (* Detect @theme variants within compileCss CSS templates. Most
              specific patterns checked first to avoid partial matches. *)
-          if Re.execp theme_inline_ref_re line then
-            current_config := Theme_inline_reference
-          else if Re.execp theme_inline_re line then
-            current_config := Theme_inline
-          else if Re.execp theme_ref_re line then
-            current_config := Theme_reference
-          else if Re.execp theme_re line then current_config := Theme;
+          if Re.execp theme_inline_ref_re line then (
+            if not !saw_keep_theme then current_config := Theme_inline_reference)
+          else if Re.execp theme_inline_re line then (
+            if not !saw_keep_theme then current_config := Theme_inline)
+          else if Re.execp theme_ref_re line then (
+            saw_keep_theme := true;
+            current_config := Theme_reference)
+          else if Re.execp theme_re line then (
+            saw_keep_theme := true;
+            current_config := Theme);
 
           (* Capture [@theme] token declarations. Enter on the opener line,
              capture [--name: value;] lines, exit when braces balance. *)

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -17936,7 +17936,7 @@ animate-none
     
 <<<>>>
 # filter
-@config theme-inline
+@config theme
 @theme-var spacing 0.25rem
 @theme-var blur-xl 24px
 @theme-var color-red-500 #ef4444
@@ -18771,7 +18771,7 @@ transition transition-[var(--value)] transition-all transition-colors transition
     
 <<<>>>
 # transition
-@config theme-inline
+@config run
 @theme-var default-transition-timing-function ease
 @theme-var default-transition-duration 100ms
 transition transition-all transition-colors
@@ -20103,7 +20103,7 @@ text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-
     
 <<<>>>
 # text
-@config theme-inline-reference
+@config run
 @theme-var text-sm 0.875rem
 -text-[#0088cc] -text-[#0088cc]/50 -text-[#0088cc]/[0.5] -text-[#0088cc]/[50%] -text-current -text-current/50 -text-current/[0.5] -text-current/[50%] -text-inherit -text-red-500 -text-red-500/50 -text-red-500/[0.5] -text-red-500/[50%] -text-sm -text-sm/6 -text-sm/[4px] -text-transparent text text-[10px]/foo text-sm/foo
 ---


### PR DESCRIPTION
Regenerates the upstream fixtures after fixing the extractor's mixed-`@theme` handling. The filter test declares a keep `@theme { … }` block (sizes, colors) and an inline `@theme inline { --drop-shadow-multi }` block; the extractor's last-wins config detection tagged the whole case `theme-inline`, so the runner got an empty keep-set and inlined the tokens Tailwind keeps — the 553 filter mismatch.

Now a keep `@theme` block wins the config over a later `@theme inline`; the runner derives the keep-set from the expected CSS and matches Tailwind. `utilities.txt` is not hand-edited — it is regenerated from the pinned `5e9f66e4` source, which changes exactly three `@config` lines (filter to `theme`, and two `run()` cases the old logic mis-tagged). Depends on the cascade pin from #95 (now merged) for the resolve_theme side of 553/560.