### PR TITLE
color: reject invalid palette shades at construction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- Reject shades the palette does not define: `bg ~shade:250 gray` raises
+  `Invalid_argument` when the value is constructed, and the CLI reports
+  `bg-gray-250` as an unknown class instead of failing with an internal
+  error (#127)
+
 ## 1.0.0
 
 - Initial public release candidate. Type-safe Tailwind CSS v4 in OCaml,

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1952,6 +1952,7 @@ let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
 
 let bg ?opacity ?(shade = 500) color =
+  Color.check_shade ~utility:"bg" color shade;
   match opacity with
   | None -> utility (Bg (color, shade))
   | Some pct ->
@@ -1961,10 +1962,13 @@ let bg ?opacity ?(shade = 500) color =
 let bg_gradient_to dir = utility (Bg_gradient_to dir)
 
 let from_color ?(shade = 500) color =
+  Color.check_shade ~utility:"from_color" color shade;
   utility (Gradient_color (Gradient_from, Gc_named (color, shade)))
 
 let via_color ?(shade = 500) color =
+  Color.check_shade ~utility:"via_color" color shade;
   utility (Gradient_color (Gradient_via, Gc_named (color, shade)))
 
 let to_color ?(shade = 500) color =
+  Color.check_shade ~utility:"to_color" color shade;
   utility (Gradient_color (Gradient_to, Gc_named (color, shade)))

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1180,6 +1180,7 @@ let border_none = utility Border_none
 (** {1 Border Color Utilities} *)
 
 let border_color ?opacity ?(shade = 500) color =
+  Color.check_shade ~utility:"border_color" color shade;
   match opacity with
   | None -> utility (Border_color (color, shade))
   | Some pct -> Color.border_color ~opacity:pct ~shade color

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1203,6 +1203,18 @@ let is_theme_named = function Theme_named _ -> true | _ -> false
 (* Check if a color should NOT have a shade suffix in class names *)
 let is_shadeless c = is_base_color c || is_custom_color c || is_theme_named c
 
+(* The shades the Tailwind v4 palette defines for named colors *)
+let palette_shades = [ 50; 100; 200; 300; 400; 500; 600; 700; 800; 900; 950 ]
+
+let is_valid_shade color shade =
+  is_shadeless color || List.mem shade palette_shades
+
+let check_shade ~utility color shade =
+  if not (is_valid_shade color shade) then
+    invalid_arg
+      (utility ^ ": " ^ pp color ^ " has no shade " ^ string_of_int shade
+     ^ " (valid shades: 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950)")
+
 (** {1 Color Application Utilities} *)
 
 (** Background color utilities *)
@@ -1494,7 +1506,8 @@ let shade_of_strings = function
       match of_string color_str with
       | Ok color -> (
           match int_of_string_opt shade_str with
-          | Some shade when shade >= 0 -> Ok (color, shade)
+          | Some shade when shade >= 0 && is_valid_shade color shade ->
+              Ok (color, shade)
           | _ -> Error (`Msg ("Invalid shade: " ^ shade_str)))
       | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
   | [ color_str ] -> (
@@ -1514,7 +1527,8 @@ let shade_and_opacity_of_strings ?theme = function
       match of_string color_str with
       | Ok color -> (
           match int_of_string_opt shade_str with
-          | Some shade when shade >= 0 -> Ok (color, shade, opacity)
+          | Some shade when shade >= 0 && is_valid_shade color shade ->
+              Ok (color, shade, opacity)
           | _ -> Error (`Msg ("Invalid shade: " ^ shade_str)))
       | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
   | [ color_str ] -> (
@@ -3307,18 +3321,21 @@ let bg_current_with_opacity ?theme opacity =
 let utility x = Utility.base (Self x)
 
 let bg ?opacity ?(shade = 500) color =
+  check_shade ~utility:"bg" color shade;
   match opacity with
   | None -> utility (Bg (color, shade))
   | Some pct ->
       utility (Bg_opacity (color, shade, Opacity_percent (Float.of_int pct)))
 
 let text ?opacity ?(shade = 500) color =
+  check_shade ~utility:"text" color shade;
   match opacity with
   | None -> utility (Text (color, shade))
   | Some pct ->
       utility (Text_opacity (color, shade, Opacity_percent (Float.of_int pct)))
 
 let border_color ?opacity ?(shade = 500) color =
+  check_shade ~utility:"border_color" color shade;
   match opacity with
   | None -> utility (Border (color, shade))
   | Some pct ->
@@ -3334,6 +3351,7 @@ let border_transparent = utility Border_transparent
 let border_current = utility Border_current
 
 let accent ?opacity ?(shade = 500) color =
+  check_shade ~utility:"accent" color shade;
   match opacity with
   | None -> utility (Accent (color, shade))
   | Some pct ->
@@ -3344,6 +3362,7 @@ let accent_current = utility Accent_current
 let accent_inherit = utility Accent_inherit
 
 let caret ?opacity ?(shade = 500) color =
+  check_shade ~utility:"caret" color shade;
   match opacity with
   | None -> utility (Caret (color, shade))
   | Some pct ->

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -189,6 +189,15 @@ val is_shadeless : color -> bool
 (** [is_shadeless color] checks if a color should NOT have a shade suffix in
     class names (base colors, custom colors, or theme-named colors). *)
 
+val is_valid_shade : color -> int -> bool
+(** [is_valid_shade color shade] checks that [shade] is one the Tailwind palette
+    defines for [color]. Shadeless colors accept any shade (it is ignored). *)
+
+val check_shade : utility:string -> color -> int -> unit
+(** [check_shade ~utility color shade] raises [Invalid_argument] if
+    [is_valid_shade color shade] is false. [utility] names the constructor in
+    the error message. *)
+
 val color_var : color -> int -> Css.color Var.theme
 (** [color_var color shade] gets or creates a memoized color variable for the
     given color and shade. *)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -3072,6 +3072,7 @@ let ring_lg = utility Ring_lg
 let ring_xl = utility Ring_xl
 
 let ring_color ?opacity ?(shade = 500) color =
+  Color.check_shade ~utility:"ring_color" color shade;
   match opacity with
   | None -> utility (Ring_color (color, shade))
   | Some pct ->

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -472,7 +472,8 @@ let () = Utility.register (module Handler)
 
 open Handler
 
-let color_util property color ?(shade = 500) () =
+let color_util name property color ?(shade = 500) () =
+  Color.check_shade ~utility:name color shade;
   let var_name =
     if Color.is_base_color color then "color-" ^ Color.to_name color
     else "color-" ^ Color.to_name color ^ "-" ^ string_of_int shade
@@ -484,8 +485,8 @@ let color_util property color ?(shade = 500) () =
   Style.style [ def; property (Css.Color (Css.Var css_var) : Css.svg_paint) ]
 
 let utility x = Utility.base (Self x)
-let fill = color_util Css.fill
-let stroke = color_util Css.stroke
+let fill = color_util "fill" Css.fill
+let stroke = color_util "stroke" Css.stroke
 let fill_none = utility Fill_none
 let fill_current = utility Fill_current
 let stroke_none = utility Stroke_none

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2909,6 +2909,7 @@ let leading n = utility_early (Typography_early.Leading n)
 let utility_late x = Utility.base (Typography_late.Self x)
 
 let decoration_color ?(shade = 500) color =
+  Color.check_shade ~utility:"decoration_color" color shade;
   utility_late (Typography_late.Decoration_color (color, Some shade))
 
 let underline = utility_late Typography_late.Underline

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -212,10 +212,23 @@ let test_border_side_color () =
     (Astring.String.is_infix ~affix:"border-inline-color:"
        (css "border-x-red-500"))
 
+let test_invalid_shade () =
+  Alcotest.check_raises "bg ~shade:250 gray raises at construction"
+    (Invalid_argument
+       "bg: gray has no shade 250 (valid shades: 50, 100, 200, 300, 400, 500, \
+        600, 700, 800, 900, 950)") (fun () -> ignore (Tw.bg ~shade:250 Tw.gray));
+  (match Tw.of_string "bg-gray-250" with
+  | Error (`Msg _) -> ()
+  | Ok _ -> Alcotest.fail "bg-gray-250 should not parse");
+  (* Valid shades still construct, and shadeless colors ignore the shade *)
+  ignore (Tw.bg ~shade:200 Tw.gray);
+  ignore (Tw.bg ~shade:250 (Tw.hex "#aabbcc"))
+
 (* Test suite *)
 let tests =
   [
     ("Per-side border colors", `Quick, test_border_side_color);
+    ("Invalid shades", `Quick, test_invalid_shade);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);
     ("RGB to hex", `Quick, test_rgb_to_hex);


### PR DESCRIPTION
A shade the palette does not define used to survive until CSS generation and fail inside the renderer, so scanning a source file containing a class like `bg-gray-250` crashed the CLI with an internal error. Constructors now raise `Invalid_argument` when the value is built, and the parser reports such classes as unknown, matching every other malformed class.