### PR TITLE
adopt Tailwind v4.3.3: regenerate upstream fixtures and close the exposed gaps

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1756,20 +1756,65 @@ module Handler = struct
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'
 
+  (* Tailwind's [--alpha(<color>/<pct>)] inside an arbitrary value is
+     [color-mix(in oklab, <color> <pct>, transparent)]. *)
+
   (** Parse a bracket inner string into a typed [Css.color], if it represents a
       valid color. Handles hex strings (with [#] prefix), CSS color functions
       like [rgb(...)], [hsl(...)], etc., and named Tailwind colors (which are
       converted to their CSS representation via [to_css]). Returns [None] for
       non-color values. *)
-  let parse_bracket_color (inner : string) : Css.color option =
-    if String.length inner > 0 && inner.[0] = '#' then Some (Css.hex inner)
-    else
-      let normalized = String.map (fun c -> if c = '_' then ' ' else c) inner in
-      if Parse.is_css_color_fn normalized then Css.parse_color normalized
-      else
-        match color_of_string inner with
-        | Ok c -> Some (to_css c 500)
-        | Error _ -> None
+  let parse_alpha_call inner =
+    let prefix = "--alpha(" in
+    let pl = String.length prefix and n = String.length inner in
+    if n > pl && String.sub inner 0 pl = prefix && inner.[n - 1] = ')' then
+      let body = String.sub inner pl (n - pl - 1) in
+      match String.rindex_opt body '/' with
+      | Some i ->
+          Some
+            ( String.sub body 0 i,
+              String.sub body (i + 1) (String.length body - i - 1) )
+      | None -> None
+    else None
+
+  let rec parse_bracket_color (inner : string) : Css.color option =
+    match parse_alpha_call inner with
+    | Some (color_str, pct_str) -> (
+        let pct =
+          let t = String.trim pct_str in
+          let t =
+            if String.length t > 0 && t.[String.length t - 1] = '%' then
+              String.sub t 0 (String.length t - 1)
+            else t
+          in
+          float_of_string_opt t
+        in
+        (* the inner colour is a raw CSS colour ([red] is the keyword, not the
+           red-500 palette entry); fall back to the palette only if CSS does not
+           know it. *)
+        let color =
+          let normalized =
+            String.map (fun c -> if c = '_' then ' ' else c) color_str
+          in
+          match Css.parse_color normalized with
+          | Some c -> Some c
+          | None -> parse_bracket_color color_str
+        in
+        match (pct, color) with
+        | Some pct, Some c ->
+            Some (Css.color_mix ~in_space:Oklab ~percent1:pct c Css.Transparent)
+        | _ -> None)
+    | None -> (
+        if String.length inner > 0 && inner.[0] = '#' then Some (Css.hex inner)
+        else
+          let normalized =
+            String.map (fun c -> if c = '_' then ' ' else c) inner
+          in
+          if Parse.is_css_color_fn normalized then Css.parse_color normalized
+          else
+            match color_of_string inner with
+            | Ok c -> Some (to_css c 500)
+            | Error _ -> None)
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -768,7 +768,10 @@ module Handler = struct
   let drop_shadow_opacity ?theme opacity =
     let alpha_str =
       match opacity with
-      | Color.Opacity_percent p -> string_of_int (int_of_float p) ^ "%"
+      | Color.Opacity_percent p ->
+          (* keep a fractional alpha (/12.5 -> 12.5%), do not truncate to 12% *)
+          if Float.is_integer p then string_of_int (int_of_float p) ^ "%"
+          else Css.Pp.string_of_float p ^ "%"
       | _ -> "100%"
     in
     let percent =

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -102,6 +102,10 @@ module Handler = struct
 
   (* Format the position value as CSS *)
   let format_position_value ?theme = function
+    | Spacing 0. ->
+        (* A mask stop is a <length-percentage>; the zero spacing step keeps its
+           unit ([0px]) here, where a bare [0] would be the folded length. *)
+        "0px"
     | Spacing n ->
         let _, len = Theme.spacing_calc_float ?theme n in
         Css.Pp.to_string ~minify:false Css.pp_length len

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -26,7 +26,7 @@ module Handler = struct
     | W_dvw (* 100dvw - dynamic viewport width *)
     | W_lvw (* 100lvw - large viewport width *)
     | W_svw (* 100svw - small viewport width *)
-    | W_xl (* width: var(--width-xl) *)
+    | W_container of string (* width: var(--container-<name>) *)
     (* Height utilities *)
     | H_auto
     | H_full
@@ -288,7 +288,6 @@ module Handler = struct
     | `Rem n -> spacing_utility ?theme max_width n
 
   (* Named width theme variable *)
-  let width_xl = Var.theme Css.Length "width-xl" ~order:(5, 20)
 
   (* Container size theme variables - ordered from smallest to largest *)
   let container_3xs = Var.theme Css.Length "container-3xs" ~order:(5, 0)
@@ -304,6 +303,40 @@ module Handler = struct
   let container_5xl = Var.theme Css.Length "container-5xl" ~order:(5, 10)
   let container_6xl = Var.theme Css.Length "container-6xl" ~order:(5, 11)
   let container_7xl = Var.theme Css.Length "container-7xl" ~order:(5, 12)
+
+  (* The container scale doubles as the named width scale in v4. Map a name to
+     its theme var and default, and to its position in the scale. *)
+  let container_binding = function
+    | "3xs" -> Some (container_3xs, (Rem 16.0 : length))
+    | "2xs" -> Some (container_2xs, Rem 18.0)
+    | "xs" -> Some (container_xs, Rem 20.0)
+    | "sm" -> Some (container_sm, Rem 24.0)
+    | "md" -> Some (container_md, Rem 28.0)
+    | "lg" -> Some (container_lg, Rem 32.0)
+    | "xl" -> Some (container_xl, Rem 36.0)
+    | "2xl" -> Some (container_2xl, Rem 42.0)
+    | "3xl" -> Some (container_3xl, Rem 48.0)
+    | "4xl" -> Some (container_4xl, Rem 56.0)
+    | "5xl" -> Some (container_5xl, Rem 64.0)
+    | "6xl" -> Some (container_6xl, Rem 72.0)
+    | "7xl" -> Some (container_7xl, Rem 80.0)
+    | _ -> None
+
+  let container_order = function
+    | "3xs" -> 0
+    | "2xs" -> 1
+    | "xs" -> 2
+    | "sm" -> 3
+    | "md" -> 4
+    | "lg" -> 5
+    | "xl" -> 6
+    | "2xl" -> 7
+    | "3xl" -> 8
+    | "4xl" -> 9
+    | "5xl" -> 10
+    | "6xl" -> 11
+    | "7xl" -> 12
+    | _ -> 99
 
   (* Breakpoint theme vars, referenced by the (v3) max-w-screen-* utilities.
      Negative suborders keep them before --container-* in the theme layer, as
@@ -479,9 +512,22 @@ module Handler = struct
     | W_dvw -> style [ width (Dvw 100.) ]
     | W_lvw -> style [ width (Lvw 100.) ]
     | W_svw -> style [ width (Svw 100.) ]
-    | W_xl ->
-        let decl, ref_ = Var.binding width_xl (Rem 36.0) in
-        style [ decl; width (Var ref_) ]
+    | W_container name -> (
+        (* v4 resolves w-<name> to --width-<name> when the theme defines it, and
+           otherwise to the --container-<name> scale (the default). *)
+        match Scheme.theme_value (Some theme) ("width-" ^ name) with
+        | Some v ->
+            let decl =
+              Css.custom_property ~layer:"theme" ("--width-" ^ name) v
+            in
+            style [ decl; width (Var (Var.theme_ref ("width-" ^ name))) ]
+        | None -> (
+            match container_binding name with
+            | Some (v, d) ->
+                let decl, ref_ = Var.binding v d in
+                style [ decl; width (Var ref_) ]
+            | None ->
+                style [ width (Var (Var.theme_ref ("container-" ^ name))) ]))
     (* Height utilities *)
     | H_auto -> h_auto'
     | H_px -> h_px'
@@ -713,7 +759,7 @@ module Handler = struct
     | "dvw" -> Ok W_dvw
     | "lvw" -> Ok W_lvw
     | "svw" -> Ok W_svw
-    | "xl" -> Ok W_xl
+    | name when container_binding name <> None -> Ok (W_container name)
     | frac when String.contains frac '/' ->
         if fraction_pct frac <> None then Ok (W_fraction frac)
         else err_invalid_value "width fraction" frac
@@ -1138,7 +1184,7 @@ module Handler = struct
     | W_px -> w + keyword_off + 7
     | W_screen -> w + keyword_off + 8
     | W_svw -> w + keyword_off + 9
-    | W_xl -> w + keyword_off + 10
+    | W_container name -> w + keyword_off + 10 + container_order name
     (* Max-width *)
     (* Tailwind orders max-width in three bands: the container scale sizes
        (2xl..7xl) by number, then the numeric spacing values, then an arbitrary
@@ -1281,7 +1327,7 @@ module Handler = struct
     | W_dvw -> "w-dvw"
     | W_lvw -> "w-lvw"
     | W_svw -> "w-svw"
-    | W_xl -> "w-xl"
+    | W_container name -> "w-" ^ name
     (* Height utilities *)
     | H_auto -> "h-auto"
     | H_full -> "h-full"

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -429,6 +429,9 @@ module Typography_early = struct
     in
     find 0 0
 
+  (* Tailwind's [--spacing(N)] inside an arbitrary value reads the spacing
+     scale: [text-[--spacing(2)]] is [font-size: calc(var(--spacing) * 2)]. *)
+
   (** Does [inner] look like something we can emit as a font-size? Accepts typed
       prefix (length/percentage/absolute-size/relative-size), font-size keyword
       (medium, xxx-large, larger, ...), length with unit (16px, 1rem, 1.5em,
@@ -436,6 +439,13 @@ module Typography_early = struct
       recognised keywords -- e.g. a bare "1A202C" is not a valid font-size: a
       length must carry a unit and a hex color must start with "#" (CSS Color
       §5.4.6). *)
+  let parse_spacing_call s =
+    let prefix = "--spacing(" in
+    let pl = String.length prefix and n = String.length s in
+    if n > pl && String.sub s 0 pl = prefix && s.[n - 1] = ')' then
+      float_of_string_opt (String.sub s pl (n - pl - 1))
+    else Stdlib.Option.None
+
   let is_valid_bracket_font_size (inner : string) : bool =
     match split_type_prefix inner with
     | Some (prefix, _)
@@ -453,7 +463,8 @@ module Typography_early = struct
                 len > 6
                 && String.sub inner 0 6 = "clamp("
                 && inner.[len - 1] = ')'
-                || Parse.is_var inner))
+                || Parse.is_var inner
+                || parse_spacing_call inner <> Stdlib.Option.None))
 
   (** Check if bracket content looks like a color (should go to color handler).
   *)
@@ -1063,31 +1074,36 @@ module Typography_early = struct
       Caller must have already passed [inner] through
       [is_valid_bracket_font_size]. *)
   let bracket_font_size_decls inner =
-    match split_type_prefix inner with
-    | Stdlib.Option.Some (prefix, value)
-      when prefix = "absolute-size" || prefix = "relative-size"
-           || prefix = "length" || prefix = "percentage" ->
-        if Parse.is_var value then
-          let bare = Parse.extract_var_name value in
-          [ font_size (Css.Var (Var.bracket bare)) ]
-        else [ font_size (Css.Var (Var.bracket value)) ]
-    | _ -> (
-        match font_size_keyword inner with
-        | Stdlib.Option.Some kw -> [ Css.font_size_kw kw ]
-        | Stdlib.Option.None -> (
-            match try_parse_length_value inner with
-            | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
+    match parse_spacing_call inner with
+    | Stdlib.Option.Some n ->
+        let decl, len = Theme.spacing_calc_float n in
+        [ decl; font_size len ]
+    | Stdlib.Option.None -> (
+        match split_type_prefix inner with
+        | Stdlib.Option.Some (prefix, value)
+          when prefix = "absolute-size" || prefix = "relative-size"
+               || prefix = "length" || prefix = "percentage" ->
+            if Parse.is_var value then
+              let bare = Parse.extract_var_name value in
+              [ font_size (Css.Var (Var.bracket bare)) ]
+            else [ font_size (Css.Var (Var.bracket value)) ]
+        | _ -> (
+            match font_size_keyword inner with
+            | Stdlib.Option.Some kw -> [ Css.font_size_kw kw ]
             | Stdlib.Option.None -> (
-                match Css.parse_length inner with
+                match try_parse_length_value inner with
                 | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
-                | Stdlib.Option.None ->
-                    if Parse.is_var inner then
-                      let bare = Parse.extract_var_name inner in
-                      [ font_size (Css.Var (Var.bracket bare)) ]
-                    else
-                      invalid_arg
-                        ("bracket_font_size_decls: not a valid font-size \
-                          value: " ^ inner))))
+                | Stdlib.Option.None -> (
+                    match Css.parse_length inner with
+                    | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
+                    | Stdlib.Option.None ->
+                        if Parse.is_var inner then
+                          let bare = Parse.extract_var_name inner in
+                          [ font_size (Css.Var (Var.bracket bare)) ]
+                        else
+                          invalid_arg
+                            ("bracket_font_size_decls: not a valid font-size \
+                              value: " ^ inner)))))
 
   (** Generate font-size-only style for bracket value. *)
   let bracket_font_size_style raw = style (bracket_font_size_decls raw)

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -42,6 +42,18 @@ let test_drop_shadow_color () =
     "drop-shadow-red-500/50 uses color-mix" true
     (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"))
 
+(* A fractional opacity modifier keeps its fraction: drop-shadow/12.5 -> alpha
+   12.5%, not the truncated 12%. *)
+let test_drop_shadow_fractional_alpha () =
+  let css =
+    match Tw.of_string "drop-shadow/12.5" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "drop-shadow/12.5: %s" m
+  in
+  Alcotest.(check bool)
+    "alpha is 12.5%, not 12%" true
+    (Astring.String.is_infix ~affix:"--tw-drop-shadow-alpha:12.5%" css)
+
 let test_backdrop () =
   check "backdrop-opacity-50";
   check "backdrop-invert"
@@ -72,6 +84,8 @@ let tests =
     test_case "blur" `Quick test_blur;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;
     test_case "drop-shadow color (default theme)" `Quick test_drop_shadow_color;
+    test_case "drop-shadow fractional alpha" `Quick
+      test_drop_shadow_fractional_alpha;
     test_case "backdrop" `Quick test_backdrop;
     test_case "backdrop-blur token" `Quick test_backdrop_blur_token;
     test_case "filters suborder matches Tailwind" `Quick

--- a/test/test_mask_gradient.ml
+++ b/test/test_mask_gradient.ml
@@ -23,7 +23,23 @@ let test_roundtrip () =
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Mask_gradient.Handler) "mask-foo"
 
+(* A mask stop is a <length-percentage>: the zero spacing step keeps its unit
+   (0px), not a bare 0, which is what Tailwind emits. *)
+let test_from_zero_keeps_unit () =
+  let css =
+    match Tw.of_string "mask-t-from-0" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "mask-t-from-0: %s" m
+  in
+  Alcotest.(check bool)
+    "from-position is 0px, not bare 0" true
+    (Astring.String.is_infix ~affix:"--tw-mask-top-from-position:0px" css)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "from-0 keeps its px unit" `Quick
+        test_from_zero_keeps_unit;
+    ]
 
 let suite = ("mask_gradient", tests)

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -25,7 +25,16 @@ let test_widths () =
   check "w-10";
   check "w-32";
   check "w-64";
-  check "w-96"
+  check "w-96";
+  (* container scale: named width sizes read the container theme var, including
+     the digit-led names, and the whole scale beyond xl *)
+  check "w-xs";
+  check "w-sm";
+  check "w-xl";
+  check "w-2xs";
+  check "w-3xs";
+  check "w-2xl";
+  check "w-7xl"
 
 let test_heights () =
   check "h-0";

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -354,6 +354,25 @@ let test_text_line_height_override () =
     "text-sm honors --text-sm--line-height override" true
     (Astring.String.is_infix ~affix:"--text-sm--line-height:1.25rem" css)
 
+(* Tailwind's [--spacing(N)] and [--alpha(<color>/<pct>)] are usable inside an
+   arbitrary value. Verified against the real v4.3.3 CLI, which emits
+   [calc(var(--spacing) * 2)] and [color-mix(in oklab, red 20%,
+   transparent)]. *)
+let test_text_bracket_functions () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "text-[--spacing(2)] is a spacing calc" true
+    (Astring.String.is_infix ~affix:"calc(var(--spacing)*2)"
+       (css "text-[--spacing(2)]"));
+  Alcotest.(check bool)
+    "text-[--alpha(red/20%)] is a color-mix" true
+    (Astring.String.is_infix ~affix:"color-mix(in oklab,red 20%,transparent)"
+       (css "text-[--alpha(red/20%)]"))
+
 let tests =
   [
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
@@ -384,6 +403,8 @@ let tests =
       test_text_bracket_size_valid;
     test_case "text-[<font-size>] invalid values" `Quick
       test_text_bracket_size_invalid;
+    test_case "text-[--spacing()/--alpha()] functions" `Quick
+      test_text_bracket_functions;
     test_case "typography of_string - invalid values" `Quick of_string_invalid;
     test_case "typography suborder matches Tailwind" `Quick
       suborder_matches_tailwind;

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -8,18 +8,15 @@
 
     {2 Generating the fixtures}
 
-    The parity target is Tailwind CSS {b v4.3.1} (the version pinned in
-    [package.json] and enforced by [Tailwind_gen.required_version]). The
-    committed [utilities.txt] and [variants.txt] were generated from the v4.3.1
-    line of the upstream test suite -- specifically commit [5e9f66e4]
-    ([v4.3.1-7]); a few cases (e.g. auto-cols) differ between the bare [v4.3.1]
-    tag and that commit, so regenerate from the same ref to avoid spurious
-    diffs. To regenerate:
+    The parity target is Tailwind CSS {b v4.3.3} (the version enforced by
+    [Tailwind_gen.required_version]). The committed [utilities.txt] and
+    [variants.txt] were generated from the [v4.3.3] tag of the upstream test
+    suite. To regenerate:
 
     {v
-    # Clone tailwindcss (or use an existing clone) at the v4.3.1 line
+    # Clone tailwindcss (or use an existing clone) at the v4.3.3 tag
     git clone https://github.com/tailwindlabs/tailwindcss.git /tmp/tailwindcss
-    cd /tmp/tailwindcss && git checkout v4.3.1
+    cd /tmp/tailwindcss && git checkout v4.3.3
 
     # Extract both fixtures
     dune exec test/upstream/extract_tests.exe -- \

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -454,7 +454,14 @@ let canonical_stylesheet_css css = String.trim css
    regression of a unit or two -- defeating the comparison -- so prefer an
    explicit allowlist that only the known stale fixtures match. *)
 let known_stale_colors =
-  [ ("#0288cc40", "#0088cc40"); ("#0288cc80", "#0088cc80") ]
+  [
+    ("#0288cc40", "#0088cc40");
+    ("#0288cc80", "#0088cc80");
+    (* --alpha(red/20%): the fixture stores oklab at 3 decimals (oklab(62.7955%
+       .224 .125/.2)), which round-trips to #ff0404 rather than the exact
+       #ff0000; tw and LightningCSS both produce the exact colour. *)
+    ("#ff040433", "#f003");
+  ]
 
 let colors_close expected actual =
   let e = String.trim expected and a = String.trim actual in
@@ -914,6 +921,9 @@ let test_color_tolerance () =
   Alcotest.(check bool)
     "stale fixture pair tolerated" true
     (colors_close "#0288cc80" "#0088cc80");
+  Alcotest.(check bool)
+    "3-decimal oklab red skew tolerated" true
+    (colors_close "#ff040433" "#f003");
   Alcotest.(check bool)
     "one-unit red skew rejected" false
     (colors_close "#0188cc80" "#0088cc80");

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -8329,18 +8329,18 @@ scrollbar-auto scrollbar-none scrollbar-thin
 scrollbar-gutter-auto scrollbar-gutter-both scrollbar-gutter-stable
 ---
 
-    .scrollbar-gutter-auto {
-      scrollbar-gutter: auto;
-    }
+      .scrollbar-gutter-auto {
+        scrollbar-gutter: auto;
+      }
 
-    .scrollbar-gutter-both {
-      scrollbar-gutter: stable both-edges;
-    }
+      .scrollbar-gutter-both {
+        scrollbar-gutter: stable both-edges;
+      }
 
-    .scrollbar-gutter-stable {
-      scrollbar-gutter: stable;
-    }
-    
+      .scrollbar-gutter-stable {
+        scrollbar-gutter: stable;
+      }
+      
 <<<>>>
 # scrollbar-gutter
 @config run
@@ -11739,7 +11739,7 @@ mask-t-from-(--my-var) mask-t-from-(color:--my-var) mask-t-from-(length:--my-var
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-top: linear-gradient(to top, var(--tw-mask-top-from-color) var(--tw-mask-top-from-position), var(--tw-mask-top-to-color) var(--tw-mask-top-to-position));
-      --tw-mask-top-from-position: 0;
+      --tw-mask-top-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -11948,7 +11948,7 @@ mask-t-to-(--my-var) mask-t-to-(color:--my-var) mask-t-to-(length:--my-var) mask
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-top: linear-gradient(to top, var(--tw-mask-top-from-color) var(--tw-mask-top-from-position), var(--tw-mask-top-to-color) var(--tw-mask-top-to-position));
-      --tw-mask-top-to-position: 0;
+      --tw-mask-top-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -12157,7 +12157,7 @@ mask-r-from-(--my-var) mask-r-from-(color:--my-var) mask-r-from-(length:--my-var
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-right: linear-gradient(to right, var(--tw-mask-right-from-color) var(--tw-mask-right-from-position), var(--tw-mask-right-to-color) var(--tw-mask-right-to-position));
-      --tw-mask-right-from-position: 0;
+      --tw-mask-right-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -12366,7 +12366,7 @@ mask-r-to-(--my-var) mask-r-to-(color:--my-var) mask-r-to-(length:--my-var) mask
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-right: linear-gradient(to right, var(--tw-mask-right-from-color) var(--tw-mask-right-from-position), var(--tw-mask-right-to-color) var(--tw-mask-right-to-position));
-      --tw-mask-right-to-position: 0;
+      --tw-mask-right-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -12575,7 +12575,7 @@ mask-b-from-(--my-var) mask-b-from-(color:--my-var) mask-b-from-(length:--my-var
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-bottom: linear-gradient(to bottom, var(--tw-mask-bottom-from-color) var(--tw-mask-bottom-from-position), var(--tw-mask-bottom-to-color) var(--tw-mask-bottom-to-position));
-      --tw-mask-bottom-from-position: 0;
+      --tw-mask-bottom-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -12784,7 +12784,7 @@ mask-b-to-(--my-var) mask-b-to-(color:--my-var) mask-b-to-(length:--my-var) mask
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-bottom: linear-gradient(to bottom, var(--tw-mask-bottom-from-color) var(--tw-mask-bottom-from-position), var(--tw-mask-bottom-to-color) var(--tw-mask-bottom-to-position));
-      --tw-mask-bottom-to-position: 0;
+      --tw-mask-bottom-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -12993,7 +12993,7 @@ mask-l-from-(--my-var) mask-l-from-(color:--my-var) mask-l-from-(length:--my-var
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-left: linear-gradient(to left, var(--tw-mask-left-from-color) var(--tw-mask-left-from-position), var(--tw-mask-left-to-color) var(--tw-mask-left-to-position));
-      --tw-mask-left-from-position: 0;
+      --tw-mask-left-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -13202,7 +13202,7 @@ mask-l-to-(--my-var) mask-l-to-(color:--my-var) mask-l-to-(length:--my-var) mask
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-left: linear-gradient(to left, var(--tw-mask-left-from-color) var(--tw-mask-left-from-position), var(--tw-mask-left-to-color) var(--tw-mask-left-to-position));
-      --tw-mask-left-to-position: 0;
+      --tw-mask-left-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -13419,9 +13419,9 @@ mask-x-from-(--my-var) mask-x-from-(color:--my-var) mask-x-from-(length:--my-var
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-right: linear-gradient(to right, var(--tw-mask-right-from-color) var(--tw-mask-right-from-position), var(--tw-mask-right-to-color) var(--tw-mask-right-to-position));
-      --tw-mask-right-from-position: 0;
+      --tw-mask-right-from-position: 0px;
       --tw-mask-left: linear-gradient(to left, var(--tw-mask-left-from-color) var(--tw-mask-left-from-position), var(--tw-mask-left-to-color) var(--tw-mask-left-to-position));
-      --tw-mask-left-from-position: 0;
+      --tw-mask-left-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -13674,9 +13674,9 @@ mask-x-to-(--my-var) mask-x-to-(color:--my-var) mask-x-to-(length:--my-var) mask
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-right: linear-gradient(to right, var(--tw-mask-right-from-color) var(--tw-mask-right-from-position), var(--tw-mask-right-to-color) var(--tw-mask-right-to-position));
-      --tw-mask-right-to-position: 0;
+      --tw-mask-right-to-position: 0px;
       --tw-mask-left: linear-gradient(to left, var(--tw-mask-left-from-color) var(--tw-mask-left-from-position), var(--tw-mask-left-to-color) var(--tw-mask-left-to-position));
-      --tw-mask-left-to-position: 0;
+      --tw-mask-left-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -13929,9 +13929,9 @@ mask-y-from-(--my-var) mask-y-from-(color:--my-var) mask-y-from-(length:--my-var
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-top: linear-gradient(to top, var(--tw-mask-top-from-color) var(--tw-mask-top-from-position), var(--tw-mask-top-to-color) var(--tw-mask-top-to-position));
-      --tw-mask-top-from-position: 0;
+      --tw-mask-top-from-position: 0px;
       --tw-mask-bottom: linear-gradient(to bottom, var(--tw-mask-bottom-from-color) var(--tw-mask-bottom-from-position), var(--tw-mask-bottom-to-color) var(--tw-mask-bottom-to-position));
-      --tw-mask-bottom-from-position: 0;
+      --tw-mask-bottom-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -14184,9 +14184,9 @@ mask-y-to-(--my-var) mask-y-to-(color:--my-var) mask-y-to-(length:--my-var) mask
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear: var(--tw-mask-left), var(--tw-mask-right), var(--tw-mask-bottom), var(--tw-mask-top);
       --tw-mask-top: linear-gradient(to top, var(--tw-mask-top-from-color) var(--tw-mask-top-from-position), var(--tw-mask-top-to-color) var(--tw-mask-top-to-position));
-      --tw-mask-top-to-position: 0;
+      --tw-mask-top-to-position: 0px;
       --tw-mask-bottom: linear-gradient(to bottom, var(--tw-mask-bottom-from-color) var(--tw-mask-bottom-from-position), var(--tw-mask-bottom-to-color) var(--tw-mask-bottom-to-position));
-      --tw-mask-bottom-to-position: 0;
+      --tw-mask-bottom-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -14569,7 +14569,7 @@ mask-linear-from-(--my-var) mask-linear-from-(color:--my-var) mask-linear-from-(
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear-stops: var(--tw-mask-linear-position), var(--tw-mask-linear-from-color) var(--tw-mask-linear-from-position), var(--tw-mask-linear-to-color) var(--tw-mask-linear-to-position);
       --tw-mask-linear: linear-gradient(var(--tw-mask-linear-stops));
-      --tw-mask-linear-from-position: 0;
+      --tw-mask-linear-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -14757,7 +14757,7 @@ mask-linear-to-(--my-var) mask-linear-to-(color:--my-var) mask-linear-to-(length
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-linear-stops: var(--tw-mask-linear-position), var(--tw-mask-linear-from-color) var(--tw-mask-linear-from-position), var(--tw-mask-linear-to-color) var(--tw-mask-linear-to-position);
       --tw-mask-linear: linear-gradient(var(--tw-mask-linear-stops));
-      --tw-mask-linear-to-position: 0;
+      --tw-mask-linear-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -15120,7 +15120,7 @@ mask-radial-from-(--my-var) mask-radial-from-(color:--my-var) mask-radial-from-(
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-radial-stops: var(--tw-mask-radial-shape) var(--tw-mask-radial-size) at var(--tw-mask-radial-position), var(--tw-mask-radial-from-color) var(--tw-mask-radial-from-position), var(--tw-mask-radial-to-color) var(--tw-mask-radial-to-position);
       --tw-mask-radial: radial-gradient(var(--tw-mask-radial-stops));
-      --tw-mask-radial-from-position: 0;
+      --tw-mask-radial-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -15322,7 +15322,7 @@ mask-radial-to-(--my-var) mask-radial-to-(color:--my-var) mask-radial-to-(length
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-radial-stops: var(--tw-mask-radial-shape) var(--tw-mask-radial-size) at var(--tw-mask-radial-position), var(--tw-mask-radial-from-color) var(--tw-mask-radial-from-position), var(--tw-mask-radial-to-color) var(--tw-mask-radial-to-position);
       --tw-mask-radial: radial-gradient(var(--tw-mask-radial-stops));
-      --tw-mask-radial-to-position: 0;
+      --tw-mask-radial-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -15663,7 +15663,7 @@ mask-conic-from-(--my-var) mask-conic-from-(color:--my-var) mask-conic-from-(len
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-conic-stops: from var(--tw-mask-conic-position), var(--tw-mask-conic-from-color) var(--tw-mask-conic-from-position), var(--tw-mask-conic-to-color) var(--tw-mask-conic-to-position);
       --tw-mask-conic: conic-gradient(var(--tw-mask-conic-stops));
-      --tw-mask-conic-from-position: 0;
+      --tw-mask-conic-from-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -15851,7 +15851,7 @@ mask-conic-to-(--my-var) mask-conic-to-(color:--my-var) mask-conic-to-(length:--
       mask-image: var(--tw-mask-linear), var(--tw-mask-radial), var(--tw-mask-conic);
       --tw-mask-conic-stops: from var(--tw-mask-conic-position), var(--tw-mask-conic-from-color) var(--tw-mask-conic-from-position), var(--tw-mask-conic-to-color) var(--tw-mask-conic-to-position);
       --tw-mask-conic: conic-gradient(var(--tw-mask-conic-stops));
-      --tw-mask-conic-to-position: 0;
+      --tw-mask-conic-to-position: 0px;
       -webkit-mask-composite: source-in;
       -webkit-mask-composite: source-in;
       mask-composite: intersect;
@@ -17944,7 +17944,7 @@ animate-none
 @theme-var drop-shadow-xl 0 9px 7px rgb(0 0 0 / 0.1)
 @theme-var drop-shadow-calc 0 0 calc(1 * var(--spacing)) black
 @theme-var drop-shadow-multi 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1)
--hue-rotate-15 -hue-rotate-[45deg] blur-[4px] blur-none blur-xl brightness-50 brightness-[1.23] contrast-50 contrast-[1.23] drop-shadow drop-shadow-[0_0_red] drop-shadow-calc drop-shadow-inherit drop-shadow-multi drop-shadow-none drop-shadow-red-500 drop-shadow-red-500/50 drop-shadow-xl drop-shadow/25 filter filter-[var(--value)] filter-none grayscale grayscale-0 grayscale-[var(--value)] hue-rotate-15 hue-rotate-[45deg] invert invert-0 invert-[var(--value)] saturate-0 saturate-[1.75] saturate-[var(--value)] sepia sepia-0 sepia-[50%] sepia-[var(--value)]
+-hue-rotate-15 -hue-rotate-[45deg] blur-[4px] blur-none blur-xl brightness-50 brightness-[1.23] contrast-50 contrast-[1.23] drop-shadow drop-shadow-[0_0_red] drop-shadow-calc drop-shadow-inherit drop-shadow-multi drop-shadow-none drop-shadow-red-500 drop-shadow-red-500/50 drop-shadow-xl drop-shadow/12.5 drop-shadow/25 filter filter-[var(--value)] filter-none grayscale grayscale-0 grayscale-[var(--value)] hue-rotate-15 hue-rotate-[45deg] invert invert-0 invert-[var(--value)] saturate-0 saturate-[1.75] saturate-[var(--value)] sepia sepia-0 sepia-[50%] sepia-[var(--value)]
 ---
 
     @layer properties {
@@ -18008,6 +18008,13 @@ animate-none
 
     .contrast-\[1\.23\] {
       --tw-contrast: contrast(1.23);
+      filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
+    }
+
+    .drop-shadow\/12\.5 {
+      --tw-drop-shadow-alpha: 12.5%;
+      --tw-drop-shadow-size: drop-shadow(0 1px 1px var(--tw-drop-shadow-color, oklab(0% 0 0 / .125)));
+      --tw-drop-shadow: drop-shadow(var(--drop-shadow));
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 
@@ -19818,7 +19825,7 @@ underline-offset-auto
 @theme-var text-sm 0.875rem
 @theme-var text-sm--line-height 1.25rem
 @theme-var leading-snug 1.375
-text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-[10px]/none text-[12px] text-[12px]/0 text-[12px]/6 text-[50%] text-[50%]/6 text-[absolute-size:var(--my-size)] text-[clamp(1rem,2rem,3rem)] text-[clamp(1rem,var(--size),3rem)] text-[clamp(1rem,var(--size),3rem)]/9 text-[color:var(--my-color)] text-[color:var(--my-color)]/50 text-[color:var(--my-color)]/[0.5] text-[color:var(--my-color)]/[50%] text-[larger] text-[larger]/6 text-[length:var(--my-size)] text-[percentage:var(--my-size)] text-[relative-size:var(--my-size)] text-[var(--my-color)] text-[var(--my-color)]/50 text-[var(--my-color)]/[0.5] text-[var(--my-color)]/[50%] text-[xx-large] text-[xx-large]/6 text-blue-500 text-current text-current/50 text-current/[0.5] text-current/[50%] text-inherit text-red-500 text-red-500/2.25 text-red-500/2.5 text-red-500/2.75 text-red-500/50 text-red-500/[0.5] text-red-500/[50%] text-sm text-sm/0 text-sm/6 text-sm/[4px] text-sm/none text-sm/snug text-transparent
+text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-[--alpha(red/20%)] text-[--spacing(2)] text-[10px]/none text-[12px] text-[12px]/0 text-[12px]/6 text-[50%] text-[50%]/6 text-[absolute-size:var(--my-size)] text-[clamp(1rem,2rem,3rem)] text-[clamp(1rem,var(--size),3rem)] text-[clamp(1rem,var(--size),3rem)]/9 text-[color:var(--my-color)] text-[color:var(--my-color)]/50 text-[color:var(--my-color)]/[0.5] text-[color:var(--my-color)]/[50%] text-[larger] text-[larger]/6 text-[length:var(--my-size)] text-[percentage:var(--my-size)] text-[relative-size:var(--my-size)] text-[var(--my-color)] text-[var(--my-color)]/50 text-[var(--my-color)]/[0.5] text-[var(--my-color)]/[50%] text-[xx-large] text-[xx-large]/6 text-blue-500 text-current text-current/50 text-current/[0.5] text-current/[50%] text-inherit text-red-500 text-red-500/2.25 text-red-500/2.5 text-red-500/2.75 text-red-500/50 text-red-500/[0.5] text-red-500/[50%] text-sm text-sm/0 text-sm/6 text-sm/[4px] text-sm/none text-sm/snug text-transparent
 ---
 
     :root, :host {
@@ -19895,6 +19902,10 @@ text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-
       line-height: var(--leading-snug);
     }
 
+    .text-\[--spacing\(2\)\] {
+      font-size: calc(var(--spacing) * 2);
+    }
+
     .text-\[12px\] {
       font-size: 12px;
     }
@@ -19933,6 +19944,10 @@ text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-
 
     .text-\[\#0088cc\]\/50, .text-\[\#0088cc\]\/\[0\.5\], .text-\[\#0088cc\]\/\[50\%\] {
       color: oklab(59.9824% -.067 -.124 / .5);
+    }
+
+    .text-\[--alpha\(red\/20\%\)\] {
+      color: oklab(62.7955% .224 .125 / .2);
     }
 
     .text-\[color\:var\(--my-color\)\], .text-\[color\:var\(--my-color\)\]\/50 {
@@ -20114,7 +20129,7 @@ text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-
 @theme-var color-red-500 #ef4444
 @theme-var text-shadow-2xs 0px 1px 0px rgb(0 0 0 / 0.1)
 @theme-var text-shadow-sm 0px 1px 2px rgb(0 0 0 / 0.06), 0px 2px 2px rgb(0 0 0 / 0.06)
-text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#0088cc]/[0.5] text-shadow-[#0088cc]/[50%] text-shadow-[10px_10px] text-shadow-[10px_10px]/25 text-shadow-[12px_12px_#0088cc] text-shadow-[12px_12px_#0088cc]/25 text-shadow-[12px_12px_var(--value)] text-shadow-[12px_12px_var(--value)]/25 text-shadow-[color:var(--value)] text-shadow-[color:var(--value)]/50 text-shadow-[color:var(--value)]/[0.5] text-shadow-[color:var(--value)]/[50%] text-shadow-[shadow:var(--value)] text-shadow-[var(--value)] text-shadow-current text-shadow-current/50 text-shadow-current/[0.5] text-shadow-current/[50%] text-shadow-inherit text-shadow-none text-shadow-red-500 text-shadow-red-500/2.25 text-shadow-red-500/2.5 text-shadow-red-500/2.75 text-shadow-red-500/50 text-shadow-red-500/[0.5] text-shadow-red-500/[50%] text-shadow-sm text-shadow-sm/25 text-shadow-transparent
+text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#0088cc]/[0.5] text-shadow-[#0088cc]/[50%] text-shadow-[10px_10px] text-shadow-[10px_10px]/25 text-shadow-[12px_12px_#0088cc] text-shadow-[12px_12px_#0088cc]/25 text-shadow-[12px_12px_var(--value)] text-shadow-[12px_12px_var(--value)]/25 text-shadow-[color:var(--value)] text-shadow-[color:var(--value)]/50 text-shadow-[color:var(--value)]/[0.5] text-shadow-[color:var(--value)]/[50%] text-shadow-[shadow:var(--value)] text-shadow-[var(--value)] text-shadow-current text-shadow-current/50 text-shadow-current/[0.5] text-shadow-current/[50%] text-shadow-inherit text-shadow-none text-shadow-red-500 text-shadow-red-500/2.25 text-shadow-red-500/2.5 text-shadow-red-500/2.75 text-shadow-red-500/50 text-shadow-red-500/[0.5] text-shadow-red-500/[50%] text-shadow-sm text-shadow-sm/12.5 text-shadow-sm/25 text-shadow-transparent
 ---
 
     @layer properties {
@@ -20155,6 +20170,11 @@ text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#008
     .text-shadow-\[12px_12px_\#0088cc\]\/25 {
       --tw-text-shadow-alpha: 25%;
       text-shadow: 12px 12px var(--tw-text-shadow-color, oklab(59.9824% -.067 -.124 / .25));
+    }
+
+    .text-shadow-sm\/12\.5 {
+      --tw-text-shadow-alpha: 12.5%;
+      text-shadow: 0px 1px 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .125)), 0px 2px 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .125));
     }
 
     .text-shadow-sm\/25 {
@@ -20418,7 +20438,7 @@ text-shadow-2xs text-shadow-[#0088cc] text-shadow-[#0088cc]/50 text-shadow-[#008
 @theme-var box-shadow-color-blue-500 #3b82f6
 @theme-var shadow-sm 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)
 @theme-var shadow-xl 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)
-shadow-[#0088cc] shadow-[#0088cc]/50 shadow-[#0088cc]/[0.5] shadow-[#0088cc]/[50%] shadow-[10px_10px] shadow-[10px_10px]/25 shadow-[12px_12px_#0088cc] shadow-[12px_12px_#0088cc]/25 shadow-[12px_12px_var(--value)] shadow-[12px_12px_var(--value)]/25 shadow-[color:var(--value)] shadow-[color:var(--value)]/50 shadow-[color:var(--value)]/[0.5] shadow-[color:var(--value)]/[50%] shadow-[shadow:var(--value)] shadow-[var(--value)] shadow-blue-500 shadow-current shadow-current/50 shadow-current/[0.5] shadow-current/[50%] shadow-inherit shadow-none shadow-red-500 shadow-red-500/2.25 shadow-red-500/2.5 shadow-red-500/2.75 shadow-red-500/50 shadow-red-500/[0.5] shadow-red-500/[50%] shadow-sm shadow-sm/25 shadow-transparent shadow-xl
+shadow-[#0088cc] shadow-[#0088cc]/50 shadow-[#0088cc]/[0.5] shadow-[#0088cc]/[50%] shadow-[10px_10px] shadow-[10px_10px]/25 shadow-[12px_12px_#0088cc] shadow-[12px_12px_#0088cc]/25 shadow-[12px_12px_var(--value)] shadow-[12px_12px_var(--value)]/25 shadow-[color:var(--value)] shadow-[color:var(--value)]/50 shadow-[color:var(--value)]/[0.5] shadow-[color:var(--value)]/[50%] shadow-[shadow:var(--value)] shadow-[var(--value)] shadow-blue-500 shadow-current shadow-current/50 shadow-current/[0.5] shadow-current/[50%] shadow-inherit shadow-none shadow-red-500 shadow-red-500/2.25 shadow-red-500/2.5 shadow-red-500/2.75 shadow-red-500/50 shadow-red-500/[0.5] shadow-red-500/[50%] shadow-sm shadow-sm/12.5 shadow-sm/25 shadow-transparent shadow-xl
 ---
 
     @layer properties {
@@ -20480,6 +20500,12 @@ shadow-[#0088cc] shadow-[#0088cc]/50 shadow-[#0088cc]/[0.5] shadow-[#0088cc]/[50
     .shadow-\[12px_12px_\#0088cc\]\/25 {
       --tw-shadow-alpha: 25%;
       --tw-shadow: 12px 12px var(--tw-shadow-color, oklab(59.9824% -.067 -.124 / .25));
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+
+    .shadow-sm\/12\.5 {
+      --tw-shadow-alpha: 12.5%;
+      --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, oklab(0% 0 0 / .125)), 0 1px 2px -1px var(--tw-shadow-color, oklab(0% 0 0 / .125));
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
@@ -20829,7 +20855,7 @@ shadow-[#0088cc] shadow-[#0088cc]/50 shadow-[#0088cc]/[0.5] shadow-[#0088cc]/[50
 @theme-var color-red-500 #ef4444
 @theme-var inset-shadow inset 0 2px 4px rgb(0 0 0 / 0.05)
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
-inset-shadow inset-shadow-[#0088cc] inset-shadow-[#0088cc]/50 inset-shadow-[#0088cc]/[0.5] inset-shadow-[#0088cc]/[50%] inset-shadow-[10px_10px] inset-shadow-[10px_10px]/25 inset-shadow-[12px_12px_#0088cc,12px_12px_var(--value,#0088cc)] inset-shadow-[12px_12px_#0088cc,12px_12px_var(--value,#0088cc)]/25 inset-shadow-[12px_12px_#0088cc] inset-shadow-[12px_12px_#0088cc]/25 inset-shadow-[12px_12px_var(--value)] inset-shadow-[12px_12px_var(--value)]/25 inset-shadow-[color:var(--value)] inset-shadow-[color:var(--value)]/50 inset-shadow-[color:var(--value)]/[0.5] inset-shadow-[color:var(--value)]/[50%] inset-shadow-[shadow:var(--value)] inset-shadow-[var(--value)] inset-shadow-current inset-shadow-current/50 inset-shadow-current/[0.5] inset-shadow-current/[50%] inset-shadow-inherit inset-shadow-none inset-shadow-red-500 inset-shadow-red-500/2.25 inset-shadow-red-500/2.5 inset-shadow-red-500/2.75 inset-shadow-red-500/50 inset-shadow-red-500/[0.5] inset-shadow-red-500/[50%] inset-shadow-sm inset-shadow-sm/25 inset-shadow-transparent
+inset-shadow inset-shadow-[#0088cc] inset-shadow-[#0088cc]/50 inset-shadow-[#0088cc]/[0.5] inset-shadow-[#0088cc]/[50%] inset-shadow-[10px_10px] inset-shadow-[10px_10px]/25 inset-shadow-[12px_12px_#0088cc,12px_12px_var(--value,#0088cc)] inset-shadow-[12px_12px_#0088cc,12px_12px_var(--value,#0088cc)]/25 inset-shadow-[12px_12px_#0088cc] inset-shadow-[12px_12px_#0088cc]/25 inset-shadow-[12px_12px_var(--value)] inset-shadow-[12px_12px_var(--value)]/25 inset-shadow-[color:var(--value)] inset-shadow-[color:var(--value)]/50 inset-shadow-[color:var(--value)]/[0.5] inset-shadow-[color:var(--value)]/[50%] inset-shadow-[shadow:var(--value)] inset-shadow-[var(--value)] inset-shadow-current inset-shadow-current/50 inset-shadow-current/[0.5] inset-shadow-current/[50%] inset-shadow-inherit inset-shadow-none inset-shadow-red-500 inset-shadow-red-500/2.25 inset-shadow-red-500/2.5 inset-shadow-red-500/2.75 inset-shadow-red-500/50 inset-shadow-red-500/[0.5] inset-shadow-red-500/[50%] inset-shadow-sm inset-shadow-sm/12.5 inset-shadow-sm/25 inset-shadow-transparent
 ---
 
     @layer properties {
@@ -20905,6 +20931,12 @@ inset-shadow inset-shadow-[#0088cc] inset-shadow-[#0088cc]/50 inset-shadow-[#008
     .inset-shadow-\[12px_12px_\#0088cc\]\/25 {
       --tw-inset-shadow-alpha: 25%;
       --tw-inset-shadow: inset 12px 12px var(--tw-inset-shadow-color, oklab(59.9824% -.067 -.124 / .25));
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+
+    .inset-shadow-sm\/12\.5 {
+      --tw-inset-shadow-alpha: 12.5%;
+      --tw-inset-shadow: inset 0 1px 1px var(--tw-inset-shadow-color, oklab(0% 0 0 / .125));
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 

--- a/test/upstream/variants.txt
+++ b/test/upstream/variants.txt
@@ -1785,6 +1785,16 @@ data-[]:flex data-[foo_^_=_"bar"]:flex data-[potato=salad]/foo:flex data-disable
 ---
 
 <<<>>>
+# data
+@config run
+aria-[état]:flex data-[état]:flex
+---
+
+    .aria-\[état\]\:flex[aria-état], .data-\[état\]\:flex[data-état] {
+      display: flex;
+    }
+    
+<<<>>>
 # portrait
 @config run
 portrait:flex


### PR DESCRIPTION
The upstream oracle was pinned to Tailwind **v4.3.1** while `required_version` is 4.3.3. Regenerating from v4.3.3 and the value fixes it requires are one atomic change: each fix flips a value the old fixture pins (`w-xl` -> `--container-xl`, `mask-*-from-0` -> `0px`, `drop-shadow/12.5` -> `12.5%`), so they cannot be separate green PRs. Six commits:

- regenerate `test/upstream/{utilities,variants}.txt` from the v4.3.3 tag
- `w-<name>` resolves to `--width-<name>` (theme) else `--container-<name>`
- `mask-*-{from,to}-0` keeps its `px` unit (closes 18 mask cases)
- fractional drop-shadow alpha (`drop-shadow/12.5` -> `12.5%`)
- `--spacing()` / `--alpha()` in arbitrary values (verified vs the real CLI)
- tolerate the `--alpha` 3-decimal oklab fixture skew (same class as the existing `#0288cc` entries)

The whole v4.3.3 upstream suite is green.