### PR TITLE
modifiers: accept any state name in a has-* variant

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -957,6 +957,10 @@ let of_string class_str =
   | cls :: modifiers -> (List.rev modifiers, cls)
 
 (* Convert modifier to its string prefix *)
+let group_state_modifiers = Style.group_state_modifiers
+let is_has_shorthand = Style.is_has_shorthand
+let has_part = Style.has_part
+
 let rec pp_modifier = function
   | Hover -> "hover"
   | Focus -> "focus"
@@ -1013,11 +1017,15 @@ let rec pp_modifier = function
       "max-[" ^ px_str ^ "px]"
   | Container query -> Containers.container_query_to_class_prefix query
   | Not m -> "not-" ^ pp_modifier m
-  | Has selector -> "has-[" ^ selector ^ "]"
-  | Group_has (selector, None) -> "group-has-[" ^ selector ^ "]"
-  | Group_has (selector, Some name) -> "group-has-[" ^ selector ^ "]/" ^ name
-  | Peer_has (selector, None) -> "peer-has-[" ^ selector ^ "]"
-  | Peer_has (selector, Some name) -> "peer-has-[" ^ selector ^ "]/" ^ name
+  (* A shorthand name is stored bare ([Has "focus"]), a bracket form with its
+     CSS punctuation ([Has ":focus"]); only the latter renders brackets. *)
+  | Has selector -> "has-" ^ has_part selector
+  | Group_has (selector, None) -> "group-has-" ^ has_part selector
+  | Group_has (selector, Some name) ->
+      "group-has-" ^ has_part selector ^ "/" ^ name
+  | Peer_has (selector, None) -> "peer-has-" ^ has_part selector
+  | Peer_has (selector, Some name) ->
+      "peer-has-" ^ has_part selector ^ "/" ^ name
   | Starting -> "starting"
   | Focus_within -> "focus-within"
   | Focus_visible -> "focus-visible"
@@ -1716,10 +1724,6 @@ let parse_group_peer_not_inner rest =
         | Some m -> Some (m, None)
         | None -> None)
 
-(* Valid has-shorthand names. These are stored as-is (without : prefix) so they
-   remain distinct from bracket forms like has-[:checked]. *)
-let is_has_shorthand = function "checked" | "hocus" -> true | _ -> false
-
 (* Extract name suffix from "rest" after prefix, e.g. "checked/name" ->
    ("checked", Some "name") *)
 let split_name rest =
@@ -1764,46 +1768,6 @@ let try_has_shorthand s =
     let base, name = split_name rest in
     if is_has_shorthand base then Some (Peer_has (base, name)) else None
   else None
