### PR TITLE
prose: sort among the margin utilities like Tailwind

### DIFF
--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2074,15 +2074,16 @@ module Handler = struct
     | _ -> Error (`Msg "Not a prose size utility")
 
   let suborder = function
-    (* Prose size utilities appear between my-* (200000-299999) and mt-*
-       (300000+). Place them at 290000+ to come after all my-* utilities. *)
-    | Prose -> 290000
-    | Prose_2xl -> 290001 (* Alphabetical: 2xl before lg, sm, xl *)
-    | Prose_lg -> 290002
-    | Prose_sm -> 290003
-    | Prose_xl -> 290004
-    | Lead -> 290005
-    | Not_prose -> 290006
+    (* Prose sorts among the priority-2 margin utilities exactly where Tailwind
+       puts it: after the inline-end margins (me-*, ~4.2-4.3M) and before the
+       top margins (mt-*, negatives at 5.0M). *)
+    | Prose -> 4650000
+    | Prose_2xl -> 4650001 (* Alphabetical: 2xl before lg, sm, xl *)
+    | Prose_lg -> 4650002
+    | Prose_sm -> 4650003
+    | Prose_xl -> 4650004
+    | Lead -> 4650005
+    | Not_prose -> 4650006
 end
 
 (* Handler for prose color variants - priority 21 *)

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1059,6 +1059,35 @@ let test_margin_value_order () =
   let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
   Test_helpers.check_ordering_matches ~test_name:"margin value order" utilities
 
+let test_prose_margin_order () =
+  (* prose is a priority-2 utility that sorts among the margin utilities exactly
+     where Tailwind puts it: after the inline-end margins me-, before the top
+     margins mt-. .prose :where(p) is specificity (0,1,0) -- :where() zeroes
+     specificity -- so it ties a margin utility like m-auto and both write
+     margin-top; the relative order is render-affecting for a p.m-auto inside
+     .prose. Asserted directly on the emitted order. *)
+  let classes = [ "me-4"; "prose"; "mt-4" ] in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let position needle =
+    let n = String.length needle and h = String.length css in
+    let rec go i =
+      if i + n > h then -1
+      else if String.sub css i n = needle then i
+      else go (i + 1)
+    in
+    go 0
+  in
+  let check_before a b =
+    let pa = position a and pb = position b in
+    Alcotest.check Alcotest.bool
+      (Printf.sprintf "%s before %s" a b)
+      true
+      (pa >= 0 && pb >= 0 && pa < pb)
+  in
+  check_before ".me-4" ".prose";
+  check_before ".prose" ".mt-4"
+
 let test_variant_same_suborder_tiebreak () =
   (* Two arbitrary values of the same utility in a variant block have equal
      (priority, suborder); they must tie-break by selector, matching Tailwind's
@@ -1226,6 +1255,7 @@ let tests =
       test_arbitrary_named_by_suffix;
     test_case "rounded position order" `Slow test_rounded_position_order;
     test_case "margin value order" `Slow test_margin_value_order;
+    test_case "prose margin order" `Slow test_prose_margin_order;
     test_case "variant same-suborder tiebreak" `Slow
       test_variant_same_suborder_tiebreak;
     test_case "variant arbitrary values sort numerically" `Slow


### PR DESCRIPTION
`prose` is a priority-2 utility, the same as margin, so their relative order is set by suborder. Its suborder placed it before every margin utility, but Tailwind emits it after the inline-end margins (`me-*`) and before the top margins (`mt-*`).

This is render-affecting, not cosmetic: `.prose :where(p):not(…)` has specificity (0,1,0) — `:where()` zeroes specificity on purpose so utilities can override prose — which ties a margin utility like `.m-auto` (also (0,1,0)), and both write `margin-top`. For a `<p class="m-auto">` inside `.prose`, source order decides the margin, so the two sheets must emit these in the same order. Placing prose between `me-` and `mt-` matches the Tailwind reference.

This is the last of the ocaml.org generation-order gaps — with the cascade comparison fixes plus #116–#119 and this, the optimized ocaml.org corpus reaches **zero rule reorders** (`✓ No differences found`). Full suite green including the 781-case upstream suite and the sort fuzzer.