### PR TITLE
typography, color: support --spacing() and --alpha() in arbitrary values

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1756,20 +1756,65 @@ module Handler = struct
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'
 
+  (* Tailwind's [--alpha(<color>/<pct>)] inside an arbitrary value is
+     [color-mix(in oklab, <color> <pct>, transparent)]. *)
+
   (** Parse a bracket inner string into a typed [Css.color], if it represents a
       valid color. Handles hex strings (with [#] prefix), CSS color functions
       like [rgb(...)], [hsl(...)], etc., and named Tailwind colors (which are
       converted to their CSS representation via [to_css]). Returns [None] for
       non-color values. *)
-  let parse_bracket_color (inner : string) : Css.color option =
-    if String.length inner > 0 && inner.[0] = '#' then Some (Css.hex inner)
-    else
-      let normalized = String.map (fun c -> if c = '_' then ' ' else c) inner in
-      if Parse.is_css_color_fn normalized then Css.parse_color normalized
-      else
-        match color_of_string inner with
-        | Ok c -> Some (to_css c 500)
-        | Error _ -> None
+  let parse_alpha_call inner =
+    let prefix = "--alpha(" in
+    let pl = String.length prefix and n = String.length inner in
+    if n > pl && String.sub inner 0 pl = prefix && inner.[n - 1] = ')' then
+      let body = String.sub inner pl (n - pl - 1) in
+      match String.rindex_opt body '/' with
+      | Some i ->
+          Some
+            ( String.sub body 0 i,
+              String.sub body (i + 1) (String.length body - i - 1) )
+      | None -> None
+    else None
+
+  let rec parse_bracket_color (inner : string) : Css.color option =
+    match parse_alpha_call inner with
+    | Some (color_str, pct_str) -> (
+        let pct =
+          let t = String.trim pct_str in
+          let t =
+            if String.length t > 0 && t.[String.length t - 1] = '%' then
+              String.sub t 0 (String.length t - 1)
+            else t
+          in
+          float_of_string_opt t
+        in
+        (* the inner colour is a raw CSS colour ([red] is the keyword, not the
+           red-500 palette entry); fall back to the palette only if CSS does not
+           know it. *)
+        let color =
+          let normalized =
+            String.map (fun c -> if c = '_' then ' ' else c) color_str
+          in
+          match Css.parse_color normalized with
+          | Some c -> Some c
+          | None -> parse_bracket_color color_str
+        in
+        match (pct, color) with
+        | Some pct, Some c ->
+            Some (Css.color_mix ~in_space:Oklab ~percent1:pct c Css.Transparent)
+        | _ -> None)
+    | None -> (
+        if String.length inner > 0 && inner.[0] = '#' then Some (Css.hex inner)
+        else
+          let normalized =
+            String.map (fun c -> if c = '_' then ' ' else c) inner
+          in
+          if Parse.is_css_color_fn normalized then Css.parse_color normalized
+          else
+            match color_of_string inner with
+            | Ok c -> Some (to_css c 500)
+            | Error _ -> None)
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -429,6 +429,9 @@ module Typography_early = struct
     in
     find 0 0
 
+  (* Tailwind's [--spacing(N)] inside an arbitrary value reads the spacing
+     scale: [text-[--spacing(2)]] is [font-size: calc(var(--spacing) * 2)]. *)
+
   (** Does [inner] look like something we can emit as a font-size? Accepts typed
       prefix (length/percentage/absolute-size/relative-size), font-size keyword
       (medium, xxx-large, larger, ...), length with unit (16px, 1rem, 1.5em,
@@ -436,6 +439,13 @@ module Typography_early = struct
       recognised keywords -- e.g. a bare "1A202C" is not a valid font-size: a
       length must carry a unit and a hex color must start with "#" (CSS Color
       §5.4.6). *)
+  let parse_spacing_call s =
+    let prefix = "--spacing(" in
+    let pl = String.length prefix and n = String.length s in
+    if n > pl && String.sub s 0 pl = prefix && s.[n - 1] = ')' then
+      float_of_string_opt (String.sub s pl (n - pl - 1))
+    else Stdlib.Option.None
+
   let is_valid_bracket_font_size (inner : string) : bool =
     match split_type_prefix inner with
     | Some (prefix, _)
@@ -453,7 +463,8 @@ module Typography_early = struct
                 len > 6
                 && String.sub inner 0 6 = "clamp("
                 && inner.[len - 1] = ')'
-                || Parse.is_var inner))
+                || Parse.is_var inner
+                || parse_spacing_call inner <> Stdlib.Option.None))
 
   (** Check if bracket content looks like a color (should go to color handler).
   *)
@@ -1063,31 +1074,36 @@ module Typography_early = struct
       Caller must have already passed [inner] through
       [is_valid_bracket_font_size]. *)
   let bracket_font_size_decls inner =
