### PR TITLE
modifiers: keep the prefix in a group/peer arbitrary variant anchor

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -262,6 +262,15 @@ let parse_arbitrary_selector_content content anchor =
         combine
           (combine (where [ anchor ]) Descendant element_sel)
           Descendant universal
+  | [ before; "" ] when String.trim before <> "" ->
+      (* "<prefix> &" → <prefix> :where(.group) * — the [&] anchor is preceded
+         by an ancestor context (e.g. [:nth-of-type(3)_&]). *)
+      let prefix_sel =
+        Css.Selector.read (Cascade.Cursor.of_string (String.trim before))
+      in
+      combine
+        (combine prefix_sel Descendant (where [ anchor ]))
+        Descendant universal
   | _ ->
       (* Fallback — just use the anchor as descendant *)
       combine (where [ anchor ]) Descendant universal

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -562,12 +562,30 @@ let test_not_bracket_arbitrary_selector () =
   check bool "not-[.foo]:block negates a plain class" true
     (Astring.String.is_infix ~affix:":not(.foo)" (css "not-[.foo]:block"))
 
+(* A group/peer arbitrary variant whose [&] anchor is preceded by a context
+   (e.g. group-[:nth-of-type(3)_&]) keeps that prefix ahead of the anchor,
+   rather than dropping it down to just :where(.group). *)
+let test_group_arbitrary_prefix () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check bool "group-[:nth-of-type(3)_&] keeps the prefix" true
+    (Astring.String.is_infix ~affix:":is(:nth-of-type(3) :where(.group) *)"
+       (css "group-[:nth-of-type(3)_&]:block"));
+  check bool "group-[&_p] anchor-first still works" true
+    (Astring.String.is_infix ~affix:":is(:where(.group) p *)"
+       (css "group-[&_p]:block"))
+
 (* Extend the suite with new tests *)
 let tests =
   tests
   @ [
       test_case "not-[selector] arbitrary negation" `Quick
         test_not_bracket_arbitrary_selector;
+      test_case "group arbitrary prefix anchor" `Quick
+        test_group_arbitrary_prefix;
       test_case "is_hover flags" `Quick test_is_hover;
       test_case "of_string parsing" `Quick test_of_string_parsing;
       test_case "pp_modifier strings" `Quick test_pp_modifier_strings;


### PR DESCRIPTION
A group/peer arbitrary variant whose `&` anchor is preceded by a context, like `group-[:nth-of-type(3)_&]`, dropped the prefix: `parse_arbitrary_selector_content` only handled content starting with `&`, so the anchor-at-end form fell to a fallback and emitted `:is(:where(.group) *)` instead of `:is(:nth-of-type(3) :where(.group) *)`. It now handles the `<prefix> &` form, keeping the ancestor context ahead of the anchor.