### PR TITLE
rule: nest the hover gate inside a wrapping media or container query

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -267,8 +267,12 @@ let indexed_rule_to_statement (r : Sort.indexed_rule) =
         Css.media ~condition
           [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
   | `Container condition ->
-      Css.container ~condition
-        [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
+      (* As for [`Media]: a compound like [@md:hover:] carries the inner hover
+         query in [nested] and has no declarations of its own. *)
+      if filtered_nested <> [] then Css.container ~condition filtered_nested
+      else
+        Css.container ~condition
+          [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
   | `Supports condition ->
       Css.supports ~condition
         [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
@@ -351,10 +355,10 @@ let rule_to_triple order_map = function
       in
       triple (`Media condition) ~selector ~props ~order ~nested ~base_class
         ~merge_key:None ~not_order
-  | Container_query { condition; selector; props; base_class } ->
+  | Container_query { condition; selector; props; base_class; nested } ->
       triple (`Container condition) ~selector ~props
         ~order:(order_of_base order_map base_class selector)
-        ~nested:[] ~base_class ~merge_key:None ~not_order:0
+        ~nested ~base_class ~merge_key:None ~not_order:0
   | Starting_style { selector; props; base_class } ->
       triple `Starting ~selector ~props
         ~order:(order_of_base order_map base_class selector)
@@ -542,30 +546,26 @@ let extract_non_tw_custom_declarations selector_props =
   let theme_vars = Hashtbl.create 32 in
   let insertion_order = ref [] in
 
+  let add_props props =
+    Css.custom_declarations ~layer:"theme" props
+    |> List.iter (fun decl ->
+        match Css.custom_declaration_name decl with
+        | Some name when not (Hashtbl.mem theme_vars name) ->
+            Hashtbl.add theme_vars name decl;
+            insertion_order := decl :: !insertion_order
+        | _ -> ())
+  in
   selector_props
   |> List.iter (function
-    | Regular { props; nested; _ } ->
-        (* Extract from top-level props *)
-        Css.custom_declarations ~layer:"theme" props
-        |> List.iter (fun decl ->
-            match Css.custom_declaration_name decl with
-            | Some name when not (Hashtbl.mem theme_vars name) ->
-                Hashtbl.add theme_vars name decl;
-                insertion_order := decl :: !insertion_order
-            | _ -> ());
-        (* Extract from nested statements *)
+    (* A compound variant like [md:hover:] holds its declarations in [nested],
+       so the tokens they declare are only reachable through it. *)
+    | Regular { props; nested; _ }
+    | Media_query { props; nested; _ }
+    | Container_query { props; nested; _ } ->
+        add_props props;
         extract_theme_from_statements theme_vars insertion_order nested
-    | Media_query { props; _ }
-    | Container_query { props; _ }
-    | Starting_style { props; _ }
-    | Supports_query { props; _ } ->
-        Css.custom_declarations ~layer:"theme" props
-        |> List.iter (fun decl ->
-            match Css.custom_declaration_name decl with
-            | Some name when not (Hashtbl.mem theme_vars name) ->
-                Hashtbl.add theme_vars name decl;
-                insertion_order := decl :: !insertion_order
-            | _ -> ()));
+    | Starting_style { props; _ } | Supports_query { props; _ } ->
+        add_props props);
   (* Return in original insertion order *)
   List.rev !insertion_order
 
@@ -660,9 +660,9 @@ let var_names_of_output = function
          hover:dark:) whose rules reference theme vars; recurse fully so those
          references are collected and their theme tokens declared. *)
       Css.vars_of_declarations props @ Css.vars_of_stylesheet (Css.v nested)
