### PR TITLE
rule: scope opacity-color @supports blocks under variants

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1601,7 +1601,7 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
 
 (* Extract selector and properties from a single Utility *)
 (* Apply modifier to extracted rule *)
-let apply_modifier_to_rule ?theme modifier = function
+let rec apply_modifier_to_rule ?theme modifier = function
   | Regular { selector; props; base_class; has_hover; _ } -> (
       let bc = Option.value base_class ~default:"" in
       match modifier with
@@ -1644,7 +1644,40 @@ let apply_modifier_to_rule ?theme modifier = function
       { condition = inner_condition; selector; props; base_class; nested; _ } ->
       apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
         ~props ~base_class ~nested
+  | Supports_query { condition; selector; props; base_class; merge_key; _ } ->
+      apply_modifier_to_supports_query ?theme modifier ~condition ~selector
+        ~props ~base_class ~merge_key
   | other -> [ other ]
+
+(* Apply a modifier to a [@supports] rule (the progressive-enhancement block an
+   opacity color or gradient emits). The modifier is applied to the inner rule
+   as if it were a plain rule, reusing all the modifier machinery (selector
+   rewriting, hover/responsive media, ...); each result is then re-wrapped in
+   [@supports]. Without this the block would keep the base class and leak a bare
+   rule outside the variant. *)
+and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
+    ~base_class ~merge_key =
+  let inner = regular ~selector ~props ?base_class ?merge_key () in
+  let wrap_supports_in_media outer sel p bc nested =
+    (* Nest the @supports inside a media query so the block stays scoped to the
+       variant. *)
+    let supports_stmt = Css.supports ~condition [ Css.rule ~selector:sel p ] in
+    media_query ~condition:outer ~selector:sel ~props:[] ?base_class:bc
+      ~nested:(supports_stmt :: nested) ()
+  in
+  apply_modifier_to_rule ?theme modifier inner
+  |> List.map (function
+    | Regular { selector; props; base_class; has_hover; _ } ->
+        (* A bare hover: rule carries [has_hover] instead of an outer media;
+           wrap the @supports in @media (hover:hover) to match. *)
+        if has_hover then
+          wrap_supports_in_media hover_media selector props base_class []
+        else
+          supports_query ~condition ~selector ~props ?base_class ?merge_key ()
+    | Media_query { condition = outer; selector; props; base_class; nested; _ }
+      ->
+        wrap_supports_in_media outer selector props base_class nested
+    | other -> other)
 
 (* Handle Modified style by recursively extracting and applying modifier *)
 let handle_modified ?theme util_inner modifier base_style extract_fn =

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -125,10 +125,31 @@ let test_arbitrary_selector_combinator () =
   check bool "[&_p] still flattens to a descendant" true
     (Astring.String.is_infix ~affix:"]\\:underline p" (css "[&_p]:underline"))
 
+(* Regression: an opacity color emits a progressive-enhancement @supports block.
+   Under a variant, that block must stay scoped to the variant instead of
+   leaking a bare base-class rule. dark:text-white/80 previously emitted a
+   top-level .text-white/80 @supports rule alongside the correct
+   .dark:text-white/80. *)
+let test_opacity_color_variant_no_leak () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  (* The base class must never appear as a standalone selector (".text-white");
+     only the variant-decorated ".dark\:text-white" / ".hover\:text-red" is
+     allowed. *)
+  check bool "dark:text-white/80 leaks no bare .text-white" false
+    (Astring.String.is_infix ~affix:".text-white" (css "dark:text-white/80"));
+  check bool "hover:text-red-500/50 leaks no bare .text-red" false
+    (Astring.String.is_infix ~affix:".text-red" (css "hover:text-red-500/50"))
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "opacity color variant does not leak base rule" `Quick
+      test_opacity_color_variant_no_leak;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
An opacity-modified color (e.g. `text-white/80`) emits a progressive-enhancement `@supports` block for the `color-mix` oklab value. Under a variant this block was passed through unchanged, so it kept the base class and escaped the variant scope: `dark:text-white/80` emitted a stray top-level `.text-white/80` rule alongside the correct `.dark:text-white/80`.

`apply_modifier_to_rule` now transforms `Supports_query` entries by applying the modifier to the inner rule (reusing the existing selector/media machinery) and re-wrapping the result in `@supports`, so the block stays scoped to the variant. Covers state, media and responsive modifiers.

Found while closing residual diffs against the ocaml.org source, which uses `dark:text-white/80`.