### PR TITLE
grid_template: accept a math-function track (min/max/clamp)

### DIFF
--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -175,8 +175,8 @@ module Handler = struct
       | Some (Pct n) -> Some (Pct n)
       | Some (Vw n) -> Some (Vw n)
       | Some (Vh n) -> Some (Vh n)
-      | Some _ -> None
-      | None ->
+      | Some l -> Some (Length l)
+      | None -> (
           let len = String.length value in
           if len >= 2 && String.sub value (len - 2) 2 = "fr" then
             match float_of_string_opt (String.sub value 0 (len - 2)) with
@@ -185,7 +185,12 @@ module Handler = struct
           else if value = "auto" then Some Auto
           else if value = "min-content" then Some Min_content
           else if value = "max-content" then Some Max_content
-          else None
+          else
+            (* A math-function track (min()/max()/clamp()/calc()) is a length,
+               which the suffix-based parse above does not recognise. *)
+            match Css.parse_length value with
+            | Some l -> Some (Length l)
+            | None -> None)
 
   (* A single grid track: a length/keyword, or one of the grid functions
      minmax()/fit-content()/repeat() (which may nest). *)

--- a/test/test_grid_template.ml
+++ b/test/test_grid_template.ml
@@ -59,7 +59,11 @@ let of_string_valid () =
   check "grid-cols-[repeat(2,1fr_2fr)]";
   check "grid-cols-[repeat(auto-fill,minmax(0,1fr))]";
   check "grid-cols-[fit-content(200px)]";
-  check "grid-rows-[repeat(4,minmax(100px,auto))]"
+  check "grid-rows-[repeat(4,minmax(100px,auto))]";
+  (* a math-function track (min/max/clamp) is a length track *)
+  check "grid-cols-[min(50%,20rem)]";
+  check "grid-cols-[min(50%,20rem)_auto]";
+  check "grid-cols-[max(200px,50%)_1fr]"
 
 let of_string_invalid () =
   let fail_maybe input =


### PR DESCRIPTION
A grid track that is a CSS math function (`grid-cols-[min(50%,20rem)]`, `grid-cols-[max(200px,50%)_1fr]`) produced no rule: `parse_track_keyword` recognised only suffix-unit lengths (`px`/`rem`/…) and named tracks, so a `min()`/`max()`/`clamp()`/`calc()` length track fell through. It now parses such a track through cascade as a `Length` track. With #177 this closes `grid-cols-[min(50%,theme(spacing.80))_auto]` on tailwindcss.com.