### PR TITLE
position: accept fractional and px spacing steps on inset sides

### DIFF
--- a/lib/position.ml
+++ b/lib/position.ml
@@ -100,6 +100,62 @@ let named_inset_value name : Css.declaration * Css.length =
 let spacing_value ?theme n : Css.declaration * Css.length =
   Theme.spacing_calc ?theme n
 
+(* The physical/axis inset sides that take the spacing scale, so a fractional
+   step (top-2.5) or the px step (left-px) can share one constructor. *)
+type pside =
+  | P_top
+  | P_right
+  | P_bottom
+  | P_left
+  | P_inset
+  | P_inset_x
+  | P_inset_y
+
+let pside_name = function
+  | P_top -> "top"
+  | P_right -> "right"
+  | P_bottom -> "bottom"
+  | P_left -> "left"
+  | P_inset -> "inset"
+  | P_inset_x -> "inset-x"
+  | P_inset_y -> "inset-y"
+
+(* [top-2.5] / [right-0.5] / [left-px]: a spacing token that is not a plain
+   integer (those keep their existing [Top of int] path). *)
+let parse_pos_spacing s : Style.spacing option =
+  if s = "px" then Some `Px
+  else
+    match float_of_string_opt s with
+    | Some f when f >= 0. && not (Float.is_integer f) -> Some (`Rem (f *. 0.25))
+    | _ -> None
+
+(* Resolve a spacing token to (optional --spacing binding, length), mirroring
+   the padding family so the px and fractional steps render identically. *)
+let pos_spacing_to_len ?theme (s : Style.spacing) :
+    Css.declaration option * Css.length =
+  match s with
+  | `Rem f ->
+      let decl, len = Theme.spacing_calc_float ?theme (f /. 0.25) in
+      (Some decl, len)
+  | `Px -> (None, Css.Px 1.)
+  | `Full -> (None, Css.Pct 100.)
+  | `Named name -> (None, Css.Var (Var.theme_ref ("spacing-" ^ name)))
+
+let pos_spacing_style ?theme side (s : Style.spacing) =
+  let decl_opt, len = pos_spacing_to_len ?theme s in
+  let decls = Option.to_list decl_opt in
+  let body =
+    match side with
+    | P_top -> [ Css.top len ]
+    | P_right -> [ Css.right len ]
+    | P_bottom -> [ Css.bottom len ]
+    | P_left -> [ Css.left len ]
+    | P_inset -> [ Css.inset [ len ] ]
+    | P_inset_x -> [ Css.inset_inline [ len ] ]
+    | P_inset_y -> [ Css.inset_block [ len ] ]
+  in
+  Style.style (decls @ body)
+
 (* A position fraction [n/m] resolves to [n/m * 100%], folded to 6 significant
    figures like Tailwind (mirrors [Sizing]'s fraction handling, including the
    supported denominators). *)
@@ -153,6 +209,8 @@ module Handler = struct
     | Inset_y_full
     | Neg_inset_y_full
     | Inset_y_3_4
+    | Pos_spacing of pside * Style.spacing
+      (* fractional or px spacing step on a physical/axis inset side *)
     | Inset of int
     | Inset_arbitrary of string * Css.length
     | Inset_named of string (* Custom property reference like inset-shadowned *)
@@ -275,6 +333,7 @@ module Handler = struct
     | Inset_y_full -> style [ Css.inset_block [ Pct 100.0 ] ]
     | Neg_inset_y_full -> style [ Css.inset_block [ Pct (-100.0) ] ]
     | Inset_y_3_4 -> style [ Css.inset_block [ Pct 75.0 ] ]
+    | Pos_spacing (side, sp) -> pos_spacing_style ~theme side sp
     | Inset n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset [ value ] ])
@@ -454,6 +513,21 @@ module Handler = struct
     let start = 12_000_000 in
     let e = 13_000_000 in
     function
+    | Pos_spacing (side, sp) ->
+        let base =
+          match side with
+          | P_top -> top
+          | P_right -> right
+          | P_bottom -> bottom
+          | P_left -> left
+          | P_inset -> inset
+          | P_inset_x -> inset_x
+          | P_inset_y -> inset_y
+        in
+        let scale =
+          match sp with `Rem f -> f /. 0.25 | `Px -> 0.05 | _ -> 0.
+        in
+        base + pos_off + int_of_float (scale *. 10.)
     | Position_absolute -> 0
     | Position_fixed -> 1
     | Position_relative -> 2
