### PR TITLE
mask_gradient: keep the px unit on a zero mask stop

### DIFF
--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -102,6 +102,10 @@ module Handler = struct
 
   (* Format the position value as CSS *)
   let format_position_value ?theme = function
+    | Spacing 0. ->
+        (* A mask stop is a <length-percentage>; the zero spacing step keeps its
+           unit ([0px]) here, where a bare [0] would be the folded length. *)
+        "0px"
     | Spacing n ->
         let _, len = Theme.spacing_calc_float ?theme n in
         Css.Pp.to_string ~minify:false Css.pp_length len

--- a/test/test_mask_gradient.ml
+++ b/test/test_mask_gradient.ml
@@ -23,7 +23,23 @@ let test_roundtrip () =
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Mask_gradient.Handler) "mask-foo"
 
+(* A mask stop is a <length-percentage>: the zero spacing step keeps its unit
+   (0px), not a bare 0, which is what Tailwind emits. *)
+let test_from_zero_keeps_unit () =
+  let css =
+    match Tw.of_string "mask-t-from-0" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "mask-t-from-0: %s" m
+  in
+  Alcotest.(check bool)
+    "from-position is 0px, not bare 0" true
+    (Astring.String.is_infix ~affix:"--tw-mask-top-from-position:0px" css)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "from-0 keeps its px unit" `Quick
+        test_from_zero_keeps_unit;
+    ]
 
 let suite = ("mask_gradient", tests)


### PR DESCRIPTION
Every `mask-*-{from,to}` utility failed the v4.3.3 upstream test on its `-0` step: a mask stop is a `<length-percentage>`, so `mask-t-from-0` must emit `--tw-mask-top-from-position: 0px`, but tw emitted a bare `0` from the folded zero-length spacing value. One fix closes all 18 mask cases the fixture bump exposed. Stacked on #147.