### PR TITLE
animations: keep @keyframes when a theme redefines the animation

### DIFF
--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -15,6 +15,37 @@ module Css = Cascade.Css
 let opt_none : 'a option = None
 let opt_some x : 'a option = Some x
 
+(* Does [value] use [name] as an animation name? Splits on the shorthand's
+   separators so a substring of a longer ident or a function argument does not
+   count. *)
+let references_animation value name =
+  let buf = Buffer.create 16 in
+  let words = ref [] in
+  let flush () =
+    if Buffer.length buf > 0 then begin
+      words := Buffer.contents buf :: !words;
+      Buffer.clear buf
+    end
+  in
+  String.iter
+    (fun c ->
+      match c with
+      | ' ' | ',' | '\t' | '\n' | '(' | ')' -> flush ()
+      | c -> Buffer.add_char buf c)
+    value;
+  flush ();
+  List.mem name !words
+
+(* Tailwind emits the built-in [@keyframes] whenever the resolved animation
+   still references it, including when a project theme redefines the token to an
+   animation of the same name. Only a value naming a different animation drops
+   them. *)
+let keyframes_rules ?theme ~token ~name rules =
+  match Scheme.theme_value theme token with
+  | None -> opt_some rules
+  | Some value ->
+      if references_animation value name then opt_some rules else opt_none
+
 module Handler = struct
   open Style
   open Css
@@ -79,22 +110,18 @@ module Handler = struct
         }
     in
     let theme_decl, spin_var = Var.binding animate_spin_var spin_animation in
-    (* Only include @keyframes when theme doesn't define the animation *)
     let rules =
-      if Scheme.theme_value theme "animate-spin" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "spin"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions [ Css.Keyframe.To ];
-                  declarations =
-                    [ Css.Declaration.transform (Rotate (Deg 360.)) ];
-                };
-              ];
-          ]
+      keyframes_rules ?theme ~token:"animate-spin" ~name:"spin"
+        [
+          Css.keyframes "spin"
+            [
+              {
+                Css.Stylesheet.selector =
+                  Css.Keyframe.Positions [ Css.Keyframe.To ];
+                declarations = [ Css.Declaration.transform (Rotate (Deg 360.)) ];
+              };
+            ];
+        ]
     in
     style ~rules [ theme_decl; Css.animation (Css.Var spin_var) ]
 
@@ -119,24 +146,22 @@ module Handler = struct
     in
     let theme_decl, ping_var = Var.binding animate_ping_var ping_animation in
     let rules =
-      if Scheme.theme_value theme "animate-ping" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "ping"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions
-                      [ Css.Keyframe.Percent 75.; Css.Keyframe.To ];
-                  declarations =
-                    [
-                      Css.Declaration.opacity (Opacity_number 0.0);
-                      Css.Declaration.transform (Scale (Num 2.0, opt_none));
-                    ];
-                };
-              ];
-          ]
+      keyframes_rules ?theme ~token:"animate-ping" ~name:"ping"
+        [
+          Css.keyframes "ping"
+            [
+              {
+                Css.Stylesheet.selector =
+                  Css.Keyframe.Positions
+                    [ Css.Keyframe.Percent 75.; Css.Keyframe.To ];
+                declarations =
+                  [
+                    Css.Declaration.opacity (Opacity_number 0.0);
+                    Css.Declaration.transform (Scale (Num 2.0, opt_none));
+                  ];
+              };
+            ];
+        ]
     in
     style ~rules [ theme_decl; Css.animation (Css.Var ping_var) ]
 
@@ -161,20 +186,17 @@ module Handler = struct
     in
     let theme_decl, pulse_var = Var.binding animate_pulse_var pulse_animation in
     let rules =
-      if Scheme.theme_value theme "animate-pulse" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "pulse"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
-                  declarations =
-                    [ Css.Declaration.opacity (Opacity_number 0.5) ];
-                };
-              ];
-          ]
+      keyframes_rules ?theme ~token:"animate-pulse" ~name:"pulse"
+        [
+          Css.keyframes "pulse"
+            [
+              {
+                Css.Stylesheet.selector =
+                  Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
+                declarations = [ Css.Declaration.opacity (Opacity_number 0.5) ];
+              };
+            ];
+        ]
     in
     style ~rules [ theme_decl; Css.animation (Css.Var pulse_var) ]
 
