### PR TITLE
sizing: accept fractions on logical min/max inline and block sizes

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -171,6 +171,7 @@ module Handler = struct
     | Inline_svw
     | Inline_container of string
     (* min-inline-size utilities *)
+    | Min_inline_fraction of string
     | Min_inline_spacing of float
     | Min_inline_arbitrary of string * Css.length
     | Min_inline_auto
@@ -185,6 +186,7 @@ module Handler = struct
     | Min_inline_min
     | Min_inline_container of string
     (* max-inline-size utilities *)
+    | Max_inline_fraction of string
     | Max_inline_spacing of float
     | Max_inline_arbitrary of string * Css.length
     | Max_inline_fit
@@ -213,6 +215,7 @@ module Handler = struct
     | Block_screen
     | Block_svh
     (* min-block-size utilities *)
+    | Min_block_fraction of string
     | Min_block_spacing of float
     | Min_block_arbitrary of string * Css.length
     | Min_block_auto
@@ -227,6 +230,7 @@ module Handler = struct
     | Min_block_screen
     | Min_block_svh
     (* max-block-size utilities *)
+    | Max_block_fraction of string
     | Max_block_spacing of float
     | Max_block_arbitrary of string * Css.length
     | Max_block_dvh
@@ -805,6 +809,10 @@ module Handler = struct
         | None ->
             style [ inline_size (Var (Var.theme_ref ("container-" ^ name))) ])
     (* min-inline-size utilities *)
+    | Min_inline_fraction f -> (
+        match fraction_pct f with
+        | Some pct -> style [ min_inline_size (Pct pct) ]
+        | None -> failwith ("Unknown min-inline-size fraction: " ^ f))
     | Min_inline_spacing n -> spacing_utility min_inline_size n
     | Min_inline_arbitrary (_, len) -> style [ min_inline_size len ]
     | Min_inline_auto -> style [ min_inline_size Auto ]
@@ -826,6 +834,10 @@ module Handler = struct
             style
               [ min_inline_size (Var (Var.theme_ref ("container-" ^ name))) ])
     (* max-inline-size utilities *)
+    | Max_inline_fraction f -> (
+        match fraction_pct f with
+        | Some pct -> style [ max_inline_size (Pct pct) ]
+        | None -> failwith ("Unknown max-inline-size fraction: " ^ f))
     | Max_inline_spacing n -> spacing_utility max_inline_size n
     | Max_inline_arbitrary (_, len) -> style [ max_inline_size len ]
     | Max_inline_fit -> style [ max_inline_size Fit_content ]
@@ -864,6 +876,10 @@ module Handler = struct
     | Block_screen -> style [ block_size (Vh 100.) ]
     | Block_svh -> style [ block_size (Svh 100.) ]
     (* min-block-size utilities *)
+    | Min_block_fraction f -> (
+        match fraction_pct f with
+        | Some pct -> style [ min_block_size (Pct pct) ]
+        | None -> failwith ("Unknown min-block-size fraction: " ^ f))
     | Min_block_spacing n -> spacing_utility min_block_size n
     | Min_block_arbitrary (_, len) -> style [ min_block_size len ]
     | Min_block_auto -> style [ min_block_size Auto ]
@@ -878,6 +894,10 @@ module Handler = struct
     | Min_block_screen -> style [ min_block_size (Vh 100.) ]
     | Min_block_svh -> style [ min_block_size (Svh 100.) ]
     (* max-block-size utilities *)
+    | Max_block_fraction f -> (
+        match fraction_pct f with
+        | Some pct -> style [ max_block_size (Pct pct) ]
+        | None -> failwith ("Unknown max-block-size fraction: " ^ f))
     | Max_block_spacing n -> spacing_utility max_block_size n
     | Max_block_arbitrary (_, len) -> style [ max_block_size len ]
     | Max_block_dvh -> style [ max_block_size (Dvh 100.) ]
