### PR TITLE
clear merlint findings

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1199,7 +1199,9 @@ let individual_layers ~theme ~layers ~include_base ~forms_base first_usage_order
       let layer, prop_rules =
         properties_layer first_usage_order all_property_statements
       in
-      if layer = Css.empty then (None, prop_rules) else (Some layer, prop_rules)
+      match Css.statements layer with
+      | [] -> (None, prop_rules)
+      | _ -> (Some layer, prop_rules)
   in
   let utilities_layer = utilities_layer ~layers ~statements in
   { theme_layer; base_layer; properties_layer; utilities_layer; property_rules }

--- a/lib/html/tw_html.mli
+++ b/lib/html/tw_html.mli
@@ -396,8 +396,8 @@ val page :
     - [title] is the page title
     - [tw_css] controls how the CSS is delivered (see {!type:tw_css}). Defaults
       to [Link "tw.css"], which references the CSS through a cache-busted
-      [<link>] tag in the HTML head. Use [Inline] to embed the CSS in the
-      document and avoid an extra HTTP request.
+      [<link>] tag in the HTML head. Use {!constructor-Inline} to embed the CSS
+      in the document and avoid an extra HTTP request.
     - [forms] explicitly enables the [\@tailwindcss/forms] plugin base layer,
       mirroring Tailwind's [\@plugin] opt-in. When omitted, the forms base is
       auto-detected from forms utility usage (like prose styling).
@@ -413,7 +413,7 @@ val html : page -> string
 val css : page -> string option * Tw.Css.t
 (** [css page] extracts the CSS filename and stylesheet from a page result. The
     filename is [Some file] when the page links to an external stylesheet
-    ([Link file]) and [None] when the CSS is inlined ([Inline]). *)
+    ([Link file]) and [None] when the CSS is inlined ({!constructor-Inline}). *)
 
 (** {1 Livereload module}
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1407,9 +1407,24 @@ let custom_variant_rule token template base_class props =
   in
   regular ~selector:sel ~props ~base_class:modified_class ()
 
+(* Rewrite [selector] for [modifier] and emit a single regular rule under the
+   modified class. The common shape for modifiers that only decorate the
+   selector (no outer media/supports wrapper). *)
+
 (** Convert a modifier and its context to a CSS rule. [inner_has_hover]
     indicates if the inner rule has a hover modifier that needs to be wrapped in
     CSS nesting with {i \@media (hover:hover)}. *)
+let modified_selector_rule modifier base_class selector props =
+  let modified_base_selector = Modifiers.to_selector modifier base_class in
+  let modified_class =
+    Rules_selector.extract_modified_class_name modified_base_selector base_class
+  in
+  let new_selector =
+    Rules_selector.transform_selector_with_modifier modified_base_selector
+      base_class modified_class selector
+  in
+  regular ~selector:new_selector ~props ~base_class:modified_class ()
+
 let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
     base_class selector props =
   match modifier with
@@ -1417,16 +1432,7 @@ let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
   | Style.Data_state _ | Style.Data_variant _ ->
       route_data_modifier modifier base_class selector props
   | Style.Data_custom _ ->
-      let modified_base_selector = Modifiers.to_selector modifier base_class in
-      let modified_class =
-        Rules_selector.extract_modified_class_name modified_base_selector
-          base_class
-      in
-      let new_selector =
-        Rules_selector.transform_selector_with_modifier modified_base_selector
-          base_class modified_class selector
-      in
-      regular ~selector:new_selector ~props ~base_class:modified_class ()
+      modified_selector_rule modifier base_class selector props
   (* Media-like modifiers: dark, motion, contrast, print, orientation,
      forced-colors, inverted-colors, pointer, any-pointer, noscript *)
   | _ when Option.is_some (media_condition_of_modifier modifier) ->
@@ -1597,15 +1603,8 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
              grouped with the utility's regular rule (same-utility order),
              rather than being treated as a different utility and reordered. *)
           [
-            Media_query
-              {
-                condition = inner_condition;
-                selector = new_selector;
-                props;
-                base_class = Some modified_class;
-                nested;
-                not_order = 0;
-              };
+            media_query ~condition:inner_condition ~selector:new_selector ~props
+              ~base_class:modified_class ~nested ();
           ])
 
 (* Extract selector and properties from a single Utility *)

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -124,20 +124,21 @@ let normalize_paren_var base_class =
     | _ -> None
   else None
 
+(* Split the [!] important marker off the base class: the v3 prefix ([!flex],
+   [md:!flex]) or the v4 trailing form ([flex!]). Each keeps its form in the
+   generated selector so it matches the source class. *)
+let split_importance base_class =
+  let n = String.length base_class in
+  if n > 1 && base_class.[0] = '!' then
+    (`Prefix, String.sub base_class 1 (n - 1))
+  else if n > 1 && base_class.[n - 1] = '!' then
+    (`Suffix, String.sub base_class 0 (n - 1))
+  else (`None, base_class)
+
 (* Parse a single class string into a Tw.t *)
 let of_string ?(theme = Scheme.default) class_str =
   let modifiers, base_class = modifiers_of_string class_str in
-  (* The [!] important marker sits right next to the utility: the v3 prefix
-     ([!flex], [md:!flex]) or the v4 trailing form ([flex!]). Each keeps its
-     form in the generated selector so it matches the source class. *)
-  let importance, base_class =
-    let n = String.length base_class in
-    if n > 1 && base_class.[0] = '!' then
-      (`Prefix, String.sub base_class 1 (n - 1))
-    else if n > 1 && base_class.[n - 1] = '!' then
-      (`Suffix, String.sub base_class 0 (n - 1))
-    else (`None, base_class)
-  in
+  let importance, base_class = split_importance base_class in
   (* Wrap [important] around the base before applying modifiers, so a
      responsive/state prefix stays outermost: md:!flex -> md:(!flex). An
      optional [alias] sits inside importance so [w-(--w)!] keeps both forms. *)

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -258,13 +258,18 @@ let selectors_in_media_sel ~condition css =
           match Css.as_rule s with Some (sel, _, _) -> Some sel | None -> None)
         stmts
 
+let selector_eq a b =
+  String.equal (Css.Selector.to_string a) (Css.Selector.to_string b)
+
 let has_selector_in_media_sel ~condition ~selector css =
   selectors_in_media_sel ~condition css
-  |> List.exists (fun sel -> sel = selector)
+  |> List.exists (fun sel -> selector_eq sel selector)
 
 let count_selector_in_media_sel ~condition ~selector css =
   selectors_in_media_sel ~condition css
-  |> List.fold_left (fun acc sel -> if sel = selector then acc + 1 else acc) 0
+  |> List.fold_left
+       (fun acc sel -> if selector_eq sel selector then acc + 1 else acc)
+       0
 
 (** Check if inline style contains a specific property *)
 let inline_has_property prop_name inline_style =


### PR DESCRIPTION
Fixes the merlint issues on main: two polymorphic comparisons in test_helpers (compare selectors via to_string), a polymorphic compare-to-empty in build.ml (match on Css.statements instead), two odoc cross-reference links for the Inline constructor in tw_html.mli, and three functions one line over the length threshold (extract split_importance in tw.ml and modified_selector_rule in rule.ml, use the media_query smart constructor).