### PR TITLE
position, sizing: accept compact calc() in arbitrary values

### DIFF
--- a/lib/position.ml
+++ b/lib/position.ml
@@ -23,8 +23,15 @@ let parse_bracket_length s : (Css.length, _) result =
       done;
       let num_s = String.sub inner 0 !i in
       let unit_s = String.sub inner !i (slen - !i) in
+      (* Fall back to the full length grammar (calc, container-query units, ...)
+         when the value is not a plain <number><unit>. *)
+      let full () =
+        match Css.parse_length (Parse.normalize_css_math_operators inner) with
+        | Some l -> Ok l
+        | None -> Error (`Msg ("Invalid length: " ^ inner))
+      in
       match Float.of_string_opt num_s with
-      | None -> Error (`Msg ("Invalid number: " ^ num_s))
+      | None -> full ()
       | Some n -> (
           let open Css in
           match unit_s with
@@ -34,7 +41,7 @@ let parse_bracket_length s : (Css.length, _) result =
           | "%" -> Ok (Pct n)
           | "vw" -> Ok (Vw n)
           | "vh" -> Ok (Vh n)
-          | _ -> Error (`Msg ("Invalid length unit: " ^ unit_s))))
+          | _ -> full ()))
   else Error (`Msg ("Not a bracket value: " ^ s))
 
 (* Negate an inset length: simple units flip sign directly; var()/calc() and

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -912,7 +912,9 @@ module Handler = struct
     let len = String.length s in
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
-      let css_value = Parse.decode_arbitrary_value inner in
+      let css_value =
+        Parse.normalize_css_math_operators (Parse.decode_arbitrary_value inner)
+      in
       match Css.parse_length css_value with
       | Some l -> Some (inner, l)
       | None -> None

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -102,6 +102,24 @@ let test_arbitrary_var () =
   check "top-[var(--t)]";
   check "left-[var(--l)]"
 
+(* Arbitrary calc() insets go through the full length grammar (the bracket
+   parser used to accept only plain <number><unit>). *)
+let test_arbitrary_calc () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "left-[calc(5%-2px)] spaces the operator" true
+    (Astring.String.is_infix ~affix:"left: calc(5% - 2px)"
+       (css "left-[calc(5%-2px)]"));
+  Alcotest.(check bool)
+    "left-[calc(50%+var(--offset))] keeps the var" true
+    (Astring.String.is_infix ~affix:"left: calc(50% + var(--offset))"
+       (css "left-[calc(50%+var(--offset))]"));
+  check "left-[calc(5%-2px)]"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -159,6 +177,7 @@ let tests =
     test_case "named inset requires theme token" `Quick
       named_inset_requires_theme_token;
     test_case "arbitrary var insets" `Quick test_arbitrary_var;
+    test_case "arbitrary calc insets" `Quick test_arbitrary_calc;
     test_case "position suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "inset value order matches Tailwind" `Quick

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -326,6 +326,14 @@ let test_max_w_screen () =
     "max-w-screen-xl defines --breakpoint-xl: 80rem" true
     (Astring.String.is_infix ~affix:"--breakpoint-xl: 80rem" xl)
 
+(* Arbitrary sizes accept compact calc() (the bracket value is normalized before
+   going through the length grammar). *)
+let test_arbitrary_calc () =
+  Alcotest.(check bool)
+    "w-[calc(100vh-4rem)] spaces the operator" true
+    (Astring.String.is_infix ~affix:"width: calc(100vh - 4rem)"
+       (css_of "w-[calc(100vh-4rem)]"))
+
 let tests =
   [
     test_case "fractional spacing" `Quick test_fractional_spacing;
@@ -337,6 +345,7 @@ let tests =
     test_case "max sizes" `Quick test_max_sizes;
     test_case "square sizes" `Quick test_square_sizes;
     test_case "sizing of_string - invalid values" `Quick of_string_invalid;
+    test_case "arbitrary calc sizes" `Quick test_arbitrary_calc;
     test_case "aspect classes" `Quick test_aspect_classes;
     test_case "aspect css" `Quick test_aspect_css;
     test_case "aspect bracket number" `Quick test_aspect_bracket_number;


### PR DESCRIPTION
Arbitrary insets and sizes rejected compact `calc(...)`: `left-[calc(5%-2px)]`, `left-[calc(50%+var(--offset))]`, and `w-[calc(100vh-4rem)]` were unknown classes. Both parsers now normalize math operators and fall through to the full length grammar, keeping the raw token for a verbatim round-trip.