### PR TITLE
color: accept var() in arbitrary border color

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1870,16 +1870,16 @@ module Handler = struct
               if String.length inner > 6 && String.sub inner 0 6 = "color:" then
                 let var_str = String.sub inner 6 (String.length inner - 6) in
                 Ok (Bg_bracket_color_var_opacity (var_str, opacity))
+              else if Parse.is_var inner then
+                (* A var() holds an unknown colour, so the alpha has to be
+                   applied at run time by color-mix, not folded here. *)
+                Ok (Bg_bracket_var_opacity (inner, opacity))
               else
                 match Color.parse_bracket_color inner with
                 | Some css_color ->
                     Ok (Bg_bracket_color_opacity (inner, css_color, opacity))
                 | None ->
-                    if Parse.is_var inner then
-                      Ok (Bg_bracket_var_opacity (inner, opacity))
-                    else
-                      Error
-                        (`Msg ("Unknown bg bracket value: " ^ bracket_stuff)))
+                    Error (`Msg ("Unknown bg bracket value: " ^ bracket_stuff)))
           | None -> Error (`Msg ("Invalid opacity: " ^ bracket_stuff))
         else
           (* Regular bracket notation: bg-[...] *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1889,43 +1889,50 @@ module Handler = struct
     else None
 
   let rec parse_bracket_color (inner : string) : Css.color option =
-    match parse_alpha_call inner with
-    | Some (color_str, pct_str) -> (
-        let pct =
-          let t = String.trim pct_str in
-          let t =
-            if String.length t > 0 && t.[String.length t - 1] = '%' then
-              String.sub t 0 (String.length t - 1)
-            else t
+    if Parse.is_var inner then
+      (* A bare var() is a valid arbitrary color: border-[var(--x)] and its
+         paren shorthand border-(--x). *)
+      Some (Css.Var (Var.bracket (Parse.extract_var_name inner)))
+    else
+      match parse_alpha_call inner with
+      | Some (color_str, pct_str) -> (
+          let pct =
+            let t = String.trim pct_str in
+            let t =
+              if String.length t > 0 && t.[String.length t - 1] = '%' then
+                String.sub t 0 (String.length t - 1)
+              else t
+            in
+            float_of_string_opt t
           in
-          float_of_string_opt t
-        in
-        (* the inner colour is a raw CSS colour ([red] is the keyword, not the
-           red-500 palette entry); fall back to the palette only if CSS does not
-           know it. *)
-        let color =
-          let normalized =
-            String.map (fun c -> if c = '_' then ' ' else c) color_str
+          (* the inner colour is a raw CSS colour ([red] is the keyword, not the
+             red-500 palette entry); fall back to the palette only if CSS does
+             not know it. *)
+          let color =
+            let normalized =
+              String.map (fun c -> if c = '_' then ' ' else c) color_str
+            in
+            match Css.parse_color normalized with
+            | Some c -> Some c
+            | None -> parse_bracket_color color_str
           in
-          match Css.parse_color normalized with
-          | Some c -> Some c
-          | None -> parse_bracket_color color_str
-        in
-        match (pct, color) with
-        | Some pct, Some c ->
-            Some (Css.color_mix ~in_space:Oklab ~percent1:pct c Css.Transparent)
-        | _ -> None)
-    | None -> (
-        if String.length inner > 0 && inner.[0] = '#' then Some (Css.hex inner)
-        else
-          let normalized =
-            String.map (fun c -> if c = '_' then ' ' else c) inner
-          in
-          if Parse.is_css_color_fn normalized then Css.parse_color normalized
+          match (pct, color) with
+          | Some pct, Some c ->
+              Some
+                (Css.color_mix ~in_space:Oklab ~percent1:pct c Css.Transparent)
+          | _ -> None)
+      | None -> (
+          if String.length inner > 0 && inner.[0] = '#' then
+            Some (Css.hex inner)
           else
-            match color_of_string inner with
-            | Ok c -> Some (to_css c 500)
-            | Error _ -> None)
+            let normalized =
+              String.map (fun c -> if c = '_' then ' ' else c) inner
+            in
+            if Parse.is_css_color_fn normalized then Css.parse_color normalized
+            else
+              match color_of_string inner with
+              | Ok c -> Some (to_css c 500)
+              | Error _ -> None)
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -224,9 +224,25 @@ let test_gradient_stop_position_properties () =
     "from-10% registers @property --tw-gradient-stops" true
     (Astring.String.is_infix ~affix:"@property --tw-gradient-stops" css)
 
+(* A var() background colour with an alpha modifier defers the alpha to
+   color-mix: the variable's value is unknown at build time, so it cannot be
+   folded into a literal colour. *)
+let test_bg_var_opacity () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  Alcotest.(check bool)
+    "bg-[var(--x)]/50 mixes at run time" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, var(--x) 50%, transparent)"
+       (css_of "bg-[var(--x)]/50"))
+
 let tests =
   [
     test_case "bg colors" `Quick test_bg_colors;
+    test_case "bg var color with opacity" `Quick test_bg_var_opacity;
     test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
     test_case "arbitrary rgba gradient stop" `Quick test_gradient_rgba_stop;
     test_case "gradient stop-position @property family" `Quick

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -232,6 +232,31 @@ let test_border_side_color () =
     (Astring.String.is_infix ~affix:"border-block-end-color:"
        (css "border-be-red-500"))
 
+(* A CSS variable in a border color bracket, and its v4 paren shorthand, resolve
+   to var(): border-[var(--x)] and border-(--x) both set border-color. *)
+let test_border_color_var () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error _ -> Alcotest.failf "could not parse %S" cls
+  in
+  Alcotest.(check bool)
+    "border-[var(--pattern-fg)] sets border-color: var()" true
+    (Astring.String.is_infix ~affix:"border-color: var(--pattern-fg)"
+       (css "border-[var(--pattern-fg)]"));
+  Alcotest.(check bool)
+    "border-(--pattern-fg) shorthand sets border-color: var()" true
+    (Astring.String.is_infix ~affix:"border-color: var(--pattern-fg)"
+       (css "border-(--pattern-fg)"));
+  Alcotest.(check bool)
+    "border-t-[var(--x)] sets border-top-color: var()" true
+    (Astring.String.is_infix ~affix:"border-top-color: var(--x)"
+       (css "border-t-[var(--x)]"));
+  (* the paren shorthand keeps its own class name *)
+  Alcotest.(check string)
+    "border-(--pattern-fg) round-trips" "border-(--pattern-fg)"
+    (Tw.pp (Result.get_ok (Tw.of_string "border-(--pattern-fg)")))
+
 let test_invalid_shade () =
   Alcotest.check_raises "bg ~shade:250 gray raises at construction"
     (Invalid_argument
@@ -285,6 +310,7 @@ let tests =
   [
     ("Achromatic colour keeps a none hue", `Quick, test_achromatic_none_hue);
     ("Per-side border colors", `Quick, test_border_side_color);
+    ("Border color var", `Quick, test_border_color_var);
     ("Invalid shades", `Quick, test_invalid_shade);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);


### PR DESCRIPTION
`border-[var(--x)]` and its v4 paren shorthand `border-(--x)` were unknown classes: `parse_bracket_color` did not recognise a bare `var()` as a valid arbitrary color, so it fell through to the palette lookup and failed. It now routes a bare `var()` to `var()` directly, which also covers the per-side forms (`border-t-[var(--x)]`, `border-x-(--x)`).

The first commit reorders the `bg-[...]/<alpha>` branch to check for a `var()` before trying to parse a colour, so the alpha keeps deferring to `color-mix` once `var()` parses as one.