### PR TITLE
sort: match Tailwind utility order for container and arbitrary values

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -384,10 +384,7 @@ let add_index triples =
          not_order;
          variant_order = Rule.compute_variant_order base_class sel;
          variant_key = Sort.variant_sort_key base_class nested;
-         normalized_base_class =
-           (match base_class with
-           | Some s -> Sort.normalize_for_sort s
-           | None -> "");
+         base_class_key = Option.value ~default:"" base_class;
          media_key;
          nested_media_key;
        }

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -16,7 +16,9 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "containers"
-  let priority = -1 (* Container appears first in utilities layer *)
+  let priority = 1
+  (* Tailwind orders .container by its width property: after the position group
+     (inset, z-index) and before margin. *)
 
   let to_class = function
     | Layout_container -> "container"

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -54,10 +54,9 @@ type indexed_rule = {
   variant_key : string * int;
       (* Precomputed (variant prefix, effective inner order) - see
          [variant_sort_key]. Read by [compare_variant_ordered]. *)
-  normalized_base_class : string;
-      (* Precomputed [normalize_for_sort base_class] ("" when no base class),
-         read by [compare_by_base_class] instead of re-mapping per
-         comparison. *)
+  base_class_key : string;
+      (* The rule's base class ("" when it has none), read by
+         [compare_by_base_class] as the lexicographic sort key. *)
   media_key : Css.Media.key option;
       (* Precomputed sort key of the rule's own media condition (the [`Media]
          case of [rule_type]); [None] otherwise. Lets media comparisons use
@@ -732,18 +731,11 @@ let compare_starting_rules = compare_by_order_then_index
 (* Main Rule Comparison *)
 (* ======================================================================== *)
 
-(* Normalize base_class for lexicographic comparison *)
-let normalize_for_sort s =
-  String.map
-    (function
-      | '_' -> ' ' | '[' | ']' -> '~' | '/' -> '|' | ':' -> '!' | c -> c)
-    s
-
-(* Compare by normalized base_class (precomputed in [add_index]), then index *)
+(* Compare by base class (precomputed in [add_index]), then index. Tailwind
+   sorts same-family variants by the raw class name (ASCII), so compare
+   as-is. *)
 let compare_by_base_class r1 r2 =
-  let class_cmp =
-    String.compare r1.normalized_base_class r2.normalized_base_class
-  in
+  let class_cmp = String.compare r1.base_class_key r2.base_class_key in
   if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
 
 (* Sort key for supports modifier variants: named before bracket *)
@@ -902,25 +894,11 @@ let bracket_content_key p =
       else 1 (* combinator/ampersand/other *)
   | _ -> 1
 
-(** Check if a prefix is an aria-/data- attribute variant where underscores
-    represent spaces. *)
-let is_attr_variant p =
-  Parse.has_prefix ~prefix:"aria-[" p
-  || Parse.has_prefix ~prefix:"data-[" p
-  || Parse.has_prefix ~prefix:"group-aria-[" p
-  || Parse.has_prefix ~prefix:"group-data-[" p
-  || Parse.has_prefix ~prefix:"peer-aria-[" p
-  || Parse.has_prefix ~prefix:"peer-data-[" p
-
-(** Compare two bracket-containing variant prefixes. Sorts by bracket content
-    type (pseudo-class before combinator), then by normalized name for
-    aria-/data- attributes, or plain string comparison otherwise. *)
+(** Compare two bracket-containing variant prefixes: by bracket content type
+    (pseudo-class before combinator), then by raw name. *)
 let compare_both_bracket_prefixes p1 p2 =
   let bk_cmp = Int.compare (bracket_content_key p1) (bracket_content_key p2) in
-  if bk_cmp <> 0 then bk_cmp
-  else if is_attr_variant p1 || is_attr_variant p2 then
-    String.compare (normalize_for_sort p1) (normalize_for_sort p2)
-  else String.compare p1 p2
+  if bk_cmp <> 0 then bk_cmp else String.compare p1 p2
 
 (** Compare variant prefixes for bracket ordering. Named variants (has-checked)
     sort before bracket variants (has-[:checked]) within the same variant group.

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -47,10 +47,9 @@ type indexed_rule = {
       (** Precomputed [(variant prefix, effective inner order)], built with
           {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
           per comparison. *)
-  normalized_base_class : string;
-      (** Precomputed [normalize_for_sort base_class] ([""] when there is no
-          base class), so [compare_indexed_rules] does not re-map it per
-          comparison. *)
+  base_class_key : string;
+      (** The rule's base class ([""] when it has none), used by
+          [compare_indexed_rules] as the lexicographic sort key. *)
   media_key : Css.Media.key option;
       (** Precomputed sort key of the rule's own media condition (the [`Media]
           case of {!field-rule_type}), [None] otherwise. Comparisons use this
@@ -61,10 +60,6 @@ type indexed_rule = {
 
 val classify_selector : Css.Selector.t -> selector_kind
 (** [classify_selector sel] classifies a selector for ordering purposes. *)
-
-val normalize_for_sort : string -> string
-(** [normalize_for_sort s] rewrites separator characters so base classes sort in
-    Tailwind order. Stored per rule in {!field-normalized_base_class}. *)
 
 val variant_sort_key : string option -> Css.statement list -> string * int
 (** [variant_sort_key base_class nested] is the

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -957,6 +957,30 @@ let test_border_width_color_ordering () =
   Test_helpers.check_ordering_matches
     ~test_name:"border width and color ordering" utilities
 
+let test_container_order () =
+  (* .container sorts by its width property (after the position group, before
+     margin), not first in the utilities layer. *)
+  let classes = [ "container"; "sr-only"; "z-0"; "top-0"; "m-4"; "w-4" ] in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"container width-property order" utilities
+
+let test_arbitrary_vs_named_order () =
+  (* Within a variant block, arbitrary values sort by their raw class name ('['
+     = 0x5b, before lowercase letters), so dark:bg-[#...] precedes
+     dark:bg-<name>. *)
+  let classes =
+    [
+      "dark:bg-[#0D2C2E]";
+      "dark:bg-gray-400";
+      "dark:bg-white";
+      "dark:bg-transparent";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"arbitrary before named within variant" utilities
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -1057,6 +1081,9 @@ let tests =
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick
       test_border_width_color_ordering;
+    test_case "container width-property order" `Slow test_container_order;
+    test_case "arbitrary before named within family" `Slow
+      test_arbitrary_vs_named_order;
     test_case "regular before media same priority" `Quick
       test_regular_before_media;
     test_case "rules_of_grouped prose merging bug" `Quick


### PR DESCRIPTION
Two utility-layer ordering divergences from Tailwind on real projects.

`.container` had priority `-1`, sorting it first in the utilities layer; Tailwind orders it by its width property, after the position group and before margin. It now carries the matching priority.

Same-family variants were compared through `normalize_for_sort`, which remapped `[`, `_`, `/` and `:` away from their ASCII positions, so an arbitrary value like `dark:bg-[#0D2C2E]` sorted after named ones instead of before. Tailwind sorts by the raw class name (`[` = 0x5b, before lowercase letters); the comparison now uses the string as-is.

Regression tests `container width-property order` and `arbitrary before named within variant` fail on the parent commit.