### PR TITLE
color: write the powerless hue of an achromatic colour as none

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1001,9 +1001,16 @@ let to_oklch_css color shade =
       | Some value -> value
       | None -> "oklch(0% 0 0)" (* Fallback *))
 
+(* Tailwind writes the powerless hue of an achromatic colour as [none] rather
+   than a number. Keeping the component missing matters: a numeric hue lets the
+   value fold to a plain hex, and interpolation would take hue 0 instead of the
+   other colour's hue. *)
+let css_color_of_oklch (o : oklch) : Css.color =
+  if o.c = 0.0 then Css.oklch_none_hue o.l o.c else Css.oklch o.l o.c o.h
+
 let oklch_node_of color shade =
   let oklch = to_oklch color shade in
-  Css.oklch oklch.l oklch.c oklch.h
+  css_color_of_oklch oklch
 
 (* The palette ([Red], [Blue], ...) is a fixed set of (colour, shade) pairs and
    its oklch nodes are immutable, so materialise each node once and share it
@@ -1018,7 +1025,7 @@ let palette_nodes =
        (fun (color, palette) ->
          List.iter
            (fun (shade, o) ->
-             Hashtbl.replace table (color, shade) (Css.oklch o.l o.c o.h))
+             Hashtbl.replace table (color, shade) (css_color_of_oklch o))
            palette)
        [
          (Gray, Tailwind.gray);
@@ -1061,7 +1068,7 @@ let to_css color shade =
         else hex
       in
       Css.hex ("#" ^ shorten_hex_str hex_value)
-  | Oklch oklch -> Css.oklch oklch.l oklch.c oklch.h
+  | Oklch oklch -> css_color_of_oklch oklch
   | Css c -> c
   | Rgb _ | Theme_named _ -> oklch_node_of color shade
   | _ -> (
@@ -3092,8 +3099,7 @@ let generic_color_with_opacity ?theme ~property c shade opacity =
     | None ->
         let oklch = to_oklch c shade in
         let fallback_color =
-          Css.color_mix ~in_space:Srgb
-            (Css.oklch oklch.l oklch.c oklch.h)
+          Css.color_mix ~in_space:Srgb (css_color_of_oklch oklch)
             Css.Transparent ~percent1:percent
         in
         oklab_with_supports ~property ~fallback_decl:(property fallback_color) c

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -1786,47 +1786,47 @@ let zinc_invert_bindings =
 (* Neutral theme: normal bindings *)
 let neutral_normal_bindings =
   [
-    (prose_body_var, Css.oklch 37.1 0.0 0.0);
-    (prose_headings_var, Css.oklch 20.5 0.0 0.0);
-    (prose_lead_var, Css.oklch 43.9 0.0 0.0);
-    (prose_links_var, Css.oklch 20.5 0.0 0.0);
-    (prose_bold_var, Css.oklch 20.5 0.0 0.0);
-    (prose_counters_var, Css.oklch 55.6 0.0 0.0);
-    (prose_bullets_var, Css.oklch 87.0 0.0 0.0);
-    (prose_hr_var, Css.oklch 92.2 0.0 0.0);
-    (prose_quotes_var, Css.oklch 20.5 0.0 0.0);
-    (prose_quote_borders_var, Css.oklch 92.2 0.0 0.0);
-    (prose_captions_var, Css.oklch 55.6 0.0 0.0);
-    (prose_kbd_var, Css.oklch 20.5 0.0 0.0);
+    (prose_body_var, Css.oklch_none_hue 37.1 0.0);
+    (prose_headings_var, Css.oklch_none_hue 20.5 0.0);
+    (prose_lead_var, Css.oklch_none_hue 43.9 0.0);
+    (prose_links_var, Css.oklch_none_hue 20.5 0.0);
+    (prose_bold_var, Css.oklch_none_hue 20.5 0.0);
+    (prose_counters_var, Css.oklch_none_hue 55.6 0.0);
+    (prose_bullets_var, Css.oklch_none_hue 87.0 0.0);
+    (prose_hr_var, Css.oklch_none_hue 92.2 0.0);
+    (prose_quotes_var, Css.oklch_none_hue 20.5 0.0);
+    (prose_quote_borders_var, Css.oklch_none_hue 92.2 0.0);
+    (prose_captions_var, Css.oklch_none_hue 55.6 0.0);
+    (prose_kbd_var, Css.oklch_none_hue 20.5 0.0);
     (prose_kbd_shadows_var, Css.oklaba 20.5 0.0 0.0 0.1);
-    (prose_code_var, Css.oklch 20.5 0.0 0.0);
-    (prose_pre_code_var, Css.oklch 92.2 0.0 0.0);
-    (prose_pre_bg_var, Css.oklch 26.9 0.0 0.0);
-    (prose_th_borders_var, Css.oklch 87.0 0.0 0.0);
-    (prose_td_borders_var, Css.oklch 92.2 0.0 0.0);
+    (prose_code_var, Css.oklch_none_hue 20.5 0.0);
+    (prose_pre_code_var, Css.oklch_none_hue 92.2 0.0);
+    (prose_pre_bg_var, Css.oklch_none_hue 26.9 0.0);
+    (prose_th_borders_var, Css.oklch_none_hue 87.0 0.0);
+    (prose_td_borders_var, Css.oklch_none_hue 92.2 0.0);
   ]
 
 (* Neutral theme: invert bindings *)
 let neutral_invert_bindings =
   [
-    (prose_invert_body_var, Css.oklch 87.0 0.0 0.0);
+    (prose_invert_body_var, Css.oklch_none_hue 87.0 0.0);
     (prose_invert_headings_var, Css.hex "fff");
-    (prose_invert_lead_var, Css.oklch 70.8 0.0 0.0);
+    (prose_invert_lead_var, Css.oklch_none_hue 70.8 0.0);
     (prose_invert_links_var, Css.hex "fff");
     (prose_invert_bold_var, Css.hex "fff");
-    (prose_invert_counters_var, Css.oklch 70.8 0.0 0.0);
-    (prose_invert_bullets_var, Css.oklch 43.9 0.0 0.0);
-    (prose_invert_hr_var, Css.oklch 37.1 0.0 0.0);
-    (prose_invert_quotes_var, Css.oklch 97.0 0.0 0.0);
-    (prose_invert_quote_borders_var, Css.oklch 37.1 0.0 0.0);
-    (prose_invert_captions_var, Css.oklch 70.8 0.0 0.0);
+    (prose_invert_counters_var, Css.oklch_none_hue 70.8 0.0);
+    (prose_invert_bullets_var, Css.oklch_none_hue 43.9 0.0);
+    (prose_invert_hr_var, Css.oklch_none_hue 37.1 0.0);
+    (prose_invert_quotes_var, Css.oklch_none_hue 97.0 0.0);
+    (prose_invert_quote_borders_var, Css.oklch_none_hue 37.1 0.0);
+    (prose_invert_captions_var, Css.oklch_none_hue 70.8 0.0);
     (prose_invert_kbd_var, Css.hex "fff");
     (prose_invert_kbd_shadows_var, Css.hex "#ffffff1a");
     (prose_invert_code_var, Css.hex "fff");
-    (prose_invert_pre_code_var, Css.oklch 87.0 0.0 0.0);
+    (prose_invert_pre_code_var, Css.oklch_none_hue 87.0 0.0);
     (prose_invert_pre_bg_var, Css.hex "00000080");
-    (prose_invert_th_borders_var, Css.oklch 43.9 0.0 0.0);
-    (prose_invert_td_borders_var, Css.oklch 37.1 0.0 0.0);
+    (prose_invert_th_borders_var, Css.oklch_none_hue 43.9 0.0);
+    (prose_invert_td_borders_var, Css.oklch_none_hue 37.1 0.0);
   ]
 
 (* Stone theme: normal bindings *)

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -225,8 +225,26 @@ let test_invalid_shade () =
   ignore (Tw.bg ~shade:250 (Tw.hex "#aabbcc"))
 
 (* Test suite *)
+(* An achromatic palette colour must keep a [none] hue. A numeric hue renders
+   the same but folds to a plain hex, which pins the hue that interpolation is
+   meant to take from the other colour. *)
+let test_achromatic_none_hue () =
+  let css =
+    Css.to_string ~minify:true (Tw.to_css [ Tw.bg ~shade:500 Tw.neutral ])
+  in
+  let contains needle =
+    let n = String.length needle and l = String.length css in
+    let rec go i = i + n <= l && (String.sub css i n = needle || go (i + 1)) in
+    go 0
+  in
+  Alcotest.check Alcotest.bool "neutral-500 keeps a none hue" true
+    (contains "none");
+  Alcotest.check Alcotest.bool "neutral-500 did not fold to hex" false
+    (contains "#737373")
+
 let tests =
   [
+    ("Achromatic colour keeps a none hue", `Quick, test_achromatic_none_hue);
     ("Per-side border colors", `Quick, test_border_side_color);
     ("Invalid shades", `Quick, test_invalid_shade);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);


### PR DESCRIPTION
Tailwind v4.3.3 writes the hue of every chroma-0 colour as `none` — the whole neutral scale, plus `zinc-50` and `mauve-50` (13 colours, and exactly the 13 with chroma 0). tw emitted a numeric hue instead.

That is not cosmetic. A numeric hue is equivalent for rendering, but it lets the value fold to a plain hex (`oklch(.556 0 none)` vs `#737373`), which pins the hue that interpolation is meant to take from the other colour. The palette conversion and the five prose colour themes each carried their own copies of these values.

Uses `Css.oklch_none_hue`, added in cascade samoht/cascade#190, so this needs that merged first.

Stacked on #130.