### PR TITLE
filters: keep a fractional drop-shadow alpha

### DIFF
--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -768,7 +768,10 @@ module Handler = struct
   let drop_shadow_opacity ?theme opacity =
     let alpha_str =
       match opacity with
-      | Color.Opacity_percent p -> string_of_int (int_of_float p) ^ "%"
+      | Color.Opacity_percent p ->
+          (* keep a fractional alpha (/12.5 -> 12.5%), do not truncate to 12% *)
+          if Float.is_integer p then string_of_int (int_of_float p) ^ "%"
+          else Css.Pp.string_of_float p ^ "%"
       | _ -> "100%"
     in
     let percent =

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -42,6 +42,18 @@ let test_drop_shadow_color () =
     "drop-shadow-red-500/50 uses color-mix" true
     (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"))
 
+(* A fractional opacity modifier keeps its fraction: drop-shadow/12.5 -> alpha
+   12.5%, not the truncated 12%. *)
+let test_drop_shadow_fractional_alpha () =
+  let css =
+    match Tw.of_string "drop-shadow/12.5" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "drop-shadow/12.5: %s" m
+  in
+  Alcotest.(check bool)
+    "alpha is 12.5%, not 12%" true
+    (Astring.String.is_infix ~affix:"--tw-drop-shadow-alpha:12.5%" css)
+
 let test_backdrop () =
   check "backdrop-opacity-50";
   check "backdrop-invert"
@@ -72,6 +84,8 @@ let tests =
     test_case "blur" `Quick test_blur;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;
     test_case "drop-shadow color (default theme)" `Quick test_drop_shadow_color;
+    test_case "drop-shadow fractional alpha" `Quick
+      test_drop_shadow_fractional_alpha;
     test_case "backdrop" `Quick test_backdrop;
     test_case "backdrop-blur token" `Quick test_backdrop_blur_token;
     test_case "filters suborder matches Tailwind" `Quick


### PR DESCRIPTION
`drop-shadow/12.5` truncated its alpha to `12%` via `int_of_float`; a fractional opacity modifier now survives as `12.5%`, matching Tailwind v4.3.3. Closes the `filter` upstream case. Stacked on #148.