-    match split_type_prefix inner with
-    | Stdlib.Option.Some (prefix, value)
-      when prefix = "absolute-size" || prefix = "relative-size"
-           || prefix = "length" || prefix = "percentage" ->
-        if Parse.is_var value then
-          let bare = Parse.extract_var_name value in
-          [ font_size (Css.Var (Var.bracket bare)) ]
-        else [ font_size (Css.Var (Var.bracket value)) ]
-    | _ -> (
-        match font_size_keyword inner with
-        | Stdlib.Option.Some kw -> [ Css.font_size_kw kw ]
-        | Stdlib.Option.None -> (
-            match try_parse_length_value inner with
-            | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
+    match parse_spacing_call inner with
+    | Stdlib.Option.Some n ->
+        let decl, len = Theme.spacing_calc_float n in
+        [ decl; font_size len ]
+    | Stdlib.Option.None -> (
+        match split_type_prefix inner with
+        | Stdlib.Option.Some (prefix, value)
+          when prefix = "absolute-size" || prefix = "relative-size"
+               || prefix = "length" || prefix = "percentage" ->
+            if Parse.is_var value then
+              let bare = Parse.extract_var_name value in
+              [ font_size (Css.Var (Var.bracket bare)) ]
+            else [ font_size (Css.Var (Var.bracket value)) ]
+        | _ -> (
+            match font_size_keyword inner with
+            | Stdlib.Option.Some kw -> [ Css.font_size_kw kw ]
             | Stdlib.Option.None -> (
-                match Css.parse_length inner with
+                match try_parse_length_value inner with
                 | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
-                | Stdlib.Option.None ->
-                    if Parse.is_var inner then
-                      let bare = Parse.extract_var_name inner in
-                      [ font_size (Css.Var (Var.bracket bare)) ]
-                    else
-                      invalid_arg
-                        ("bracket_font_size_decls: not a valid font-size \
-                          value: " ^ inner))))
+                | Stdlib.Option.None -> (
+                    match Css.parse_length inner with
+                    | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
+                    | Stdlib.Option.None ->
+                        if Parse.is_var inner then
+                          let bare = Parse.extract_var_name inner in
+                          [ font_size (Css.Var (Var.bracket bare)) ]
+                        else
+                          invalid_arg
+                            ("bracket_font_size_decls: not a valid font-size \
+                              value: " ^ inner)))))
 
   (** Generate font-size-only style for bracket value. *)
   let bracket_font_size_style raw = style (bracket_font_size_decls raw)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -354,6 +354,25 @@ let test_text_line_height_override () =
     "text-sm honors --text-sm--line-height override" true
     (Astring.String.is_infix ~affix:"--text-sm--line-height:1.25rem" css)
 
+(* Tailwind's [--spacing(N)] and [--alpha(<color>/<pct>)] are usable inside an
+   arbitrary value. Verified against the real v4.3.3 CLI, which emits
+   [calc(var(--spacing) * 2)] and [color-mix(in oklab, red 20%,
+   transparent)]. *)
+let test_text_bracket_functions () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "text-[--spacing(2)] is a spacing calc" true
+    (Astring.String.is_infix ~affix:"calc(var(--spacing)*2)"
+       (css "text-[--spacing(2)]"));
+  Alcotest.(check bool)
+    "text-[--alpha(red/20%)] is a color-mix" true
+    (Astring.String.is_infix ~affix:"color-mix(in oklab,red 20%,transparent)"
+       (css "text-[--alpha(red/20%)]"))
+
 let tests =
   [
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
@@ -384,6 +403,8 @@ let tests =
       test_text_bracket_size_valid;
     test_case "text-[<font-size>] invalid values" `Quick
       test_text_bracket_size_invalid;
+    test_case "text-[--spacing()/--alpha()] functions" `Quick
+      test_text_bracket_functions;
     test_case "typography of_string - invalid values" `Quick of_string_invalid;
     test_case "typography suborder matches Tailwind" `Quick
       suborder_matches_tailwind;


### PR DESCRIPTION
`text-[--spacing(2)]` and `text-[--alpha(red/20%)]` were rejected outright. Both are Tailwind functions usable inside an arbitrary value: `--spacing(N)` reads the spacing scale, and `--alpha(<color>/<pct>)` is a `color-mix` against `transparent`. Verified against the real v4.3.3 CLI, which emits `calc(var(--spacing) * 2)` and `color-mix(in oklab, red 20%, transparent)` — tw now matches byte for byte.

This makes the aggregate `upstream utilities parse parity` test pass. The `text` case itself still fails, but **only on stale fixture colours**, not a tw or cascade bug:

- `color-mix(in oklab, C p%, transparent)` is, per CSS Color 5 premultiplied-alpha interpolation, exactly `C` at `p%` alpha. cascade emits `#0088cc80` / `#f003` accordingly.
- Real Tailwind `--minify` (LightningCSS) emits `oklab(59.9824% -.0672516 -.124144/.5)`, which converts back to exactly `#0088cc` — so LightningCSS agrees with cascade.
- The fixture claims `#0288cc80` / `#ff040433`, which match neither and could not be reproduced from any oklab rounding (6/4/3 significant digits all give the exact values).

The existing `is_allowed_canonicalization_diff` already documents this skew for the `#0088cc]/50` case. Stacked on #149.