### PR TITLE
sort: order stacked variants by their variant-order list

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -369,6 +369,7 @@ let add_index triples =
       Css.Selector.to_buffer buf sel;
       let selector_str = Buffer.contents buf in
       let media_key, nested_media_key = Sort.media_sort_keys typ nested in
+      let variant_order = Rule.compute_variant_order base_class sel in
       ({
          index = i;
          rule_type = typ;
@@ -382,8 +383,9 @@ let add_index triples =
          base_class;
          merge_key;
          not_order;
-         variant_order = Rule.compute_variant_order base_class sel;
+         variant_order;
          variant_key = Sort.variant_sort_key base_class nested;
+         variant_orders = Sort.variant_order_list base_class variant_order;
          base_class_key = Option.value ~default:"" base_class;
          media_key;
          nested_media_key;

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1568,9 +1568,12 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
     Css.media ~condition:inner_condition (inner_rule :: nested)
   in
   let wrap_in_media condition =
+    (* Use the modified class (e.g. "dark:md:block") as the wrapped rule's base
+       class, not the inner rule's original one ("md:block"), so the sort sees
+       the full variant stack and orders it by its highest-order component. *)
     [
-      media_query ~condition ~selector:new_selector ~props:[] ?base_class
-        ~nested:[ inner_media ] ();
+      media_query ~condition ~selector:new_selector ~props:[]
+        ~base_class:modified_class ~nested:[ inner_media ] ();
     ]
   in
   match media_condition_of_modifier modifier with

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -54,6 +54,13 @@ type indexed_rule = {
   variant_key : string * int;
       (* Precomputed (variant prefix, effective inner order) - see
          [variant_sort_key]. Read by [compare_variant_ordered]. *)
+  variant_orders : (int * int) list;
+      (* The rule's variant order keys sorted descending - see
+         [variant_order_list]. Compared lexicographically by
+         [compare_variant_ordered] so a stacked variant sorts into the group of
+         its highest-order component, after that group's base rules, and two
+         stacks with the same variant multiset (e.g. group:hover and
+         hover:group) get identical keys. *)
   base_class_key : string;
       (* The rule's base class ("" when it has none), read by
          [compare_by_base_class] as the lexicographic sort key. *)
@@ -884,6 +891,56 @@ let variant_sort_key base_class nested =
   let prefix = variant_prefix base_class in
   (prefix, effective_ivo_of nested prefix)
 
+(* One modifier token's sort key: its variant order, paired with the inner
+   pseudo order for group-/peer- wrappers so group-focus and group-has (both
+   order 500) keep their focus-before-has order. Non-wrapper tokens use 0. *)
+let token_order_key token =
+  let primary = Modifiers.variant_order_of_prefix token in
+  let secondary =
+    if
+      Parse.has_prefix ~prefix:"group-" token
+      || Parse.has_prefix ~prefix:"peer-" token
+    then strip_group_peer_vo token
+    else 0
+  in
+  (primary, secondary)
+
+(* The variant order keys of a class's modifier stack, sorted descending.
+   Tailwind sorts a candidate by this list compared lexicographically ascending,
+   so a stacked variant sorts into the group of its highest-order component and
+   after that group's base rules, and two stacks with the same variant multiset
+   (group:hover vs hover:group) get identical keys. Falls back to the scalar
+   [variant_order] for selector-derived variants (before:/after:) that carry no
+   order-bearing prefix in the base class. *)
+let variant_order_list base_class variant_order =
+  let from_bc =
+    match base_class with
+    | None -> []
+    | Some bc ->
+        let modifiers, _ = Modifiers.of_string bc in
+        List.filter_map
+          (fun m ->
+            let ((primary, _) as key) = token_order_key m in
+            if primary > 0 then Some key else None)
+          modifiers
+        |> List.sort (fun a b -> compare b a)
+  in
+  match from_bc with
+  | [] when variant_order > 0 -> [ (variant_order, 0) ]
+  | l -> l
+
+(* Compare two descending variant-order-key lists lexicographically, ascending
+   on the first differing key, with a shorter (prefix) list sorting first so
+   base rules precede the compounds built on them. *)
+let rec compare_variant_order_lists l1 l2 =
+  match (l1, l2) with
+  | [], [] -> 0
+  | [], _ -> -1
+  | _, [] -> 1
+  | a :: r1, b :: r2 ->
+      let c = compare a b in
+      if c <> 0 then c else compare_variant_order_lists r1 r2
+
 (** Classify bracket content: pseudo-class brackets ([:checked]) sort before
     combinator/ampersand brackets ([&>img], [+img], etc.). *)
 let bracket_content_key p =
@@ -931,62 +988,63 @@ let compare_variant_ordered r1 r2 =
   | `Supports _, `Supports _ when r1.variant_order = r2.variant_order ->
       compare_supports_by_key r1 r2
   | _ -> (
-      let vo_cmp = Int.compare r1.variant_order r2.variant_order in
-      if vo_cmp <> 0 then vo_cmp
+      let list_cmp =
+        compare_variant_order_lists r1.variant_orders r2.variant_orders
+      in
+      if list_cmp <> 0 then list_cmp
       else
-        let p1_prefix, ivo1 = r1.variant_key in
-        let p2_prefix, ivo2 = r2.variant_key in
-        let ivo_cmp = Int.compare ivo1 ivo2 in
-        if ivo_cmp <> 0 then ivo_cmp
+        let p1_prefix, _ = r1.variant_key in
+        let p2_prefix, _ = r2.variant_key in
+        (* The descending variant-order lists tie (same variant multiset). The
+           remaining keys order within that group: a nested breakpoint or hover,
+           the media condition itself (sm before md), then the prefix and the
+           utility's own priority. *)
+        let nested_cmp =
+          Int.compare
+            (nested_order r1.rule_type r1.nested)
+            (nested_order r2.rule_type r2.nested)
+        in
+        if nested_cmp <> 0 then nested_cmp
         else
-          let nested_cmp =
-            Int.compare
-              (nested_order r1.rule_type r1.nested)
-              (nested_order r2.rule_type r2.nested)
+          let media_cmp =
+            match (r1.media_key, r2.media_key) with
+            | Some k1, Some k2 ->
+                let cmp = Css.Media.compare_keys k1 k2 in
+                if cmp <> 0 then cmp else compare_nested_media r1 r2
+            | _ -> 0
           in
-          if nested_cmp <> 0 then nested_cmp
+          if media_cmp <> 0 then media_cmp
           else
-            let media_cmp =
-              match (r1.media_key, r2.media_key) with
-              | Some k1, Some k2 ->
-                  let cmp = Css.Media.compare_keys k1 k2 in
-                  if cmp <> 0 then cmp else compare_nested_media r1 r2
-              | _ -> 0
-            in
-            if media_cmp <> 0 then media_cmp
+            let prefix_cmp = compare_bracket_prefixes p1_prefix p2_prefix in
+            if prefix_cmp <> 0 then prefix_cmp
             else
-              let prefix_cmp = compare_bracket_prefixes p1_prefix p2_prefix in
-              if prefix_cmp <> 0 then prefix_cmp
+              let p1, s1 = r1.order and p2, s2 = r2.order in
+              let prio_cmp = Int.compare p1 p2 in
+              if prio_cmp <> 0 then prio_cmp
               else
-                let p1, s1 = r1.order and p2, s2 = r2.order in
-                let prio_cmp = Int.compare p1 p2 in
-                if prio_cmp <> 0 then prio_cmp
+                let sub_cmp = Int.compare s1 s2 in
+                if sub_cmp <> 0 then sub_cmp
                 else
-                  let sub_cmp = Int.compare s1 s2 in
-                  if sub_cmp <> 0 then sub_cmp
-                  else
-                    match (r1.selector_kind, r2.selector_kind) with
-                    | Simple, Simple ->
-                        (* Same priority/suborder simple rules (e.g. two
-                           arbitrary bg colors) break ties by selector like the
-                           regular layer, matching Tailwind's alphabetical
-                           order. *)
-                        natural_compare r1.selector_str r2.selector_str
-                    | _ ->
-                        (* Complex rules (prose's descendant selectors) keep
-                           base class + source order so a component stays one
-                           block. Arbitrary values in a variant, e.g.
-                           hover:from-[rgba(5,...)] vs
-                           hover:from-[rgba(14,...)], share a prefix and differ
-                           only in the numeric part, so order those numerically
-                           like Tailwind. Identical base classes (prose's :where
-                           rules all key on "prose") tie at 0 and fall back to
-                           source order, unchanged. *)
-                        let class_cmp =
-                          natural_compare r1.base_class_key r2.base_class_key
-                        in
-                        if class_cmp <> 0 then class_cmp
-                        else Int.compare r1.index r2.index)
+                  match (r1.selector_kind, r2.selector_kind) with
+                  | Simple, Simple ->
+                      (* Same priority/suborder simple rules (e.g. two arbitrary
+                         bg colors) break ties by selector like the regular
+                         layer, matching Tailwind's alphabetical order. *)
+                      natural_compare r1.selector_str r2.selector_str
+                  | _ ->
+                      (* Complex rules (prose's descendant selectors) keep base
+                         class + source order so a component stays one block.
+                         Arbitrary values in a variant, e.g.
+                         hover:from-[rgba(5,...)] vs hover:from-[rgba(14,...)],
+                         share a prefix and differ only in the numeric part, so
+                         order those numerically like Tailwind. Identical base
+                         classes (prose's :where rules all key on "prose") tie
+                         at 0 and fall back to source order, unchanged. *)
+                      let class_cmp =
+                        natural_compare r1.base_class_key r2.base_class_key
+                      in
+                      if class_cmp <> 0 then class_cmp
+                      else Int.compare r1.index r2.index)
 
 (* Compare two Supports rules *)
 let compare_supports_rules r1 r2 =

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -47,6 +47,11 @@ type indexed_rule = {
       (** Precomputed [(variant prefix, effective inner order)], built with
           {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
           per comparison. *)
+  variant_orders : (int * int) list;
+      (** The rule's variant order keys sorted descending, built with
+          {!variant_order_list}. Compared lexicographically by
+          [compare_indexed_rules] so a stacked variant sorts into the group of
+          its highest-order component. *)
   base_class_key : string;
       (** The rule's base class ([""] when it has none), used by
           [compare_indexed_rules] as the lexicographic sort key. *)
@@ -65,6 +70,12 @@ val variant_sort_key : string option -> Css.statement list -> string * int
 (** [variant_sort_key base_class nested] is the
     [(variant prefix, effective inner variant order)] pair stored in
     {!field-variant_key}. *)
+
+val variant_order_list : string option -> int -> (int * int) list
+(** [variant_order_list base_class variant_order] is the descending list of
+    variant order keys stored in {!field-variant_orders}. [variant_order] is the
+    scalar fallback for selector-derived variants with no order-bearing prefix.
+*)
 
 val media_sort_keys :
   [ `Regular

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1006,6 +1006,41 @@ let test_variant_arbitrary_numeric_order () =
   Test_helpers.check_ordering_matches
     ~test_name:"variant arbitrary values sort numerically" utilities
 
+let test_compound_variant_highest_component () =
+  (* A stacked variant sorts into the group of its highest-order component,
+     after that group's base rules, matching Tailwind. dark:md:block (dark > md)
+     and contrast-more:dark:text-white (dark > contrast-more) both sort with the
+     dark rules, after the plain dark rules, even though one has dark as its
+     outer token and the other as its inner token. *)
+  let classes =
+    [
+      "dark:flex";
+      "dark:font-semibold";
+      "dark:md:block";
+      "contrast-more:underline";
+      "contrast-more:dark:text-white";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"compound variant highest component" utilities
+
+let test_compound_variant_same_multiset () =
+  (* group-[&_p]:hover and hover:group-[&_p] apply the same variant multiset in
+     different nesting orders, so Tailwind gives them the same sort position and
+     they collapse into one block. *)
+  let classes =
+    [
+      "group-[&_p]:flex";
+      "group-[&_p]:hover:flex";
+      "hover:group-[&_p]:flex";
+      "hover:group-[&_p]:hover:flex";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"compound variant same multiset" utilities
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -1113,6 +1148,10 @@ let tests =
       test_variant_same_suborder_tiebreak;
     test_case "variant arbitrary values sort numerically" `Slow
       test_variant_arbitrary_numeric_order;
+    test_case "compound variant highest component" `Slow
+      test_compound_variant_highest_component;
+    test_case "compound variant same multiset" `Slow
+      test_compound_variant_same_multiset;
     test_case "regular before media same priority" `Quick
       test_regular_before_media;
     test_case "rules_of_grouped prose merging bug" `Quick


### PR DESCRIPTION
tw sorted a stacked variant by its outermost variant token. That misplaced compounds whose inner variant outranks the outer: `dark:md:block` sorted by `md` and `contrast-more:dark:text-white` by `contrast-more`, when Tailwind sorts both by `dark`.

Tailwind sorts a candidate by its variants' orders sorted descending, compared lexicographically: a stacked variant lands in the group of its highest-order component, after that group's base rules, and two stacks with the same variant multiset (`group:hover` and `hover:group`) share a position and merge into one block. This reimplements that model — each rule carries its descending variant-order key list, and `compare_variant_ordered` compares those. Group-/peer- wrappers keep their inner-pseudo order via a paired key. The media wrapper now keeps the full compound class (`dark:md:block`, not `md:block`) as its base class so the sort sees the whole stack.

Full suite green including the 781-case upstream parity suite, the sort fuzzer, and all example runtests (accessibility's `contrast-more:dark:`, modifiers' `group-*`).