### PR TITLE
color: apply /opacity to ring colours on var-ref themes

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -3198,7 +3198,12 @@ let hex_alpha_color ?theme c shade opacity =
          hex, so an /opacity modifier still resolves to a colour. *)
       if is_base_color c then
         Some (hex_with_alpha (to_oklch_css c shade) percent)
-      else None
+      else
+        (* A theme that binds palette colours to var references has no scheme
+           hex; convert through oklch so the /opacity modifier still resolves,
+           as [color_with_opacity_style] does for bg/text/border. *)
+        let hex_value = rgb_to_hex (oklch_to_rgb (to_oklch c shade)) in
+        Some (hex_with_alpha hex_value percent)
 
 let color_mix_supports_condition = Handler.color_mix_supports_condition
 

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -61,6 +61,12 @@ let test_ring_shadeless_color () =
     (Astring.String.is_infix ~affix:"--tw-ring-color" (css "ring-black"));
   Alcotest.check bool "ring-white/10 uses color-mix" true
     (Astring.String.is_infix ~affix:"color-mix" (css "ring-white/10"));
+  (* Palette colours (blue-500) also apply the /opacity modifier on a var-ref
+     theme; the ring family resolves it via oklab like bg/text do. *)
+  Alcotest.check bool "ring-blue-500/50 applies opacity" true
+    (Astring.String.is_infix ~affix:"color-mix" (css "ring-blue-500/50"));
+  Alcotest.check bool "inset-ring-gray-950/10 applies opacity" true
+    (Astring.String.is_infix ~affix:"color-mix" (css "inset-ring-gray-950/10"));
   match Tw.of_string "ring-red" with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "ring-red (no shade) should be rejected"


### PR DESCRIPTION
On a theme that binds palette colours to var references (no concrete hex in the scheme), `ring-blue-500/50`, `inset-ring-*/N`, and `ring-offset-*/N` dropped the `/opacity` modifier and emitted `--tw-ring-color: var(--color-blue-500)` at full opacity, while `bg`/`text`/`border` applied it.

`Color.hex_alpha_color` now converts the colour through oklch in that case (the same path `color_with_opacity_style` already uses for bg/text/border), so the ring family applies the alpha. Colours the scheme resolves to a concrete hex are unaffected.