### PR TITLE
padding: accept the full length grammar in arbitrary values

### DIFF
--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -8,7 +8,7 @@ module Handler = struct
 
   type padding_value =
     | Standard of spacing
-    | Arbitrary of Css.length (* p-[4px] *)
+    | Arbitrary of string * Css.length (* p-[4px], raw kept for round-trip *)
     | Arbitrary_var of string (* p-[var(--value)] *)
 
   type t = {
@@ -20,18 +20,6 @@ module Handler = struct
 
   let name = "padding"
   let priority _ = 23
-
-  let pp_float n =
-    let s = string_of_float n in
-    if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
-    else s
-
-  let pp_length_suffix (len : Css.length) =
-    match len with
-    | Px n -> "[" ^ pp_float n ^ "px]"
-    | Rem n -> "[" ^ pp_float n ^ "rem]"
-    | Pct n -> "[" ^ pp_float n ^ "%]"
-    | _ -> "[<length>]"
 
   let to_class { axis; value } =
     let prefix =
@@ -51,7 +39,7 @@ module Handler = struct
     let value_suffix =
       match value with
       | Standard s -> Spacing.pp_spacing_suffix s
-      | Arbitrary len -> pp_length_suffix len
+      | Arbitrary (raw, _) -> "[" ^ raw ^ "]"
       | Arbitrary_var s -> "[" ^ s ^ "]"
     in
     prefix ^ value_suffix
@@ -100,7 +88,7 @@ module Handler = struct
   let apply_prop_list ?theme (prop : length list -> declaration) value =
     match value with
     | Standard s -> vs_spacing ?theme prop s
-    | Arbitrary len -> style [ prop [ len ] ]
+    | Arbitrary (_, len) -> style [ prop [ len ] ]
     | Arbitrary_var var_str ->
         let bare_name = Parse.extract_var_name var_str in
         style [ prop [ Var (Var.bracket bare_name) ] ]
@@ -108,7 +96,7 @@ module Handler = struct
   let apply_prop ?theme (prop : length -> declaration) value =
     match value with
     | Standard s -> v_spacing ?theme prop s
-    | Arbitrary len -> style [ prop len ]
+    | Arbitrary (_, len) -> style [ prop len ]
     | Arbitrary_var var_str ->
         let bare_name = Parse.extract_var_name var_str in
         style [ prop (Var (Var.bracket bare_name)) ]
@@ -151,17 +139,12 @@ module Handler = struct
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
       if Parse.is_var inner then Some (Arbitrary_var inner)
-      else if String.ends_with ~suffix:"px" inner then
-        let n = String.sub inner 0 (String.length inner - 2) in
-        match float_of_string_opt n with
-        | Some f -> Some (Arbitrary (Css.Px f))
+      else
+        (* Full length grammar (percent, container units, calc), raw kept for
+           round-trip. *)
+        match Css.parse_length (Parse.normalize_css_math_operators inner) with
+        | Some l -> Some (Arbitrary (inner, l))
         | None -> None
-      else if String.ends_with ~suffix:"rem" inner then
-        let n = String.sub inner 0 (String.length inner - 3) in
-        match float_of_string_opt n with
-        | Some f -> Some (Arbitrary (Css.Rem f))
-        | None -> None
-      else None
     else None
 
   let padding_axis_of_prefix = function

--- a/test/test_padding.ml
+++ b/test/test_padding.ml
@@ -67,6 +67,34 @@ let test_css_values () =
   Alcotest.check bool "px-10 uses spacing*10" true
     (Astring.String.is_infix ~affix:"*10)" (css_for (px 10)))
 
+(* Arbitrary paddings accept the full length grammar (percent, calc), not just
+   px/rem, and round-trip verbatim. *)
+let test_arbitrary_length_grammar () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "p-[calc(var(--spacing-6)-1px)] spaces the operator" true
+    (Astring.String.is_infix ~affix:"padding:calc(var(--spacing-6) - 1px)"
+       (css "p-[calc(var(--spacing-6)-1px)]"));
+  Alcotest.(check bool)
+    "pl-[calc(100%-21.5rem)] spaces the operator" true
+    (Astring.String.is_infix ~affix:"padding-left:calc(100% - 21.5rem)"
+       (css "pl-[calc(100%-21.5rem)]"));
+  Alcotest.(check bool)
+    "px-[50%] keeps the percent" true
+    (Astring.String.is_infix ~affix:"padding-inline:50%" (css "px-[50%]"));
+  let check c =
+    match Tw.Padding.Handler.of_class Tw.Scheme.default c with
+    | Ok u ->
+        Alcotest.check string "roundtrip" c (Tw.Padding.Handler.to_class u)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" c m
+  in
+  check "px-[50%]";
+  check "p-[calc(var(--spacing-6)-1px)]"
+
 let tests =
   [
     test_case "padding of_string - valid values" `Quick of_string_valid;
@@ -74,6 +102,7 @@ let tests =
     test_case "padding suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "padding CSS values" `Quick test_css_values;
+    test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
   ]
 
 let suite = ("padding", tests)


### PR DESCRIPTION
Arbitrary paddings only parsed `px`/`rem`, so `p-[calc(var(--spacing-6)-1px)]`, `pl-[calc(100%-21.5rem)]`, and `px-[50%]` were unknown classes. The bracket value now goes through `Css.parse_length` (with math-operator normalization), keeping the raw token for a verbatim round-trip.