-
-(* Map of simple state names to base modifiers for compound variant parsing *)
-let group_state_modifiers =
-  [
-    ("hover", Hover);
-    ("focus", Focus);
-    ("active", Active);
-    ("visited", Visited);
-    ("disabled", Disabled);
-    ("checked", Checked);
-    ("empty", Empty);
-    ("required", Required);
-    ("valid", Valid);
-    ("invalid", Invalid);
-    ("indeterminate", Indeterminate);
-    ("default", Default);
-    ("open", Open);
-    ("target", Target);
-    ("optional", Optional);
-    ("read-only", Read_only);
-    ("read-write", Read_write);
-    ("inert", Inert);
-    ("user-valid", User_valid);
-    ("user-invalid", User_invalid);
-    ("placeholder-shown", Placeholder_shown);
-    ("autofill", Autofill);
-    ("in-range", In_range);
-    ("out-of-range", Out_of_range);
-    ("focus-within", Focus_within);
-    ("focus-visible", Focus_visible);
-    ("enabled", Enabled);
-    ("first", First);
-    ("last", Last);
-    ("only", Only);
-    ("odd", Odd);
-    ("even", Even);
-    ("first-of-type", First_of_type);
-    ("last-of-type", Last_of_type);
-    ("only-of-type", Only_of_type);
-  ]
 
 (* Try to parse compound named group variants: not-group-STATE/name,
    has-group-STATE/name, in-group-STATE/name, group-peer-STATE/name *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -410,8 +410,8 @@ let preprocess_has_selector s =
   done;
   Buffer.contents buf
 
-let has_like_selector kind ?name ?shorthand ~not_order selector_str base_class
-    props =
+let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
+    selector_str base_class props =
   let open Css.Selector in
   let processed = preprocess_has_selector selector_str in
   let parsed_selector =
@@ -424,7 +424,8 @@ let has_like_selector kind ?name ?shorthand ~not_order selector_str base_class
   | `Has ->
       let class_name = "has-" ^ has_part selector_str ^ ":" ^ base_class in
       let sel = compound [ class_ class_name; has [ parsed_selector ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
+        ()
   | `Group_has ->
       let name_suffix = match name with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -439,7 +440,8 @@ let has_like_selector kind ?name ?shorthand ~not_order selector_str base_class
           Descendant universal
       in
       let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
+        ()
   | `Peer_has ->
       let name_suffix = match name with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -454,7 +456,8 @@ let has_like_selector kind ?name ?shorthand ~not_order selector_str base_class
           Subsequent_sibling universal
       in
       let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
+        ()
 
 (* Pseudo-class modifiers: transform the base selector and mark hover when
    needed. *)
@@ -670,11 +673,19 @@ let route_data_bracket_modifier modifier base_class props =
       let sel = compound [ Class class_name; is_ [ rel ] ] in
       regular ~selector:sel ~props ~base_class:class_name ~not_order ()
 
-(* Resolve has-shorthand names to CSS selector strings *)
+(* The selector a has-shorthand name stands for. [has-<state>] takes the same
+   state names as the group/peer variants and matches what that state matches,
+   so most map straight to their pseudo-class. *)
 let resolve_has_shorthand = function
-  | "checked" -> ":checked"
   | "hocus" -> ":hover, :focus"
-  | s -> s
+  | "open" -> ":is([open], :popover-open, :open)"
+  | "inert" -> ":is([inert], [inert] *)"
+  | "odd" -> ":nth-child(odd)"
+  | "even" -> ":nth-child(even)"
+  | "first" -> ":first-child"
+  | "last" -> ":last-child"
+  | "only" -> ":only-child"
+  | s -> ":" ^ s
 
 (* Route :has() variants to appropriate handler *)
 let route_has_modifier modifier base_class props =
@@ -697,8 +708,12 @@ let route_has_modifier modifier base_class props =
     && raw_str.[0] <> '.'
     && not (String.contains raw_str ' ')
   in
-  let selector_str = resolve_has_shorthand raw_str in
+  let selector_str =
+    if is_shorthand then resolve_has_shorthand raw_str else raw_str
+  in
   let shorthand = if is_shorthand then Some raw_str else None in
+  (* [has-hover] gates on the pointer just like [hover] itself does. *)
+  let has_hover = is_shorthand && raw_str = "hover" in
   (* Ordering: shorthands before brackets; pseudo-class brackets before
      combinator brackets. Named vs unnamed ordering handled by
      normalize_for_sort since '/' maps to '|' which sorts after ':' → '!'. *)
@@ -708,8 +723,8 @@ let route_has_modifier modifier base_class props =
     else 30
   in
   let not_order = base_order in
-  has_like_selector kind ?name ?shorthand ~not_order selector_str base_class
-    props
+  has_like_selector kind ?name ?shorthand ~has_hover ~not_order selector_str
+    base_class props
 
 (* Parse an aria expression string into an attribute name and match. "modal" →
    ("aria-modal", Presence) "valuenow=1" → ("aria-valuenow", Exact "1")

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -335,6 +335,54 @@ let rec container_size_name = function
       ^ "]"
 
 (* Convert modifier to string prefix *)
+(* Map of simple state names to base modifiers for compound variant parsing *)
+let group_state_modifiers =
+  [
+    ("hover", Hover);
+    ("focus", Focus);
+    ("active", Active);
+    ("visited", Visited);
+    ("disabled", Disabled);
+    ("checked", Checked);
+    ("empty", Empty);
+    ("required", Required);
+    ("valid", Valid);
+    ("invalid", Invalid);
+    ("indeterminate", Indeterminate);
+    ("default", Default);
+    ("open", Open);
+    ("target", Target);
+    ("optional", Optional);
+    ("read-only", Read_only);
+    ("read-write", Read_write);
+    ("inert", Inert);
+    ("user-valid", User_valid);
+    ("user-invalid", User_invalid);
+    ("placeholder-shown", Placeholder_shown);
+    ("autofill", Autofill);
+    ("in-range", In_range);
+    ("out-of-range", Out_of_range);
+    ("focus-within", Focus_within);
+    ("focus-visible", Focus_visible);
+    ("enabled", Enabled);
+    ("first", First);
+    ("last", Last);
+    ("only", Only);
+    ("odd", Odd);
+    ("even", Even);
+    ("first-of-type", First_of_type);
+    ("last-of-type", Last_of_type);
+    ("only-of-type", Only_of_type);
+  ]
+
+(* Valid has-shorthand names. These are stored as-is (without : prefix) so they
+   remain distinct from bracket forms like has-[:checked]. *)
+let is_has_shorthand name =
+  name = "hocus" || List.mem_assoc name group_state_modifiers
+
+let has_part selector =
+  if is_has_shorthand selector then selector else "[" ^ selector ^ "]"
+
 let rec pp_modifier = function
   | Hover -> "hover"
   | Focus -> "focus"
@@ -388,12 +436,15 @@ let rec pp_modifier = function
   | Data_inactive -> "data-inactive"
   | Data_custom (k, v) -> String.concat "" [ "data-"; k; "="; v ]
   | Not m -> String.concat "" [ "not("; pp_modifier m; ")" ]
-  | Has s -> String.concat "" [ "has-["; s; "]" ]
-  | Group_has (s, None) -> String.concat "" [ "group-has-["; s; "]" ]
+  (* A shorthand name is stored bare ([Has "focus"]), a bracket form with its
+     CSS punctuation ([Has ":focus"]); only the latter renders brackets. *)
+  | Has s -> String.concat "" [ "has-"; has_part s ]
+  | Group_has (s, None) -> String.concat "" [ "group-has-"; has_part s ]
   | Group_has (s, Some name) ->
-      String.concat "" [ "group-has-["; s; "]/"; name ]
-  | Peer_has (s, None) -> String.concat "" [ "peer-has-["; s; "]" ]
-  | Peer_has (s, Some name) -> String.concat "" [ "peer-has-["; s; "]/"; name ]
+      String.concat "" [ "group-has-"; has_part s; "/"; name ]
+  | Peer_has (s, None) -> String.concat "" [ "peer-has-"; has_part s ]
+  | Peer_has (s, Some name) ->
+      String.concat "" [ "peer-has-"; has_part s; "/"; name ]
   | Starting -> "starting"
   | Focus_within -> "focus-within"
   | Focus_visible -> "focus-visible"

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -280,6 +280,19 @@ val pp_nth : string -> string -> string
 (** [pp_nth prefix expr] formats an nth modifier, using numeric or bracket form.
 *)
 
+val group_state_modifiers : (string * modifier) list
+(** [group_state_modifiers] maps a state name (["focus"], ["first"]) to the
+    modifier it stands for. Variants that take a state name — [group-*],
+    [peer-*], [has-*] — share this table. *)
+
+val is_has_shorthand : string -> bool
+(** [is_has_shorthand name] is whether [name] is a state name a [has-*] variant
+    accepts, as opposed to a bracketed CSS selector. *)
+
+val has_part : string -> string
+(** [has_part s] is the class-name fragment a [has-*] variant spells [s] with:
+    a state name bare, a CSS selector in brackets. *)
+
 val pp_modifier : modifier -> string
 (** [pp_modifier m] converts a modifier to its string representation. *)
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -445,6 +445,31 @@ let test_apply_bracketed_has () =
   check string "peer-has class" "peer-has-[.z]:bg-blue-500"
     (Tw.Utility.to_class (Option.get u3))
 
+(* [has-<state>] takes the same state names as the group/peer variants, not just
+   checked: the name resolves to the pseudo-class that state matches, and
+   has-hover keeps the pointer gate hover itself carries. *)
+let test_has_state_shorthands () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has_infix affix cls =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has_infix ".has-focus\\:flex:has(:focus)" "has-focus:flex";
+  has_infix ".has-focus-visible\\:flex:has(:focus-visible)"
+    "has-focus-visible:flex";
+  has_infix ".has-first\\:flex:has(:first-child)" "has-first:flex";
+  has_infix ".has-odd\\:flex:has(:nth-child(odd))" "has-odd:flex";
+  has_infix ".group-has-focus\\:flex:is(:where(.group):has(:focus) *)"
+    "group-has-focus:flex";
+  check bool "has-hover keeps the pointer gate" true
+    (Astring.String.is_infix ~affix:"@media(hover:hover)" (css "has-hover:flex"));
+  (* the class name round-trips through the shorthand, not the bracket form *)
+  check string "has-focus round-trips" "has-focus:flex"
+    (Tw.pp (Result.get_ok (Tw.of_string "has-focus:flex")))
+
 (* Test ARIA and data modifiers class names *)
 let test_aria_and_data_modifiers () =
   check string "aria-checked:p-4" "aria-checked:p-4"
@@ -592,6 +617,7 @@ let tests =
       test_case "container query scale" `Quick test_container_query_scale;
       test_case "container query min/max" `Quick test_container_query_min_max;
       test_case "apply bracketed has variants" `Quick test_apply_bracketed_has;
+      test_case "has state shorthands" `Quick test_has_state_shorthands;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "before/after modifiers" `Quick test_before_after_modifiers;
       test_case "nested modifier class names" `Quick


### PR DESCRIPTION
`has-checked` and `has-hocus` were the only shorthands the parser knew, so `has-focus`, `has-open`, `has-first` and the rest were unknown classes. The `has-*` variants now take the same state names as `group-*` and `peer-*`, from one shared table in `Style`, and `has-hover` keeps the pointer gate `hover` itself carries.

A shorthand now also renders back without brackets, which fixes a mismatch that predates this: `Tw.pp` spelled the class `has-[checked]` while the emitted selector was `.has-checked`.