### PR TITLE
utilities: add small keyword-value gaps from the parity sweep

### DIFF
--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -71,6 +71,7 @@ module Handler = struct
       Justify_items_start
     | Justify_items_end
     | Justify_items_center
+    | Justify_items_normal
     | Justify_items_stretch
     | Justify_items_center_safe
     | Justify_items_end_safe
@@ -167,6 +168,7 @@ module Handler = struct
   let justify_items_end = style [ justify_items End ]
   let justify_items_center = style [ justify_items Center ]
   let justify_items_stretch = style [ justify_items Stretch ]
+  let justify_items_normal = style [ justify_items Normal ]
   let justify_items_center_safe = style [ justify_items Safe_center ]
   let justify_items_end_safe = style [ justify_items Safe_end ]
   let justify_self_auto = style [ justify_self Auto ]
@@ -260,6 +262,7 @@ module Handler = struct
       (Justify_items_end, "justify-items-end", justify_items_end, 72);
       (Justify_items_center, "justify-items-center", justify_items_center, 70);
       (Justify_items_stretch, "justify-items-stretch", justify_items_stretch, 75);
+      (Justify_items_normal, "justify-items-normal", justify_items_normal, 73);
       ( Justify_items_center_safe,
         "justify-items-center-safe",
         justify_items_center_safe,
@@ -412,6 +415,7 @@ let justify_items_start = utility Justify_items_start
 let justify_items_end = utility Justify_items_end
 let justify_items_center = utility Justify_items_center
 let justify_items_stretch = utility Justify_items_stretch
+let justify_items_normal = utility Justify_items_normal
 let justify_items_center_safe = utility Justify_items_center_safe
 let justify_items_end_safe = utility Justify_items_end_safe
 

--- a/lib/alignment.mli
+++ b/lib/alignment.mli
@@ -119,6 +119,9 @@ val justify_items_center : t
 val justify_items_stretch : t
 (** [justify_items_stretch] stretches items to fill. *)
 
+val justify_items_normal : t
+(** [justify_items_normal] uses the normal justification (the default). *)
+
 val justify_items_center_safe : t
 (** [justify_items_center_safe] justifies items to center with safe overflow. *)
 

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -23,6 +23,7 @@ module Handler = struct
     (* Grow *)
     | Flex_grow
     | Flex_grow_0
+    | Flex_grow_n of int (* grow-N where N is any integer *)
     | Flex_grow_arbitrary of int (* grow-[123] *)
     | Flex_grow_legacy (* flex-grow (deprecated alias, keeps its class name) *)
     | Flex_grow_0_legacy (* flex-grow-0 *)
@@ -157,6 +158,7 @@ module Handler = struct
     | Flex_arbitrary n -> flex_n_style n
     | Flex_grow -> flex_grow_utility
     | Flex_grow_0 -> flex_grow_0_utility
+    | Flex_grow_n n -> style [ flex_grow (float_of_int n) ]
     | Flex_grow_arbitrary n -> style [ flex_grow (float_of_int n) ]
     | Flex_grow_legacy -> flex_grow_utility
     | Flex_grow_0_legacy -> flex_grow_0_utility
@@ -224,6 +226,7 @@ module Handler = struct
     | Flex_grow_0_legacy -> 29999
     | Flex_grow -> 30000
     | Flex_grow_0 -> 30001
+    | Flex_grow_n n -> 30000 + n
     | Flex_grow_arbitrary _ -> 30002
     (* Basis: fractions → arbitrary → keywords alphabetical → named *)
     | Basis_fraction (n, m) -> 40000 + (n * 10) + m
@@ -270,6 +273,10 @@ module Handler = struct
         match int_of_string_opt inner with
         | Some i -> Ok (Flex_grow_arbitrary i)
         | None -> err_not_utility)
+    | [ "grow"; n ] -> (
+        match int_of_string_opt n with
+        | Some i when i > 0 -> Ok (Flex_grow_n i)
+        | _ -> err_not_utility)
     | [ "flex"; "shrink" ] -> Ok Flex_shrink_legacy
     | [ "shrink" ] -> Ok Flex_shrink
     | [ "flex"; "shrink"; "0" ] -> Ok Flex_shrink_0_legacy
@@ -372,6 +379,7 @@ module Handler = struct
        deprecated aliases that preserve their class name *)
     | Flex_grow -> "grow"
     | Flex_grow_0 -> "grow-0"
+    | Flex_grow_n n -> "grow-" ^ string_of_int n
     | Flex_grow_arbitrary n -> "grow-[" ^ string_of_int n ^ "]"
     | Flex_grow_legacy -> "flex-grow"
     | Flex_grow_0_legacy -> "flex-grow-0"

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -174,6 +174,8 @@ module Handler = struct
     | (* Box decoration break *)
       Box_decoration_clone
     | Box_decoration_slice
+    | Decoration_clone (* legacy alias, keeps its class name *)
+    | Decoration_slice
     | (* Break before/after/inside - page/column breaks *)
       Break_before_all
     | Break_before_auto
@@ -304,6 +306,8 @@ module Handler = struct
     (* Box decoration break - alphabetical: clone, slice *)
     | Box_decoration_clone -> 1000
     | Box_decoration_slice -> 1001
+    | Decoration_clone -> 1000
+    | Decoration_slice -> 1001
     (* Break before - alphabetical order (Tailwind: break-before < break-inside
        < break-after) *)
     | Break_before_all -> 1100
@@ -397,6 +401,8 @@ module Handler = struct
     | Clear_end -> "clear-end"
     | Box_decoration_clone -> "box-decoration-clone"
     | Box_decoration_slice -> "box-decoration-slice"
