### PR TITLE
sort: place svg, object-fit and table-layout in canonical order

### DIFF
--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -20,7 +20,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "accessibility"
-  let priority _ = 27
+  let priority _ = 29
 
   let to_class = function
     | Forced_color_adjust_auto -> "forced-color-adjust-auto"

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -64,7 +64,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "arbitrary"
-  let priority _ = 36
+  let priority _ = 37
 
   (* Render a known colour-property declaration ([color], [background-color],
      ...) with a parsed colour value and an /opacity modifier. *)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -784,35 +784,33 @@ module Handler = struct
     | Border_8 -> 1004
     | Border_width n -> 1001 + n
     | Border_width_bracket _ -> 1005
-    (* Per-side arbitrary widths join their side's group (1200-1399), sorting
-       after that side's numeric widths, matching Tailwind. *)
+    (* Border sides are side-major (Tailwind groups each side's bare width, its
+       numeric widths and its arbitrary width together): t, r, b, l, then x, y.
+       Within a side: bare, 0, 2, 4, 8, arbitrary. *)
     | Border_side_width_bracket (side, _) -> (
-        match side with "t" -> 1204 | "r" -> 1214 | "b" -> 1224 | _ -> 1234)
-    (* Border side/axis utilities (1100-1199) - clockwise from top: t, r, b,
-       l *)
+        match side with "t" -> 1105 | "r" -> 1115 | "b" -> 1125 | _ -> 1135)
     | Border_t -> 1100
-    | Border_r -> 1101
-    | Border_b -> 1102
-    | Border_l -> 1103
-    | Border_x -> 1104
-    | Border_y -> 1105
-    (* Border side utilities with widths (1200-1399) *)
-    | Border_t_0 -> 1200
-    | Border_t_2 -> 1201
-    | Border_t_4 -> 1202
-    | Border_t_8 -> 1203
-    | Border_r_0 -> 1210
-    | Border_r_2 -> 1211
-    | Border_r_4 -> 1212
-    | Border_r_8 -> 1213
-    | Border_b_0 -> 1220
-    | Border_b_2 -> 1221
-    | Border_b_4 -> 1222
-    | Border_b_8 -> 1223
-    | Border_l_0 -> 1230
-    | Border_l_2 -> 1231
-    | Border_l_4 -> 1232
-    | Border_l_8 -> 1233
+    | Border_t_0 -> 1101
+    | Border_t_2 -> 1102
+    | Border_t_4 -> 1103
+    | Border_t_8 -> 1104
+    | Border_r -> 1110
+    | Border_r_0 -> 1111
+    | Border_r_2 -> 1112
+    | Border_r_4 -> 1113
+    | Border_r_8 -> 1114
+    | Border_b -> 1120
+    | Border_b_0 -> 1121
+    | Border_b_2 -> 1122
+    | Border_b_4 -> 1123
+    | Border_b_8 -> 1124
+    | Border_l -> 1130
+    | Border_l_0 -> 1131
+    | Border_l_2 -> 1132
+    | Border_l_4 -> 1133
+    | Border_l_8 -> 1134
+    | Border_x -> 1140
+    | Border_y -> 1150
     (* Border style utilities (1400-1499) - alphabetical *)
     | Border_dashed -> 1400
     | Border_dotted -> 1401

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1122,12 +1122,14 @@ module Outline_style_handler = struct
         let decl, _ = Var.binding Handler.outline_style_var Css.Solid in
         style [ decl; Css.outline_style Css.Solid ]
 
+  (* outline-style sorts after outline-width (borders handler, up to ~2009 at
+     priority 28); alphabetical: dashed, dotted, double, none, solid. *)
   let suborder = function
