### PR TITLE
clear all merlint issues

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -416,43 +416,43 @@ let paths_arg =
   let doc = "Files or directories to scan for Tailwind classes" in
   Arg.(value & pos_all file [] & info [] ~docv:"PATH" ~doc)
 
+let man =
+  [
+    `S Manpage.s_description;
+    `P "tw is a tool that generates CSS from Tailwind-like utility classes.";
+    `P
+      "It can generate CSS for a single class using -s (no base styles by \
+       default), or scan files/directories and generate a complete stylesheet \
+       (with base styles by default).";
+    `S Manpage.s_examples;
+    `P "Generate CSS for a single class (no Base layer by default):";
+    `Pre "  tw -s bg-blue-500";
+    `P "Generate CSS for a single class with the Base layer:";
+    `Pre "  tw -s bg-blue-500 --base";
+    `P "Scan files and generate CSS (with the Base layer by default):";
+    `Pre "  tw index.html src/";
+    `P "Scan files and generate CSS without the Base layer:";
+    `Pre "  tw --no-base index.html src/";
+    `P "Generate inline mode (no variables, no layers):";
+    `Pre "  tw --inline index.html src/";
+    `P "Generate minified CSS:";
+    `Pre "  tw --minify index.html src/";
+    `P "Generate optimized CSS (rule merging/deduplication):";
+    `Pre "  tw --optimize index.html src/";
+    `P "Generate both minified and optimized CSS:";
+    `Pre "  tw --minify --optimize index.html src/";
+    `P "Use real Tailwind CSS:";
+    `Pre "  tw -s bg-blue-500 --tailwind";
+    `P "Compare tw output with real Tailwind CSS:";
+    `Pre "  tw -s prose-sm --diff --diff-mode=canonical";
+    `P "Use structural diff output when regrouping/order is relevant:";
+    `Pre "  tw -s prose-sm --diff --diff-mode=tree";
+    `S Manpage.s_see_also;
+    `P "https://tailwindcss.com";
+  ]
+
 let cmd =
   let doc = "A Tailwind CSS-like utility class generator for OCaml" in
-  let man =
-    [
-      `S Manpage.s_description;
-      `P "tw is a tool that generates CSS from Tailwind-like utility classes.";
-      `P
-        "It can generate CSS for a single class using -s (no base styles by \
-         default), or scan files/directories and generate a complete \
-         stylesheet (with base styles by default).";
-      `S Manpage.s_examples;
-      `P "Generate CSS for a single class (no Base layer by default):";
-      `Pre "  tw -s bg-blue-500";
-      `P "Generate CSS for a single class with the Base layer:";
-      `Pre "  tw -s bg-blue-500 --base";
-      `P "Scan files and generate CSS (with the Base layer by default):";
-      `Pre "  tw index.html src/";
-      `P "Scan files and generate CSS without the Base layer:";
-      `Pre "  tw --no-base index.html src/";
-      `P "Generate inline mode (no variables, no layers):";
-      `Pre "  tw --inline index.html src/";
-      `P "Generate minified CSS:";
-      `Pre "  tw --minify index.html src/";
-      `P "Generate optimized CSS (rule merging/deduplication):";
-      `Pre "  tw --optimize index.html src/";
-      `P "Generate both minified and optimized CSS:";
-      `Pre "  tw --minify --optimize index.html src/";
-      `P "Use real Tailwind CSS:";
-      `Pre "  tw -s bg-blue-500 --tailwind";
-      `P "Compare tw output with real Tailwind CSS:";
-      `Pre "  tw -s prose-sm --diff --diff-mode=canonical";
-      `P "Use structural diff output when regrouping/order is relevant:";
-      `Pre "  tw -s prose-sm --diff --diff-mode=tree";
-      `S Manpage.s_see_also;
-      `P "https://tailwindcss.com";
-    ]
-  in
   let info = Cmd.info "tw" ~version:"0.1.0" ~doc ~man in
   Cmd.v info
     Term.(

--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,7 @@
   cascade
   cmdliner
   fmt
-  re
+  (re :with-test)
   uutf
   (brr (>= 0.0.6))
   js_of_ocaml

--- a/lib/tools/dune
+++ b/lib/tools/dune
@@ -1,3 +1,3 @@
 (library
  (name tw_tools)
- (libraries fmt unix uutf cascade cascade.diff))
+ (libraries fmt unix uutf))

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,6 @@
  (name test)
  (libraries
   tw
-  tw.html
   alcotest
   re
   astring

--- a/test/helpers/dune
+++ b/test/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name test_helpers)
- (libraries tw tw_tools alcotest re fmt cascade cascade.diff))
+ (libraries tw tw_tools alcotest fmt cascade cascade.diff))