@@ -612,12 +686,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_x x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_x_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_x_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_inset_x, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Inset_x_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Inset_x_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "inset"; "x"; frac ] when frac_valid frac ->
         Ok (Neg_inset_x_fraction frac)
     | [ ""; "inset"; "x"; n ] ->
@@ -626,12 +703,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_y x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_y_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_y_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_inset_y, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Inset_y_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Inset_y_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "inset"; "y"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset_y (-x))
     (* inset-s = inset-inline-start *)
@@ -708,12 +788,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_inset, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Inset_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Inset_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "inset"; frac ] when frac_valid frac -> Ok (Neg_inset_fraction frac)
     | [ ""; "inset"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Inset (-x))
@@ -725,12 +808,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Top x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Top_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Top_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_top, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Top_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Top_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "top"; frac ] when frac_valid frac -> Ok (Neg_top_fraction frac)
     | [ ""; "top"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Top (-x))
@@ -742,12 +828,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Right x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Right_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Right_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_right, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Right_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Right_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "right"; frac ] when frac_valid frac -> Ok (Neg_right_fraction frac)
     | [ ""; "right"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Right (-x))
@@ -759,12 +848,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Bottom x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Bottom_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Bottom_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_bottom, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Bottom_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Bottom_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "bottom"; n ] ->
         int_of_string_with_sign n |> Result.map (fun x -> Bottom (-x))
     | [ "left"; frac ] when frac_valid frac -> Ok (Left_fraction frac)
@@ -775,12 +867,15 @@ module Handler = struct
         match int_of_string_with_sign n with
         | Ok x -> Ok (Left x)
         | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Left_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Left_named n)
-            | Error _ -> Error (`Msg "invalid")))
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Pos_spacing (P_left, sp))
+            | None -> (
+                match parse_bracket_length n with
+                | Ok len -> Ok (Left_arbitrary (n, len))
+                | Error _
+                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
+                    Ok (Left_named n)
+                | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "left"; frac ] when frac_valid frac -> Ok (Neg_left_fraction frac)
     | [ ""; "left"; n ] -> (
         match int_of_string_with_sign n with
@@ -827,6 +922,8 @@ module Handler = struct
     | Inset_y_full -> "inset-y-full"
     | Neg_inset_y_full -> "-inset-y-full"
     | Inset_y_3_4 -> "inset-y-3/4"
+    | Pos_spacing (side, sp) ->
+        pside_name side ^ "-" ^ Spacing.pp_spacing_suffix sp
     | Inset n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-" ^ string_of_int (abs n)

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -102,6 +102,35 @@ let test_arbitrary_var () =
   check "top-[var(--t)]";
   check "left-[var(--l)]"
 
+(* Fractional spacing steps (top-2.5) resolve to calc(var(--spacing) * n) and
+   the px step (left-px) to 1px, on the physical/axis inset sides. *)
+let test_spacing_steps () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "top-2.5 uses calc(var(--spacing)*2.5)" true
+    (Astring.String.is_infix ~affix:"top:calc(var(--spacing)*2.5)"
+       (css "top-2.5"));
+  Alcotest.(check bool)
+    "inset-y-0.5 uses the block axis" true
+    (Astring.String.is_infix ~affix:"inset-block:calc(var(--spacing)*.5)"
+       (css "inset-y-0.5"));
+  Alcotest.(check bool)
+    "left-px is 1px" true
+    (Astring.String.is_infix ~affix:"left:1px" (css "left-px"));
+  Alcotest.(check bool)
+    "inset-px is 1px" true
+    (Astring.String.is_infix ~affix:"inset:1px" (css "inset-px"));
+  (* round-trip the class names, escaped dot included *)
+  check "top-2.5";
+  check "right-1.5";
+  check "top-14.25";
+  check "left-px";
+  check "inset-px"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -159,6 +188,7 @@ let tests =
     test_case "named inset requires theme token" `Quick
       named_inset_requires_theme_token;
     test_case "arbitrary var insets" `Quick test_arbitrary_var;
+    test_case "spacing steps (fractional + px)" `Quick test_spacing_steps;
     test_case "position suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "inset value order matches Tailwind" `Quick


### PR DESCRIPTION
Inset utilities (`top`, `right`, `bottom`, `left`, `inset`, `inset-x`, `inset-y`) rejected non-integer and `px` spacing steps, so `top-2.5`, `right-0.5`, `left-px`, `inset-px`, `inset-y-0.5` were unknown classes. A single `Pos_spacing` constructor renders the spacing scale (`calc(var(--spacing) * n)`) or `1px` on those sides, alongside the existing integer path.