-    | Dashed -> 0
-    | Dotted -> 1
-    | Double -> 2
-    | None_ -> 3
-    | Solid -> 4
+    | Dashed -> 2050
+    | Dotted -> 2051
+    | Double -> 2052
+    | None_ -> 2053
+    | Solid -> 2054
 
   let err_not_utility = Error (`Msg "Not an outline style utility")
 

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -133,7 +133,20 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "borders"
-  let priority _ = 19
+
+  (* border-width/color/radius sort at priority 19. outline-* (canonical rank
+     ~92) comes much later - after box-shadow and ring (effects, priority 27),
+     before the filters (priority 30) - so the outline variants return priority
+     28. *)
+  let priority = function
+    | Outline | Outline_0 | Outline_width _ | Outline_width_bracket _
+    | Outline_width_var _ | Outline_hidden | Outline_offset_0 | Outline_offset_1
+    | Outline_offset_2 | Outline_offset_4 | Outline_offset_8
+    | Outline_offset_var _ | Outline_offset_arbitrary _ | Neg_outline_offset_1
+    | Neg_outline_offset_2 | Neg_outline_offset_4 | Neg_outline_offset_8
+    | Neg_outline_offset_var _ ->
+        28
+    | _ -> 19
 
   (* Create border style variable with @property for utilities that reference
      it. Position 6 to match Tailwind's order after translate (0-2) and scale

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1092,7 +1092,7 @@ module Outline_style_handler = struct
   type Utility.base += Self of t
 
   let name = "outline_style"
-  let priority _ = 26
+  let priority _ = 28
 
   let to_style _theme = function
     | Dashed ->

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -36,10 +36,17 @@ let extract_base_utility class_name_no_pseudo =
           find_last_colon (i + 1) bracket_depth paren_depth (Some i)
       | _ -> find_last_colon (i + 1) bracket_depth paren_depth last_colon
   in
-  match find_last_colon 0 0 0 None with
-  | Some colon_pos ->
-      String.sub class_name_no_pseudo (colon_pos + 1) (len - colon_pos - 1)
-  | None -> class_name_no_pseudo
+  let base =
+    match find_last_colon 0 0 0 None with
+    | Some colon_pos ->
+        String.sub class_name_no_pseudo (colon_pos + 1) (len - colon_pos - 1)
+    | None -> class_name_no_pseudo
+  in
+  (* Strip a leading [!] important marker so [!flex] orders like [flex] rather
+     than failing to parse and falling to the default (last) order. *)
+  if String.length base > 0 && base.[0] = '!' then
+    String.sub base 1 (String.length base - 1)
+  else base
 
 (** Parse utility and get ordering, with fallback for non-utility classes *)
 let parse_utility_order base_utility =

--- a/lib/clipping.ml
+++ b/lib/clipping.ml
@@ -10,7 +10,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "clipping"
-  let priority _ = 26
+  let priority _ = 28
 
   (** Convert float percentage pairs to typed length pairs for clip-path polygon
   *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1711,7 +1711,21 @@ module Handler = struct
   open Css
 
   let name = "color"
-  let priority _ = 25
+
+  (* Non-text color families (accent, caret, ...) sort at priority 25.
+     text-color (the `color` property, canonical rank ~86) interleaves inside
+     the late-typography block - after text-transform, before font-style/italic
+     - so the Text_* variants return priority 26 with a suborder in that gap.
+     Text_opacity leads the match so the type resolves to the color [t] rather
+     than [Css.user_select] (which also has a [Text] constructor). *)
+  let priority = function
+    | Text_opacity _ | Text _ | Text_transparent | Text_current
+    | Text_current_opacity _ | Text_inherit | Text_bracket_color _
+    | Text_bracket_color_opacity _ | Text_bracket_var _
+    | Text_bracket_var_opacity _ | Text_bracket_typed_var _
+    | Text_bracket_typed_var_opacity _ ->
+        26
+    | _ -> 25
 
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'
@@ -2665,10 +2679,10 @@ module Handler = struct
         with_pseudo Css.Selector.Placeholder
           (color_with_opacity_style ~property:Css.color c 500 opacity)
 
-  (* Suborder determines order within the color priority group. Tailwind orders:
-     border -> bg -> text So we use: border (0-9999), bg (10000-19999), text
-     (20000-29999) NOTE: Bg must be first pattern to infer local type t vs
-     shadowed Css.Border *)
+  (* Suborder for the non-text color families: border (0-9999) then bg
+     (10000-19999). text-color runs at priority 26 (see [priority]) with a fixed
+     suborder inside the late-typography block. NOTE: Bg must be first pattern
+     to infer local type t vs shadowed Css.Border. *)
   let suborder = function
     | Bg (color, shade) ->
         (* All background colors use the same suborder (10000) to allow
@@ -2682,23 +2696,24 @@ module Handler = struct
     | Bg_current -> 10000
     | Bg_current_opacity _ -> 10000
     | Text (color, shade) ->
-        (* All text colors use the same suborder (20000) to allow alphabetical
-           sorting, matching Tailwind v4 behavior. *)
+        (* All text colors share suborder 8370 (priority 26, after
+           text-transform and before font-style) so they sort alphabetically,
+           matching Tailwind. *)
         let _ = (color, shade) in
-        20000
+        8370
     | Text_opacity (color, shade, _) ->
         let _ = (color, shade) in
-        20000
-    | Text_transparent -> 20000
-    | Text_current -> 20000
-    | Text_current_opacity _ -> 20000
-    | Text_inherit -> 20000
-    | Text_bracket_color _ -> 20000
-    | Text_bracket_color_opacity _ -> 20000
-    | Text_bracket_var _ -> 20000
-    | Text_bracket_var_opacity _ -> 20000
-    | Text_bracket_typed_var _ -> 20000
-    | Text_bracket_typed_var_opacity _ -> 20000
+        8370
+    | Text_transparent -> 8370
+    | Text_current -> 8370
+    | Text_current_opacity _ -> 8370
+    | Text_inherit -> 8370
+    | Text_bracket_color _ -> 8370
+    | Text_bracket_color_opacity _ -> 8370
+    | Text_bracket_var _ -> 8370
+    | Text_bracket_var_opacity _ -> 8370
+    | Text_bracket_typed_var _ -> 8370
+    | Text_bracket_typed_var_opacity _ -> 8370
     | Border (color, shade) ->
         (* All border colors use the same suborder (0) to allow alphabetical
            sorting, matching Tailwind v4 behavior. *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1712,13 +1712,18 @@ module Handler = struct
 
   let name = "color"
 
-  (* Non-text color families (accent, caret, ...) sort at priority 25.
-     text-color (the `color` property, canonical rank ~86) interleaves inside
-     the late-typography block - after text-transform, before font-style/italic
-     - so the Text_* variants return priority 26 with a suborder in that gap.
-     Text_opacity leads the match so the type resolves to the color [t] rather
-     than [Css.user_select] (which also has a [Text] constructor). *)
+  (* Color families sort at their property's canonical rank, not together:
+     border-color (rank ~65) joins border-width/style at priority 19; text-color
+     (the `color` property, rank ~86) interleaves inside the late-typography
+     block, after text-transform and before font-style, at priority 26. The rest
+     (accent, caret, ...) stay at 25. [_opacity] variants lead each group so the
+     type resolves to the color [t] rather than the shadowed [Css.Border] /
+     [Css.user_select] [Text] constructors. *)
   let priority = function
+    | Border_opacity _ | Border _ | Border_transparent | Border_current
+    | Border_current_opacity _ | Border_bracket_color _ | Border_side_color _
+    | Border_bracket_color_opacity _ ->
+        19
     | Text_opacity _ | Text _ | Text_transparent | Text_current
     | Text_current_opacity _ | Text_inherit | Text_bracket_color _
     | Text_bracket_color_opacity _ | Text_bracket_var _
@@ -2715,19 +2720,20 @@ module Handler = struct
     | Text_bracket_typed_var _ -> 8370
     | Text_bracket_typed_var_opacity _ -> 8370
     | Border (color, shade) ->
-        (* All border colors use the same suborder (0) to allow alphabetical
-           sorting, matching Tailwind v4 behavior. *)
+        (* All border colors share suborder 5000 (priority 19, after
+           border-width and border-style in borders.ml) so they sort
+           alphabetically, matching Tailwind. *)
         let _ = (color, shade) in
-        0
+        5000
     | Border_opacity (color, shade, _) ->
         let _ = (color, shade) in
-        0
-    | Border_transparent -> 0
-    | Border_current -> 0
-    | Border_current_opacity _ -> 0
-    | Border_bracket_color _ -> 0
-    | Border_side_color _ -> 0
-    | Border_bracket_color_opacity _ -> 0
+        5000
+    | Border_transparent -> 5000
+    | Border_current -> 5000
+    | Border_current_opacity _ -> 5000
+    | Border_bracket_color _ -> 5000
+    | Border_side_color _ -> 5000
+    | Border_bracket_color_opacity _ -> 5000
     | Accent (color, shade) ->
         (* All accent colors use the same suborder (50000) to allow alphabetical
            sorting, matching Tailwind v4 behavior. *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1711,7 +1711,7 @@ module Handler = struct
   open Css
 
   let name = "color"
-  let priority _ = 23
+  let priority _ = 25
 
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2720,20 +2720,21 @@ module Handler = struct
     | Text_bracket_typed_var _ -> 8370
     | Text_bracket_typed_var_opacity _ -> 8370
     | Border (color, shade) ->
-        (* All border colors share suborder 5000 (priority 19, after
-           border-width and border-style in borders.ml) so they sort
-           alphabetically, matching Tailwind. *)
+        (* Border colors share suborder 1500 with borders.ml's named border
+           colors (Border_color), at priority 19, so named and arbitrary tie and
+           sort together by class name - matching Tailwind. *)
         let _ = (color, shade) in
-        5000
+        1500
     | Border_opacity (color, shade, _) ->
         let _ = (color, shade) in
-        5000
-    | Border_transparent -> 5000
-    | Border_current -> 5000
-    | Border_current_opacity _ -> 5000
-    | Border_bracket_color _ -> 5000
-    | Border_side_color _ -> 5000
-    | Border_bracket_color_opacity _ -> 5000
+        1500
+    | Border_transparent -> 1500
+    | Border_current -> 1500
+    | Border_current_opacity _ -> 1500
+    | Border_bracket_color _ -> 1500
+    | Border_bracket_color_opacity _ -> 1500
+    (* Per-side border colors sort after the all-sides colors. *)
+    | Border_side_color _ -> 1600
     | Accent (color, shade) ->
         (* All accent colors use the same suborder (50000) to allow alphabetical
            sorting, matching Tailwind v4 behavior. *)

--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -20,7 +20,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "contain"
-  let priority _ = 32
+  let priority _ = 34
 
   (* Single source of truth: (handler, class_suffix, suborder) for
      non-arbitrary. Composable utilities (inline-size, layout, paint, size,

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -178,7 +178,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "effects"
-  let priority _ = 25
+  let priority _ = 27
 
   (* Shadow variables with property registration. Order: translate (0-2), scale
      (3-5), border-style (6), gradients (7-15), font-weight (16), shadows

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -86,7 +86,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "filters"
-  let priority _ = 28
+  let priority _ = 30
 
   (* Register filter variables in the Var system for @property generation *)
   let blur_var =

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -64,7 +64,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "interactivity"
-  let priority _ = 29
+  let priority _ = 31
   let select_none_s = style [ webkit_user_select None; user_select None ]
   let select_text_s = style [ webkit_user_select Text; user_select Text ]
   let select_all_s = style [ webkit_user_select All; user_select All ]

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -64,7 +64,18 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "interactivity"
-  let priority _ = 31
+
+  (* Most interactivity utilities (user-select, will-change, scroll-snap, ...)
+     sort late (priority 31). resize (canonical rank 47) and appearance (rank
+     49) belong right after cursor (priority 11), around list-style (rank 48);
+     they return priority 11 with a suborder above cursor's range (<1000),
+     leaving a gap for list-style at ~2M. *)
+  let priority = function
+    | Resize | Resize_none | Resize_x | Resize_y | Appearance_auto
+    | Appearance_none ->
+        11
+    | _ -> 31
+
   let select_none_s = style [ webkit_user_select None; user_select None ]
   let select_text_s = style [ webkit_user_select Text; user_select Text ]
   let select_all_s = style [ webkit_user_select All; user_select All ]
@@ -226,14 +237,16 @@ module Handler = struct
     | Snap_start -> 19
     | Snap_x -> 20
     | Snap_y -> 21
-    | Resize -> 22
-    | Resize_none -> 23
-    | Resize_x -> 24
-    | Resize_y -> 25
+    (* resize (priority 11) - after cursor (<1000), before list-style (~2M) *)
+    | Resize -> 1_000_000 + 22
+    | Resize_none -> 1_000_000 + 23
+    | Resize_x -> 1_000_000 + 24
+    | Resize_y -> 1_000_000 + 25
     | Pointer_events_auto -> 26
     | Pointer_events_none -> 27
-    | Appearance_auto -> 28
-    | Appearance_none -> 29
+    (* appearance (priority 11) - after list-style (~2M) *)
+    | Appearance_auto -> 3_000_000 + 28
+    | Appearance_none -> 3_000_000 + 29
     | Will_change_auto -> 31
     | Will_change_contents -> 32
     | Will_change_scroll -> 33

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -210,6 +210,15 @@ module Handler = struct
     | Neg_z _ | Z_0 | Z _ | Z_10 | Z_20 | Z_30 | Z_40 | Z_50 | Neg_z_arbitrary _
     | Z_arbitrary _ | Z_auto ->
         0
+    (* object-fit / object-position (rank ~72): after svg fill/stroke (21),
+       before padding (23). *)
+    | Object_contain | Object_cover | Object_fill | Object_none
+    | Object_scale_down | Object_center | Object_top | Object_bottom
+    | Object_left | Object_right | Object_bottom_left | Object_bottom_right
+    | Object_left_bottom | Object_left_top | Object_right_bottom
+    | Object_right_top | Object_top_left | Object_top_right | Object_arbitrary _
+      ->
+        22
     | _ -> 4
 
   let suborder = function

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -74,7 +74,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "mask_gradient"
-  let priority _ = 21
+  let priority _ = 23
 
   let direction_name = function
     | Top -> "top"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -75,7 +75,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "masks"
-  let priority _ = 21 (* After backgrounds, before filters *)
+  let priority _ = 23 (* After backgrounds, before filters *)
 
   (* Helper to create webkit + standard declarations for mask properties *)
 

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -19,7 +19,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "padding"
-  let priority _ = 21
+  let priority _ = 23
 
   let pp_float n =
     let s = string_of_float n in

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2104,7 +2104,7 @@ module Color_Handler = struct
   (** Priority for prose color utilities *)
   let name = "prose-color"
 
-  let priority _ = 23 (* Same as color utilities *)
+  let priority _ = 25 (* Same as color utilities *)
 
   (** {1 Utility Conversion Functions} *)
 

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -1066,13 +1066,14 @@ module Handler = struct
        5M) and arbitrary/keyword offsets never overflow into the next family.
        Within a family: spacing/fractions interleaved by magnitude, then
        arbitrary, then keywords (alphabetical). *)
-    let h = 0 in
-    let max_h = 10_000_000 in
-    let min_h = 20_000_000 in
-    let w = 30_000_000 in
-    let max_w = 40_000_000 in
-    let min_w = 50_000_000 in
-    let size = 60_000_000 in
+    (* size-* (width+height) sorts first in Tailwind, before h/w/max/min. *)
+    let size = 0 in
+    let h = 10_000_000 in
+    let max_h = 20_000_000 in
+    let min_h = 30_000_000 in
+    let w = 40_000_000 in
+    let max_w = 50_000_000 in
+    let min_w = 60_000_000 in
     let inline = 70_000_000 in
     let min_inline = 80_000_000 in
     let max_inline = 90_000_000 in

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -1140,33 +1140,33 @@ module Handler = struct
     | W_svw -> w + keyword_off + 9
     | W_xl -> w + keyword_off + 10
     (* Max-width *)
-    | Max_w_spacing n -> max_w + spacing_value_order n
-    (* Named sizes sort by raw suffix: the digit-prefixed sizes (2xl..7xl) come
-       before an arbitrary value ('[' > digits), which comes before the
-       letter-prefixed sizes ('[' < 'f'). *)
-    | Max_w_2xl -> max_w + keyword_off + 0
-    | Max_w_3xl -> max_w + keyword_off + 1
-    | Max_w_4xl -> max_w + keyword_off + 2
-    | Max_w_5xl -> max_w + keyword_off + 3
-    | Max_w_6xl -> max_w + keyword_off + 4
-    | Max_w_7xl -> max_w + keyword_off + 5
-    | Max_w_arbitrary _ -> max_w + keyword_off + 6
-    | Max_w_fit -> max_w + keyword_off + 7
-    | Max_w_full -> max_w + keyword_off + 8
-    | Max_w_lg -> max_w + keyword_off + 9
-    | Max_w_max -> max_w + keyword_off + 10
-    | Max_w_md -> max_w + keyword_off + 11
-    | Max_w_min -> max_w + keyword_off + 12
-    | Max_w_none -> max_w + keyword_off + 13
-    | Max_w_prose -> max_w + keyword_off + 14
-    | Max_w_screen_2xl -> max_w + keyword_off + 15
-    | Max_w_screen_lg -> max_w + keyword_off + 16
-    | Max_w_screen_md -> max_w + keyword_off + 17
-    | Max_w_screen_sm -> max_w + keyword_off + 18
-    | Max_w_screen_xl -> max_w + keyword_off + 19
-    | Max_w_sm -> max_w + keyword_off + 20
-    | Max_w_xl -> max_w + keyword_off + 21
-    | Max_w_xs -> max_w + keyword_off + 22
+    (* Tailwind orders max-width in three bands: the container scale sizes
+       (2xl..7xl) by number, then the numeric spacing values, then an arbitrary
+       value, then the letter-prefixed keywords alphabetically. *)
+    | Max_w_2xl -> max_w + 0
+    | Max_w_3xl -> max_w + 1
+    | Max_w_4xl -> max_w + 2
+    | Max_w_5xl -> max_w + 3
+    | Max_w_6xl -> max_w + 4
+    | Max_w_7xl -> max_w + 5
+    | Max_w_spacing n -> max_w + 1_000_000 + spacing_value_order n
+    | Max_w_arbitrary _ -> max_w + arbitrary_off
+    | Max_w_fit -> max_w + keyword_off + 0
+    | Max_w_full -> max_w + keyword_off + 1
+    | Max_w_lg -> max_w + keyword_off + 2
+    | Max_w_max -> max_w + keyword_off + 3
+    | Max_w_md -> max_w + keyword_off + 4
+    | Max_w_min -> max_w + keyword_off + 5
+    | Max_w_none -> max_w + keyword_off + 6
+    | Max_w_prose -> max_w + keyword_off + 7
+    | Max_w_screen_2xl -> max_w + keyword_off + 8
+    | Max_w_screen_lg -> max_w + keyword_off + 9
+    | Max_w_screen_md -> max_w + keyword_off + 10
+    | Max_w_screen_sm -> max_w + keyword_off + 11
+    | Max_w_screen_xl -> max_w + keyword_off + 12
+    | Max_w_sm -> max_w + keyword_off + 13
+    | Max_w_xl -> max_w + keyword_off + 14
+    | Max_w_xs -> max_w + keyword_off + 15
     (* Min-width *)
     | Min_w_0 -> min_w + 0
     | Min_w_spacing n -> min_w + spacing_value_order n

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -47,7 +47,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "svg"
-  let priority _ = 30
+  let priority _ = 21
 
   (* Format opacity modifier for class names *)
   let opacity_suffix = function

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -42,7 +42,7 @@ module Handler = struct
   (** Priority for table utilities - comes before layout utilities *)
   let name = "tables"
 
-  let priority _ = 4
+  let priority _ = 8
   let err_not_utility = Error (`Msg "Not a table utility")
 
   (** CSS variables for border-spacing - initialized to 0 in the properties

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -38,7 +38,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "text_shadow"
-  let priority _ = 35
+  let priority _ = 36
 
   let text_shadow_color_var =
     Var.channel ~needs_property:true ~property_order:35 ~family:`Text_shadow

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -42,7 +42,7 @@ module Handler = struct
   let name = "transitions"
 
   let priority _ =
-    30 (* Transition utilities come after all other styling utilities *)
+    32 (* Transition utilities come after all other styling utilities *)
 
   (* Theme variables for default transition settings. Duration has lower order
      (8,0) so it appears before timing-function (8,1) in the theme layer output,

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1402,7 +1402,25 @@ module Typography_late = struct
   type Utility.base += Self of t
 
   let name = "typography_late"
-  let priority _ = 26
+
+  (* Most late-typography families (decoration, tracking, whitespace,
+     word-break) sort at priority 26. Three occupy earlier canonical slots:
+     list-style (rank 48, by cursor/resize at priority 11),
+     text-overflow/truncate (rank 62, just before overflow at priority 18), and
+     vertical-align (rank 80, right after text-align in the early handler at
+     priority 24). *)
+  let priority = function
+    | List_none | List_disc | List_decimal | List_inside | List_outside
+    | List_image_none | List_image_url _ | List_bracket_var _
+    | List_image_bracket_var _ ->
+        11
+    | Truncate -> 17
+    | Align_baseline | Align_top | Align_middle | Align_bottom | Align_sub
+    | Align_super | Align_text_top | Align_text_bottom | Align_arbitrary_var _
+      ->
+        24
+    | _ -> 26
+
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not a late typography utility")
 
@@ -1879,26 +1897,28 @@ module Typography_late = struct
     | Whitespace_pre -> 8503
     | Whitespace_pre_line -> 8504
     | Whitespace_pre_wrap -> 8505
-    (* Vertical align - alphabetical order *)
-    | Align_arbitrary_var _ -> 8600
-    | Align_baseline -> 8600
-    | Align_bottom -> 8601
-    | Align_middle -> 8602
-    | Align_sub -> 8603
-    | Align_super -> 8604
-    | Align_text_bottom -> 8605
-    | Align_text_top -> 8606
-    | Align_top -> 8607
-    (* List utilities - alphabetical order *)
-    | List_bracket_var _ -> 8699
-    | List_decimal -> 8700
-    | List_disc -> 8701
-    | List_image_bracket_var _ -> 8698
-    | List_image_none -> 8702
-    | List_inside -> 8703
-    | List_none -> 8704
-    | List_outside -> 8705
-    | List_image_url _ -> 8706
+    (* Vertical align (priority 24) - between text-align (~1005) and font-family
+       (~1501) in the early handler's suborder space. Alphabetical. *)
+    | Align_arbitrary_var _ -> 1200
+    | Align_baseline -> 1200
+    | Align_bottom -> 1201
+    | Align_middle -> 1202
+    | Align_sub -> 1203
+    | Align_super -> 1204
+    | Align_text_bottom -> 1205
+    | Align_text_top -> 1206
+    | Align_top -> 1207
+    (* List utilities (priority 11) - after resize (~1M), before appearance
+       (~3M). Alphabetical. *)
+    | List_bracket_var _ -> 2_000_000 + 8699
+    | List_decimal -> 2_000_000 + 8700
+    | List_disc -> 2_000_000 + 8701
+    | List_image_bracket_var _ -> 2_000_000 + 8698
+    | List_image_none -> 2_000_000 + 8702
+    | List_inside -> 2_000_000 + 8703
+    | List_none -> 2_000_000 + 8704
+    | List_outside -> 2_000_000 + 8705
+    | List_image_url _ -> 2_000_000 + 8706
     (* Underline offset — negatives first, then positives, then auto *)
     | Underline_offset_neg_px px -> 50000 + int_of_float px
     | Underline_offset_neg_var _ -> 59990
@@ -1913,10 +1933,12 @@ module Typography_late = struct
     (* Antialiased *)
     | Antialiased -> 70000
     | Subpixel_antialiased -> 70001
-    (* Text overflow - alphabetical order: text-clip, text-ellipsis, truncate *)
+    (* Text overflow (priority 17 for Truncate) - alphabetical: text-clip,
+       text-ellipsis, truncate. Truncate sorts before overflow (priority 18) via
+       a suborder above alignment/gap's range. *)
     | Text_clip -> 9000
     | Text_ellipsis -> 9001
-    | Truncate -> 9002
+    | Truncate -> 9_000_000 (* priority 17, after alignment/gap (max ~2100) *)
     (* Text wrap - alphabetical order *)
     | Text_balance -> 9100
     | Text_nowrap -> 9101

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -683,9 +683,10 @@ module Typography_early = struct
     | Font_bracket_family_name _ -> 1500
     (* Bracket font weights come before named font weights *)
     (* Font family - comes between text-align and text-size *)
-    | Font_sans -> 1501
-    | Font_serif -> 1502
-    | Font_mono -> 1503
+    (* Alphabetical by class name: mono, sans, serif *)
+    | Font_mono -> 1501
+    | Font_sans -> 1502
+    | Font_serif -> 1503
     (* Bracket font-size with line-height modifier — before named sizes *)
     | Text_bracket_fs_lh _ -> 2000
     (* Font sizes come second - alphabetical order *)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1941,8 +1941,8 @@ module Typography_late = struct
     (* Text overflow (priority 17 for Truncate) - alphabetical: text-clip,
        text-ellipsis, truncate. Truncate sorts before overflow (priority 18) via
        a suborder above alignment/gap's range. *)
-    | Text_clip -> 9000
-    | Text_ellipsis -> 9001
+    | Text_clip -> 8320
+    | Text_ellipsis -> 8321
     | Truncate -> 9_000_000 (* priority 17, after alignment/gap (max ~2100) *)
     (* Text wrap - alphabetical order *)
     | Text_balance -> 9100

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -341,7 +341,12 @@ module Typography_early = struct
   type Utility.base += Self of t
 
   let name = "typography_early"
-  let priority _ = 24
+
+  (* Most early-typography families (text-align, font, leading) sort at priority
+     24. font-style (italic) is canonically later (rank 87, after tracking/
+     whitespace/text-transform), so it joins the late handler's band at priority
+     26 via a suborder just above text-transform (~8360). *)
+  let priority = function Italic | Not_italic -> 26 | _ -> 24
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not an early typography utility")
 
@@ -745,8 +750,8 @@ module Typography_early = struct
     | Font_features_var _ -> 5000
     | Font_features_bare_var _ -> 5000
     (* Italic *)
-    | Italic -> 7001
-    | Not_italic -> 7002
+    | Italic -> 8380
+    | Not_italic -> 8381
 
   (* Text utilities use theme record for line height variable reference *)
   let text_size_utility (size_var : Css.length Var.theme)
@@ -1855,10 +1860,10 @@ module Typography_late = struct
     | Decoration_bracket_var _ -> 4200
     | Decoration_bracket_var_opacity _ -> 4200
     (* Text decoration lines - suborder >= 8000 (alphabetical) *)
-    | Line_through -> 8000
-    | No_underline -> 8001
-    | Overline -> 8002
-    | Underline -> 8003
+    | Line_through -> 8400
+    | No_underline -> 8401
+    | Overline -> 8402
+    | Underline -> 8403
     (* Decoration styles - same suborder, sorted by class name *)
     | Decoration_solid -> 8100
     | Decoration_double -> 8100
@@ -1886,17 +1891,17 @@ module Typography_late = struct
     | Tracking_wider -> 8304
     | Tracking_widest -> 8305
     (* Text transform - alphabetical order *)
-    | Capitalize -> 8400
-    | Lowercase -> 8401
-    | Normal_case -> 8402
-    | Uppercase -> 8403
+    | Capitalize -> 8360
+    | Lowercase -> 8361
+    | Normal_case -> 8362
+    | Uppercase -> 8363
     (* Whitespace - alphabetical order *)
-    | Whitespace_break_spaces -> 8500
-    | Whitespace_normal -> 8501
-    | Whitespace_nowrap -> 8502
-    | Whitespace_pre -> 8503
-    | Whitespace_pre_line -> 8504
-    | Whitespace_pre_wrap -> 8505
+    | Whitespace_break_spaces -> 8330
+    | Whitespace_normal -> 8331
+    | Whitespace_nowrap -> 8332
+    | Whitespace_pre -> 8333
+    | Whitespace_pre_line -> 8334
+    | Whitespace_pre_wrap -> 8335
     (* Vertical align (priority 24) - between text-align (~1005) and font-family
        (~1501) in the early handler's suborder space. Alphabetical. *)
     | Align_arbitrary_var _ -> 1200
@@ -1931,8 +1936,8 @@ module Typography_late = struct
     | Underline_offset_var _ -> 69990
     | Underline_offset_auto -> 69999
     (* Antialiased *)
-    | Antialiased -> 70000
-    | Subpixel_antialiased -> 70001
+    | Antialiased -> 8700
+    | Subpixel_antialiased -> 8701
     (* Text overflow (priority 17 for Truncate) - alphabetical: text-clip,
        text-ellipsis, truncate. Truncate sorts before overflow (priority 18) via
        a suborder above alignment/gap's range. *)
@@ -1945,9 +1950,9 @@ module Typography_late = struct
     | Text_pretty -> 9102
     | Text_wrap -> 9103
     (* Break utilities *)
-    | Break_normal -> 9200
-    | Break_words -> 9201
-    | Break_all -> 9202
+    | Break_normal -> 8310
+    | Break_words -> 8311
+    | Break_all -> 8312
     | Break_keep -> 9203
     (* Overflow wrap *)
     | Overflow_wrap_normal -> 9300

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1884,9 +1884,11 @@ module Typography_late = struct
     | Neg_tracking_var _ -> 8250
     | Tracking_arbitrary _ -> 8255
     | Tracking_var _ -> 8260
-    | Tracking_tighter -> 8300
+    (* Alphabetical by class name: normal, tight, tighter, wide, wider,
+       widest *)
+    | Tracking_normal -> 8300
     | Tracking_tight -> 8301
-    | Tracking_normal -> 8302
+    | Tracking_tighter -> 8302
     | Tracking_wide -> 8303
     | Tracking_wider -> 8304
     | Tracking_widest -> 8305

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -341,7 +341,7 @@ module Typography_early = struct
   type Utility.base += Self of t
 
   let name = "typography_early"
-  let priority _ = 22
+  let priority _ = 24
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not an early typography utility")
 
@@ -1402,7 +1402,7 @@ module Typography_late = struct
   type Utility.base += Self of t
 
   let name = "typography_late"
-  let priority _ = 24
+  let priority _ = 26
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not a late typography utility")
 

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -42,7 +42,7 @@ let check_conflict_order () =
 
   (* Test basic selector parsing *)
   let prio, sub = Tw.Build.conflict_order ".p-4" in
-  check int "p-4 priority" 21 prio;
+  check int "p-4 priority" 23 prio;
 
   (* Padding priority *)
 
@@ -56,7 +56,7 @@ let check_conflict_order () =
   let bg_prio, _ = Tw.Build.conflict_order ".bg-blue-500" in
   check bool "margin before background" true (m4_prio < bg_prio);
   (* bg-blue-500 is a background color (priority 20), which comes before Padding
-     (priority 21) *)
+     (priority 23) *)
   check bool "background color before padding" true (bg_prio < prio);
 
   (* Test unknown utility gets high priority *)


### PR DESCRIPTION
Stacked on #121. Completes the family-order re-calibration so the ocaml.org corpus is render-identical to Tailwind v4: **`tw <corpus> --diff` now prints `No differences found`** (from 52 reorders + 5 container block-placement markers at the start).

Every displaced family moved to its canonical slot, via per-variant `priority : t -> int` where a module spans several families:
- svg fill/stroke and object-fit before padding (priority band 21..30 shifted up two to open the slot)
- table-layout after flex; size-* first among sizing
- resize/appearance out of interactivity; list-style/truncate/vertical-align out of typography; to their early slots
- outline after box-shadow/ring
- late-typography reordered to tracking < word-break < whitespace < text-transform < italic < text-decoration < font-smoothing
- text-color interleaved into late-typography; border-color placed with border-width
- `!important` classes order by their base family instead of falling to last place

Plus the within-family value orders: tracking and font-family alphabetical; border sides side-major; outline-style after outline-width; max-width in Tailwind's three bands (container scale, numeric, keywords); and named/arbitrary border colors sharing a suborder so they interleave by class name.