### PR TITLE
rule: sort compound variants by their outer variant

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1568,9 +1568,12 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
     Css.media ~condition:inner_condition (inner_rule :: nested)
   in
   let wrap_in_media condition =
+    (* Use the modified class (e.g. "dark:md:block"), not the inner rule's
+       original base_class ("md:block"), so the wrapped rule sorts by its
+       outermost variant (dark) rather than the inner one (md). *)
     [
-      media_query ~condition ~selector:new_selector ~props:[] ?base_class
-        ~nested:[ inner_media ] ();
+      media_query ~condition ~selector:new_selector ~props:[]
+        ~base_class:modified_class ~nested:[ inner_media ] ();
     ]
   in
   match media_condition_of_modifier modifier with

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -990,6 +990,17 @@ let test_variant_same_suborder_tiebreak () =
   Test_helpers.check_ordering_matches
     ~test_name:"variant same-suborder tiebreak" utilities
 
+let test_compound_variant_order () =
+  (* A compound variant that nests a responsive breakpoint inside another
+     variant (dark:md:block -> @media dark { @media md { ... } }) must sort by
+     its outermost variant (dark), after the base dark: rules, not by the inner
+     breakpoint (md). Tailwind emits dark:flex and dark:font-semibold before
+     dark:md:block. *)
+  let classes = [ "dark:flex"; "dark:font-semibold"; "dark:md:block" ] in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"compound variant sorts by outer variant" utilities
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -1095,6 +1106,8 @@ let tests =
       test_arbitrary_vs_named_order;
     test_case "variant same-suborder tiebreak" `Slow
       test_variant_same_suborder_tiebreak;
+    test_case "compound variant sorts by outer variant" `Slow
+      test_compound_variant_order;
     test_case "regular before media same priority" `Quick
       test_regular_before_media;
     test_case "rules_of_grouped prose merging bug" `Quick


### PR DESCRIPTION
A compound variant that nests a responsive breakpoint inside another variant, such as `dark:md:block`, is emitted as `@media dark { @media md { ... } }`. When the outer variant wrapped the already-responsive rule it kept the inner rule's base_class (`md:block`), so the rule sorted by the breakpoint (`md`) rather than the outer variant (`dark`) and landed before the base `dark:` rules instead of after them.

The wrapper now uses the modified class as its base_class, matching the sibling hover and other-modifier cases that already did so. This removes the last ordering gap in the optimized ocaml.org corpus.

Stacked on #114.