### PR TITLE
gap: accept the full length grammar in arbitrary values

### DIFF
--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -8,7 +8,7 @@ module Handler = struct
 
   type gap_value =
     | Standard of spacing
-    | Arbitrary of Css.length (* gap-[4px] *)
+    | Arbitrary of string * Css.length (* gap-[4px], raw kept for round-trip *)
     | Arbitrary_var of string (* gap-[var(--value)] *)
 
   type t =
@@ -92,7 +92,7 @@ module Handler = struct
         | `All -> gap_standard ?theme s
         | `X -> gap_x_standard ?theme s
         | `Y -> gap_y_standard ?theme s)
-    | Arbitrary len -> (
+    | Arbitrary (_, len) -> (
         match axis with
         | `All -> gap_arb len
         | `X -> gap_x_arb len
@@ -314,11 +314,6 @@ module Handler = struct
     let rule = Css.rule ~selector [ decl ] in
     style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
 
-  let pp_float n =
-    let s = string_of_float n in
-    if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
-    else s
-
   let to_style theme t =
     let gap_value axis value = gap_value ~theme axis value in
     let space_x n = space_x ~theme n in
@@ -387,13 +382,7 @@ module Handler = struct
 
   let pp_gap_value_suffix = function
     | Standard s -> Spacing.pp_spacing_suffix s
-    | Arbitrary len -> (
-        match len with
-        | Zero -> "[0]"
-        | Px n -> "[" ^ pp_float n ^ "px]"
-        | Rem n -> "[" ^ pp_float n ^ "rem]"
-        | Pct n -> "[" ^ pp_float n ^ "%]"
-        | _ -> "[<length>]")
+    | Arbitrary (raw, _) -> "[" ^ raw ^ "]"
     | Arbitrary_var s -> "[" ^ s ^ "]"
 
   let to_class = function
@@ -419,21 +408,13 @@ module Handler = struct
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
       if Parse.is_var inner then Some (Arbitrary_var inner)
-      else if String.ends_with ~suffix:"px" inner then
-        let n = String.sub inner 0 (String.length inner - 2) in
-        match float_of_string_opt n with
-        | Some f -> Some (Arbitrary (Css.Px f))
-        | None -> None
-      else if String.ends_with ~suffix:"rem" inner then
-        let n = String.sub inner 0 (String.length inner - 3) in
-        match float_of_string_opt n with
-        | Some f -> Some (Arbitrary (Css.Rem f))
-        | None -> None
       else
-        (* Unitless zero ([0], [-0]) is a valid CSS length. *)
-        match float_of_string_opt inner with
-        | Some f when f = 0.0 -> Some (Arbitrary Css.Zero)
-        | _ -> None
+        (* Route the value through the full length grammar (percent,
+           container-query units, calc), keeping the raw token for
+           round-trip. *)
+        match Css.parse_length (Parse.normalize_css_math_operators inner) with
+        | Some l -> Some (Arbitrary (inner, l))
+        | None -> None
     else None
 
   let parse_gap_value value =
@@ -468,7 +449,7 @@ module Handler = struct
             Ok (Space { negative = false; axis = `X; value = `Px })
           else
             match parse_gap_arbitrary value with
-            | Some (Arbitrary len) ->
+            | Some (Arbitrary (_, len)) ->
                 Ok (Space_arb { axis = `X; value = len; raw = value })
             | _ -> (
                 match Parse.spacing_value ~name:"space-x" value with
@@ -487,7 +468,7 @@ module Handler = struct
             Ok (Space { negative = false; axis = `Y; value = `Px })
           else
             match parse_gap_arbitrary value with
-            | Some (Arbitrary len) ->
+            | Some (Arbitrary (_, len)) ->
                 Ok (Space_arb { axis = `Y; value = len; raw = value })
             | _ -> (
                 match Parse.spacing_value ~name:"space-y" value with

--- a/test/test_gap.ml
+++ b/test/test_gap.ml
@@ -111,6 +111,28 @@ let test_css_values () =
   Alcotest.check bool "gap-x-10 uses spacing*10" true
     (Astring.String.is_infix ~affix:"*10)" (css_for (gap_x 10)))
 
+(* Arbitrary gaps accept the full length grammar (container-query units, calc,
+   and the CSS-wide keywords), not just px/rem, and round-trip verbatim. *)
+let test_arbitrary_length_grammar () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "gap-[5cqw] keeps the cqw unit" true
+    (Astring.String.is_infix ~affix:"gap:5cqw" (css "gap-[5cqw]"));
+  Alcotest.(check bool)
+    "gap-[calc(1rem/16*7)] spaces the calc" true
+    (Astring.String.is_infix ~affix:"gap:calc(1rem/16*7)"
+       (css "gap-[calc(1rem/16*7)]"));
+  Alcotest.(check bool)
+    "gap-[inherit] passes the keyword through" true
+    (Astring.String.is_infix ~affix:"gap:inherit" (css "gap-[inherit]"));
+  check "gap-[5cqw]";
+  check "gap-[inherit]";
+  check "gap-[4px]"
+
 let tests =
   [
     test_case "gap of_string - valid values" `Quick of_string_valid;
@@ -122,6 +144,7 @@ let tests =
       mixed_gap_axis_arbitrary_order_matches_tailwind;
     test_case "space-px CSS values" `Quick test_space_px_values;
     test_case "gap CSS values" `Quick test_css_values;
+    test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
   ]
 
 let suite = ("gap", tests)


### PR DESCRIPTION
Arbitrary gaps only parsed `px`/`rem`/`0`, so `gap-[5cqw]`, `gap-[calc(1rem/16*7)]`, and `gap-[inherit]` were unknown classes. The bracket value now goes through `Css.parse_length` (with math-operator normalization), keeping the raw token for a verbatim round-trip; the shared `space-x`/`space-y` arbitrary path benefits too.