### PR TITLE
flex_props: accept the digit-led container scale for basis

### DIFF
--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -246,6 +246,14 @@ module Handler = struct
         | _ -> None)
     | _ -> None
 
+  (* The container scale, whose digit-led names ([2xl], [3xs])
+     [is_named_spacing] rejects. *)
+  let is_container_size = function
+    | "3xs" | "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl"
+    | "5xl" | "6xl" | "7xl" ->
+        true
+    | _ -> false
+
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
@@ -295,7 +303,11 @@ module Handler = struct
             match parse_fraction value with
             | Some (n, m) -> Ok (Basis_fraction (n, m))
             | None ->
-                if Spacing.is_named_spacing value then Ok (Basis_named value)
+                (* A container-scale name may lead with a digit ([2xl], [3xs]),
+                   which [is_named_spacing] rejects; [basis] emits
+                   [var(--container-<name>)] for the whole scale. *)
+                if Spacing.is_named_spacing value || is_container_size value
+                then Ok (Basis_named value)
                 else err_not_utility))
     | [ "order"; "first" ] -> Ok Order_first
     | [ "order"; "last" ] -> Ok Order_last

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -32,6 +32,13 @@ let of_string_valid () =
   check "basis-7";
   check "basis-auto";
   check "basis-full";
+  (* container scale, including the digit-led names is_named_spacing rejects *)
+  check "basis-xs";
+  check "basis-xl";
+  check "basis-2xs";
+  check "basis-3xs";
+  check "basis-2xl";
+  check "basis-7xl";
 
   (* Order *)
   check "order-0";
@@ -55,6 +62,8 @@ let of_string_invalid () =
 
   fail_maybe [ "flex"; "invalid" ];
   fail_maybe [ "basis" ];
+  (* not a container-scale name *)
+  fail_maybe [ "basis"; "4xs" ];
   (* Missing value *)
   fail_maybe [ "order" ];
   fail_maybe []


### PR DESCRIPTION
On tailwindcss.com, `basis-2xl` through `basis-7xl` and `basis-2xs`/`basis-3xs` were missing: the basis parser gated names on `is_named_spacing`, which requires a leading letter, so the digit-led container sizes were rejected even though the renderer already emits `var(--container-<name>)` for the whole scale.

Stacked on the scanner fix.