### PR TITLE
typography: update --font-sans to the 4.3.2 system stack

### DIFF
--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -90,11 +90,18 @@ let var_ref (type a)
 
 (** HTML and body defaults *)
 let root_resets ~default_font_ref ~font_feature_ref ~font_variation_ref =
+  (* Mirrors [Typography.default_sans_stack]; Tailwind v4.3.2 system-font
+     stack. *)
   let fallback_stack : font_family =
     List
       [
-        Ui_sans_serif;
-        System_ui;
+        Name "-apple-system";
+        Name "BlinkMacSystemFont";
+        Segoe_ui;
+        Roboto;
+        Helvetica_neue;
+        Noto_sans;
+        Arial;
         Sans_serif;
         Apple_color_emoji;
         Segoe_ui_emoji;

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -216,11 +216,18 @@ let default_font_family_var =
 let default_mono_font_family_var =
   Var.theme Css.Font_family "default-mono-font-family" ~order:(9, 1)
 
+(* Tailwind v4.3.2 replaced the [ui-sans-serif, system-ui, ...] default with the
+   platform system-font stack. *)
 let default_sans_stack : Css.font_family =
   List
     [
-      Ui_sans_serif;
-      System_ui;
+      Name "-apple-system";
+      Name "BlinkMacSystemFont";
+      Segoe_ui;
+      Roboto;
+      Helvetica_neue;
+      Noto_sans;
+      Arial;
       Sans_serif;
       Apple_color_emoji;
       Segoe_ui_emoji;


### PR DESCRIPTION
Tailwind v4.3.2 replaced the `ui-sans-serif, system-ui, ...` default with the platform system-font stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", ...`). tw still emitted the old one.

The stack is emitted twice, once as the `--font-sans` theme token and once as the preflight `html` font-family fallback, so both copies move together; updating only the token leaves the fallback contradicting it. Because the value lands in the preamble, this single difference was failing every full-output parity test.

Stacked on #128.