### PR TITLE
build: fix border-spacing and outline-style @property order

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -474,9 +474,13 @@ module Handler = struct
 
   (* Outline style variable - used by outline utilities that set the style *)
   let outline_style_var =
+    (* Tailwind emits @property --tw-outline-style after the ring group and
+       before the filters. property_order 21 places it just after
+       --tw-ring-offset-shadow (20) in the cross-family comparison; the earlier
+       value of 0 wrongly sorted it ahead of the whole ring/border block. *)
     Var.property_default Css.Outline_style
       ~initial:(Solid : Css.outline_style)
-      ~property_order:0 ~family:`Border "tw-outline-style"
+      ~property_order:21 ~family:`Border "tw-outline-style"
 
   (* Base outline utility - sets outline-style from var and width from scheme *)
   let outline ?theme () =

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -45,13 +45,15 @@ module Handler = struct
   let priority = 4
   let err_not_utility = Error (`Msg "Not a table utility")
 
-  (** CSS variables for border-spacing - initialized to 0 in properties layer *)
+  (** CSS variables for border-spacing - initialized to 0 in the properties
+      layer. Tailwind emits these first; a negative property_order with no
+      family sorts them ahead of every other composition variable. *)
   let border_spacing_x_var =
-    Var.property_default Css.Length ~initial:Zero ~property_order:20
+    Var.property_default Css.Length ~initial:Zero ~property_order:(-2)
       "tw-border-spacing-x"
 
   let border_spacing_y_var =
-    Var.property_default Css.Length ~initial:Zero ~property_order:21
+    Var.property_default Css.Length ~initial:Zero ~property_order:(-1)
       "tw-border-spacing-y"
 
   (** Get spacing value - uses theme variable var(--spacing-N) *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -279,6 +279,43 @@ let check_space_reverse_after_transforms () =
   check bool "--tw-translate-x before --tw-space-y-reverse" true
     (index_of "--tw-translate-x" < index_of "--tw-space-y-reverse")
 
+let index_of_prop names n =
+  let rec loop i = function
+    | [] -> fail (n ^ " missing from @property rules")
+    | x :: _ when x = n -> i
+    | _ :: t -> loop (i + 1) t
+  in
+  loop 0 names
+
+(* Regression: Tailwind emits @property --tw-border-spacing-* first in @layer
+   properties, ahead of the transforms. A negative property_order with no family
+   sorts them there. *)
+let check_border_spacing_first () =
+  let names =
+    property_rule_names
+      (Tw.to_css ~base:false ~layers:true
+         [ Tw.border_spacing 2.; Tw.translate_x 4; Tw.blur ])
+  in
+  let index_of = index_of_prop names in
+  check bool "--tw-border-spacing-x before --tw-translate-x" true
+    (index_of "--tw-border-spacing-x" < index_of "--tw-translate-x")
+
+(* Regression: @property --tw-outline-style sorts after the ring group and
+   before the filters, not with the border-style block. *)
+let check_outline_style_after_ring () =
+  let outline =
+    match Tw.of_string "outline" with Ok u -> u | Error (`Msg m) -> fail m
+  in
+  let names =
+    property_rule_names
+      (Tw.to_css ~base:false ~layers:true [ outline; Tw.ring; Tw.blur ])
+  in
+  let index_of = index_of_prop names in
+  check bool "--tw-outline-style after --tw-ring-shadow" true
+    (index_of "--tw-ring-shadow" < index_of "--tw-outline-style");
+  check bool "--tw-outline-style before --tw-blur" true
+    (index_of "--tw-outline-style" < index_of "--tw-blur")
+
 (* Regression: content-none uses a literal [content: none] and must NOT register
    @property --tw-content, matching Tailwind (which emits it only for content
    utilities that reference var(--tw-content), and for before/after
@@ -801,6 +838,9 @@ let tests =
     test_case "@property trailing and order" `Quick check_property_rules_order;
     test_case "@property space-reverse after transforms" `Quick
       check_space_reverse_after_transforms;
+    test_case "@property border-spacing first" `Quick check_border_spacing_first;
+    test_case "@property outline-style after ring" `Quick
+      check_outline_style_after_ring;
     test_case "content-none emits no @property --tw-content" `Quick
       check_content_none_no_property;
     test_case "resolve_dependencies" `Quick test_resolve_dependencies;


### PR DESCRIPTION
Two targeted @property-order fixes, keeping the existing first-usage ordering intact (unlike the reverted #101, whose fixed canonical table broke the usage-dependent order the property_order_scale_first/duration_first tests encode).

`--tw-border-spacing-*` sorted dead last instead of first (Tailwind emits it ahead of the transforms); a negative property_order with no family places it first. `--tw-outline-style` had property_order 0, which sorted it ahead of the whole ring/border block; bumping it to 21 places it just after `--tw-ring-offset-shadow` and before the filters, matching Tailwind — its family stays Border.

These are the two consistently-misordered variables. The remaining ocaml.org @property scatter (gradients, tracking) is context-dependent first-usage behaviour that is byte-clean in isolation, so it's left alone rather than reintroduce a rigid table.