### PR TITLE
test/upstream: normalise oklab precision like Tailwind snapshots

### DIFF
--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -31,18 +31,21 @@ module Css = Cascade.Css
 open Cascade_diff
 open Alcotest
 
-(* One tolerance sits on top of the raw upstream fixtures:
-   [is_allowed_canonicalization_diff], and it is pure fixture skew, not a tw
-   bug. The hard-coded expectations in Tailwind's [*.test.ts] predate
-   LightningCSS, so they carry the pre-optimise opacity hex ([#0088cc]/50 ->
-   [#0288cc80]) where the real v4.3.1 CLI -- and tw -- emit [#0088cc80] (checked
-   with [tw -s ... --diff]); only cascade rounding oklab to LightningCSS
-   precision retires it. Set [TW_UPSTREAM_STRICT=1] to disable it and watch for
-   changes that close the gap. (A [--text-*--line-height] allowance, a
-   mask-angle calc allowance, an [@property --spacing] hint and a prose
-   selector-permutation allowance were all dropped earlier, once tw honoured
-   theme line-height overrides, emitted Tailwind's exact mask degrees, and
-   cascade gained typed calc + the custom-property prune.) *)
+(* Colour comparison is normalised the way Tailwind normalises its own
+   snapshots: [color_mix_to_oklab] then [truncate_color_precision] run on both
+   sides before the diff, so an [oklab] fixture and tw's exact colour describe
+   the same value. That is pure fixture skew, not a tw bug: Tailwind's snapshot
+   serialiser truncates oklab axes for cross-OS stability, and the fixtures fold
+   a concrete-colour opacity to [oklab] where tw keeps the shorter exact colour.
+   One tolerance remains on top of that -- [is_allowed_canonicalization_diff],
+   for [--font-sans] / [--tw-prose-*] custom-property skew. Set
+   [TW_UPSTREAM_STRICT=1] to disable it and watch for changes that close the
+   gap. (A [--text-*--line-height] allowance, a mask-angle calc allowance, an
+   [@property --spacing] hint, a prose selector-permutation allowance and the
+   hard-coded stale-colour allowlist were all dropped earlier, once tw honoured
+   theme line-height overrides, emitted Tailwind's exact mask degrees, cascade
+   gained typed calc + the custom-property prune, and the colour normalisation
+   above replaced the allowlist.) *)
 let strict = Sys.getenv_opt "TW_UPSTREAM_STRICT" <> None
 
 type theme_config =
@@ -443,72 +446,68 @@ let theme_config config expected =
 
 let canonical_stylesheet_css css = String.trim css
 
-(* The upstream fixtures store one opacity-modified arbitrary colour --
-   [#0088cc], at 25% and 50% -- as Tailwind's LightningCSS-rounded oklab, which
-   round-trips back to hex two units high in the red channel ([#0288cc40] /
-   [#0288cc80]). tw keeps full precision and emits the true [#0088cc40] /
-   [#0088cc80]. Those are the *only* fixture colours that skew, and they recur
-   across every colour utility (accent, bg, ring, gradient, shadow, ...), so
-   allow exactly those pairs. A fuzzy [abs (x - y) <= 2] per-channel threshold
-   would also cover them, but it would silently absorb a genuine colour
-   regression of a unit or two -- defeating the comparison -- so prefer an
-   explicit allowlist that only the known stale fixtures match. *)
-let known_stale_colors =
-  [
-    ("#0288cc40", "#0088cc40");
-    ("#0288cc80", "#0088cc80");
-    (* --alpha(red/20%): the fixture stores oklab at 3 decimals (oklab(62.7955%
-       .224 .125/.2)), which round-trips to #ff0404 rather than the exact
-       #ff0000; tw and LightningCSS both produce the exact colour. *)
-    ("#ff040433", "#f003");
-  ]
+(* [color-mix(in oklab, C p%, transparent)] denotes the concrete colour C at
+   alpha p, which LightningCSS folds to an [oklab(...)] in the fixtures. tw
+   keeps the colour itself (exact and shorter once cascade folds it to a hex),
+   so re-express it as that oklab -- resolving C through cascade's own colour
+   fold, which handles named colours like [red] that have no public name->rgb
+   table -- and let the shared truncation reconcile it with the fixture. A
+   [var()] or [currentcolor] operand does not fold to a hex (the [[^,()]+]
+   capture also skips [var(...)]), so its color-mix is left untouched. *)
+let color_mix_re =
+  (* [our_css] is minified ([,] with no following space) while the fixtures keep
+     [, ]; match either. *)
+  Re.Pcre.regexp
+    {|color-mix\(in oklab,\s*([^,()]+?)\s+([0-9.]+)%,\s*transparent\)|}
 
-let colors_close expected actual =
-  let e = String.trim expected and a = String.trim actual in
-  String.equal e a
-  || List.exists
-       (fun (stale, correct) -> String.equal e stale && String.equal a correct)
-       known_stale_colors
+let hex_re = Re.Pcre.regexp {|#[0-9a-fA-F]+|}
 
-(* Split a value into its non-hex skeleton and the list of [#...] colours, so a
-   colour embedded in a larger value (e.g. a shadow's [var(--c, #0288cc40)]) can
-   be compared channel-wise like a bare colour. *)
-let split_hexes s =
-  let n = String.length s in
-  let skel = Buffer.create n and hexes = ref [] in
-  let is_hex c =
-    (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
-  in
-  let i = ref 0 in
-  while !i < n do
-    if s.[!i] = '#' then (
-      let j = ref (!i + 1) in
-      while !j < n && is_hex s.[!j] do
-        incr j
-      done;
-      let len = !j - !i - 1 in
-      if len = 3 || len = 4 || len = 6 || len = 8 then (
-        hexes := String.sub s !i (!j - !i) :: !hexes;
-        Buffer.add_char skel '#';
-        i := !j)
-      else (
-        Buffer.add_char skel s.[!i];
-        incr i))
-    else (
-      Buffer.add_char skel s.[!i];
-      incr i)
-  done;
-  (Buffer.contents skel, List.rev !hexes)
+let color_mix_to_oklab s =
+  Re.replace color_mix_re s ~f:(fun g ->
+      let whole = Re.Group.get g 0 in
+      match Css.of_string (Fmt.str ".x{color:%s}" whole) with
+      | Error _ -> whole
+      | Ok { stylesheet; _ } -> (
+          let folded = Css.to_string ~minify:true (Css.optimize stylesheet) in
+          match Re.exec_opt hex_re folded with
+          | None -> whole (* did not fold to a hex: keep (var / currentcolor) *)
+          | Some m -> (
+              (* A short hex parses to [Authored_hex] (source spelling kept);
+                 both it and [Hex] carry decoded [r]/[g]/[b]. *)
+              match Css.parse_color (Re.Group.get m 0) with
+              | Some
+                  ( Css.Hex { r; g = green; b; _ }
+                  | Css.Authored_hex { r; g = green; b; _ } ) ->
+                  let f x = float_of_int x /. 255. in
+                  let l, a, b =
+                    Cascade.Color_space.oklab_of_linear_srgb
+                      (Cascade.Color_space.linear_rgb_of_rgb
+                         (f r, f green, f b))
+                  in
+                  let alpha = float_of_string (Re.Group.get g 2) /. 100. in
+                  Fmt.str "oklab(%.6f%% %.6f %.6f / %.6f)" (l *. 100.) a b alpha
+              | _ -> whole)))
 
-let values_close expected actual =
-  colors_close expected actual
-  ||
-  let skel_e, hexes_e = split_hexes expected in
-  let skel_a, hexes_a = split_hexes actual in
-  skel_e = skel_a
-  && List.length hexes_e = List.length hexes_a
-  && hexes_e <> []
-  && List.for_all2 colors_close hexes_e hexes_a
+(* Reduce the precision of [oklab]/[oklch]/[lab]/[lch] coefficients to three
+   decimals, mirroring Tailwind's own snapshot serialiser
+   ([test-utils/custom-serializer.ts]): it truncates those axes because
+   "lightningcss generat[es] different decimal places in the last position when
+   run on different operating systems". cascade keeps the full-precision colour,
+   so tw's [oklab(59.98238277% -.06725164 -.12414399 / .5)] and the fixture's
+   truncated [oklab(59.9824% -.067 -.124 / .5)] describe the same colour that
+   only differs in serialisation noise. Applied to both sides before the diff,
+   the two spellings collapse to an identical value (and identical folded hex),
+   so no per-colour allowlist is needed. It is truncation, not rounding
+   ([.224863] -> [.224], never [.225]), and a genuine regression that moves a
+   coefficient at the third decimal or coarser still shows as a diff. *)
+let truncate_color_precision =
+  let frac = Re.Pcre.regexp {|\.(\d{3})\d+|} in
+  let color_fn = Re.Pcre.regexp {|\b(oklab|oklch|lab|lch)\(([^()]*)\)|} in
+  fun s ->
+    Re.replace color_fn s ~f:(fun g ->
+        let name = Re.Group.get g 1 and args = Re.Group.get g 2 in
+        let args = Re.replace frac args ~f:(fun d -> "." ^ Re.Group.get d 1) in
+        name ^ "(" ^ args ^ ")")
 
 let is_allowed_canonicalization_diff diff =
   let allowed_custom_property = function
@@ -523,8 +522,7 @@ let is_allowed_canonicalization_diff diff =
         property_changes <> []
         && List.for_all
              (fun (change : Tree_diff.declaration) ->
-               allowed_custom_property change.property_name
-               || values_close change.expected_value change.actual_value)
+               allowed_custom_property change.property_name)
              property_changes
     | _ -> false
   in
@@ -874,9 +872,13 @@ let run_test_case test () =
     let expected_css = canonical_stylesheet_css expected in
     if our_css = "" && expected = "" then ()
     else
+      let normalize_colors s =
+        truncate_color_precision (color_mix_to_oklab s)
+      in
       let result =
         Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
-          expected_css our_css
+          (normalize_colors expected_css)
+          (normalize_colors our_css)
       in
       if
         (match result.Css_compare.result with
@@ -913,23 +915,46 @@ let run_test_case test () =
              (String.concat " " test.classes)
              (Buffer.contents buf) expected got rejected_note)
 
-(* Guards [colors_close]: a documented stale fixture pair is accepted, but a
-   near-miss the previous [abs (x - y) <= 2] blanket would have wrongly accepted
-   is now rejected, so a real colour regression cannot hide behind the
-   tolerance. *)
+(* Guards [truncate_color_precision]: it truncates (never rounds) the
+   oklab-family axes to three decimals like Tailwind's snapshot serialiser, so
+   tw's full-precision colour and the fixture's reduced spelling collapse to the
+   same value, while a coarser regression still survives as a diff. *)
 let test_color_tolerance () =
+  let check msg expected input =
+    Alcotest.(check string) msg expected (truncate_color_precision input)
+  in
+  (* Truncates, never rounds: .224863 -> .224 (rounding would give .225). *)
+  check "oklab axes truncated to 3 decimals" "oklab(62.795% .224 .125 / .2)"
+    "oklab(62.7955% .224863 .125846 / .2)";
+  (* tw's full precision and the fixture's reduced form collapse to equal. *)
+  Alcotest.(check string)
+    "full and reduced spellings collapse"
+    (truncate_color_precision "oklab(59.9824% -.067 -.124 / .5)")
+    (truncate_color_precision "oklab(59.98238277% -.06725164 -.12414399 / .5)");
+  (* Leaves the [in oklab] interpolation keyword and short values untouched. *)
+  check "color-mix keyword untouched"
+    "color-mix(in oklab, #0088cc 50%, transparent)"
+    "color-mix(in oklab, #0088cc 50%, transparent)";
+  (* A difference at the third decimal survives truncation. *)
   Alcotest.(check bool)
-    "stale fixture pair tolerated" true
-    (colors_close "#0288cc80" "#0088cc80");
-  Alcotest.(check bool)
-    "3-decimal oklab red skew tolerated" true
-    (colors_close "#ff040433" "#f003");
-  Alcotest.(check bool)
-    "one-unit red skew rejected" false
-    (colors_close "#0188cc80" "#0088cc80");
-  Alcotest.(check bool)
-    "unrelated near colour rejected" false
-    (colors_close "#123456" "#123458")
+    "coarse difference preserved" false
+    (String.equal
+       (truncate_color_precision "oklab(62.795% .224 .125 / .2)")
+       (truncate_color_precision "oklab(62.795% .223 .125 / .2)"));
+  (* [color_mix_to_oklab] re-expresses a concrete-colour opacity (resolving the
+     named colour [red]) as the oklab the fixtures store; truncated, it lands on
+     the fixture value. *)
+  Alcotest.(check string)
+    "color-mix(red 20%) re-expressed as the fixture oklab"
+    "oklab(62.795% 0.224 0.125 / 0.200)"
+    (truncate_color_precision
+       (color_mix_to_oklab "color-mix(in oklab, red 20%, transparent)"));
+  (* A var() operand cannot fold to a concrete colour, so its color-mix (which
+     the fixtures also keep) is left alone. *)
+  Alcotest.(check string)
+    "color-mix(var) left untouched"
+    "color-mix(in oklab, var(--x) 50%, transparent)"
+    (color_mix_to_oklab "color-mix(in oklab, var(--x) 50%, transparent)")
 
 let print_parity_report () =
   Fmt.epr "@.=== upstream parity report ===@.";
@@ -979,7 +1004,7 @@ let () =
       variant_tests
   in
   let tolerance_cases =
-    [ test_case "colour stale-fixture allowlist" `Quick test_color_tolerance ]
+    [ test_case "oklab precision truncation" `Quick test_color_tolerance ]
   in
   let suites =
     [ ("utilities", utility_cases); ("tolerance", tolerance_cases) ]


### PR DESCRIPTION
The upstream fixtures store colours the way Tailwind's snapshot serialiser does, truncating oklab/oklch/lab/lch axes to three decimals and letting LightningCSS fold a concrete-colour opacity to oklab, while cascade emits the exact colour. This normalises both sides the same way before the diff (`truncate_color_precision` mirrors Tailwind's `custom-serializer.ts`; `color_mix_to_oklab` re-expresses tw's exact colour as the fixture's oklab via cascade's own fold), replacing the hard-coded stale-colour allowlist that could not separate a truncation artifact from a real regression. The guard test still rejects a genuine third-decimal skew.
