### PR TITLE
transforms: keep the raw token for arbitrary translate values

### DIFF
--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -21,11 +21,11 @@ module Handler = struct
     | Translate_x of int
     | Translate_x_full
     | Translate_x_px
-    | Translate_x_arbitrary of Css.length
+    | Translate_x_arbitrary of string * Css.length
     | Translate_y of int
     | Translate_y_full
     | Translate_y_px
-    | Translate_y_arbitrary of Css.length
+    | Translate_y_arbitrary of string * Css.length
     | Scale of int
     | Scale_x of int
     | Scale_x_arbitrary of float
@@ -48,7 +48,7 @@ module Handler = struct
     | Translate_px
     | Translate_1_2
     | Translate_fraction of int * int
-    | Translate_arbitrary of Css.length
+    | Translate_arbitrary of string * Css.length
     | (* Negative translate utilities *)
       Neg_translate of int
     | Neg_translate_arbitrary of string
@@ -308,7 +308,9 @@ module Handler = struct
     if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']' then (
       let inner = String.sub s 1 (String.length s - 2) in
       let slen = String.length inner in
-      let i = ref 0 in
+      (* Allow a leading minus so negative arbitrary values
+         (translate-x-[-0.5px], translate-y-[-110%]) parse. *)
+      let i = ref (if slen > 0 && inner.[0] = '-' then 1 else 0) in
       while
         !i < slen
         && ((inner.[!i] >= '0' && inner.[!i] <= '9') || inner.[!i] = '.')
@@ -1178,12 +1180,12 @@ module Handler = struct
     | Translate_x n -> translate_x n
     | Translate_x_full -> translate_x_full
     | Translate_x_px -> translate_x_px
-    | Translate_x_arbitrary len -> translate_x_arbitrary len
+    | Translate_x_arbitrary (_, len) -> translate_x_arbitrary len
     | Translate_x_fraction (num, denom) -> translate_x_fraction num denom
     | Translate_y n -> translate_y n
     | Translate_y_full -> translate_y_full
     | Translate_y_px -> translate_y_px
-    | Translate_y_arbitrary len -> translate_y_arbitrary len
+    | Translate_y_arbitrary (_, len) -> translate_y_arbitrary len
     | Translate_y_fraction (num, denom) -> translate_y_fraction num denom
     | Translate n -> translate_spacing n
     | Neg_translate n -> translate_spacing (-n)
@@ -1192,7 +1194,7 @@ module Handler = struct
     | Translate_px -> translate_px
     | Translate_1_2 -> translate_1_2
     | Translate_fraction (num, denom) -> translate_fraction num denom
-    | Translate_arbitrary len -> translate_arbitrary len
+    | Translate_arbitrary (_, len) -> translate_arbitrary len
     | Neg_translate_arbitrary s -> neg_translate_arbitrary_style s
     | Neg_translate_full -> neg_translate_full
     | Neg_translate_px -> neg_translate_px
@@ -1474,7 +1476,9 @@ module Handler = struct
     | [ "rotate"; n ] -> Parse.int_any n >|= fun n -> Rotate n
     | [ "translate"; "x"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_bracket_length n with
-        | Ok len -> Ok (Translate_x_arbitrary len)
+        | Ok len ->
+            Ok
+              (Translate_x_arbitrary (String.sub n 1 (String.length n - 2), len))
         | Error _ -> err_not_utility)
     | [ "translate"; "x"; "full" ] -> Ok Translate_x_full
     | [ "translate"; "x"; "px" ] -> Ok Translate_x_px
@@ -1485,7 +1489,9 @@ module Handler = struct
     | [ "translate"; "x"; n ] -> Parse.int_any n >|= fun n -> Translate_x n
     | [ "translate"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_bracket_length n with
-        | Ok len -> Ok (Translate_y_arbitrary len)
+        | Ok len ->
+            Ok
+              (Translate_y_arbitrary (String.sub n 1 (String.length n - 2), len))
         | Error _ -> err_not_utility)
     | [ "translate"; "y"; "full" ] -> Ok Translate_y_full
     | [ "translate"; "y"; "px" ] -> Ok Translate_y_px
@@ -1516,7 +1522,10 @@ module Handler = struct
            | _ -> true -> (
         let value = String.concat "-" rest in
         match parse_bracket_length value with
-        | Ok len -> Ok (Translate_arbitrary len)
+        | Ok len ->
+            Ok
+              (Translate_arbitrary
+                 (String.sub value 1 (String.length value - 2), len))
         | Error _ -> err_not_utility)
     (* Negative translate utilities: -translate-x-N, -translate-y-N,
        -translate-z-N Split by '-' gives [""; "translate"; axis; n] *)
@@ -1751,9 +1760,6 @@ module Handler = struct
 
   let pp_angle_bracket a = "[" ^ Css.Pp.to_string Css.pp_angle a ^ "]"
 
-  let pp_length_bracket len =
-    "[" ^ Css.Pp.to_string (pp_length ~always:true) len ^ "]"
-
   let pp_number_bracket f =
     let s = string_of_float f in
     let s =
@@ -1782,13 +1788,13 @@ module Handler = struct
     | Translate_x n -> neg_class "translate-x-" n
     | Translate_x_full -> "translate-x-full"
     | Translate_x_px -> "translate-x-px"
-    | Translate_x_arbitrary len -> "translate-x-" ^ pp_length_bracket len
+    | Translate_x_arbitrary (raw, _) -> "translate-x-[" ^ raw ^ "]"
     | Translate_x_fraction (num, denom) ->
         "translate-x-" ^ string_of_int num ^ "/" ^ string_of_int denom
     | Translate_y n -> neg_class "translate-y-" n
     | Translate_y_full -> "translate-y-full"
     | Translate_y_px -> "translate-y-px"
-    | Translate_y_arbitrary len -> "translate-y-" ^ pp_length_bracket len
+    | Translate_y_arbitrary (raw, _) -> "translate-y-[" ^ raw ^ "]"
     | Translate_y_fraction (num, denom) ->
         "translate-y-" ^ string_of_int num ^ "/" ^ string_of_int denom
     | Translate_z n -> neg_class "translate-z-" n
@@ -1804,7 +1810,7 @@ module Handler = struct
     | Translate_1_2 -> "translate-1/2"
     | Translate_fraction (num, denom) ->
         "translate-" ^ string_of_int num ^ "/" ^ string_of_int denom
-    | Translate_arbitrary len -> "translate-" ^ pp_length_bracket len
+    | Translate_arbitrary (raw, _) -> "translate-" ^ "[" ^ raw ^ "]"
     | Neg_translate_arbitrary s -> "-translate-[" ^ s ^ "]"
     | Neg_translate_full -> "-translate-full"
     | Neg_translate_px -> "-translate-px"

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -26,6 +26,11 @@ let test_translate_px_and_neg_arbitrary () =
   check "-translate-y-px";
   check "-translate-y-[110%]";
   check "-translate-x-[3px]";
+  (* A negative value inside the bracket (not a leading -) parses, and the raw
+     token is kept verbatim in the class name (-0.5px, not the folded -.5px). *)
+  check "translate-x-[-0.5px]";
+  check "translate-y-[-110%]";
+  check "translate-x-[-1.15rem]";
   let css cls =
     match Tw.of_string cls with
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
@@ -37,7 +42,11 @@ let test_translate_px_and_neg_arbitrary () =
   Alcotest.(check bool)
     "-translate-y-[110%] negates the value" true
     (Astring.String.is_infix ~affix:"calc(110% * -1)"
-       (css "-translate-y-[110%]"))
+       (css "-translate-y-[110%]"));
+  Alcotest.(check bool)
+    "translate-x-[-0.5px] keeps the negative value" true
+    (Astring.String.is_infix ~affix:"--tw-translate-x: -.5px"
+       (css "translate-x-[-0.5px]"))
 
 let test_of_string_invalid () =
   (* Invalid transform utilities *)


### PR DESCRIPTION
A negative value inside the bracket (`translate-x-[-0.5px]`, `translate-y-[-110%]`) was rejected because the bracket parser did not accept a leading minus, and once parsed the length re-serialised to `-.5px`, giving a class name that no longer matched the HTML. Translate arbitrary values now allow a leading minus and store the raw inner token so the selector round-trips verbatim, like the other arbitrary families.