### PR TITLE
tools: track Tailwind CSS 4.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+      # tw and cascade are developed together, so CI tracks cascade's main
+      # rather than its last opam release. Drop this once a release carries
+      # what tw needs.
+      - name: Pin cascade to main
+        run: opam pin add -n cascade https://github.com/samoht/cascade.git#main
+
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ the same typed variable-and-layer pipeline Tailwind uses, producing
 byte-for-byte identical output. Unknown utilities are caught at compile time,
 and nothing depends on Node.js, PostCSS, or the Tailwind CLI at run time.
 
+**Tracked version:** `tw` targets **Tailwind CSS v4.3.3** (the latest release).
+Its generated CSS is checked byte-for-byte against that exact version.
+
 ```ocaml
 open Tw
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name tw)
  (name main)
- (libraries tw cascade cascade.diff tw_tools cmdliner fmt))
+ (libraries tw tw.info cascade cascade.diff tw_tools cmdliner fmt))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -453,7 +453,7 @@ let man =
 
 let cmd =
   let doc = "A Tailwind CSS-like utility class generator for OCaml" in
-  let info = Cmd.info "tw" ~version:"0.1.0" ~doc ~man in
+  let info = Cmd.info "tw" ~version:Tw_info.version ~doc ~man in
   Cmd.v info
     Term.(
       ret

--- a/dune-project
+++ b/dune-project
@@ -27,6 +27,7 @@
   dune
   (cascade (>= 1.0.0))
   cmdliner
+  dune-build-info
   fmt
   (re :with-test)
   uutf

--- a/homebrew.yml
+++ b/homebrew.yml
@@ -1,0 +1,15 @@
+handle: samoht
+
+storage:
+  bucket: homebrew-bottles
+  region: fr-par
+  profile: homebrew-samoht
+
+tap:
+  clone_url: https://github.com/samoht/homebrew-tap.git
+  push_url: git@github.com:samoht/homebrew-tap
+
+packages:
+  - name: tw
+    target: bin/main.exe
+    description: "Type-safe Tailwind CSS v4 in OCaml"

--- a/lib/info/dune
+++ b/lib/info/dune
@@ -1,0 +1,17 @@
+(library
+ (name tw_info)
+ (public_name tw.info)
+ (libraries dune-build-info))
+
+; Packaging builds (bottler) export PROJECT_VERSION and expect the binary to
+; report that exact string; Tw_info falls back to dune-build-info and then
+; "dev" when it is unset.
+
+(rule
+ (target project_version.ml)
+ (deps
+  (env_var PROJECT_VERSION))
+ (action
+  (with-stdout-to
+   %{target}
+   (bash "printf 'let env = \"%s\"\\n' \"${PROJECT_VERSION:-dev}\""))))

--- a/lib/info/tw_info.ml
+++ b/lib/info/tw_info.ml
@@ -1,0 +1,7 @@
+let version =
+  match Project_version.env with
+  | "dev" -> (
+      match Build_info.V1.version () with
+      | Some v -> Build_info.V1.Version.to_string v
+      | None -> "dev")
+  | v -> v

--- a/lib/info/tw_info.mli
+++ b/lib/info/tw_info.mli
@@ -1,0 +1,11 @@
+(** Build-time metadata for the tw binary.
+
+    Exposes a {!version} string taken from the [PROJECT_VERSION] environment
+    variable when the build exports one (packaging builds such as bottler), from
+    [dune-build-info] otherwise (tagged opam releases), or ["dev"] during
+    development. *)
+
+val version : string
+(** [version] is the current version string: the [PROJECT_VERSION] environment
+    variable when set at build time, the dune-build-info version when available,
+    or ["dev"]. *)

--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -48,12 +48,13 @@ export default {
 let availability_result = ref None
 let tailwind_command = ref None
 
-(* The fixtures and utility expectations target Tailwind v4.3.1 (see CLAUDE.md).
-   The unit spacing multiplier changed between v4.2 (calc(var(--spacing) * 1))
-   and v4.3 (bare var(--spacing)), so an older native binary yields a stale
-   reference. We therefore use a native tailwindcss only when it is at least
-   this version, and otherwise fall back to the pinned node_modules build. *)
-let required_version = (4, 3, 1)
+(* The reference build must be the exact Tailwind version tw tracks: a different
+   release changes default tokens (e.g. the v4.2 -> v4.3 unit-spacing change,
+   [calc(var(--spacing) * 1)] to a bare [var(--spacing)]), so an off-version
+   binary yields a stale reference. We use a native tailwindcss only when it
+   matches this version, and otherwise fall back to the pinned node_modules
+   build. *)
+let required_version = (4, 3, 3)
 
 let parse_version v =
   let to_int s =

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@tailwindcss/cli": "^4.3.1",
-        "@tailwindcss/forms": "^0.5.11",
-        "@tailwindcss/typography": "^0.5.20",
-        "tailwindcss": "^4.3.1"
+        "@tailwindcss/cli": "4.3.3",
+        "@tailwindcss/forms": "0.5.11",
+        "@tailwindcss/typography": "0.5.20",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -371,19 +371,19 @@
       }
     },
     "node_modules/@tailwindcss/cli": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.1.tgz",
-      "integrity": "sha512-ZWPy20rF+TBfTImxDMG3Wr75Y3RpaPlo9lc+oJbInlMyjT+XPkTVKVIL5RZ7JirXuIahcfHoLNFRmDorKi+JQQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.3.tgz",
+      "integrity": "sha512-ZvS/n1ZHOBKcVlhkt8l5NNr1EDXk1NboYO5CYDOs6NUmvT9z6bzkwsosaJftY57T/3gWNzWMJzIXLodZC8ssdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "2.5.1",
-        "@tailwindcss/node": "4.3.1",
-        "@tailwindcss/oxide": "4.3.1",
-        "enhanced-resolve": "5.21.6",
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "enhanced-resolve": "^5.24.1",
         "mri": "^1.2.0",
         "picocolors": "^1.1.1",
-        "tailwindcss": "4.3.1"
+        "tailwindcss": "4.3.3"
       },
       "bin": {
         "tailwindcss": "dist/index.mjs"
@@ -403,49 +403,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.1"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-x64": "4.3.1",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
-      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -477,9 +477,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
-      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
-      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
-      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
-      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
-      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
-      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
-      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
-      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -614,9 +614,9 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
         "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
-      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
-      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1155,9 +1155,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "@tailwindcss/cli": "4.3.1",
+    "@tailwindcss/cli": "4.3.3",
     "@tailwindcss/forms": "0.5.11",
     "@tailwindcss/typography": "0.5.20",
-    "tailwindcss": "4.3.1"
+    "tailwindcss": "4.3.3"
   }
 }

--- a/test/info/dune
+++ b/test/info/dune
@@ -1,0 +1,3 @@
+(test
+ (name test)
+ (libraries alcotest tw.info))

--- a/test/info/test.ml
+++ b/test/info/test.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "info" [ Test_tw_info.suite ]

--- a/test/info/test_tw_info.ml
+++ b/test/info/test_tw_info.ml
@@ -1,0 +1,19 @@
+let test_non_empty () =
+  Alcotest.(check bool) "version is non-empty" true (Tw_info.version <> "")
+
+(* The version string is spliced into an OCaml literal by a printf rule; a
+   quote, backslash, newline or space in it means the rule mangled the
+   PROJECT_VERSION value. *)
+let test_well_formed () =
+  String.iter
+    (fun c ->
+      let bad = c = '"' || c = '\\' || c = '\n' || c = ' ' in
+      Alcotest.(check bool) (Printf.sprintf "version has no %C" c) false bad)
+    Tw_info.version
+
+let suite =
+  ( "tw_info",
+    [
+      Alcotest.test_case "non-empty" `Quick test_non_empty;
+      Alcotest.test_case "well-formed" `Quick test_well_formed;
+    ] )

--- a/test/info/test_tw_info.mli
+++ b/test/info/test_tw_info.mli
@@ -1,0 +1,4 @@
+(** Tests for the build-time version metadata. *)
+
+val suite : string * unit Alcotest.test_case list
+(** [suite] is the test suite for {!Tw_info}. *)

--- a/tw.opam
+++ b/tw.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "3.21"}
   "cascade" {>= "1.0.0"}
   "cmdliner"
+  "dune-build-info"
   "fmt"
   "re" {with-test}
   "uutf"


### PR DESCRIPTION
Bumps the pinned tailwindcss reference from 4.3.1 to the current release (4.3.3) and requires it exactly for the parity generator, so `--diff` compares against the version tw claims to track. The README now states that version prominently.

Base of a stack: bumping the reference exposes the generation tw still owes 4.3.2/4.3.3, so the parity suite is red here and each stacked PR fixes one difference — the `--font-sans` default (#129), the `:-moz-focusring` reset (#130), and the achromatic `none` hue 4.3.3 introduced across the neutral scale (#132, which needs samoht/cascade#190).

One known difference is not yet fixed: a project `@theme` makes tw drop the built-in `@keyframes` (a site loses `@keyframes ping`). #131 attempted it and was closed — the rule depends on whether the default theme is still in effect, which `Scheme` cannot currently express.