@@ -1163,6 +1183,9 @@ module Handler = struct
     | "max" -> Ok Min_inline_max
     | "min" -> Ok Min_inline_min
     | name when container_binding name <> None -> Ok (Min_inline_container name)
+    | frac when String.contains frac '/' ->
+        if fraction_pct frac <> None then Ok (Min_inline_fraction frac)
+        else err_invalid_value "min-inline-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
         | Some (raw, len) -> Ok (Min_inline_arbitrary (raw, len))
@@ -1184,6 +1207,9 @@ module Handler = struct
     | "max" -> Ok Max_inline_max
     | "none" -> Ok Max_inline_none
     | name when container_binding name <> None -> Ok (Max_inline_container name)
+    | frac when String.contains frac '/' ->
+        if fraction_pct frac <> None then Ok (Max_inline_fraction frac)
+        else err_invalid_value "max-inline-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
         | Some (raw, len) -> Ok (Max_inline_arbitrary (raw, len))
@@ -1228,6 +1254,9 @@ module Handler = struct
     | "min" -> Ok Min_block_min
     | "screen" -> Ok Min_block_screen
     | "svh" -> Ok Min_block_svh
+    | frac when String.contains frac '/' ->
+        if fraction_pct frac <> None then Ok (Min_block_fraction frac)
+        else err_invalid_value "min-block-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
         | Some (raw, len) -> Ok (Min_block_arbitrary (raw, len))
@@ -1249,6 +1278,9 @@ module Handler = struct
     | "none" -> Ok Max_block_none
     | "screen" -> Ok Max_block_screen
     | "svh" -> Ok Max_block_svh
+    | frac when String.contains frac '/' ->
+        if fraction_pct frac <> None then Ok (Max_block_fraction frac)
+        else err_invalid_value "max-block-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
         match parse_arbitrary v with
         | Some (raw, len) -> Ok (Max_block_arbitrary (raw, len))
@@ -1531,6 +1563,7 @@ module Handler = struct
     | Inline_svw -> inline + keyword_off + 8
     | Inline_container name -> inline + keyword_off + 9 + container_order name
     (* min-inline-size *)
+    | Min_inline_fraction f -> min_inline + fraction_value_order f
     | Min_inline_spacing n -> min_inline + spacing_value_order n
     | Min_inline_arbitrary _ -> min_inline + arbitrary_off
     | Min_inline_auto -> min_inline + keyword_off + 0
@@ -1546,6 +1579,7 @@ module Handler = struct
     | Min_inline_container name ->
         min_inline + keyword_off + 5 + container_order name
     (* max-inline-size *)
+    | Max_inline_fraction f -> max_inline + fraction_value_order f
     | Max_inline_spacing n -> max_inline + spacing_value_order n
     | Max_inline_arbitrary _ -> max_inline + arbitrary_off
     | Max_inline_fit -> max_inline + keyword_off + 0
@@ -1575,6 +1609,7 @@ module Handler = struct
     | Block_screen -> block + keyword_off + 8
     | Block_svh -> block + keyword_off + 9
     (* min-block-size *)
+    | Min_block_fraction f -> min_block + fraction_value_order f
     | Min_block_spacing n -> min_block + spacing_value_order n
     | Min_block_arbitrary _ -> min_block + arbitrary_off
     | Min_block_auto -> min_block + keyword_off + 0
@@ -1589,6 +1624,7 @@ module Handler = struct
     | Min_block_screen -> min_block + keyword_off + 8
     | Min_block_svh -> min_block + keyword_off + 9
     (* max-block-size *)
+    | Max_block_fraction f -> max_block + fraction_value_order f
     | Max_block_spacing n -> max_block + spacing_value_order n
     | Max_block_arbitrary _ -> max_block + arbitrary_off
     | Max_block_dvh -> max_block + keyword_off + 0
@@ -1773,6 +1809,7 @@ module Handler = struct
     | Inline_svw -> "inline-svw"
     | Inline_container name -> "inline-" ^ name
     (* min-inline-size utilities *)
