### PR TITLE
sort: match Tailwind within-family order for rounded and margin

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -742,22 +742,27 @@ module Handler = struct
     (* Border radius utilities - flat suborder per position group for natural
        sort by class name *)
     | Rounded (pos, _) -> (
+        (* Position groups sort by the CSS properties they write, matching
+           Tailwind: the logical corners (start/end) first, then the physical
+           ones grouped by their first corner clockwise -- top, then left, then
+           right, then bottom. Values within a group share a suborder and
+           tie-break by class name. *)
         match pos with
         | Rp_all -> 0
+        | Rp_s -> 10
+        | Rp_ss -> 20
+        | Rp_e -> 30
+        | Rp_se -> 40
+        | Rp_ee -> 50
+        | Rp_es -> 60
         | Rp_t -> 100
-        | Rp_r -> 110
-        | Rp_b -> 120
-        | Rp_l -> 130
-        | Rp_tl -> 200
-        | Rp_tr -> 210
-        | Rp_br -> 220
-        | Rp_bl -> 230
-        | Rp_s -> 240
-        | Rp_e -> 250
-        | Rp_ss -> 260
-        | Rp_se -> 270
-        | Rp_ee -> 280
-        | Rp_es -> 290)
+        | Rp_l -> 110
+        | Rp_tl -> 120
+        | Rp_r -> 130
+        | Rp_tr -> 140
+        | Rp_b -> 150
+        | Rp_br -> 160
+        | Rp_bl -> 170)
     (* Border width utilities (1000-1099) *)
     | Border -> 1000
     | Border_0 -> 1001

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -112,16 +112,21 @@ module Handler = struct
     let decl, len = spacing_to_decl_len ?theme ~negative:true s in
     style (Option.to_list decl @ [ prop [ len ] ])
 
+  (* Spacing keywords sort by their suffix's first character, matching
+     Tailwind's raw order after the numeric rem values: auto ('a') < a named
+     spacing like big ('b') < full ('f') < px ('p'). *)
+  let keyword_order c = 100000 + Char.code c
+
   let spacing_value_order = function
-    | `Px -> 1
-    | `Full -> 10000
-    | `Named _ -> 150000 (* after auto (99999) *)
     | `Rem f ->
         let units = f /. 0.25 in
         int_of_float (units *. 10.)
+    | `Named s -> keyword_order (if String.length s > 0 then s.[0] else '~')
+    | `Full -> keyword_order 'f'
+    | `Px -> keyword_order 'p'
 
   let margin_value_order = function
-    | `Auto -> 99999 (* Auto comes after numeric values in Tailwind *)
+    | `Auto -> keyword_order 'a'
     | #spacing as s -> spacing_value_order s
 
   (* Get the CSS property function for an axis *)

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1005,6 +1005,60 @@ let test_arbitrary_named_by_suffix () =
   Test_helpers.check_ordering_matches
     ~test_name:"arbitrary value sorts by suffix within family" utilities
 
+let test_rounded_position_order () =
+  (* Border-radius position groups sort by the CSS corners they write, matching
+     Tailwind: the physical ones grouped by first corner clockwise -- top, then
+     left, then right, then bottom (t, l, tl, r, tr, b, br, bl). rounded-l and
+     rounded-b both write border-bottom-left-radius, so the order is
+     render-affecting. Asserted directly on the emitted order because the
+     ordering helper compares unoptimized output where the conflict is
+     hidden. *)
+  let classes =
+    [
+      "rounded-t-full";
+      "rounded-l-full";
+      "rounded-tl-full";
+      "rounded-r-full";
+      "rounded-b-full";
+      "rounded-bl-full";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let position needle =
+    let n = String.length needle and h = String.length css in
+    let rec go i =
+      if i + n > h then -1
+      else if String.sub css i n = needle then i
+      else go (i + 1)
+    in
+    go 0
+  in
+  let check_before a b =
+    let pa = position a and pb = position b in
+    Alcotest.check Alcotest.bool
+      (Printf.sprintf "%s before %s" a b)
+      true
+      (pa >= 0 && pb >= 0 && pa < pb)
+  in
+  check_before ".rounded-t-full" ".rounded-l-full";
+  check_before ".rounded-l-full" ".rounded-tl-full";
+  check_before ".rounded-tl-full" ".rounded-r-full";
+  check_before ".rounded-r-full" ".rounded-b-full";
+  check_before ".rounded-b-full" ".rounded-bl-full"
+
+let test_margin_value_order () =
+  (* Margin values sort by raw suffix: numeric, then arbitrary ('['), then
+     keywords auto < full < px. -ml-4 and -ml-px conflict on margin-left, so the
+     order matters; a lexical/legacy order put px before the numbers. *)
+  let classes =
+    [
+      "ml-0"; "ml-1"; "ml-4"; "ml-[3px]"; "ml-auto"; "ml-px"; "-ml-4"; "-ml-px";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches ~test_name:"margin value order" utilities
+
 let test_variant_same_suborder_tiebreak () =
   (* Two arbitrary values of the same utility in a variant block have equal
      (priority, suborder); they must tie-break by selector, matching Tailwind's
@@ -1170,6 +1224,8 @@ let tests =
       test_arbitrary_vs_named_order;
     test_case "arbitrary value sorts by suffix within family" `Slow
       test_arbitrary_named_by_suffix;
+    test_case "rounded position order" `Slow test_rounded_position_order;
+    test_case "margin value order" `Slow test_margin_value_order;
     test_case "variant same-suborder tiebreak" `Slow
       test_variant_same_suborder_tiebreak;
     test_case "variant arbitrary values sort numerically" `Slow


### PR DESCRIPTION
Two families emit conflicting same-property rules whose relative order is render-affecting (e.g. `rounded-l` and `rounded-b` both write `border-bottom-left-radius`; `-ml-px` and `-ml-4` both write `margin-left`), and tw's native generation order differed from the Tailwind reference.

Border-radius position groups now sort by the corners they write, matching Tailwind: logical corners (start/end) first, then the physical ones grouped by their first corner clockwise — top, left, right, bottom. Margin values now sort by their raw suffix: numeric rem first, then keywords by first character (`auto`, a named spacing like `big`, `full`, `px`), fixing `-ml-px` sorting ahead of the numeric values.

Found via the ocaml.org corpus (takes it from 4 to 2 reorders; the last 2 are cross-family non-conflicting position drift, render-equivalent). Full suite green including the 781-case upstream parity suite (whose custom-theme `mx`/`big` case pins the keyword order) and the sort fuzzer.