### PR TITLE
modifiers: resolve theme() in container-query arbitrary values

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1963,6 +1963,26 @@ let container_size_of_string = function
   | "7xl" -> Some Container_7xl
   | _ -> None
 
+(* A container-query arbitrary value may reference a theme token, e.g.
+   [@min-[theme(--breakpoint-lg)]]. [theme(--breakpoint-lg)] resolves to the
+   [--breakpoint-lg] default (64rem) via the same token table the [lg:] variant
+   publishes, so a plain length parse falls back to token resolution. *)
+let parse_container_length content =
+  match Css.parse_length content with
+  | Some _ as len -> len
+  | None ->
+      let s = String.trim content in
+      let n = String.length s in
+      if n > 7 && String.sub s 0 6 = "theme(" && s.[n - 1] = ')' then
+        let inner = String.trim (String.sub s 6 (n - 7)) in
+        let name =
+          if String.length inner >= 2 && String.sub inner 0 2 = "--" then
+            String.sub inner 2 (String.length inner - 2)
+          else inner
+        in
+        Option.bind (Scheme.token_default name) Css.parse_length
+      else None
+
 let try_container_query s =
   (* Match ["<prefix>[<len>]"] and build a modifier from the parsed length. *)
   let bracketed prefix mk =
@@ -1973,7 +1993,9 @@ let try_container_query s =
       && s.[plen] = '['
       && s.[slen - 1] = ']'
     then
-      match Css.parse_length (String.sub s (plen + 1) (slen - plen - 2)) with
+      match
+        parse_container_length (String.sub s (plen + 1) (slen - plen - 2))
+      with
       | Some len -> Some (mk len)
       | None -> None
     else None

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -420,6 +420,10 @@ let test_container_query_min_max () =
   has "@min-[20rem]:flex" "@container (width >= 20rem)";
   has "@max-[40rem]:flex" "@container (not (width >= 40rem))";
   has "@[480px]:flex" "@container (width >= 480px)";
+  (* A theme(--breakpoint-lg) arbitrary value resolves to the breakpoint the
+     [lg:] variant uses (64rem). *)
+  has "@min-[theme(--breakpoint-lg)]:flex" "@container (width >= 64rem)";
+  has "@max-[theme(--breakpoint-lg)]:flex" "@container (not (width >= 64rem))";
   check string "@max-md round-trips" "@max-md:p-4"
     (Tw.Utility.to_class (Option.get (apply [ "@max-md" ] (p 4))));
   check string "@min-[20rem] round-trips" "@min-[20rem]:p-4"


### PR DESCRIPTION
Container-query variants with a `theme()` reference in the arbitrary value (`@min-[theme(--breakpoint-lg)]:...`, `@max-[theme(...)]:...`) produce no rule, so tailwindcss.com's `@min-[theme(--breakpoint-*)]` / `@max-[theme(--breakpoint-*)]` utilities are unreachable.

`@min-[...]` / `@max-[...]` now resolve a `theme(--name)` value through `Scheme.token_default` (the same table the `sm:`/`lg:` variants publish), so `theme(--breakpoint-lg)` is `64rem`. Plain lengths (`@min-[400px]`) and named sizes (`@lg`) go through the existing path unchanged.