### PR TITLE
sort: order variant arbitrary values numerically

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -975,8 +975,18 @@ let compare_variant_ordered r1 r2 =
                     | _ ->
                         (* Complex rules (prose's descendant selectors) keep
                            base class + source order so a component stays one
-                           block. *)
-                        compare_by_base_class r1 r2)
+                           block. Arbitrary values in a variant, e.g.
+                           hover:from-[rgba(5,...)] vs
+                           hover:from-[rgba(14,...)], share a prefix and differ
+                           only in the numeric part, so order those numerically
+                           like Tailwind. Identical base classes (prose's :where
+                           rules all key on "prose") tie at 0 and fall back to
+                           source order, unchanged. *)
+                        let class_cmp =
+                          natural_compare r1.base_class_key r2.base_class_key
+                        in
+                        if class_cmp <> 0 then class_cmp
+                        else Int.compare r1.index r2.index)
 
 (* Compare two Supports rules *)
 let compare_supports_rules r1 r2 =

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -990,6 +990,22 @@ let test_variant_same_suborder_tiebreak () =
   Test_helpers.check_ordering_matches
     ~test_name:"variant same-suborder tiebreak" utilities
 
+let test_variant_arbitrary_numeric_order () =
+  (* Arbitrary values in a variant block (hover:from-[rgba(5,...)] etc.) must
+     order numerically like the regular layer, not lexically: rgba(5,...) sorts
+     before rgba(14,...) and rgba(255,...). A lexical sort would place
+     rgba(14,...) and rgba(255,...) first because '1' and '2' precede '5'. *)
+  let classes =
+    [
+      "hover:from-[rgba(14,220,174,0.60)]";
+      "hover:from-[rgba(5,74,218,0.60)]";
+      "hover:from-[rgba(255,0,64,0.60)]";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"variant arbitrary values sort numerically" utilities
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -1095,6 +1111,8 @@ let tests =
       test_arbitrary_vs_named_order;
     test_case "variant same-suborder tiebreak" `Slow
       test_variant_same_suborder_tiebreak;
+    test_case "variant arbitrary values sort numerically" `Slow
+      test_variant_arbitrary_numeric_order;
     test_case "regular before media same priority" `Quick
       test_regular_before_media;
     test_case "rules_of_grouped prose merging bug" `Quick


### PR DESCRIPTION
Arbitrary values inside a variant block, such as `hover:from-[rgba(5,74,218,0.60)]` and `hover:from-[rgba(14,220,174,0.60)]`, sorted lexically rather than numerically: because the selectors carry a `:hover` pseudo-class they are not `Simple`, so the variant tiebreak fell through to a lexical `base_class` comparison and placed `rgba(14,...)` and `rgba(255,...)` before `rgba(5,...)`.

The regular utility layer already orders these numerically. The variant tiebreak's complex-selector branch now uses `natural_compare` on the base class, matching it. Prose's descendant rules share an identical base class (`prose`), so they still tie at zero and fall back to source order, keeping each component in one block.

Stacked on #115.