### PR TITLE
rule: fix stacked hover:dark compound variant

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -650,7 +650,10 @@ let theme_layer_rule ~layers = function
    nested @media/@supports). *)
 let var_names_of_output = function
   | Regular { props; nested; _ } | Media_query { props; nested; _ } ->
-      Css.vars_of_declarations props @ Css.vars_of_rules nested
+      (* [nested] can hold @media statements (compound variants like
+         hover:dark:) whose rules reference theme vars; recurse fully so those
+         references are collected and their theme tokens declared. *)
+      Css.vars_of_declarations props @ Css.vars_of_stylesheet (Css.v nested)
   | Container_query { props; _ }
   | Starting_style { props; _ }
   | Supports_query { props; _ } ->

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1579,10 +1579,19 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
             responsive_modifier_condition ?theme modifier
           in
           wrap_in_media outer_condition
+      | _ when Modifiers.is_hover modifier ->
+          (* hover: gates on hover-capable devices via @media (hover:hover).
+             Applied to an inner media block (e.g. dark:), it must nest as
+             @media (hover:hover) { @media (dark) { .sel:hover { props } } };
+             dropping the wrapper makes the hover style apply on touch. *)
+          [
+            media_query ~condition:hover_media ~selector:new_selector ~props:[]
+              ~base_class:modified_class ~nested:[ inner_media ] ();
+          ]
       | _ ->
-          (* State/pseudo modifiers (focus, hover, ...) don't add an outer media
-             condition; they rewrite the inner rule's selector so a utility
-             whose own output is a media block (e.g. outline-hidden's
+          (* Other state/pseudo modifiers (focus, active, ...) don't add an
+             outer media condition; they rewrite the inner rule's selector so a
+             utility whose own output is a media block (e.g. outline-hidden's
              forced-colors reset) gets the modified selector inside the block.
              The base_class is updated to the modified class so this media stays
              grouped with the utility's regular rule (same-utility order),

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -83,6 +83,20 @@ let check_properties_layer () =
   check bool "has --tw-ring-offset-width" true
     (List.mem "--tw-ring-offset-width" vars)
 
+(* Regression: a theme color referenced only inside a compound variant's nested
+   media (hover:dark:text-white puts var(--color-white) two media levels deep)
+   must still be declared in the theme layer. The var collection used to stop at
+   the first level and miss it, so --color-white got pruned. *)
+let check_compound_variant_theme_var () =
+  let u =
+    match Tw.of_string "hover:dark:text-white" with
+    | Ok u -> u
+    | Error (`Msg m) -> fail m
+  in
+  let css = Tw.to_css ~base:false ~layers:true [ u ] in
+  check bool "theme layer declares --color-white" true
+    (has_var_in_layer "--color-white" "theme" css)
+
 let check_css_variables_with_base () =
   let config = { Tw.Build.base = true; forms = None; layers = true } in
   let css = Tw.Build.to_css ~config [] in
@@ -789,6 +803,8 @@ let tests =
       check_conflict_order;
     test_case "properties layer generation" `Quick check_properties_layer;
     test_case "to_css variables with base" `Quick check_css_variables_with_base;
+    test_case "compound variant theme var" `Quick
+      check_compound_variant_theme_var;
     test_case "to_css variables without base" `Quick
       check_css_variables_without_base;
     test_case "to_css inline with base" `Quick check_css_inline_with_base;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -144,12 +144,32 @@ let test_opacity_color_variant_no_leak () =
   check bool "hover:text-red-500/50 leaks no bare .text-red" false
     (Astring.String.is_infix ~affix:".text-red" (css "hover:text-red-500/50"))
 
+(* Regression: a stacked hover:dark:* variant must keep the @media (hover:hover)
+   wrapper (nested inside the dark media), matching Tailwind. tw used to emit a
+   bare @media (dark) block, so the hover style also applied on touch
+   devices. *)
+let test_hover_dark_media_wrapper () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let s = css "hover:dark:text-white" in
+  check bool "hover:dark keeps @media (hover:hover)" true
+    (Astring.String.is_infix ~affix:"@media (hover:hover)" s
+    || Astring.String.is_infix ~affix:"@media(hover:hover)" s);
+  check bool "hover:dark keeps the dark media" true
+    (Astring.String.is_infix ~affix:"prefers-color-scheme:dark" s
+    || Astring.String.is_infix ~affix:"prefers-color-scheme: dark" s)
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
     test_case "opacity color variant does not leak base rule" `Quick
       test_opacity_color_variant_no_leak;
+    test_case "hover:dark keeps hover media wrapper" `Quick
+      test_hover_dark_media_wrapper;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
A stacked `hover:dark:*` variant dropped the `@media (hover:hover)` wrapper: tw emitted a bare `@media (prefers-color-scheme:dark)` block, so the hover style also applied on touch devices where Tailwind gates it out. The hover modifier applied to an inner media block now nests as `@media (hover:hover) { @media (dark) { .sel:hover { ... } } }`.

The second commit fixes a related pruning bug it surfaced: a theme color referenced only inside such a doubly-nested media (`var(--color-white)` in `hover:dark:text-white`) was not collected for the theme layer, so `--color-white` got pruned; the variable collection now recurses into nested media.

Found while closing residual diffs against the ocaml.org source.