### PR TITLE
bin: scan .md/.mdx/.ts/.js for classes

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -311,8 +311,25 @@ let collect_files paths =
     (fun path ->
       if Sys.file_exists path then
         if Sys.is_directory path then
+          (* Classes live outside component sources too: a docs site keeps most
+             of its markup in .md/.mdx, and plain .ts/.js hold class strings
+             just as .tsx does. Skipping them emits a fraction of the utilities
+             the project uses, with nothing to say so. *)
           files path
-            [ ".html"; ".eml"; ".ml"; ".re"; ".jsx"; ".tsx"; ".vue"; ".svelte" ]
+            [
+              ".html";
+              ".eml";
+              ".ml";
+              ".re";
+              ".js";
+              ".jsx";
+              ".ts";
+              ".tsx";
+              ".vue";
+              ".svelte";
+              ".md";
+              ".mdx";
+            ]
         else [ path ]
       else [])
     paths

--- a/test/cli/scan-content.t
+++ b/test/cli/scan-content.t
@@ -1,0 +1,25 @@
+Classes are scanned from content files, not only component sources: a docs
+site keeps most of its markup in .md/.mdx, and .ts/.js hold class strings
+just as .tsx does.
+
+  $ mkdir -p site
+  $ cat > site/page.mdx <<EOF
+  > # Title
+  > <div className="mdx-only:flex p-7" />
+  > EOF
+  $ cat > site/helper.ts <<EOF
+  > export const cls = "m-9";
+  > EOF
+  $ cat > site/app.tsx <<EOF
+  > export const A = () => <div className="p-3" />;
+  > EOF
+
+  $ tw --minify site | grep -c '\.p-7{'
+  1
+  $ tw --minify site | grep -c '\.m-9{'
+  1
+
+The formats that already worked keep working:
+
+  $ tw --minify site | grep -c '\.p-3{'
+  1


### PR DESCRIPTION
Only component sources were scanned, so a docs site keeping its markup in `.mdx` had most of its classes ignored, silently. On tailwindcss.com (262 `.mdx` files) output goes from 220 KB to 494 KB against Tailwind's 668 KB.

Stacked on #136, which the crash fix in #135 unblocked.