### PR TITLE
source_scan: a bracket before whitespace is not a candidate

### DIFF
--- a/lib/tools/source_scan.ml
+++ b/lib/tools/source_scan.ml
@@ -47,10 +47,14 @@ let is_candidate_start d i =
   | c when is_ascii_digit c -> true
   | 0x2d | 0x21 | 0x40 | 0x2a -> true
   | 0x5b ->
+      (* [ opens an arbitrary value ([color:red]) or property, whose first
+         character is neither a quote nor whitespace. [ followed by whitespace
+         is a plain array bracket ([rows={[ ...]), not a candidate: consuming it
+         as one would swallow every class named inside the array. *)
       i + 1 < Array.length d.chars
       &&
       let next = char_at d (i + 1) in
-      next <> 0x22 && next <> 0x27 && next <> 0x60
+      next <> 0x22 && next <> 0x27 && next <> 0x60 && not (is_whitespace next)
   | _ -> false
 
 let is_candidate_char = function

--- a/test/test_source_scan.ml
+++ b/test/test_source_scan.ml
@@ -41,6 +41,21 @@ let test_tw_str_html_space () =
     [ "flex"; "items-center"; "p-4" ]
     (Tw.str "flex\titems-center\np-4" |> List.map Tw.pp)
 
+(* A [ that opens an arbitrary value is followed immediately by its content, as
+   in [text-[13px]]. A [ followed by whitespace is a plain array bracket, like
+   the JS [rows={[ ... ]] in a docs table: consuming it as one candidate would
+   swallow every class named inside the array. *)
+let test_scan_bracket_before_whitespace () =
+  let source =
+    {|<ApiTable rows={[
+    ["accent-inherit", "accent-color: inherit;"],
+    ["accent-current", "accent-color: currentColor;"],
+  ]} />|}
+  in
+  check_strings "classes inside the array survive"
+    [ "accent-current"; "accent-inherit" ]
+    (known_classes source)
+
 let tests =
   [
     test_case "split whitespace" `Quick test_split_whitespace;
@@ -48,6 +63,8 @@ let tests =
     test_case "scan JS static classes" `Quick test_scan_js_static_classes;
     test_case "scan UTF-8 source" `Quick test_scan_utf8_source;
     test_case "Tw.str splits HTML whitespace" `Quick test_tw_str_html_space;
+    test_case "bracket before whitespace is not a candidate" `Quick
+      test_scan_bracket_before_whitespace;
   ]
 
 let suite = ("source_scan", tests)


### PR DESCRIPTION
A `[` that opens an arbitrary value is followed by its content, as in `text-[13px]`. A `[` followed by whitespace is a plain array bracket, like the JS `rows={[` in a docs table; the scanner consumed the whole multi-line array as one candidate and swallowed every class named inside it, so a docs page emitted almost none of the utilities it demonstrates.

On tailwindcss.com this recovers 351 utility rules. Stacked on the render guard, which keeps the newly surfaced `prop-[<value>]` doc placeholders from crashing generation.