### PR TITLE
sort: tie-break same-suborder variant rules by selector

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -930,7 +930,7 @@ let compare_variant_ordered r1 r2 =
   match (r1.rule_type, r2.rule_type) with
   | `Supports _, `Supports _ when r1.variant_order = r2.variant_order ->
       compare_supports_by_key r1 r2
-  | _ ->
+  | _ -> (
       let vo_cmp = Int.compare r1.variant_order r2.variant_order in
       if vo_cmp <> 0 then vo_cmp
       else
@@ -963,7 +963,20 @@ let compare_variant_ordered r1 r2 =
                 if prio_cmp <> 0 then prio_cmp
                 else
                   let sub_cmp = Int.compare s1 s2 in
-                  if sub_cmp <> 0 then sub_cmp else compare_by_base_class r1 r2
+                  if sub_cmp <> 0 then sub_cmp
+                  else
+                    match (r1.selector_kind, r2.selector_kind) with
+                    | Simple, Simple ->
+                        (* Same priority/suborder simple rules (e.g. two
+                           arbitrary bg colors) break ties by selector like the
+                           regular layer, matching Tailwind's alphabetical
+                           order. *)
+                        natural_compare r1.selector_str r2.selector_str
+                    | _ ->
+                        (* Complex rules (prose's descendant selectors) keep
+                           base class + source order so a component stays one
+                           block. *)
+                        compare_by_base_class r1 r2)
 
 (* Compare two Supports rules *)
 let compare_supports_rules r1 r2 =

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -981,6 +981,15 @@ let test_arbitrary_vs_named_order () =
   Test_helpers.check_ordering_matches
     ~test_name:"arbitrary before named within variant" utilities
 
+let test_variant_same_suborder_tiebreak () =
+  (* Two arbitrary values of the same utility in a variant block have equal
+     (priority, suborder); they must tie-break by selector, matching Tailwind's
+     alphabetical order (dark:bg-[#003357] before dark:bg-[#0D2C2E]). *)
+  let classes = [ "dark:bg-[#0D2C2E]"; "dark:bg-[#003357]" ] in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"variant same-suborder tiebreak" utilities
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -1084,6 +1093,8 @@ let tests =
     test_case "container width-property order" `Slow test_container_order;
     test_case "arbitrary before named within family" `Slow
       test_arbitrary_vs_named_order;
+    test_case "variant same-suborder tiebreak" `Slow
+      test_variant_same_suborder_tiebreak;
     test_case "regular before media same priority" `Quick
       test_regular_before_media;
     test_case "rules_of_grouped prose merging bug" `Quick


### PR DESCRIPTION
Stacked on #112.

In a variant block (`dark:`, `hover:`, ...) two arbitrary values of one utility have equal `(priority, suborder)`; `compare_variant_ordered` fell through to base class then source index, so two arbitrary background colors (e.g. `dark:bg-[#003357]` and `dark:bg-[#0D2C2E]`) kept input order instead of Tailwind's alphabetical order. Simple rules now tie-break by selector like the regular layer; complex rules (prose's descendant selectors) keep base class + source order so a component stays one block.

Regression test `variant same-suborder tiebreak` fails on the parent commit.