-  | Container_query { props; _ }
-  | Starting_style { props; _ }
-  | Supports_query { props; _ } ->
+  | Container_query { props; nested; _ } ->
+      Css.vars_of_declarations props @ Css.vars_of_stylesheet (Css.v nested)
+  | Starting_style { props; _ } | Supports_query { props; _ } ->
       Css.vars_of_declarations props
 
 (* Theme tokens referenced via var() (e.g. an arbitrary [color:var(--color-red-

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -26,6 +26,7 @@ type t =
       selector : Css.Selector.t;
       props : Css.declaration list;
       base_class : string option;
+      nested : Css.statement list;
     }
   | Starting_style of {
       selector : Css.Selector.t;
@@ -58,8 +59,8 @@ let media_query ~condition ~selector ~props ?base_class ?(nested = [])
     ?(not_order = 0) () =
   Media_query { condition; selector; props; base_class; nested; not_order }
 
-let container_query ~condition ~selector ~props ?base_class () =
-  Container_query { condition; selector; props; base_class }
+let container_query ~condition ~selector ~props ?base_class ?(nested = []) () =
+  Container_query { condition; selector; props; base_class; nested }
 
 let starting_style ~selector ~props ?base_class () =
   Starting_style { selector; props; base_class }

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -44,6 +44,7 @@ type t =
       selector : Css.Selector.t;
       props : Css.declaration list;
       base_class : string option;
+      nested : Css.statement list;
     }
   | Starting_style of {
       selector : Css.Selector.t;
@@ -94,6 +95,7 @@ val container_query :
   selector:Css.Selector.t ->
   props:Css.declaration list ->
   ?base_class:string ->
+  ?nested:Css.statement list ->
   unit ->
   t
 (** [container_query ~condition ~selector ~props ()] constructs a

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -282,17 +282,31 @@ let selector_with_data_key selector key value =
   let attr_selector = Css.Selector.attribute key (Exact value) in
   Css.Selector.combine selector Descendant attr_selector
 
-let media_rule_with_prefix prefix condition base_class selector props =
+(* A [hover:] rule carries its own [@media (hover:hover)]. An outer query nests
+   the two rather than swallowing the inner one, which is the structure Tailwind
+   emits for [lg:hover:X] and [@md:hover:X]. *)
+let nested_hover ~selector ~props =
+  [ Css.media ~condition:hover_media [ Css.rule ~selector props ] ]
+
+let media_rule_with_prefix ?(inner_has_hover = false) prefix condition
+    base_class selector props =
   let modified_class = prefix ^ ":" ^ base_class in
   let new_selector =
     Rules_selector.replace_class_in_selector ~old_class:base_class
       ~new_class:modified_class selector
   in
-  media_query ~condition ~selector:new_selector ~props
-    ~base_class:modified_class ()
+  if inner_has_hover then
+    media_query ~condition ~selector:new_selector ~props:[]
+      ~base_class:modified_class
+      ~nested:(nested_hover ~selector:new_selector ~props)
+      ()
+  else
+    media_query ~condition ~selector:new_selector ~props
+      ~base_class:modified_class ()
 
-let responsive_rule ?theme breakpoint base_class selector props =
-  media_rule_with_prefix
+let responsive_rule ?theme ?inner_has_hover breakpoint base_class selector props
+    =
+  media_rule_with_prefix ?inner_has_hover
     (string_of_breakpoint breakpoint)
     (breakpoint_condition ?theme breakpoint)
     base_class selector props
@@ -308,14 +322,16 @@ let responsive_breakpoint_prefix prefix breakpoint =
   in
   prefix ^ "-" ^ suffix
 
-let min_responsive_rule ?theme breakpoint base_class selector props =
-  media_rule_with_prefix
+let min_responsive_rule ?theme ?inner_has_hover breakpoint base_class selector
+    props =
+  media_rule_with_prefix ?inner_has_hover
     (responsive_breakpoint_prefix "min" breakpoint)
     (breakpoint_condition ?theme breakpoint)
     base_class selector props
 
-let max_responsive_rule ?theme breakpoint base_class selector props =
-  media_rule_with_prefix
+let max_responsive_rule ?theme ?inner_has_hover breakpoint base_class selector
+    props =
+  media_rule_with_prefix ?inner_has_hover
     (responsive_breakpoint_prefix "max" breakpoint)
     (breakpoint_not_condition ?theme breakpoint)
     base_class selector props
@@ -324,30 +340,31 @@ let arbitrary_px_string px =
   if Float.is_integer px then Int.to_string (Float.to_int px)
   else Float.to_string px
 
-let min_arbitrary_rule px base_class selector props =
+let min_arbitrary_rule ?inner_has_hover px base_class selector props =
   let prefix = "min-[" ^ arbitrary_px_string px ^ "px]" in
-  media_rule_with_prefix prefix (media_min_width_px px) base_class selector
-    props
+  media_rule_with_prefix ?inner_has_hover prefix (media_min_width_px px)
+    base_class selector props
 
-let max_arbitrary_rule px base_class selector props =
+let max_arbitrary_rule ?inner_has_hover px base_class selector props =
   let prefix = "max-[" ^ arbitrary_px_string px ^ "px]" in
-  media_rule_with_prefix prefix
+  media_rule_with_prefix ?inner_has_hover prefix
     (media_not_min_width_px px)
     base_class selector props
 
-let arbitrary_length_rule prefix condition l base_class selector props =
+let arbitrary_length_rule ?inner_has_hover prefix condition l base_class
+    selector props =
   let len_str = Modifiers.compact_length l in
-  media_rule_with_prefix
+  media_rule_with_prefix ?inner_has_hover
     (prefix ^ "-[" ^ len_str ^ "]")
     condition base_class selector props
 
-let min_arbitrary_length_rule l base_class selector props =
-  arbitrary_length_rule "min"
+let min_arbitrary_length_rule ?inner_has_hover l base_class selector props =
+  arbitrary_length_rule ?inner_has_hover "min"
     (Css.media_min_width_length l)
     l base_class selector props
 
-let max_arbitrary_length_rule l base_class selector props =
-  arbitrary_length_rule "max"
+let max_arbitrary_length_rule ?inner_has_hover l base_class selector props =
+  arbitrary_length_rule ?inner_has_hover "max"
     (Css.media_not_min_width_length l)
     l base_class selector props
 
@@ -356,27 +373,28 @@ let custom_breakpoint ?theme name =
   | Some px -> px
   | None -> failwith ("unknown custom breakpoint: " ^ name)
 
-let custom_media_rule ?theme prefix condition_of_px name base_class selector
-    props =
+let custom_media_rule ?theme ?inner_has_hover prefix condition_of_px name
+    base_class selector props =
   let px = custom_breakpoint ?theme name in
-  media_rule_with_prefix (prefix name) (condition_of_px px) base_class selector
-    props
+  media_rule_with_prefix ?inner_has_hover (prefix name) (condition_of_px px)
+    base_class selector props
 
-let custom_responsive_rule ?theme name base_class selector props =
-  custom_media_rule ?theme Fun.id media_min_width_px name base_class selector
-    props
+let custom_responsive_rule ?theme ?inner_has_hover name base_class selector
+    props =
+  custom_media_rule ?theme ?inner_has_hover Fun.id media_min_width_px name
+    base_class selector props
 
-let min_custom_rule ?theme name base_class selector props =
-  custom_media_rule ?theme
+let min_custom_rule ?theme ?inner_has_hover name base_class selector props =
+  custom_media_rule ?theme ?inner_has_hover
     (fun name -> "min-" ^ name)
     media_min_width_px name base_class selector props
 
-let max_custom_rule ?theme name base_class selector props =
-  custom_media_rule ?theme
+let max_custom_rule ?theme ?inner_has_hover name base_class selector props =
+  custom_media_rule ?theme ?inner_has_hover
     (fun name -> "max-" ^ name)
     media_not_min_width_px name base_class selector props
 
-let container_rule query base_class selector props =
+let container_rule ?(inner_has_hover = false) query base_class selector props =
   let prefix = Containers.container_query_to_class_prefix query in
   let modified_class = prefix ^ ":" ^ base_class in
   let new_selector =
@@ -384,7 +402,11 @@ let container_rule query base_class selector props =
       ~new_class:modified_class selector
   in
   let condition = Containers.container_query_to_condition query in
-  container_query ~condition ~selector:new_selector ~props ~base_class ()
+  if inner_has_hover then
+    container_query ~condition ~selector:new_selector ~props:[] ~base_class
+      ~nested:(nested_hover ~selector:new_selector ~props)
+      ()
+  else container_query ~condition ~selector:new_selector ~props ~base_class ()
 
 (** Preprocess a has-[...] selector string for CSS parsing. Replaces & with *
     (nesting reference) and ensures combinators (+, >, ~) have proper spacing.
@@ -1469,24 +1491,31 @@ let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
       handle_supports_modifier condition_str base_class selector props
   (* Responsive and container *)
   | Style.Responsive breakpoint ->
-      responsive_rule ?theme breakpoint base_class selector props
+      responsive_rule ?theme ~inner_has_hover breakpoint base_class selector
+        props
   | Style.Min_responsive breakpoint ->
-      min_responsive_rule ?theme breakpoint base_class selector props
+      min_responsive_rule ?theme ~inner_has_hover breakpoint base_class selector
+        props
   | Style.Max_responsive breakpoint ->
-      max_responsive_rule ?theme breakpoint base_class selector props
-  | Style.Min_arbitrary px -> min_arbitrary_rule px base_class selector props
-  | Style.Max_arbitrary px -> max_arbitrary_rule px base_class selector props
+      max_responsive_rule ?theme ~inner_has_hover breakpoint base_class selector
+        props
+  | Style.Min_arbitrary px ->
+      min_arbitrary_rule ~inner_has_hover px base_class selector props
+  | Style.Max_arbitrary px ->
+      max_arbitrary_rule ~inner_has_hover px base_class selector props
   | Style.Min_arbitrary_length l ->
-      min_arbitrary_length_rule l base_class selector props
+      min_arbitrary_length_rule ~inner_has_hover l base_class selector props
   | Style.Max_arbitrary_length l ->
-      max_arbitrary_length_rule l base_class selector props
+      max_arbitrary_length_rule ~inner_has_hover l base_class selector props
   | Style.Custom_responsive name ->
-      custom_responsive_rule ?theme name base_class selector props
+      custom_responsive_rule ?theme ~inner_has_hover name base_class selector
+        props
   | Style.Min_custom name ->
-      min_custom_rule ?theme name base_class selector props
+      min_custom_rule ?theme ~inner_has_hover name base_class selector props
   | Style.Max_custom name ->
-      max_custom_rule ?theme name base_class selector props
-  | Style.Container query -> container_rule query base_class selector props
+      max_custom_rule ?theme ~inner_has_hover name base_class selector props
+  | Style.Container query ->
+      container_rule ~inner_has_hover query base_class selector props
   (* :not(), :not-bracket, group-not, peer-not — handled in
      apply_modifier_to_rule for multi-rule support *)
   | Style.Not _ | Style.Not_bracket _ | Style.Group_not _ | Style.Peer_not _ ->

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -583,20 +583,42 @@ let test_md_media_dedup () =
        css)
 
 let test_md_hover_extra_media () =
-  (* Responsive+hover should not introduce a separate (hover:hover) gate *)
+  (* A responsive prefix wraps the hover rule's own (hover:hover) gate rather
+     than replacing it, which is the structure Tailwind emits. *)
   let css = Tw.Build.to_css [ md [ hover [ p 4 ] ] ] in
-  check bool "no (hover:hover) condition" false
+  check bool "keeps the (hover:hover) gate" true
     (has_media_condition "(hover: hover)" css);
-  (* Selector is inside md media block with :hover pseudo, assert
-     structurally *)
+  (* The rule sits in the inner block, so the md block holds no rule of its
+     own. *)
   let md_sels = selectors_in_media_sel ~condition:"(min-width: 48rem)" css in
+  check
+    (list Test_helpers.selector_testable)
+    "no rule directly in md" [] md_sels;
+  let hover_sels = selectors_in_media_sel ~condition:"(hover: hover)" css in
   let expected =
     Css.Selector.compound
       [ Css.Selector.class_ "md:hover:p-4"; Css.Selector.Hover ]
   in
   check
     (list Test_helpers.selector_testable)
-    "md:hover selector in md block" [ expected ] md_sels
+    "md:hover selector in the hover block" [ expected ] hover_sels
+
+(* A container query wraps the hover gate the same way a media query does, and
+   the rule inside it still reaches its theme token: the declarations live in
+   the nested block, so a collector that stops at the top level prunes
+   --spacing. *)
+let test_container_hover_nests () =
+  let css = Tw.Build.to_css [ Tw.Containers.container_md [ hover [ p 4 ] ] ] in
+  let hover_sels = selectors_in_media_sel ~condition:"(hover: hover)" css in
+  let expected =
+    Css.Selector.compound
+      [ Css.Selector.class_ "@md:hover:p-4"; Css.Selector.Hover ]
+  in
+  check
+    (list Test_helpers.selector_testable)
+    "@md:hover selector in the hover block" [ expected ] hover_sels;
+  check bool "theme layer declares --spacing" true
+    (has_var_in_layer "--spacing" "theme" css)
 
 let test_container_and_media () =
   let statements =
@@ -876,8 +898,8 @@ let tests =
     test_case "rule_sets_groups_md_media_query" `Quick test_rule_sets_md_media;
     test_case "multi-breakpoint grouping+order" `Quick test_media_grouping_order;
     test_case "md media dedup" `Quick test_md_media_dedup;
-    test_case "md:hover has no global hover gate" `Quick
-      test_md_hover_extra_media;
+    test_case "md:hover nests the hover gate" `Quick test_md_hover_extra_media;
+    test_case "container hover nests the gate" `Quick test_container_hover_nests;
     test_case "container + media together" `Quick test_container_and_media;
     test_case "media query deduplication" `Quick test_media_query_deduplication;
     test_case "rule_sets" `Quick test_rule_sets;


### PR DESCRIPTION
`hover:X` emits `@media (hover: hover)`, but a responsive or container prefix in front of it replaced that query instead of wrapping it, so `lg:hover:X` and `@md:hover:X` applied on a touch device where Tailwind's do not. The outer query now nests the inner one.

The theme-token collector had to follow a nested block as well, since the compound's declarations no longer sit at the top level of its rule and `--spacing` was getting pruned.