### PR TITLE
backgrounds: keep both axes in a keyword+length bg-position bracket

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -704,20 +704,25 @@ module Handler = struct
     in
     match parts with
     | [ x; y ] -> (
-        (* Two values - but Tailwind seems to collapse to single in some
-           cases *)
+        (* Each axis is a keyword edge (left/right/top/bottom/center, normalised
+           to its percentage) or a length. *)
         let parse_len s : Css.length option =
-          if String.ends_with ~suffix:"px" s then
-            let n =
-              String.sub s 0 (String.length s - 2) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Css.Px f : Css.length)) n
-          else if String.ends_with ~suffix:"%" s then
-            let n =
-              String.sub s 0 (String.length s - 1) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Css.Pct f : Css.length)) n
-          else None
+          match s with
+          | "left" | "top" -> Some (Css.Pct 0.)
+          | "center" -> Some (Css.Pct 50.)
+          | "right" | "bottom" -> Some (Css.Pct 100.)
+          | _ ->
+              if String.ends_with ~suffix:"px" s then
+                let n =
+                  String.sub s 0 (String.length s - 2) |> float_of_string_opt
+                in
+                Option.map (fun f -> (Css.Px f : Css.length)) n
+              else if String.ends_with ~suffix:"%" s then
+                let n =
+                  String.sub s 0 (String.length s - 1) |> float_of_string_opt
+                in
+                Option.map (fun f -> (Css.Pct f : Css.length)) n
+              else None
         in
         let xl = parse_len x in
         let yl = parse_len y in

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -108,6 +108,23 @@ let test_bracket_length_keywords () =
     (Astring.String.is_infix ~affix:"background-size: contain"
        (css "bg-[length:contain]"))
 
+(* A two-axis bg-position bracket mixes a keyword edge with a length, e.g.
+   bg-position-[center_-100px] -> background-position: 50% -100px. *)
+let test_bg_position_bracket_keyword_length () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "bg-position-[center_-100px] keeps both axes" true
+    (Astring.String.is_infix ~affix:"background-position: 50% -100px"
+       (css "bg-position-[center_-100px]"));
+  Alcotest.(check bool)
+    "bg-position-[left_top] normalises keywords" true
+    (Astring.String.is_infix ~affix:"background-position: 0% 0%"
+       (css "bg-position-[left_top]"))
+
 let test_bracket_image_literal () =
   let css cls =
     match Tw.of_string cls with
@@ -217,6 +234,8 @@ let tests =
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "bracket image literal" `Quick test_bracket_image_literal;
     test_case "bracket length keywords" `Quick test_bracket_length_keywords;
+    test_case "bg-position bracket keyword+length" `Quick
+      test_bg_position_bracket_keyword_length;
     test_case "bare radial and conic gradients" `Quick test_radial_conic;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
A two-axis `bg-position-[…]` value that mixed a keyword edge with a length (e.g. `bg-position-[center_-100px]`) fell back to a bare `center`, silently dropping the length. `parse_bracket_position` now parses each axis as a keyword edge (`left`/`right`/`top`/`bottom`/`center`, normalised to its percentage) or a length, so `bg-position-[center_-100px]` emits `background-position: 50% -100px`.