### PR TITLE
bin: skip a candidate that fails to render

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -730,7 +730,17 @@ let parse_known_candidates ?(theme = Tw.Scheme.default) ?input_css candidates =
       if (not typography) && is_prose_class cls then None
       else
         match Tw.of_string ~theme cls with
-        | Ok style -> Some (cls, style)
+        | Ok style -> (
+            (* A handler may accept a class at parse yet raise when it renders
+               an arbitrary value it cannot serialise, as the docs'
+               [prop-[<value>]] placeholders do. Such a class produces no rule,
+               so drop it rather than let it abort the whole sheet. *)
+            match Tw.to_css ~theme [ style ] with
+            | (_ : Css.t) -> Some (cls, style)
+            | exception
+                (Invalid_argument _ | Failure _ | Cascade.Error.Parse_error _)
+              ->
+                None)
         | Error _ -> None)
     candidates
 

--- a/test/cli/placeholder.t
+++ b/test/cli/placeholder.t
@@ -1,0 +1,26 @@
+A class can parse yet fail to render, as the docs' [prop-[<value>]]
+placeholders do: [animate-[<value>]] and [backdrop-blur-[<value>]] are
+accepted by their handlers but raise when they render an arbitrary value
+they cannot serialise. Such a class produces no rule, so it is dropped
+rather than aborting the whole sheet.
+
+  $ cat > docs.mdx <<'EOF'
+  > A table of utilities:
+  >   ["animate-[<value>]", "animation: <value>;"],
+  >   ["backdrop-blur-[<value>]", "backdrop-filter: blur(<value>);"],
+  > And a real class: <div class="p-4"></div>
+  > EOF
+
+The placeholder classes do not crash generation, and the real class
+still lands in the output:
+
+  $ tw --minify --no-base docs.mdx | grep -c '\.p-4{padding:'
+  1
+
+An arbitrary value that is valid still renders:
+
+  $ cat > ok.html <<'EOF'
+  > <div class="animate-[wiggle_1s_ease-in-out_infinite]"></div>
+  > EOF
+  $ tw --minify --no-base ok.html | grep -c 'animation:wiggle'
+  1


### PR DESCRIPTION
A class can parse yet raise when a handler renders an arbitrary value it cannot serialise, as the docs `prop-[<value>]` placeholders do. One such token aborted the whole sheet. A candidate that does not render is now dropped, the way Tailwind discards the junk its own scanner surfaces.

Stacked on #143.