### PR TITLE
utilities: add duration-initial, ease-initial, via-none

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -83,6 +83,7 @@ module Handler = struct
     | Bg_gradient_to of direction
     | Gradient_color of gradient_target * gradient_color_source
     | Gradient_stop_position of gradient_target * gradient_position_source
+    | Via_none (* via-none: clears the gradient's via stops *)
     | Bg_origin_border
     | Bg_origin_padding
     | Bg_origin_content
@@ -227,6 +228,7 @@ module Handler = struct
         | Top_left -> "bg-gradient-to-tl"
         | Left -> "bg-gradient-to-l"
         | Bottom_left -> "bg-gradient-to-bl")
+    | Via_none -> "via-none"
     | Gradient_color (target, src) ->
         let prefix =
           match target with
@@ -1371,6 +1373,13 @@ module Handler = struct
         | Gp_pct p -> gradient_position_style pos_var (Pct p)
         | Gp_bracket v ->
             gradient_position_style pos_var (parse_bracket_position_value v))
+    | Via_none ->
+        let property_rules =
+          match Var.property_rule gradient_via_stops_var with
+          | Some r -> r
+          | None -> Css.empty
+        in
+        style ~property_rules [ Var.binding_initial gradient_via_stops_var ]
     | Bg_origin_border -> bg_origin_border
     | Bg_origin_padding -> bg_origin_padding
     | Bg_origin_content -> bg_origin_content
@@ -1547,6 +1556,7 @@ module Handler = struct
     (* Gradient color utilities *)
     | Gradient_color (Gradient_from, _) -> 110000
     | Gradient_color (Gradient_via, _) -> 120000
+    | Via_none -> 120002
     | Gradient_color (Gradient_to, _) -> 130000
     (* Gradient position utilities *)
     | Gradient_stop_position (Gradient_from, _) -> 110001
@@ -1946,6 +1956,7 @@ module Handler = struct
         | Ok (color, shade) -> Ok (Bg (color, shade))
         | Error _ -> Error (`Msg "Invalid background color"))
     | "from" :: rest -> parse_gradient_color ~theme Gradient_from rest
+    | [ "via"; "none" ] -> Ok Via_none
     | "via" :: rest -> parse_gradient_color ~theme Gradient_via rest
     | "to" :: rest -> parse_gradient_color ~theme Gradient_to rest
     | _ -> Error (`Msg "Unknown background class")

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -28,6 +28,7 @@ module Handler = struct
     | Transition
     | Transition_arbitrary of string
     | Duration of int
+    | Duration_initial
     | Duration_arbitrary of string * Css.duration
     | Delay of int
     | Delay_arbitrary of string * Css.duration
@@ -35,6 +36,7 @@ module Handler = struct
     | Ease_in
     | Ease_out
     | Ease_in_out
+    | Ease_initial
     | Ease_arbitrary of string
 
   type Utility.base += Self of t
@@ -311,6 +313,22 @@ module Handler = struct
     style ~property_rules
       [ tw_duration_decl; Css.transition_duration duration_val ]
 
+  (* duration-initial / ease-initial reset the channel to the CSS initial
+     keyword, clearing any inherited value. *)
+  let duration_initial =
+    let property_rules =
+      match Var.property_rule tw_duration_var with
+      | Some r -> r
+      | None -> Css.empty
+    in
+    style ~property_rules [ Var.binding_initial tw_duration_var ]
+
+  let ease_initial =
+    let property_rules =
+      match Var.property_rule tw_ease_var with Some r -> r | None -> Css.empty
+    in
+    style ~property_rules [ Var.binding_initial tw_ease_var ]
+
   (* Theme variables for easing functions - order (7, 9-12) places them after
      radius (7, 0-8) but before animate (7, 13-17) *)
   let ease_in_var = Var.theme Css.Timing_function "ease-in" ~order:(7, 9)
@@ -489,6 +507,7 @@ module Handler = struct
     | Transition -> transition ()
     | Transition_arbitrary s -> transition_arbitrary s
     | Duration n -> duration n
+    | Duration_initial -> duration_initial
     | Duration_arbitrary (_, d) -> duration_arbitrary d
     | Delay n -> delay n
     | Delay_arbitrary (_, d) -> delay_arbitrary d
@@ -496,6 +515,7 @@ module Handler = struct
     | Ease_in -> ease_in
     | Ease_out -> ease_out
     | Ease_in_out -> ease_in_out
+    | Ease_initial -> ease_initial
     | Ease_arbitrary s -> ease_arbitrary s
 
   let suborder = function
@@ -513,6 +533,7 @@ module Handler = struct
     | Delay n -> 100 + n
     | Delay_arbitrary _ -> 100000
     | Duration n -> 200 + n