@@ -202,35 +224,33 @@ module Handler = struct
       Var.binding animate_bounce_var bounce_animation
     in
     let rules =
-      if Scheme.theme_value theme "animate-bounce" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "bounce"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions
-                      [ Css.Keyframe.Percent 0.; Css.Keyframe.To ];
-                  declarations =
-                    [
-                      Css.Declaration.animation_timing_function
-                        (Cubic_bezier (0.8, 0., 1., 1.));
-                      Css.Declaration.transform (Translate_y (Pct (-25.)));
-                    ];
-                };
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
-                  declarations =
-                    [
-                      Css.Declaration.animation_timing_function
-                        (Cubic_bezier (0., 0., 0.2, 1.));
-                      Css.Declaration.transform None;
-                    ];
-                };
-              ];
-          ]
+      keyframes_rules ?theme ~token:"animate-bounce" ~name:"bounce"
+        [
+          Css.keyframes "bounce"
+            [
+              {
+                Css.Stylesheet.selector =
+                  Css.Keyframe.Positions
+                    [ Css.Keyframe.Percent 0.; Css.Keyframe.To ];
+                declarations =
+                  [
+                    Css.Declaration.animation_timing_function
+                      (Cubic_bezier (0.8, 0., 1., 1.));
+                    Css.Declaration.transform (Translate_y (Pct (-25.)));
+                  ];
+              };
+              {
+                Css.Stylesheet.selector =
+                  Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
+                declarations =
+                  [
+                    Css.Declaration.animation_timing_function
+                      (Cubic_bezier (0., 0., 0.2, 1.));
+                    Css.Declaration.transform None;
+                  ];
+              };
+            ];
+        ]
     in
     style ~rules [ theme_decl; Css.animation (Css.Var bounce_var) ]
 

--- a/test/test_animations.ml
+++ b/test/test_animations.ml
@@ -103,6 +103,26 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"animations suborder matches Tailwind" shuffled
 
+(* Redefining --animate-ping in a project [@theme] must not drop the built-in
+   keyframes: the value still names [ping], so Tailwind keeps emitting
+   [@keyframes ping], and without them the animation never runs. *)
+let test_keyframes_survive_theme_override () =
+  let theme =
+    {
+      Tw.Scheme.default with
+      token_overrides =
+        [ ("animate-ping", "ping 1s cubic-bezier(0, 0, 0.2, 1) infinite") ];
+    }
+  in
+  let css = Css.to_string ~minify:true (Tw.to_css ~theme [ Tw.animate_ping ]) in
+  let contains needle =
+    let n = String.length needle and l = String.length css in
+    let rec go i = i + n <= l && (String.sub css i n = needle || go (i + 1)) in
+    go 0
+  in
+  Alcotest.check bool "@keyframes ping survives a theme override" true
+    (contains "@keyframes ping")
+
 let tests =
   [
     test_case "transitions" `Quick test_transitions;
@@ -110,6 +130,8 @@ let tests =
     test_case "duration + delay" `Quick test_duration_delay;
     test_case "animation CSS output" `Quick test_animation_css;
     test_case "transition CSS output" `Quick test_transition_css;
+    test_case "keyframes survive a theme override" `Quick
+      test_keyframes_survive_theme_override;
     test_case "animations suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
   ]


### PR DESCRIPTION
The built-in keyframes were emitted only when the theme left the `--animate-*` token alone, so a project `@theme` that redefines `--animate-ping` dropped `@keyframes ping` and the animation never ran. This is the dropped `ping` keyframe seen when diffing a real site, which has its own `@theme`.

Tailwind keys the keyframes off the animation the resolved value *names*, not off whether the token was overridden, so tw now does the same for all four built-ins. A value naming a different animation still drops them.

Stacked on #130.