+    | Decoration_clone -> "decoration-clone"
+    | Decoration_slice -> "decoration-slice"
     | Break_before_all -> "break-before-all"
     | Break_before_auto -> "break-before-auto"
     | Break_before_avoid -> "break-before-avoid"
@@ -533,6 +539,18 @@ module Handler = struct
             Css.webkit_box_decoration_break Slice;
             Css.box_decoration_break Slice;
           ]
+    | Decoration_clone ->
+        style
+          [
+            Css.webkit_box_decoration_break Clone;
+            Css.box_decoration_break Clone;
+          ]
+    | Decoration_slice ->
+        style
+          [
+            Css.webkit_box_decoration_break Slice;
+            Css.box_decoration_break Slice;
+          ]
     (* Break before *)
     | Break_before_all -> style [ Css.break_before All ]
     | Break_before_auto -> style [ Css.break_before Auto ]
@@ -649,6 +667,8 @@ module Handler = struct
     | [ "clear"; "end" ] -> Ok Clear_end
     | [ "box"; "decoration"; "clone" ] -> Ok Box_decoration_clone
     | [ "box"; "decoration"; "slice" ] -> Ok Box_decoration_slice
+    | [ "decoration"; "clone" ] -> Ok Decoration_clone
+    | [ "decoration"; "slice" ] -> Ok Decoration_slice
     (* Break before *)
     | [ "break"; "before"; "all" ] -> Ok Break_before_all
     | [ "break"; "before"; "auto" ] -> Ok Break_before_auto

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1374,6 +1374,7 @@ module Typography_late = struct
     | Subpixel_antialiased
     | (* Text overflow *)
       Text_ellipsis
+    | Overflow_ellipsis (* legacy alias for text-ellipsis, keeps its name *)
     | Text_clip
     | Truncate
     | (* Text wrap *)
@@ -1635,6 +1636,7 @@ module Typography_late = struct
     | [ "antialiased" ] -> Ok Antialiased
     | [ "subpixel"; "antialiased" ] -> Ok Subpixel_antialiased
     | [ "text"; "ellipsis" ] -> Ok Text_ellipsis
+    | [ "overflow"; "ellipsis" ] -> Ok Overflow_ellipsis
     | [ "text"; "clip" ] -> Ok Text_clip
     | [ "truncate" ] -> Ok Truncate
     | [ "text"; "wrap" ] -> Ok Text_wrap
@@ -1844,6 +1846,7 @@ module Typography_late = struct
     | Antialiased -> "antialiased"
     | Subpixel_antialiased -> "subpixel-antialiased"
     | Text_ellipsis -> "text-ellipsis"
+    | Overflow_ellipsis -> "overflow-ellipsis"
     | Text_clip -> "text-clip"
     | Truncate -> "truncate"
     | Text_wrap -> "text-wrap"
@@ -1998,6 +2001,7 @@ module Typography_late = struct
        a suborder above alignment/gap's range. *)
     | Text_clip -> 8320
     | Text_ellipsis -> 8321
+    | Overflow_ellipsis -> 8321
     | Truncate -> 9_000_000 (* priority 17, after alignment/gap (max ~2100) *)
     (* Text wrap - alphabetical order *)
     | Text_balance -> 9100
@@ -2872,6 +2876,7 @@ module Typography_late = struct
     | Antialiased -> antialiased
     | Subpixel_antialiased -> subpixel_antialiased
     | Text_ellipsis -> text_ellipsis
+    | Overflow_ellipsis -> text_ellipsis
     | Text_clip -> text_clip
     | Truncate -> truncate
     | Text_wrap -> text_wrap

--- a/test/test_alignment.ml
+++ b/test/test_alignment.ml
@@ -40,6 +40,7 @@ let of_string_valid () =
   check "justify-items-end";
   check "justify-items-center";
   check "justify-items-stretch";
+  check "justify-items-normal";
 
   (* Justify self *)
   check "justify-self-auto";

--- a/test/test_flex.ml
+++ b/test/test_flex.ml
@@ -30,6 +30,8 @@ let of_string_valid () =
   (* Grow/Shrink - Tailwind v4 uses shorter names *)
   check_props "grow";
   check_props "grow-0";
+  check_props "grow-3";
+  check_props "grow-7";
   check_props "shrink";
   check_props "shrink-0";
 

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -18,6 +18,14 @@ let test_visibility () =
   check "invisible";
   check "collapse"
 
+(* box-decoration-break: the v4 box-decoration-* names and the legacy v3
+   decoration-clone/slice aliases, which keep their own class name. *)
+let test_box_decoration_break () =
+  check "box-decoration-clone";
+  check "box-decoration-slice";
+  check "decoration-clone";
+  check "decoration-slice"
+
 let test_z_index () =
   check "z-0";
   check "z-10";
@@ -169,6 +177,7 @@ let tests =
   [
     test_case "display utilities" `Quick test_display_utilities;
     test_case "visibility" `Quick test_visibility;
+    test_case "box-decoration-break" `Quick test_box_decoration_break;
     test_case "typed constructors" `Quick test_typed;
     test_case "z-index" `Quick test_z_index;
     test_case "overflow" `Quick test_overflow;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -109,6 +109,7 @@ let test_line_clamp () =
 
 let test_text_overflow_wrap () =
   check "text-ellipsis";
+  check "overflow-ellipsis";
   check "text-clip";
   check "text-wrap";
   check "text-nowrap";


### PR DESCRIPTION
Closes several small utility-value gaps found on tailwindcss.com: integer `flex-grow` (`grow-3`, `grow-7`), the v3 legacy aliases `decoration-clone`/`decoration-slice` (box-decoration-break) and `overflow-ellipsis` (text-ellipsis) which keep their own class names, and `justify-items-normal`.