--- a/test/html/dune
+++ b/test/html/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries tw tw.html cascade alcotest re astring fmt))
+ (libraries tw tw.html cascade alcotest astring fmt))

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -428,7 +428,7 @@ let test_handler_priority_ordering () =
     | a :: (b :: _ as rest) ->
         let pa = position ("." ^ a) and pb = position ("." ^ b) in
         check bool
-          (Printf.sprintf "%s before %s" a b)
+          (Fmt.str "%s before %s" a b)
           true
           (pa >= 0 && pb >= 0 && pa < pb);
         check_chain rest
@@ -1020,7 +1020,7 @@ let test_rounded_position_order () =
   let check_before a b =
     let pa = position a and pb = position b in
     Alcotest.check Alcotest.bool
-      (Printf.sprintf "%s before %s" a b)
+      (Fmt.str "%s before %s" a b)
       true
       (pa >= 0 && pb >= 0 && pa < pb)
   in
@@ -1064,7 +1064,7 @@ let test_prose_margin_order () =
   let check_before a b =
     let pa = position a and pb = position b in
     Alcotest.check Alcotest.bool
-      (Printf.sprintf "%s before %s" a b)
+      (Fmt.str "%s before %s" a b)
       true
       (pa >= 0 && pb >= 0 && pa < pb)
   in

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -268,7 +268,7 @@ let fixture_path filename =
   |> List.find_opt Sys.file_exists
   |> Option.value ~default:filename
 
-let find_separator lines =
+let separator lines =
   let rec go before = function
     | [] -> None
     | line :: rest ->
@@ -279,7 +279,7 @@ let find_separator lines =
 
 let parse_upstream_block source block =
   let lines = String.split_on_char '\n' block in
-  match find_separator lines with
+  match separator lines with
   | None -> None
   | Some (before, after) ->
       let before = List.map String.trim before in
@@ -376,7 +376,7 @@ let register_upstream_variant_directives directives =
     match String.split_on_char ' ' d with
     | "container" :: name :: (_ :: _ as rest) -> (
         let header = String.concat " " rest in
-        try Some (name, container_of_header header) with _ -> None)
+        try Some (name, container_of_header header) with Failure _ -> None)
     | _ -> None
   in
   Tw.Modifiers.register_custom_variants
@@ -494,10 +494,9 @@ let check_upstream_positive_fixture_parse filename () =
             Fmt.str "%s / %s / %s: %s" c.source c.name cls msg)
         |> String.concat "\n"
       in
-      Alcotest.fail
-        (Fmt.str
-           "Unparsed upstream classes that Tailwind emitted (%d rejected).\n%s"
-           (List.length rejected) sample)
+      Alcotest.failf
+        "Unparsed upstream classes that Tailwind emitted (%d rejected).\n%s"
+        (List.length rejected) sample
 
 (* ===== CORE TESTS (renamed to shorter names) ===== *)
 

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -797,7 +797,7 @@ let run_test_case test () =
       match String.split_on_char ' ' d with
       | "container" :: name :: (_ :: _ as rest) -> (
           let header = String.concat " " rest in
-          try Some (name, container_of_header header) with _ -> None)
+          try Some (name, container_of_header header) with Failure _ -> None)
       | _ -> None
     in
     Tw.Modifiers.register_custom_variants

--- a/tw.opam
+++ b/tw.opam
@@ -14,7 +14,7 @@ depends: [
   "cascade"
   "cmdliner"
   "fmt"
-  "re"
+  "re" {with-test}
   "uutf"
   "brr" {>= "0.0.6"}
   "js_of_ocaml"


### PR DESCRIPTION
Two independent cleanups flagged by merlint. 35c1aba drops library dependencies no compilation unit imports (E956) and moves `re` to a `with-test` filter (E943). 2019d7c addresses the code-quality lints: narrowing two catch-all handlers to `Failure`, a function rename, `Printf` to `Fmt`, `fail`/`Fmt.str` to `failf`, and hoisting the `tw` man page out of `cmd`.