### PR TITLE
arbitrary: normalize calc operators in [property:value]

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -238,7 +238,7 @@ module Handler = struct
            filter drops layerless custom properties). *)
         match
           Css.parse_declaration ~layer:"utilities" property
-            (unescape_value value)
+            (Parse.normalize_css_math_operators (unescape_value value))
         with
         | Some decl -> style [ decl ]
         | None -> style [])
@@ -365,7 +365,10 @@ module Handler = struct
               else
                 (* Plain [property:value]: any property whose value cascade can
                    parse becomes a typed declaration. *)
-                match Css.parse_declaration property (unescape_value value) with
+                match
+                  Css.parse_declaration property
+                    (Parse.normalize_css_math_operators (unescape_value value))
+                with
                 | Some _ -> Ok (Parsed_decl { property; value })
                 | None -> err_not_utility))
 end

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -59,6 +59,11 @@ val decode_arbitrary_value : string -> string
     spaces and normalizes omitted whitespace around binary [+] and [-] operators
     inside CSS math functions such as [calc()]. *)
 
+val normalize_css_math_operators : string -> string
+(** [normalize_css_math_operators s] inserts the spaces CSS math functions
+    (calc/min/max/...) require around binary [+] and [-], e.g.
+    [calc(var(--a)-var(--b))] becomes [calc(var(--a) - var(--b))]. *)
+
 val is_var : string -> bool
 (** [is_var s] returns [true] if [s] starts with ["var("]. Works on inner
     bracket content (without surrounding brackets). *)

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -38,6 +38,19 @@ let css cls =
   | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
   | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
 
+(* An arbitrary [property:value] normalises omitted whitespace around calc
+   operators, like the utility form: [margin:calc(100%-10px)] emits margin:
+   calc(100% - 10px). *)
+let test_property_calc_operators () =
+  Alcotest.(check bool)
+    "[margin:calc(100%-10px)] spaces the operator" true
+    (Astring.String.is_infix ~affix:"margin: calc(100% - 10px)"
+       (css "[margin:calc(100%-10px)]"));
+  Alcotest.(check bool)
+    "[width:calc(var(--a)-var(--b))] spaces the operator" true
+    (Astring.String.is_infix ~affix:"width: calc(var(--a) - var(--b))"
+       (css "[width:calc(var(--a)-var(--b))]"))
+
 (* A var-valued colour with /opacity used to raise invalid_arg; it now emits an
    oklab color-mix under @supports, with a fallback, type-safely. *)
 let test_var_color_opacity () =
@@ -75,6 +88,8 @@ let tests =
   [
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
     test_case "arbitrary of_string - invalid values" `Quick of_string_invalid;
+    test_case "property value calc operators" `Quick
+      test_property_calc_operators;
     test_case "var-valued colour with opacity" `Quick test_var_color_opacity;
     test_case "custom property with opacity" `Quick test_custom_prop_opacity;
     test_case "deferred and var inputs never crash" `Quick test_no_crash;


### PR DESCRIPTION
An arbitrary property whose value omits the whitespace CSS math requires around binary `+`/`-` (e.g. `[margin:calc(100%-10px)]`, `[width:calc(var(--a)-var(--b))]`) was rejected, because only the arbitrary *utility* form (`m-[calc(...)]`) ran `normalize_css_math_operators`. The `[property:value]` form now runs it at both the parse guard and the render, so `[margin:calc(100%-10px)]` emits `margin: calc(100% - 10px)`.