+    | Min_inline_fraction f -> "min-inline-" ^ f
     | Min_inline_spacing n -> "min-inline-" ^ class_float (n *. 4.)
     | Min_inline_arbitrary (raw, _) -> "min-inline-[" ^ raw ^ "]"
     | Min_inline_auto -> "min-inline-auto"
@@ -1787,6 +1824,7 @@ module Handler = struct
     | Min_inline_min -> "min-inline-min"
     | Min_inline_container name -> "min-inline-" ^ name
     (* max-inline-size utilities *)
+    | Max_inline_fraction f -> "max-inline-" ^ f
     | Max_inline_spacing n -> "max-inline-" ^ class_float (n *. 4.)
     | Max_inline_arbitrary (raw, _) -> "max-inline-[" ^ raw ^ "]"
     | Max_inline_fit -> "max-inline-fit"
@@ -1815,6 +1853,7 @@ module Handler = struct
     | Block_screen -> "block-screen"
     | Block_svh -> "block-svh"
     (* min-block-size utilities *)
+    | Min_block_fraction f -> "min-block-" ^ f
     | Min_block_spacing n -> "min-block-" ^ class_float (n *. 4.)
     | Min_block_arbitrary (raw, _) -> "min-block-[" ^ raw ^ "]"
     | Min_block_auto -> "min-block-auto"
@@ -1829,6 +1868,7 @@ module Handler = struct
     | Min_block_screen -> "min-block-screen"
     | Min_block_svh -> "min-block-svh"
     (* max-block-size utilities *)
+    | Max_block_fraction f -> "max-block-" ^ f
     | Max_block_spacing n -> "max-block-" ^ class_float (n *. 4.)
     | Max_block_arbitrary (raw, _) -> "max-block-[" ^ raw ^ "]"
     | Max_block_dvh -> "max-block-dvh"

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -115,7 +115,12 @@ let test_max_sizes () =
   check "max-w-1/2";
   check "max-w-1/3";
   check "max-h-1/2";
-  check "max-h-3/4"
+  check "max-h-3/4";
+  (* fractions on the logical min/max inline and block axes *)
+  check "max-block-1/2";
+  check "min-block-1/3";
+  check "max-inline-3/4";
+  check "min-inline-2/3"
 
 let test_square_sizes () =
   check "size-0";
@@ -182,6 +187,25 @@ let test_aspect_bracket_number () =
   Alcotest.(check string)
     "aspect-[1.333] round-trips" "aspect-[1.333]"
     (Tw.pp (Result.get_ok (Tw.of_string "aspect-[1.333]")))
+
+(* A fraction on a logical min/max inline or block axis resolves to a
+   percentage, like the physical max-w/max-h families do. *)
+let test_logical_size_fractions () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " is " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "max-block-1/2" "max-block-size:50%";
+  has "min-block-1/3" "min-block-size:33.3333%";
+  has "max-inline-3/4" "max-inline-size:75%";
+  has "min-inline-2/3" "min-inline-size:66.6667%"
 
 (* aspect-square inlines the 1/1 ratio in v4; it used to emit aspect-ratio:
    var(--aspect-square) with a stray --aspect-square theme token that bare
@@ -336,6 +360,7 @@ let tests =
     test_case "min sizes" `Quick test_min_sizes;
     test_case "max sizes" `Quick test_max_sizes;
     test_case "square sizes" `Quick test_square_sizes;
+    test_case "logical size fractions" `Quick test_logical_size_fractions;
     test_case "sizing of_string - invalid values" `Quick of_string_invalid;
     test_case "aspect classes" `Quick test_aspect_classes;
     test_case "aspect css" `Quick test_aspect_css;


### PR DESCRIPTION
The `inline-size`/`block-size` families already took fraction values, but the four logical `min-inline`/`max-inline`/`min-block`/`max-block` families rejected them. A class like `max-block-1/2` now resolves to a percentage (`max-block-size: 50%`), matching how the physical `max-w`/`max-h` families handle fractions.

Closes ~18 utility classes from the tailwindcss.com canonical-parity sweep.