### PR TITLE
transforms: keep the unit on a zero translate

### DIFF
--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -413,11 +413,18 @@ module Handler = struct
     let spacing_decl, spacing_ref =
       Var.binding Theme.spacing_var (Css.Rem 0.25)
     in
+    (* [calc(var(--spacing) * 0)] is zero whatever the spacing is, and Tailwind
+       writes that zero with a unit. The target is a [--tw-*] custom property,
+       an opaque token stream where [0] and [0px] are not the same token, so the
+       unit has to be written here rather than left to length-level zero
+       folding. *)
     let spacing_value : Css.length =
-      Css.Calc
-        (Css.Calc.mul
-           (Css.Calc.length (Css.Var spacing_ref))
-           (Css.Calc.float (float_of_int n)))
+      if n = 0 then Css.Px 0.
+      else
+        Css.Calc
+          (Css.Calc.mul
+             (Css.Calc.length (Css.Var spacing_ref))
+             (Css.Calc.float (float_of_int n)))
     in
     let axis_decl, _ = Var.binding axis_var spacing_value in
     style ~property_rules:translate_props

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -104,8 +104,19 @@ let test_typed () =
   Test_helpers.check_typed_class "origin-top-right" Tw.origin_top_right;
   Test_helpers.check_typed_class "origin-bottom-left" Tw.origin_bottom_left
 
+(* [--tw-translate-*] is a custom property, an opaque token stream where [0] and
+   [0px] are different tokens, so the zero has to keep its unit. Leaving it to
+   the length-level zero fold emits a bare [0] and diverges from Tailwind. *)
+let test_translate_zero_keeps_unit () =
+  let css = Tw.to_css ~base:false [ Tw.translate_x 0 ] |> Tw.Css.to_string in
+  Alcotest.(check bool)
+    "translate-x-0 writes 0px" true
+    (Astring.String.is_infix ~affix:"--tw-translate-x: 0px" css)
+
 let tests =
   [
+    test_case "translate zero keeps its unit" `Quick
+      test_translate_zero_keeps_unit;
     test_case "translate+rotate" `Quick test_translate_rotate;
     test_case "translate-px and negative arbitrary" `Quick
       test_translate_px_and_neg_arbitrary;


### PR DESCRIPTION
Re-lands #133, which merged into its stacked base rather than `main`, so the commit is orphaned and `main` never got it.

`calc(var(--spacing) * 0)` is zero whatever the spacing is, and Tailwind writes it `0px`. The length-level zero fold strips the unit, which is right for a length but not for a `--tw-*` custom property, where `0` and `0px` are different tokens. This is what `examples/animations` fails on.