### PR TITLE
rule: expand a bare property in supports-[...] to a feature test

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -814,9 +814,15 @@ let normalize_supports_condition condition_str =
   else if String.contains cond ':' then
     (* Property: value → wrap in parens *)
     "(" ^ cond ^ ")"
-  else
+  else if String.contains cond '(' then
     (* Function call like font-format(opentype) or var(--test) *)
     cond
+  else
+    (* Bare property name: backdrop-filter -> (backdrop-filter: var(--tw)), the
+       same expansion as the bare custom property above. A lone identifier is
+       not a condition the CSS grammar has a production for, so leaving it
+       raised a parse error out of the scanner. *)
+    "(" ^ cond ^ ": var(--tw))"
 
 (** Handle [@supports] modifier: builds modified class name, updates selector,
     normalizes condition, and emits a supports query rule. *)


### PR DESCRIPTION
`supports-[backdrop-filter]:…` aborted the run with `Cascade.Error.Parse_error`: the bracket holds a property name, not a condition, and a lone identifier has no CSS grammar production. Found scanning tailwindcss.com.

Bare custom properties and the `supports-<property>` shorthand already expanded to `(x: var(--tw))`; a bare property name now does too, so the condition parses and the bracket class name still round-trips.

Stacked on #134.