### PR TITLE
containers: compose a container query with the variants around it

### DIFF
--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -179,8 +179,8 @@ let container_query_to_condition q =
       Css.Container.Named (name, geq (Css.Values.Px (float_of_int width)))
   | Style.Container_size (cmp, inner) ->
       width_cond cmp (rem (Option.value ~default:0. (container_size_rem inner)))
-  | Style.Container_len len -> geq len
-  | Style.Container_len_cmp (cmp, len) -> width_cond cmp len
+  | Style.Container_len (_, len) -> geq len
+  | Style.Container_len_cmp (cmp, _, len) -> width_cond cmp len
 
 let container_query_to_class_prefix = function
   | Style.Container_3xs -> "@3xs"

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1966,10 +1966,9 @@ let try_container_query s =
       && s.[plen] = '['
       && s.[slen - 1] = ']'
     then
-      match
-        parse_container_length (String.sub s (plen + 1) (slen - plen - 2))
-      with
-      | Some len -> Some (mk len)
+      let raw = String.sub s (plen + 1) (slen - plen - 2) in
+      match parse_container_length raw with
+      | Some len -> Some (mk raw len)
       | None -> None
     else None
   in
@@ -1989,13 +1988,14 @@ let try_container_query s =
     List.find_map
       (fun f -> f ())
       [
-        (fun () -> bracketed "@" (fun len -> Container (Container_len len)));
         (fun () ->
-          bracketed "@min-" (fun len ->
-              Container (Container_len_cmp (Cq_min, len))));
+          bracketed "@" (fun raw len -> Container (Container_len (raw, len))));
         (fun () ->
-          bracketed "@max-" (fun len ->
-              Container (Container_len_cmp (Cq_max, len))));
+          bracketed "@min-" (fun raw len ->
+              Container (Container_len_cmp (Cq_min, raw, len))));
+        (fun () ->
+          bracketed "@max-" (fun raw len ->
+              Container (Container_len_cmp (Cq_max, raw, len))));
         (fun () -> sized "@min-" Cq_min);
         (fun () -> sized "@max-" Cq_max);
       ]

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -431,10 +431,13 @@ let container_rule ?(inner_has_hover = false) query base_class selector props =
   in
   let condition = Containers.container_query_to_condition query in
   if inner_has_hover then
-    container_query ~condition ~selector:new_selector ~props:[] ~base_class
+    container_query ~condition ~selector:new_selector ~props:[]
+      ~base_class:modified_class
       ~nested:(nested_hover ~selector:new_selector ~props)
       ()
