### PR TITLE
rule: parse arbitrary selector in not-[...] instead of escaping it

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1210,15 +1210,23 @@ let handle_not_bracket content base_class props =
         ~props ~base_class:modified_class ();
     ]
   else
-    (* Unknown bracket content - treat as raw selector *)
+    (* Arbitrary selector content: [_] is a space and [&] is the utility's own
+       element, which inside a negation becomes the universal selector. So
+       [not-[.os-macos_&]] negates the descendant context [.os-macos &] as
+       [:not(.os-macos <star>)]. Parse the transformed string as a selector so
+       combinators and compounds flatten, rather than escaping it as a single
+       class name. *)
+    let sel_str =
+      content
+      |> String.map (fun c -> if c = '_' then ' ' else c)
+      |> String.split_on_char '&' |> String.concat "*"
+    in
+    let inner = Css.Selector.read (Cascade.Cursor.of_string sel_str) in
     [
       regular ~not_order:nvo
         ~selector:
           (Css.Selector.compound
-             [
-               Css.Selector.Class modified_class;
-               Css.Selector.Not [ Css.Selector.Class content ];
-             ])
+             [ Css.Selector.Class modified_class; Css.Selector.Not [ inner ] ])
         ~props ~base_class:modified_class ();
     ]
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -541,10 +541,29 @@ let test_nested_modifier_css_generation () =
       Alcotest.failf "Nested modifier CSS parse failed:\n%s"
         (Cascade.Error.to_string e)
 
+(* not-[<selector>] with an arbitrary selector parses [_] as a space and [&] as
+   the element, which becomes the universal selector inside the negation (so
+   not-[.os-macos_&]:block negates the descendant context as a :not over
+   .os-macos descendants). It used to escape the bracket content as one class
+   name instead. *)
+let test_not_bracket_arbitrary_selector () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check bool "not-[.os-macos_&]:block negates the descendant context" true
+    (Astring.String.is_infix ~affix:":not(.os-macos *)"
+       (css "not-[.os-macos_&]:block"));
+  check bool "not-[.foo]:block negates a plain class" true
+    (Astring.String.is_infix ~affix:":not(.foo)" (css "not-[.foo]:block"))
+
 (* Extend the suite with new tests *)
 let tests =
   tests
   @ [
+      test_case "not-[selector] arbitrary negation" `Quick
+        test_not_bracket_arbitrary_selector;
       test_case "is_hover flags" `Quick test_is_hover;
       test_case "of_string parsing" `Quick test_of_string_parsing;
       test_case "pp_modifier strings" `Quick test_pp_modifier_strings;


### PR DESCRIPTION
The `not-[<selector>]` variant treated any non-pseudo, non-media bracket content as a single class name, so `not-[.os-macos_&]:block` emitted `:not(.\.os-macos_\&)` instead of `:not(.os-macos *)` (and `not-[.foo]` gave `:not(.\.foo)`, `not-[[open]]` gave `:not(.\[open\])`).

It now parses the bracket content as a selector, with `_` as a space and `&` as the universal selector inside the negation, matching Tailwind. Invalid combinator-leading forms (`not-[+img]`) are still rejected upstream and emit nothing.