### PR TITLE
opam: bump cascade pin to dd9ee700

### DIFF
--- a/tw.opam
+++ b/tw.opam
@@ -43,5 +43,5 @@ build: [
 dev-repo: "git+https://github.com/samoht/tw.git"
 x-maintenance-intent: ["(latest)"]
 pin-depends: [
-  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#e986369dffa01d5d839c9a9ba54ec421bdba186e" ]
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#dd9ee700b0b8a282d46c3d35382f830b6c531804" ]
 ]

--- a/tw.opam.template
+++ b/tw.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#e986369dffa01d5d839c9a9ba54ec421bdba186e" ]
+  [ "cascade.dev" "git+https://github.com/samoht/cascade.git#dd9ee700b0b8a282d46c3d35382f830b6c531804" ]
 ]


### PR DESCRIPTION
Bumps the cascade pin to dd9ee700 (cascade #153/#154 canonical decl-order + group normalization, #155 color-approximation fix), which the parity suite now relies on.

Rebased onto main; the mixed @theme/@theme-inline extractor fix this needed is already on main via #98, so this PR is just the pin. Unblocks #99 and #101, which fail on the old pin.