+    | Duration_initial -> 200001
     | Duration_arbitrary _ -> 200000
     (* Ease utilities come after Duration. Tailwind orders: duration then ease.
        Use a high base to ensure even duration-5000 (suborder 5200) < ease.
@@ -521,6 +542,7 @@ module Handler = struct
     | Ease_in_out -> 100001
     | Ease_linear -> 100002
     | Ease_out -> 100003
+    | Ease_initial -> 100004
     | Ease_arbitrary _ -> 99999
 
   let ( >|= ) = Parse.( >|= )
@@ -561,6 +583,7 @@ module Handler = struct
             | None -> Error (`Msg "Invalid duration value")
           else Error (`Msg "Invalid duration unit")
         else Error (`Msg "Invalid arbitrary syntax")
+    | [ "duration"; "initial" ] -> Ok Duration_initial
     | [ "duration"; n ] ->
         Parse.int_pos ~name:"duration" n >|= fun n -> Duration n
     | [ "delay"; n ] when String.length n > 0 && n.[0] = '[' ->
@@ -592,6 +615,7 @@ module Handler = struct
     | [ "ease"; "in" ] -> Ok Ease_in
     | [ "ease"; "out" ] -> Ok Ease_out
     | [ "ease"; "in"; "out" ] -> Ok Ease_in_out
+    | [ "ease"; "initial" ] -> Ok Ease_initial
     | [ "ease"; value ] when Parse.is_bracket_value value ->
         Ok (Ease_arbitrary (Parse.bracket_inner value))
     | _ -> Error (`Msg "Not a transition utility")
@@ -608,6 +632,7 @@ module Handler = struct
     | Transition -> "transition"
     | Transition_arbitrary s -> "transition-[" ^ s ^ "]"
     | Duration n -> "duration-" ^ string_of_int n
+    | Duration_initial -> "duration-initial"
     | Duration_arbitrary (s, _) -> "duration-[" ^ s ^ "]"
     | Delay n -> "delay-" ^ string_of_int n
     | Delay_arbitrary (s, _) -> "delay-[" ^ s ^ "]"
@@ -615,6 +640,7 @@ module Handler = struct
     | Ease_in -> "ease-in"
     | Ease_out -> "ease-out"
     | Ease_in_out -> "ease-in-out"
+    | Ease_initial -> "ease-initial"
     | Ease_arbitrary s -> "ease-[" ^ s ^ "]"
 end
 

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -394,6 +394,12 @@ let property_rules : type a. (a, [< `Property_default ]) t -> Css.t =
    reference *)
 let binding var ?fallback value = var.binding ?fallback value
 
+(* Reset a channel to the CSS-wide [initial] keyword ([--tw-x: initial]). Used
+   by the [*-initial] / [via-none] utilities, which clear a channel var rather
+   than set it to a typed value. *)
+let binding_initial var =
+  Css.custom_property ~layer:"utilities" ("--" ^ var.name) "initial"
+
 (* Create a variable reference for variables with @property defaults OR
    fallback *)
 let reference : type a b. (a, b) t -> a Css.var =

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -524,6 +524,12 @@ val binding :
       (e.g., text-xs references --tw-leading with --text-xs--line-height as
       fallback). *)
 
+val binding_initial :
+  ('a, [< `Property_default | `Channel ]) t -> Css.declaration
+(** [binding_initial var] resets the channel to the CSS-wide [initial] keyword
+    ([--name: initial]). Used by the [*-initial] and [via-none] utilities, which
+    clear a channel var instead of setting it to a typed value. *)
+
 val reference : ('a, [< `Ref_only | `Property_default ]) t -> 'a Css.var
 (** [reference var] creates a reference to a variable. For ref_only and
     property_default variables only. *)

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -22,6 +22,21 @@ let test_gradient_colors () =
   Alcotest.check string "via-blue-600" "via-blue-600" (Utility.to_class via);
   Alcotest.check string "to-green-500" "to-green-500" (Utility.to_class to_)
 
+(* via-none clears the gradient's via stops by resetting the channel var to the
+   CSS initial keyword. *)
+let test_via_none () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.check string "via-none round-trips" "via-none"
+    (Tw.pp (Result.get_ok (Tw.of_string "via-none")));
+  Alcotest.(check bool)
+    "via-none sets --tw-gradient-via-stops:initial" true
+    (Astring.String.is_infix ~affix:"--tw-gradient-via-stops:initial"
+       (css "via-none"))
+
 (* Bare bg-radial / bg-conic (and bg-conic-{angle}) set --tw-gradient-position
    to the default oklab interpolation and the matching gradient image; they used
    to be unknown classes (only the /interp and bracket forms were handled). *)
@@ -238,6 +253,7 @@ let tests =
       test_bg_position_bracket_keyword_length;
     test_case "bare radial and conic gradients" `Quick test_radial_conic;
     test_case "gradient colors" `Quick test_gradient_colors;
+    test_case "via-none" `Quick test_via_none;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "backgrounds suborder matches Tailwind" `Quick
       suborder_matches_tailwind;

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -18,14 +18,34 @@ let test_roundtrip () =
   check "ease-linear";
   check "ease-in";
   check "ease-out";
-  check "ease-in-out"
+  check "ease-in-out";
+  (* the initial keyword resets the duration/ease channel *)
+  check "duration-initial";
+  check "ease-initial"
 
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Transitions.Handler) "duration";
   Test_helpers.check_invalid_input (module Tw.Transitions.Handler) "delay";
   Test_helpers.check_invalid_input (module Tw.Transitions.Handler) "ease"
 
+(* duration-initial / ease-initial reset their channel var to the CSS initial
+   keyword. *)
+let test_initial_resets () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "duration-initial sets --tw-duration:initial" true
+    (Astring.String.is_infix ~affix:"--tw-duration:initial"
+       (css "duration-initial"));
+  Alcotest.(check bool)
+    "ease-initial sets --tw-ease:initial" true
+    (Astring.String.is_infix ~affix:"--tw-ease:initial" (css "ease-initial"))
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [ Alcotest.test_case "initial resets" `Quick test_initial_resets ]
 
 let suite = ("transitions", tests)


### PR DESCRIPTION
Each of these resets a channel custom property to the CSS-wide `initial` keyword (`--tw-duration: initial`, `--tw-ease: initial`, `--tw-gradient-via-stops: initial`). Adds `Var.binding_initial`, which emits the reset declaration tagged for the utilities layer so it survives the utility-property filter (a raw untagged custom property was dropped from the rule).