-  else container_query ~condition ~selector:new_selector ~props ~base_class ()
+  else
+    container_query ~condition ~selector:new_selector ~props
+      ~base_class:modified_class ()
 
 (** Preprocess a has-[...] selector string for CSS parsing. Replaces & with *
     (nesting reference) and ensures combinators (+, >, ~) have proper spacing.
@@ -1763,7 +1766,39 @@ let rec apply_modifier_to_rule ?theme modifier = function
   | Supports_query { condition; selector; props; base_class; merge_key; _ } ->
       apply_modifier_to_supports_query ?theme modifier ~condition ~selector
         ~props ~base_class ~merge_key
+  | Container_query { condition; selector; props; base_class; nested } ->
+      apply_modifier_to_container_query ?theme modifier ~condition ~selector
+        ~props ~base_class ~nested
   | other -> [ other ]
+
+(* Apply a modifier to a [@container] rule, the way the [@supports] case does:
+   run it on the inner rule so all the selector and media machinery applies,
+   then put each result back inside [@container]. Without this an outer variant
+   fell through and vanished -- [sm:@max-md:X] lost its breakpoint entirely. *)
+and apply_modifier_to_container_query ?theme modifier ~condition ~selector
+    ~props ~base_class ~nested =
+  let inner = regular ~selector ~props ?base_class ~nested () in
+  let contained sel p = Css.container ~condition [ Css.rule ~selector:sel p ] in
+  apply_modifier_to_rule ?theme modifier inner
+  |> List.map (function
+    | Regular { selector; props; base_class; has_hover; nested; _ } ->
+        if has_hover then
+          media_query ~condition:hover_media ~selector ~props:[] ?base_class
+            ~nested:(contained selector props :: nested)
+            ()
+        else container_query ~condition ~selector ~props ?base_class ~nested ()
+    | Media_query { condition = outer; selector; props; base_class; nested; _ }
+      ->
+        (* Tailwind keeps the outer query outside and nests the container. *)
+        media_query ~condition:outer ~selector ~props:[] ?base_class
+          ~nested:(contained selector props :: nested)
+          ()
+    | Container_query { condition = outer; selector; props; base_class; nested }
+      ->
+        container_query ~condition:outer ~selector ~props:[] ?base_class
+          ~nested:(contained selector props :: nested)
+          ()
+    | other -> other)
 
 (* Apply a modifier to a [@supports] rule (the progressive-enhancement block an
    opacity color or gradient emits). The modifier is applied to the inner rule

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -21,8 +21,8 @@ type container_query =
   | Container_7xl
   | Container_named of string * int
   | Container_size of container_cmp * container_query
-  | Container_len of Css.length
-  | Container_len_cmp of container_cmp * Css.length
+  | Container_len of string * Css.length
+  | Container_len_cmp of container_cmp * string * Css.length
 
 type modifier =
   | Hover
@@ -327,12 +327,11 @@ let rec container_size_name = function
   | Container_named (n, size) -> n ^ "/" ^ string_of_int size
   | Container_size (cmp, inner) ->
       container_cmp_prefix cmp ^ container_size_name inner
-  | Container_len l ->
-      "[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
-  | Container_len_cmp (cmp, l) ->
-      container_cmp_prefix cmp ^ "["
-      ^ Css.Pp.to_string (Css.pp_length ~always:true) l
-      ^ "]"
+  (* The raw bracket token, not the parsed length: [theme(--breakpoint-lg)]
+     must not come back as its resolved [64rem]. *)
+  | Container_len (raw, _) -> "[" ^ raw ^ "]"
+  | Container_len_cmp (cmp, raw, _) ->
+      container_cmp_prefix cmp ^ "[" ^ raw ^ "]"
 
 (* Convert modifier to string prefix *)
 (* Map of simple state names to base modifiers for compound variant parsing *)

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -28,8 +28,10 @@ type container_query =
   | Container_size of container_cmp * container_query
       (** [@min-<size>] / [@max-<size>]; the inner query is a bare named size.
       *)
-  | Container_len of Css.length  (** [@[<len>]]: [width >= len]. *)
-  | Container_len_cmp of container_cmp * Css.length
+  | Container_len of string * Css.length
+      (** [@[<len>]]: [width >= len]. Carries the raw bracket token so the
+          class name round-trips. *)
+  | Container_len_cmp of container_cmp * string * Css.length
       (** [@min-[<len>]] / [@max-[<len>]]. *)
 
 type modifier =

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -70,9 +70,34 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"containers suborder matches Tailwind" shuffled
 
+(* A container-query variant keeps the raw bracket token in its class name, and
+   an outer variant wraps it rather than replacing it: the composition used to
+   fall through, so [sm:@max-md:X] lost its breakpoint entirely. *)
+let test_container_variant_composition () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  (* [theme()] resolves in the condition but not in the class name *)
+  has "@min-[theme(--breakpoint-lg)]:hidden"
+    ".\\@min-\\[theme\\(--breakpoint-lg\\)\\]\\:hidden";
+  has "@min-[theme(--breakpoint-lg)]:hidden" "@container(width>=64rem)";
+  (* an outer breakpoint stays outside the container query *)
+  has "sm:@max-[40rem]:inline-block"
+    "@media(min-width:40rem){@container not \
+     (width>=40rem){.sm\\:\\@max-\\[40rem\\]\\:inline-block";
+  (* two container queries nest *)
+  has "@sm:@max-md:flex-col"
+    "@container(width>=24rem){@container not (width>=28rem)"
+
 let tests =
   [
     test_case "types" `Quick test_container_types;
+    test_case "variant composition" `Quick test_container_variant_composition;
     test_case "name" `Quick test_container_name;
     test_case "multiple named containers" `Quick test_multiple_named_containers;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
An outer variant fell through the `@container` case in the modifier composition and vanished, so `sm:@max-md:X` lost both its breakpoint and its class name. The query now nests inside whatever wraps it and reports the prefixed class.

It also keeps the raw bracket token, so `@min-[theme(--breakpoint-lg)]` no longer comes back as its resolved `64rem`.
Stacked on #210. Merge in order; each PR is based on the one below it.
