### PR TITLE
bin: hoist the properties layer out of an applied utility

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -415,12 +415,17 @@ let peel_declared_variants defs name =
   in
   go 0 []
 
+(* The declarations of [names], rewritten to nest under the [&] of whatever rule
+   applies them, plus the statements that must stay at the top of the sheet. A
+   [@layer properties] block holds the initial value of the variables the
+   utilities set, on the universal selector: nested under an author rule it
+   would come out as [.box *], so it is hoisted instead. *)
 let nested_utilities ~theme names =
   let of_name n =
     match Tw.of_string ~theme n with Ok s -> Some s | Error _ -> None
   in
   match List.filter_map of_name names with
-  | [] -> ""
+  | [] -> ("", "")
   | styles ->
       let sheet =
         Tw.to_css ~theme ~base:false ~forms:false ~layers:false styles
@@ -434,10 +439,25 @@ let nested_utilities ~theme names =
             let s = Cascade.Selector.to_string ~minify:true sel in
             String.length s > 0 && s.[0] = '.'
       in
-      Css.statements sheet |> List.filter from_utility
-      |> Css.map (fun sel decls ->
-          Css.rule ~selector:(nest_on_ampersand sel) decls)
-      |> Css.v |> Css.to_string ~minify:true
+      let hoisted, nestable =
+        Css.statements sheet |> List.filter from_utility
+        |> List.partition (fun stmt -> Css.as_layer stmt <> None)
+      in
+      let render stmts =
+        stmts
+        |> Css.map (fun sel decls ->
+            Css.rule ~selector:(nest_on_ampersand sel) decls)
+        |> Css.v |> Css.to_string ~minify:true
+      in
+      (render nestable, Css.to_string ~minify:true (Css.v hoisted))
+
+(* Append [s] unless it is already there: every utility that sets the same
+   variable brings back the same hoisted block. *)
+let add_once buf seen s =
+  if s <> "" && not (List.mem s !seen) then begin
+    seen := s :: !seen;
+    Buffer.add_string buf s
+  end
 
 (* Tailwind's [@apply] pulls a utility's declarations into an author rule. It is
    not CSS, so the at-rule drops out and takes the whole rule with it once the
@@ -445,6 +465,8 @@ let nested_utilities ~theme names =
 let expand_apply ~theme ~defs css =
   let len = String.length css in
   let buf = Buffer.create len in
+  let hoisted = Buffer.create 0 in
+  let seen = ref [] in
   let ident c =
     (c >= 'a' && c <= 'z')
     || (c >= 'A' && c <= 'Z')
@@ -471,7 +493,8 @@ let expand_apply ~theme ~defs css =
       in
       let emit name =
         let variants, bare = peel_declared_variants defs name in
-        let body = nested_utilities ~theme [ bare ] in
+        let body, top = nested_utilities ~theme [ bare ] in
+        add_once hoisted seen top;
         if body = "" then ()
         else begin
           List.iter
@@ -491,6 +514,9 @@ let expand_apply ~theme ~defs css =
     end
   in
   go 0;
+  (* The hoisted blocks go last: their layer is ordered by the sheet's [@layer]
+     statement, not by where they sit. *)
+  Buffer.add_buffer buf hoisted;
   Buffer.contents buf
 
 let apply_variants ?(extra_defs = []) ~theme css =

--- a/test/cli/apply.t
+++ b/test/cli/apply.t
@@ -39,6 +39,21 @@ falling back to the built-in of the same name:
   0
   [1]
 
+A utility that sets one of tw's own variables brings an [@layer properties]
+block holding its initial value on the universal selector. That block cannot
+nest inside the author's rule, where the leading [*] would come out as a
+descendant of it, so it is hoisted to the top level:
+
+  $ cat > border.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > .box { @apply border-t border-dashed; }
+  > EOF
+  $ tw --minify --input-css border.css index.html | grep -cF '*,:before,:after,::backdrop{--tw-border-style:solid}'
+  1
+  $ tw --minify --input-css border.css index.html | grep -c '\.box \*'
+  0
+  [1]
+
 An unknown utility is skipped rather than aborting the sheet:
 
   $ cat > bad.css <<EOF


### PR DESCRIPTION
An `@apply` of a utility that sets one of tw's variables pulled the whole generated sheet into the author's rule, `@layer properties` included. Its universal selector then flattened to a descendant of that rule, so the initial value landed on `.box *` instead of `*`. The block is hoisted to the top level instead, where its layer position is fixed by the sheet's `@layer` statement rather than by where it sits.