### PR TITLE
svg: accept shadeless stroke colors (stroke-white, stroke-black)

### DIFF
--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -452,10 +452,8 @@ module Handler = struct
     | [ "stroke"; "0" ] -> Ok Stroke_0
     | [ "stroke"; "1" ] -> Ok Stroke_1
     | [ "stroke"; "2" ] -> Ok Stroke_2
-    | [ "stroke"; n ] -> (
-        match int_of_string_opt n with
-        | Some width -> Ok (Stroke_width width)
-        | None -> err_not_utility)
+    | [ "stroke"; n ] when int_of_string_opt n <> None ->
+        Ok (Stroke_width (int_of_string n))
     | "stroke" :: color_parts when List.exists has_opacity color_parts -> (
         match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -6,5 +6,32 @@ let basic_svg () =
   check_class "fill-none" Tw.Svg.fill_none;
   check_class "stroke-2" Tw.Svg.stroke_2
 
-let tests = [ test_case "basic svg" `Quick basic_svg ]
+(* Shadeless stroke colours (stroke-white/black) used to be swallowed by the
+   stroke-width case and rejected; the width case now only matches integers, so
+   they reach the colour parse. *)
+let stroke_shadeless_colors () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "stroke-white references --color-white" true
+    (Astring.String.is_infix ~affix:"stroke:var(--color-white)"
+       (css "stroke-white"));
+  Alcotest.(check bool)
+    "stroke-black references --color-black" true
+    (Astring.String.is_infix ~affix:"stroke:var(--color-black)"
+       (css "stroke-black"));
+  (* integer widths still parse as widths, not colours *)
+  Alcotest.(check bool)
+    "stroke-2 stays a width" true
+    (Astring.String.is_infix ~affix:"stroke-width:2px" (css "stroke-2"))
+
+let tests =
+  [
+    test_case "basic svg" `Quick basic_svg;
+    test_case "stroke shadeless colors" `Quick stroke_shadeless_colors;
+  ]
+
 let suite = ("svg", tests)


### PR DESCRIPTION
The stroke-width case matched any `[stroke; n]` and rejected non-integers before the color parse ran, so `stroke-white` and `stroke-black` were unknown classes (unlike `fill-white`, which has no width case). Guarding the width case on an integer lets shadeless colors fall through to the color parse.