### PR TITLE
backgrounds: accept keyword sizes in bg-[length:...]

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -663,21 +663,29 @@ module Handler = struct
         match (wl, hl) with
         | Some w, Some h -> Some (Css.background_size (Size (w, h)))
         | _ -> None)
-    | [ v ] ->
-        let parse_len s =
-          if String.ends_with ~suffix:"px" s then
-            let n =
-              String.sub s 0 (String.length s - 2) |> float_of_string_opt
+    | [ v ] -> (
+        (* Keywords are valid background-size values even under a [length:...]
+           hint (Tailwind emits e.g. bg-[length:cover] as
+           background-size:cover). *)
+        match v with
+        | "cover" -> Some (Css.background_size Cover)
+        | "contain" -> Some (Css.background_size Contain)
+        | "auto" -> Some (Css.background_size Auto)
+        | _ ->
+            let parse_len s =
+              if String.ends_with ~suffix:"px" s then
+                let n =
+                  String.sub s 0 (String.length s - 2) |> float_of_string_opt
+                in
+                Option.map (fun f -> (Length (Px f) : Css.background_size)) n
+              else if String.ends_with ~suffix:"%" s then
+                let n =
+                  String.sub s 0 (String.length s - 1) |> float_of_string_opt
+                in
+                Option.map (fun f -> (Length (Pct f) : Css.background_size)) n
+              else None
             in
-            Option.map (fun f -> (Length (Px f) : Css.background_size)) n
-          else if String.ends_with ~suffix:"%" s then
-            let n =
-              String.sub s 0 (String.length s - 1) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Length (Pct f) : Css.background_size)) n
-          else None
-        in
-        Option.map Css.background_size (parse_len v)
+            Option.map Css.background_size (parse_len v))
     | _ -> None
 
   (* Parse a bracket position value like "120px_120px" or "120px" or "50%" *)

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -90,6 +90,24 @@ let test_of_string_invalid () =
 (* bg-[image:<gradient>] emits the literal background-image; it used to wrap the
    value in a bogus var(--radial-gradient(...)). var() and url() image values
    are unchanged. *)
+(* Regression: keyword background-size values under a [length:...] hint
+   (bg-[length:cover]) used to fall through to background-size:auto because
+   parse_bracket_size only handled numeric lengths. *)
+let test_bracket_length_keywords () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "bg-[length:cover] emits background-size: cover" true
+    (Astring.String.is_infix ~affix:"background-size: cover"
+       (css "bg-[length:cover]"));
+  Alcotest.(check bool)
+    "bg-[length:contain] emits background-size: contain" true
+    (Astring.String.is_infix ~affix:"background-size: contain"
+       (css "bg-[length:contain]"))
+
 let test_bracket_image_literal () =
   let css cls =
     match Tw.of_string cls with
@@ -198,6 +216,7 @@ let tests =
       test_gradient_stop_position_properties;
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "bracket image literal" `Quick test_bracket_image_literal;
+    test_case "bracket length keywords" `Quick test_bracket_length_keywords;
     test_case "bare radial and conic gradients" `Quick test_radial_conic;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
`bg-[length:cover]` and `bg-[length:contain]` emitted `background-size:auto`: `parse_bracket_size` only recognised numeric lengths, so the keyword fell through to the `auto` default. It now accepts the `cover`/`contain`/`auto` keywords (valid background-size values even under a `[length:...]` hint, which is what Tailwind emits).

Found while closing residual diffs against the ocaml.org source, which uses `md:bg-[length:cover]`.