### PR TITLE
sort: place arbitrary rotate and max-w values by their suffix

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -1140,29 +1140,32 @@ module Handler = struct
     | W_xl -> w + keyword_off + 10
     (* Max-width *)
     | Max_w_spacing n -> max_w + spacing_value_order n
-    | Max_w_arbitrary _ -> max_w + arbitrary_off
+    (* Named sizes sort by raw suffix: the digit-prefixed sizes (2xl..7xl) come
+       before an arbitrary value ('[' > digits), which comes before the
+       letter-prefixed sizes ('[' < 'f'). *)
     | Max_w_2xl -> max_w + keyword_off + 0
     | Max_w_3xl -> max_w + keyword_off + 1
     | Max_w_4xl -> max_w + keyword_off + 2
     | Max_w_5xl -> max_w + keyword_off + 3
     | Max_w_6xl -> max_w + keyword_off + 4
     | Max_w_7xl -> max_w + keyword_off + 5
-    | Max_w_fit -> max_w + keyword_off + 6
-    | Max_w_full -> max_w + keyword_off + 7
-    | Max_w_lg -> max_w + keyword_off + 8
-    | Max_w_max -> max_w + keyword_off + 9
-    | Max_w_md -> max_w + keyword_off + 10
-    | Max_w_min -> max_w + keyword_off + 11
-    | Max_w_none -> max_w + keyword_off + 12
-    | Max_w_prose -> max_w + keyword_off + 13
-    | Max_w_screen_2xl -> max_w + keyword_off + 14
-    | Max_w_screen_lg -> max_w + keyword_off + 15
-    | Max_w_screen_md -> max_w + keyword_off + 16
-    | Max_w_screen_sm -> max_w + keyword_off + 17
-    | Max_w_screen_xl -> max_w + keyword_off + 18
-    | Max_w_sm -> max_w + keyword_off + 19
-    | Max_w_xl -> max_w + keyword_off + 20
-    | Max_w_xs -> max_w + keyword_off + 21
+    | Max_w_arbitrary _ -> max_w + keyword_off + 6
+    | Max_w_fit -> max_w + keyword_off + 7
+    | Max_w_full -> max_w + keyword_off + 8
+    | Max_w_lg -> max_w + keyword_off + 9
+    | Max_w_max -> max_w + keyword_off + 10
+    | Max_w_md -> max_w + keyword_off + 11
+    | Max_w_min -> max_w + keyword_off + 12
+    | Max_w_none -> max_w + keyword_off + 13
+    | Max_w_prose -> max_w + keyword_off + 14
+    | Max_w_screen_2xl -> max_w + keyword_off + 15
+    | Max_w_screen_lg -> max_w + keyword_off + 16
+    | Max_w_screen_md -> max_w + keyword_off + 17
+    | Max_w_screen_sm -> max_w + keyword_off + 18
+    | Max_w_screen_xl -> max_w + keyword_off + 19
+    | Max_w_sm -> max_w + keyword_off + 20
+    | Max_w_xl -> max_w + keyword_off + 21
+    | Max_w_xs -> max_w + keyword_off + 22
     (* Min-width *)
     | Min_w_0 -> min_w + 0
     | Min_w_spacing n -> min_w + spacing_value_order n

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1314,8 +1314,11 @@ module Handler = struct
     | Neg_rotate_arbitrary _ -> 799
     | Rotate_bare_var _ -> 800
     | Rotate n -> 801 + n
-    | Rotate_3d_arbitrary _ -> 898
-    | Rotate_arbitrary _ -> 899
+    (* An arbitrary rotate sorts after every named rotate ('[' > any digit), so
+       it must sit past the largest [Rotate n] (rotate-180 -> 801 + 180 = 981),
+       not mid-range. *)
+    | Rotate_3d_arbitrary _ -> 982
+    | Rotate_arbitrary _ -> 983
     | Neg_rotate_x_bare_var _ -> 900
     | Neg_rotate_x_arbitrary _ -> 949
     | Rotate_x_bare_var _ -> 950

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -981,6 +981,30 @@ let test_arbitrary_vs_named_order () =
   Test_helpers.check_ordering_matches
     ~test_name:"arbitrary before named within variant" utilities
 
+let test_arbitrary_named_by_suffix () =
+  (* Within a utility family, an arbitrary value sorts by its raw suffix like a
+     named one, not always first: '[' is above digits and below letters, so
+     rotate-180 precedes rotate-[-10deg], and max-w-3xl precedes max-w-[50%]
+     which precedes max-w-sm. Arbitrary values order among themselves by value
+     (rotate-[5deg] before rotate-[200deg]). *)
+  let classes =
+    [
+      "rotate-90";
+      "rotate-180";
+      "rotate-[-10deg]";
+      "rotate-[5deg]";
+      "rotate-[200deg]";
+      "max-w-3xl";
+      "max-w-[6%]";
+      "max-w-[50%]";
+      "max-w-sm";
+      "max-w-xs";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"arbitrary value sorts by suffix within family" utilities
+
 let test_variant_same_suborder_tiebreak () =
   (* Two arbitrary values of the same utility in a variant block have equal
      (priority, suborder); they must tie-break by selector, matching Tailwind's
@@ -1144,6 +1168,8 @@ let tests =
     test_case "container width-property order" `Slow test_container_order;
     test_case "arbitrary before named within family" `Slow
       test_arbitrary_vs_named_order;
+    test_case "arbitrary value sorts by suffix within family" `Slow
+      test_arbitrary_named_by_suffix;
     test_case "variant same-suborder tiebreak" `Slow
       test_variant_same_suborder_tiebreak;
     test_case "variant arbitrary values sort numerically" `Slow


### PR DESCRIPTION
Tailwind orders values within a utility family by their raw suffix, so an arbitrary value slots by where `[` falls — above digits, below letters — not always first. tw's suborder tables gave arbitrary values a fixed band that sorted them ahead of the digit-prefixed named sizes (`max-w-2xl`..`7xl`) and mid-range among named rotates, so `rotate-[-10deg]` landed before `rotate-180` and `max-w-[50%]` before `max-w-3xl`.

This places each family's arbitrary variant at its suffix position: `rotate-180` then `rotate-[-10deg]`; `max-w-3xl`, `max-w-[50%]`, then `max-w-sm`. Values within the arbitrary group still tie on suborder and fall to the existing natural selector compare, so `rotate-[5deg]` precedes `rotate-[200deg]`.

Found via the ocaml.org corpus (these were the only two families the corpus exercised with mixed named/arbitrary values). Full suite green including the 781-case upstream suite and the sort fuzzer.