### PR TITLE
sort: order early utility families by canonical rank

### DIFF
--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -20,7 +20,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "accessibility"
-  let priority = 27
+  let priority _ = 27
 
   let to_class = function
     | Forced_color_adjust_auto -> "forced-color-adjust-auto"

--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -121,7 +121,7 @@ module Handler = struct
      alignment: suborder 0-999 (before gap's 25000+) - Self alignment: suborder
      50000+ (after gap) *)
   (* Same priority as gap; comes after flex_props *)
-  let priority = 17
+  let priority _ = 17
   let justify_start = style [ justify_content Flex_start ]
   let justify_end = style [ justify_content Flex_end ]
   let justify_center = style [ justify_content Center ]

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -33,7 +33,7 @@ module Handler = struct
   let name = "animations"
 
   (* Match Tailwind ordering: animations after transforms, before cursor *)
-  let priority = 10
+  let priority _ = 10
 
   let animate_none ?theme () =
     (* If theme defines --animate-none, use the theme variable. Otherwise use

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -64,7 +64,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "arbitrary"
-  let priority = 36
+  let priority _ = 36
 
   (* Render a known colour-property declaration ([color], [background-color],
      ...) with a parsed colour value and an /opacity modifier. *)

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -431,7 +431,7 @@ module Handler = struct
   open Css
 
   let name = "backgrounds"
-  let priority = 20
+  let priority _ = 20
 
   (* Gradient variables with proper @property definitions matching Tailwind v4.
      Order in @layer properties: translate (0-2), scale (3-5), border-style (6),

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -133,7 +133,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "borders"
-  let priority = 19
+  let priority _ = 19
 
   (* Create border style variable with @property for utilities that reference
      it. Position 6 to match Tailwind's order after translate (0-2) and scale
@@ -1092,7 +1092,7 @@ module Outline_style_handler = struct
   type Utility.base += Self of t
 
   let name = "outline_style"
-  let priority = 26
+  let priority _ = 26
 
   let to_style _theme = function
     | Dashed ->

--- a/lib/box_sizing.ml
+++ b/lib/box_sizing.ml
@@ -10,7 +10,10 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "box_sizing"
-  let priority = 2
+
+  (* box-sizing (rank 25) sorts after margin/prose (priority 2) and before the
+     display family (priority 4). *)
+  let priority _ = 3
   let suborder = function Border -> 0 | Content -> 1
   let to_class = function Border -> "box-border" | Content -> "box-content"
 

--- a/lib/clipping.ml
+++ b/lib/clipping.ml
@@ -10,7 +10,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "clipping"
-  let priority = 26
+  let priority _ = 26
 
   (** Convert float percentage pairs to typed length pairs for clip-path polygon
   *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1711,7 +1711,7 @@ module Handler = struct
   open Css
 
   let name = "color"
-  let priority = 23
+  let priority _ = 23
 
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -32,7 +32,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "columns"
-  let priority = 12
+  let priority _ = 12
 
   (* Helper to create a columns style with a container variable. Container theme
      variables are exported from Sizing module. *)

--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -20,7 +20,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "contain"
-  let priority = 32
+  let priority _ = 32
 
   (* Single source of truth: (handler, class_suffix, suborder) for
      non-arbitrary. Composable utilities (inline-size, layout, paint, size,

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -16,7 +16,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "containers"
-  let priority = 1
+  let priority _ = 1
   (* Tailwind orders .container by its width property: after the position group
      (inset, z-index) and before margin. *)
 
@@ -68,7 +68,10 @@ module Handler = struct
     | Container_named _ -> 0
     | Container -> 1
     | Container_normal -> 2
-    | Layout_container -> 3 (* After @container utilities *)
+    (* The .container utility (rank 15) sorts after grid_item's grid-column /
+       grid-row utilities (priority 1, suborder up to ~2000), and after the
+       @container query utilities above. *)
+    | Layout_container -> 9_000_000
 
   let of_class _theme = function
     | "container" -> Ok Layout_container

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -52,7 +52,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "cursor"
-  let priority = 11
+  let priority _ = 11
 
   (* Single source of truth: (handler, class_suffix, css_value) *)
   (* Alphabetically ordered - suborder derived from position *)

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -34,7 +34,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "divide"
-  let priority = 5
+  let priority _ = 5
 
   (* CSS Variables for divide reverse. Property order 4/5 places these BEFORE
      --tw-border-style (order 6) in within-utility sorting, which determines

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -178,7 +178,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "effects"
-  let priority = 25
+  let priority _ = 25
 
   (* Shadow variables with property registration. Order: translate (0-2), scale
      (3-5), border-style (6), gradients (7-15), font-weight (16), shadows

--- a/lib/field_sizing.ml
+++ b/lib/field_sizing.ml
@@ -10,7 +10,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "field_sizing"
-  let priority = 2
+  let priority _ = 2
   let suborder = function Content -> 0 | Fixed -> 1
 
   let to_class = function

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -86,7 +86,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "filters"
-  let priority = 28
+  let priority _ = 28
 
   (* Register filter variables in the Var system for @property generation *)
   let blur_var =

--- a/lib/flex.ml
+++ b/lib/flex.ml
@@ -16,7 +16,7 @@ module Handler = struct
       4 and are ordered alphabetically by suborder. *)
   let name = "flex"
 
-  let priority = 4
+  let priority _ = 4
   let flex = style [ display Flex ]
   let inline_flex = style [ display Inline_flex ]
   let to_style _theme = function Flex -> flex | Inline_flex -> inline_flex

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -23,7 +23,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "flex_layout"
-  let priority = 16
+  let priority _ = 16
 
   let flex_data =
     [

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -54,8 +54,15 @@ module Handler = struct
 
   let name = "flex_props"
 
-  (** Priority 7 - after sizing (6), before transforms (9) *)
-  let priority = 7
+  (* flex/grow/shrink/basis are the flexbox family (priority 7 - after sizing,
+     before transforms). order- occupies an early canonical slot (rank 13, right
+     after z-index), so it returns priority 0 with a suborder above z-index's
+     ~20M band and below container (priority 1). *)
+  let priority = function
+    | Order _ | Neg_order _ | Neg_order_arbitrary _ | Order_arbitrary _
+    | Order_first | Order_last | Order_none ->
+        0
+    | _ -> 7
 
   (* Flex shortcuts *)
   let flex_1 = style [ flex (Grow (Number 1.0)) ]
@@ -182,15 +189,16 @@ module Handler = struct
     | Order_none -> order_none
 
   let suborder : t -> int = function
-    (* Order - comes first in Tailwind's output. Ordering: negative first, then
-       positive, then first/last/none, then arbitrary *)
-    | Neg_order n -> n (* negative comes first *)
-    | Neg_order_arbitrary _ -> 50 (* negative arbitrary after negative ints *)
-    | Order n -> 100 + n
-    | Order_arbitrary _ -> 150
-    | Order_first -> 200
-    | Order_last -> 201
-    | Order_none -> 202
+    (* Order (priority 0) - after z-index (~20M band in layout.ml), before
+       container (priority 1). Ordering: negative first, then positive, then
+       first/last/none, then arbitrary. *)
+    | Neg_order n -> 21_000_000 + n (* negative comes first *)
+    | Neg_order_arbitrary _ -> 21_000_000 + 50
+    | Order n -> 21_000_000 + 100 + n
+    | Order_arbitrary _ -> 21_000_000 + 150
+    | Order_first -> 21_000_000 + 200
+    | Order_last -> 21_000_000 + 201
+    | Order_none -> 21_000_000 + 202
     (* Tailwind flex order: flex-1 < fractions < numbers < auto < initial <
        none. Note: flex-* utilities come AFTER order-* utilities *)
     | Flex_1 -> 1000

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -114,7 +114,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "forms"
-  let priority = 3
+  let priority _ = 3
 
   let form_input =
     let open Css in
@@ -372,7 +372,7 @@ module Select = struct
   type Utility.base += Self of t
 
   let name = "forms_select"
-  let priority = 8 (* After sizing (6), flex_props (7) *)
+  let priority _ = 8 (* After sizing (6), flex_props (7) *)
 
   let form_textarea =
     let open Css in

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -23,7 +23,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "gap"
-  let priority = 17
+  let priority _ = 17
 
   (* Space reverse variables for flex-reverse support. Property order 2/3 places
      these after the transform group but before --tw-divide-*-reverse (4/5) and

--- a/lib/grid.ml
+++ b/lib/grid.ml
@@ -16,7 +16,7 @@ module Handler = struct
       4 and are ordered alphabetically by suborder. *)
   let name = "grid"
 
-  let priority = 4
+  let priority _ = 4
   let grid = style [ display Grid ]
   let inline_grid = style [ display Inline_grid ]
   let to_style _theme = function Grid -> grid | Inline_grid -> inline_grid

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -94,7 +94,7 @@ module Handler = struct
   let name = "grid_item"
 
   (** Priority 1 - before margin (priority 2) *)
-  let priority = 1
+  let priority _ = 1
 
   let col n = style [ grid_column (Num n, Auto) ]
   let neg_col n = style [ grid_column (Num (-n), Auto) ]

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -62,7 +62,7 @@ module Handler = struct
   let name = "grid_template"
 
   (* Before flex_props (16) and alignment/gap (17) *)
-  let priority = 15
+  let priority _ = 15
 
   let grid_cols n =
     if n < 1 || n > 999 then

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -64,7 +64,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "interactivity"
-  let priority = 29
+  let priority _ = 29
   let select_none_s = style [ webkit_user_select None; user_select None ]
   let select_text_s = style [ webkit_user_select Text; user_select Text ]
   let select_all_s = style [ webkit_user_select All; user_select All ]

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -11,7 +11,7 @@ module Screen_reader_handler = struct
   type Utility.base += Self of t
 
   let name = "screen_reader"
-  let priority = 0
+  let priority _ = 0
 
   let suborder = function
     (* Negative suborders to appear before absolute (suborder 0) *)
@@ -198,12 +198,19 @@ module Handler = struct
 
   type Utility.base += Self of t
 
-  (** Priority for layout utilities. Set to 4 for display utilities (block,
-      inline, inline-block, hidden). All display utilities share priority 4 to
-      group together and sort alphabetically. *)
   let name = "layout"
 
-  let priority = 4
+  (* Most layout utilities are the display family (priority 4). Visibility and
+     z-index occupy distinct canonical positions in Tailwind's order, so they
+     return their own priority: visibility comes first (rank 0), z-index right
+     after inset (rank 12) via priority 0 with a suborder above inset's range
+     (position.ml uses up to ~13M) and below container (priority 1). *)
+  let priority = function
+    | Collapse | Invisible | Visible -> 0
+    | Neg_z _ | Z_0 | Z _ | Z_10 | Z_20 | Z_30 | Z_40 | Z_50 | Neg_z_arbitrary _
+    | Z_arbitrary _ | Z_auto ->
+        0
+    | _ -> 4
 
   let suborder = function
     (* Display utilities - ordered alphabetically per Tailwind. Gaps left for
@@ -230,26 +237,27 @@ module Handler = struct
     | Table_header_group -> 21
     | Table_row -> 22
     | Table_row_group -> 23
-    (* Visibility - alphabetical order: collapse, invisible, visible *)
-    | Collapse -> 100
-    | Invisible -> 101
-    | Visible -> 102
+    (* Visibility (priority 0) - first in Tailwind's order, before sr-only
+       (suborder -2). Alphabetical: collapse, invisible, visible. *)
+    | Collapse -> -20
+    | Invisible -> -19
+    | Visible -> -18
     (* Isolation - order: isolate, isolation-auto *)
     | Isolate -> 200
     | Isolation_auto -> 201
-    (* Z-index - order: negative first, then positive, then arbitrary, then
-       auto *)
-    | Neg_z n -> 500 + n (* -z-50 = 550, -z-10 = 510 *)
-    | Z_0 -> 600
-    | Z n -> 601 + n (* z-10 = 611 *)
-    | Z_10 -> 611
-    | Z_20 -> 621
-    | Z_30 -> 631
-    | Z_40 -> 641
-    | Z_50 -> 651
-    | Neg_z_arbitrary _ -> 560
-    | Z_arbitrary _ -> 700
-    | Z_auto -> 750
+    (* Z-index (priority 0) - after inset (up to ~13M in position.ml), before
+       container (priority 1). Order: negative, positive, arbitrary, auto. *)
+    | Neg_z n -> 20_000_000 + 500 + n (* -z-50, -z-10 *)
+    | Z_0 -> 20_000_000 + 600
+    | Z n -> 20_000_000 + 601 + n (* z-10 *)
+    | Z_10 -> 20_000_000 + 611
+    | Z_20 -> 20_000_000 + 621
+    | Z_30 -> 20_000_000 + 631
+    | Z_40 -> 20_000_000 + 641
+    | Z_50 -> 20_000_000 + 651
+    | Neg_z_arbitrary _ -> 20_000_000 + 560
+    | Z_arbitrary _ -> 20_000_000 + 700
+    | Z_auto -> 20_000_000 + 750
     (* Object fit *)
     | Object_contain -> 600
     | Object_cover -> 601

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -23,7 +23,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "margin"
-  let priority = 2
+  let priority _ = 2
 
   (** {2 Typed Margin Utilities} *)
 

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -74,7 +74,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "mask_gradient"
-  let priority = 21
+  let priority _ = 21
 
   let direction_name = function
     | Top -> "top"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -75,7 +75,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "masks"
-  let priority = 21 (* After backgrounds, before filters *)
+  let priority _ = 21 (* After backgrounds, before filters *)
 
   (* Helper to create webkit + standard declarations for mask properties *)
 

--- a/lib/overflow.ml
+++ b/lib/overflow.ml
@@ -32,7 +32,7 @@ module Handler = struct
   let name = "overflow"
 
   (* Overflow comes after alignment (17) in Tailwind's utility ordering. *)
-  let priority = 18
+  let priority _ = 18
 
   (* Single source of truth: (handler, class_suffix, style_fn, suborder) *)
   let overflow_data =

--- a/lib/overflow_wrap.ml
+++ b/lib/overflow_wrap.ml
@@ -17,7 +17,7 @@ module Handler = struct
   let name = "overflow_wrap"
 
   (* Typography-adjacent priority *)
-  let priority = 13
+  let priority _ = 13
   let suborder = function Anywhere -> 0 | Break_word -> 1 | Normal -> 2
 
   let to_class = function

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -32,7 +32,7 @@ module Handler = struct
   let name = "overscroll"
 
   (* Same priority as overflow (18) - these are related utilities *)
-  let priority = 18
+  let priority _ = 18
 
   (* Single source of truth: (handler, class_suffix, style_fn, suborder) *)
   let overscroll_data =

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -19,7 +19,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "padding"
-  let priority = 21
+  let priority _ = 21
 
   let pp_float n =
     let s = string_of_float n in

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -211,7 +211,7 @@ module Handler = struct
   let name = "position"
 
   (** Priority for position utilities *)
-  let priority = 0
+  let priority _ = 0
 
   (** {1 Utility Conversion Functions} *)
 

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2039,7 +2039,7 @@ module Handler = struct
   (** Priority for prose size utilities *)
   let name = "prose"
 
-  let priority = 2 (* Same as margin to allow interleaving by suborder *)
+  let priority _ = 2 (* Same as margin to allow interleaving by suborder *)
 
   (** {1 Utility Conversion Functions} *)
 
@@ -2104,7 +2104,7 @@ module Color_Handler = struct
   (** Priority for prose color utilities *)
   let name = "prose-color"
 
-  let priority = 23 (* Same as color utilities *)
+  let priority _ = 23 (* Same as color utilities *)
 
   (** {1 Utility Conversion Functions} *)
 

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -37,7 +37,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "scroll"
-  let priority = 2
+  let priority _ = 2
 
   (** Get (declaration, length) for spacing value using Theme.spacing_calc_float
   *)

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -35,7 +35,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "scrollbar"
-  let priority = 2
+  let priority _ = 2
 
   let alpha_order s =
     let v = ref 0 in

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -197,7 +197,7 @@ module Handler = struct
 
   (** Priority 6: Sizing utilities (w-*, h-*, max-w-*, etc.) come before
       flex-1/flex-col etc. in Tailwind's order. *)
-  let priority = 6
+  let priority _ = 6
 
   (** Helper to create spacing-based utilities with consistent pattern. [n] is
       in rem units (e.g., 16.0 for w-64). We convert to class units by
@@ -1621,7 +1621,7 @@ let aspect_ratio w h = utility (Aspect_ratio (float_of_int w, float_of_int h))
 
 (* Order exposure for this module *)
 let order (u : Utility.base) =
-  match u with Self x -> Some (priority, suborder x) | _ -> None
+  match u with Self x -> Some (priority x, suborder x) | _ -> None
 
 (* Export container theme variables for use by other modules (e.g., Columns) *)
 let container_3xs = Handler.container_3xs

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -47,7 +47,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "svg"
-  let priority = 30
+  let priority _ = 30
 
   (* Format opacity modifier for class names *)
   let opacity_suffix = function

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -9,7 +9,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "tab"
-  let priority = 2
+  let priority _ = 2
   let suborder = function Tab n -> n | Tab_arbitrary _ -> 1000
 
   let to_class = function

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -42,7 +42,7 @@ module Handler = struct
   (** Priority for table utilities - comes before layout utilities *)
   let name = "tables"
 
-  let priority = 4
+  let priority _ = 4
   let err_not_utility = Error (`Msg "Not a table utility")
 
   (** CSS variables for border-spacing - initialized to 0 in the properties

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -38,7 +38,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "text_shadow"
-  let priority = 35
+  let priority _ = 35
 
   let text_shadow_color_var =
     Var.channel ~needs_property:true ~property_order:35 ~family:`Text_shadow

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -24,7 +24,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "touch"
-  let priority = 14
+  let priority _ = 14
 
   (* CSS Variables for composable touch-action values *)
   let tw_pan_x_var =

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -136,7 +136,7 @@ module Handler = struct
   let name = "transforms"
 
   (* Match Tailwind ordering: transforms before animations and cursor *)
-  let priority = 9
+  let priority _ = 9
 
   (* Tailwind v4 uses rotate-x/y/z and skew-x/y variables for the transform
      utility. These variables contain the full transform function values, e.g.:

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -41,7 +41,7 @@ module Handler = struct
 
   let name = "transitions"
 
-  let priority =
+  let priority _ =
     30 (* Transition utilities come after all other styling utilities *)
 
   (* Theme variables for default transition settings. Duration has lower order

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -341,7 +341,7 @@ module Typography_early = struct
   type Utility.base += Self of t
 
   let name = "typography_early"
-  let priority = 22
+  let priority _ = 22
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not an early typography utility")
 
@@ -1402,7 +1402,7 @@ module Typography_late = struct
   type Utility.base += Self of t
 
   let name = "typography_late"
-  let priority = 24
+  let priority _ = 24
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not a late typography utility")
 

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -23,7 +23,7 @@ module type Handler = sig
 
   val name : string
   val to_style : Scheme.t -> t -> Style.t
-  val priority : int
+  val priority : t -> int
   val suborder : t -> int
   val of_class : Scheme.t -> string -> (t, [ `Msg of string ]) result
   val to_class : t -> string
@@ -122,7 +122,7 @@ let order (u : base) : int * int =
            utility system."
     | H (module M) :: rest -> (
         match u with
-        | M.Self x -> (M.priority, M.suborder x)
+        | M.Self x -> (M.priority x, M.suborder x)
         | _ -> try_handlers rest)
   in
   try_handlers !handlers

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -17,7 +17,7 @@
         type Utility.base += Self of t
 
         let name = "example"
-        let priority = 4
+        let priority _ = 4
 
         let to_style _theme = function
           | Block -> Style.style [ Css.display Css.Block ]
@@ -99,8 +99,10 @@ module type Handler = sig
   (** [to_style theme u] converts utility [u] to a style, reading any theme
       values it needs from [theme]. *)
 
-  val priority : int
-  (** Priority for ordering utilities. *)
+  val priority : t -> int
+  (** [priority u] is the primary ordering key for utility [u]. Usually a module
+      constant ([let priority _ = n]); modules whose variants span several
+      canonical families (e.g. layout) return per-variant values. *)
 
   val suborder : t -> int
   (** [suborder u] is the suborder within the same priority. *)

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -9,7 +9,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "zoom"
-  let priority = 2
+  let priority _ = 2
   let suborder = function Zoom_pct _ -> 0 | Zoom_arbitrary _ -> 1
 
   let num_to_string n =

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -727,7 +727,7 @@ let test_style_rules_props () =
     type Tw.Utility.base += Self of t
 
     let name = "test"
-    let priority = 0
+    let priority _ = 0
     let to_class _t = "test"
     let to_style _theme _t = style
     let suborder _t = 0

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -392,66 +392,49 @@ let test_priority_order_per_group () =
   Test_helpers.check_ordering_matches
     ~test_name:"priority order matches Tailwind" utilities
 
-(* Verify Handler.priority values are in correct relative order *)
+(* Verify utility families emit in Tailwind's canonical order. Priority is now
+   per-variant (visibility, z-index and order live in modules whose other
+   variants sort elsewhere), so this asserts the emitted rule order directly
+   rather than poking module-level priority constants. *)
 let test_handler_priority_ordering () =
-  (* Get priority values directly from Handler modules. Note: Some modules
-     (Prose, Display, Tables) don't expose Handler in their .mli, so we skip
-     them in this test. Their ordering is still verified by
-     test_priority_order_per_group which compares against Tailwind output. *)
-  let position_prio = Tw.Position.Handler.priority in
-  let margin_prio = Tw.Margin.Handler.priority in
-  let layout_prio = Tw.Layout.Handler.priority in
-  let flex_prio = Tw.Flex.Handler.priority in
-  let grid_prio = Tw.Grid.Handler.priority in
-  let sizing_prio = Tw.Sizing.Handler.priority in
-  let cursor_prio = Tw.Cursor.Handler.priority in
-  let grid_template_prio = Tw.Grid_template.Handler.priority in
-  let alignment_prio = Tw.Alignment.Handler.priority in
-  let gap_prio = Tw.Gap.Handler.priority in
-  let border_prio = Tw.Borders.Handler.priority in
-  let bg_prio = Tw.Backgrounds.Handler.priority in
-  let padding_prio = Tw.Padding.Handler.priority in
-  let typography_early_prio = Tw.Typography.Typography_early.priority in
-  let typography_late_prio = Tw.Typography.Typography_late.priority in
-  let color_prio = Tw.Color.Handler.priority in
-  let effect_prio = Tw.Effects.Handler.priority in
-  let transform_prio = Tw.Transforms.Handler.priority in
-  let animation_prio = Tw.Animations.Handler.priority in
-  let filter_prio = Tw.Filters.Handler.priority in
-
-  (* Verify priority ordering - mostly total order with one exception: display
-     utilities (layout, flex, grid, tables) all share priority 4 *)
-  check bool "position < margin" true (position_prio < margin_prio);
-  (* prose priority 3 skipped - Handler not exposed *)
-  check bool "margin < layout" true (margin_prio < layout_prio);
-  (* Display utilities all share priority 4: layout, flex, grid, tables. They
-     are ordered by suborder instead of priority. *)
-  check bool "layout = flex" true (layout_prio = flex_prio);
-  check bool "flex = grid" true (flex_prio = grid_prio);
-  check bool "grid < sizing" true (grid_prio < sizing_prio);
-  check bool "sizing < flex_props" true
-    (sizing_prio < Tw.Flex_props.Handler.priority);
-  check bool "flex_props < transform" true
-    (Tw.Flex_props.Handler.priority < transform_prio);
-  check bool "transform < animation" true (transform_prio < animation_prio);
-  check bool "animation < cursor" true (animation_prio < cursor_prio);
-  check bool "cursor < grid_template" true (cursor_prio < grid_template_prio);
-  check bool "grid_template < flex_layout" true
-    (grid_template_prio < Tw.Flex_layout.Handler.priority);
-  check bool "flex_layout < alignment" true
-    (Tw.Flex_layout.Handler.priority < alignment_prio);
-  (* Alignment and gap share priority 15, differentiated by suborder *)
-  check bool "alignment = gap" true (alignment_prio = gap_prio);
-  check bool "gap < border" true (gap_prio < border_prio);
-  check bool "border < bg" true (border_prio < bg_prio);
-  check bool "bg < padding" true (bg_prio < padding_prio);
-  check bool "padding < typography_early" true
-    (padding_prio < typography_early_prio);
-  check bool "typography_early < color" true (typography_early_prio < color_prio);
-  check bool "color < typography_late" true (color_prio < typography_late_prio);
-  check bool "typography_late < effect" true (typography_late_prio < effect_prio);
-  check bool "effect < filter" true (effect_prio < filter_prio)
-(* display and tables priority checked in test_priority_order_per_group *)
+  let classes =
+    [
+      "collapse";
+      "sr-only";
+      "absolute";
+      "inset-0";
+      "z-10";
+      "order-1";
+      "col-span-2";
+      "container";
+      "m-4";
+      "box-border";
+      "flex";
+      "h-4";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let position needle =
+    let n = String.length needle and h = String.length css in
+    let rec go i =
+      if i + n > h then -1
+      else if String.sub css i n = needle then i
+      else go (i + 1)
+    in
+    go 0
+  in
+  let rec check_chain = function
+    | a :: (b :: _ as rest) ->
+        let pa = position ("." ^ a) and pb = position ("." ^ b) in
+        check bool
+          (Printf.sprintf "%s before %s" a b)
+          true
+          (pa >= 0 && pb >= 0 && pa < pb);
+        check_chain rest
+    | _ -> ()
+  in
+  check_chain classes
 
 (* Test 2: Verify suborder within same group *)
 let test_suborder_within_group () =


### PR DESCRIPTION
This PR makes utility priority per-variant (`Utility.Handler.priority : t -> int`) and uses it to place visibility, z-index, `order`, container and box-sizing in Tailwind's canonical family order.

tw emitted these families out of order relative to the Tailwind reference: visibility (canonical rank 0) and z-index (rank 12) were lumped into `layout.ml`'s display-family priority, `order` sat in `flex_props` after sizing, and container/box-sizing sorted ahead of grid-column/margin. Priority was a single per-module constant, so families sharing a handler could not occupy distinct canonical slots; making it per-variant lets layout's visibility/z-index and flex_props' `order` sort into their own positions while the rest of each module stays put. The remaining mid- and late-section families are a separate, larger renumber left for a follow-up.