### PR TITLE
bin: thread the entrypoint theme through --input-css generation

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -779,9 +779,12 @@ let native_files paths flag ~(opts : gen_opts) =
       List.concat_map Tw_tools.Source_scan.candidates_from_file all_files
       |> List.sort_uniq String.compare
     in
-    let known = parse_known_candidates ?input_css:opts.input_css all_classes in
+    let known =
+      parse_known_candidates ~theme:opts.theme ?input_css:opts.input_css
+        all_classes
+    in
     let tw_styles = List.map snd known in
-    let stylesheet = Tw.to_css ~base:include_base tw_styles in
+    let stylesheet = Tw.to_css ~theme:opts.theme ~base:include_base tw_styles in
     let stylesheet =
       match opts.input_css_path with
       | Some path -> splice_into_entrypoint ~theme:opts.theme ~path stylesheet

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -27,3 +27,18 @@ The generated utility is spliced in where the package import sat:
 
   $ tw --minify --input-css app.css index.html | grep -c '\.flex{display:flex}'
   1
+
+A utility named after a custom @theme token resolves against the entrypoint's
+theme, so an animate-* utility uses the project's --animate-* value:
+
+  $ cat > anim.css <<EOF
+  > @import "tailwindcss";
+  > @theme { --animate-wiggle: wiggle 1s ease-in-out infinite; }
+  > EOF
+
+  $ cat > page.html <<EOF
+  > <div class="animate-wiggle"></div>
+  > EOF
+
+  $ tw --minify --input-css anim.css page.html | grep -c '\.animate-wiggle{animation:var(--animate-wiggle)}'
+  1


### PR DESCRIPTION
The `--input-css` generate path called `parse_known_candidates` and `Tw.to_css` against `Tw.Scheme.default` instead of the theme built from the project entrypoint, so a utility named after a custom `@theme` token (e.g. `animate-flash-code` from `--animate-flash-code`) produced no rule. The other generate path already threads `opts.theme`; this one now does too.