### PR TITLE
modifiers: name a group or peer on any state, and take a bare data attribute

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1178,15 +1178,17 @@ let rec pp_modifier = function
   | In_bracket content -> "in-[" ^ content ^ "]"
   | In_data attr -> "in-data-" ^ attr
   | Data_bracket expr -> "data-[" ^ expr ^ "]"
-  | Group_data (expr, None) -> "group-data-[" ^ expr ^ "]"
-  | Group_data (expr, Some name) -> "group-data-[" ^ expr ^ "]/" ^ name
-  | Peer_data (expr, None) -> "peer-data-[" ^ expr ^ "]"
-  | Peer_data (expr, Some name) -> "peer-data-[" ^ expr ^ "]/" ^ name
+  | Group_data (spelling, None) -> "group-data-" ^ spelling
+  | Group_data (spelling, Some name) -> "group-data-" ^ spelling ^ "/" ^ name
+  | Peer_data (spelling, None) -> "peer-data-" ^ spelling
+  | Peer_data (spelling, Some name) -> "peer-data-" ^ spelling ^ "/" ^ name
   | Aria_bracket expr -> "aria-[" ^ expr ^ "]"
   | Group_aria (expr, None) -> "group-aria-" ^ expr
   | Group_aria (expr, Some name) -> "group-aria-" ^ expr ^ "/" ^ name
   | Peer_aria (expr, None) -> "peer-aria-" ^ expr
   | Peer_aria (expr, Some name) -> "peer-aria-" ^ expr ^ "/" ^ name
+  | Named_group (inner, name) -> "group-" ^ pp_modifier inner ^ "/" ^ name
+  | Named_peer (inner, name) -> "peer-" ^ pp_modifier inner ^ "/" ^ name
   | Not_named_group (inner, name) ->
       "not-group-" ^ pp_modifier inner ^ "/" ^ name
   | Has_named_group (inner, name) ->
@@ -1230,6 +1232,72 @@ let extract_bracket_content ~prefix s =
   else None
 
 (* Extract bracketed content allowing an optional /name suffix *)
+(* Extract name suffix from "rest" after prefix, e.g. "checked/name" ->
+   ("checked", Some "name") *)
+let split_name rest =
+  match String.index_opt rest '/' with
+  | Some i ->
+      let base = String.sub rest 0 i in
+      let name = String.sub rest (i + 1) (String.length rest - i - 1) in
+      if name <> "" then (base, Some name) else (rest, None)
+  | None -> (rest, None)
+
+(* Try parsing has-shorthand modifiers like has-checked,
+   group-has-checked/name *)
+(* Known aria shorthand names that map to [aria-X=true] *)
+let is_aria_shorthand = function
+  | "busy" | "checked" | "disabled" | "expanded" | "hidden" | "pressed"
+  | "readonly" | "required" | "selected" ->
+      true
+  | _ -> false
+
+(* Try parsing group-aria-*/peer-aria-* shorthand with optional /name *)
+let try_aria_shorthand s =
+  if String.length s > 11 && String.sub s 0 11 = "group-aria-" then
+    let rest = String.sub s 11 (String.length s - 11) in
+    let base, name = split_name rest in
+    if is_aria_shorthand base then Some (Group_aria (base, name)) else None
+  else if String.length s > 10 && String.sub s 0 10 = "peer-aria-" then
+    let rest = String.sub s 10 (String.length s - 10) in
+    let base, name = split_name rest in
+    if is_aria_shorthand base then Some (Peer_aria (base, name)) else None
+  else None
+
+let try_has_shorthand s =
+  if String.length s > 4 && String.sub s 0 4 = "has-" then
+    let rest = String.sub s 4 (String.length s - 4) in
+    if is_has_shorthand rest then Some (Has rest) else None
+  else if String.length s > 10 && String.sub s 0 10 = "group-has-" then
+    let rest = String.sub s 10 (String.length s - 10) in
+    let base, name = split_name rest in
+    if is_has_shorthand base then Some (Group_has (base, name)) else None
+  else if String.length s > 9 && String.sub s 0 9 = "peer-has-" then
+    let rest = String.sub s 9 (String.length s - 9) in
+    let base, name = split_name rest in
+    if is_has_shorthand base then Some (Peer_has (base, name)) else None
+  else None
+
+(* A plain identifier: what a group/peer name or a bare data attribute may be
+   spelled with. *)
+let is_plain_ident str =
+  str <> ""
+  && String.for_all
+       (fun c ->
+         (c >= 'a' && c <= 'z')
+         || (c >= 'A' && c <= 'Z')
+         || (c >= '0' && c <= '9')
+         || c = '-' || c = '_')
+       str
+
+(* [group-data-dragging] is [group-data-[dragging]] with a different spelling,
+   so it keeps its own class name. *)
+let try_bare_data s prefix make =
+  let plen = String.length prefix in
+  if String.length s <= plen || String.sub s 0 plen <> prefix then None
+  else
+    let base, name = split_name (String.sub s plen (String.length s - plen)) in
+    if is_plain_ident base then Some (make base name) else None
+
 let extract_bracket_content_with_name ~prefix s =
   if String.starts_with ~prefix s then
     let rest =
@@ -1311,8 +1379,14 @@ let bracket_named_patterns s =
     (fun () -> try_named "group-aria-[" (fun e n -> Group_aria (e, n)));
     (fun () -> try_named "peer-aria-[" (fun e n -> Peer_aria (e, n)));
     (fun () -> try_pattern "aria-[" (fun expr -> Aria_bracket expr));
-    (fun () -> try_named "group-data-[" (fun e n -> Group_data (e, n)));
-    (fun () -> try_named "peer-data-[" (fun e n -> Peer_data (e, n)));
+    (fun () ->
+      try_named "group-data-[" (fun e n -> Group_data ("[" ^ e ^ "]", n)));
+    (fun () ->
+      try_named "peer-data-[" (fun e n -> Peer_data ("[" ^ e ^ "]", n)));
+    (* Bare shorthand: [group-data-dragging] is [group-data-[dragging]] with a
+       different spelling, so it keeps its own class name. *)
+    (fun () -> try_bare_data s "group-data-" (fun e n -> Group_data (e, n)));
+    (fun () -> try_bare_data s "peer-data-" (fun e n -> Peer_data (e, n)));
     (fun () ->
       let* expr = extract_bracket_content ~prefix:"data-[" s in
       if expr = "" then None else Some (Data_bracket expr));
@@ -1724,51 +1798,6 @@ let parse_group_peer_not_inner rest =
         | Some m -> Some (m, None)
         | None -> None)
 
-(* Extract name suffix from "rest" after prefix, e.g. "checked/name" ->
-   ("checked", Some "name") *)
-let split_name rest =
-  match String.index_opt rest '/' with
-  | Some i ->
-      let base = String.sub rest 0 i in
-      let name = String.sub rest (i + 1) (String.length rest - i - 1) in
-      if name <> "" then (base, Some name) else (rest, None)
-  | None -> (rest, None)
-
-(* Try parsing has-shorthand modifiers like has-checked,
-   group-has-checked/name *)
-(* Known aria shorthand names that map to [aria-X=true] *)
-let is_aria_shorthand = function
-  | "busy" | "checked" | "disabled" | "expanded" | "hidden" | "pressed"
-  | "readonly" | "required" | "selected" ->
-      true
-  | _ -> false
-
-(* Try parsing group-aria-*/peer-aria-* shorthand with optional /name *)
-let try_aria_shorthand s =
-  if String.length s > 11 && String.sub s 0 11 = "group-aria-" then
-    let rest = String.sub s 11 (String.length s - 11) in
-    let base, name = split_name rest in
-    if is_aria_shorthand base then Some (Group_aria (base, name)) else None
-  else if String.length s > 10 && String.sub s 0 10 = "peer-aria-" then
-    let rest = String.sub s 10 (String.length s - 10) in
-    let base, name = split_name rest in
-    if is_aria_shorthand base then Some (Peer_aria (base, name)) else None
-  else None
-
-let try_has_shorthand s =
-  if String.length s > 4 && String.sub s 0 4 = "has-" then
-    let rest = String.sub s 4 (String.length s - 4) in
-    if is_has_shorthand rest then Some (Has rest) else None
-  else if String.length s > 10 && String.sub s 0 10 = "group-has-" then
-    let rest = String.sub s 10 (String.length s - 10) in
-    let base, name = split_name rest in
-    if is_has_shorthand base then Some (Group_has (base, name)) else None
-  else if String.length s > 9 && String.sub s 0 9 = "peer-has-" then
-    let rest = String.sub s 9 (String.length s - 9) in
-    let base, name = split_name rest in
-    if is_has_shorthand base then Some (Peer_has (base, name)) else None
-  else None
-
 (* Try to parse compound named group variants: not-group-STATE/name,
    has-group-STATE/name, in-group-STATE/name, group-peer-STATE/name *)
 let try_compound_named_group s =
@@ -1778,23 +1807,26 @@ let try_compound_named_group s =
       let rest = String.sub s plen (String.length s - plen) in
       let base, name_opt = split_name rest in
       match name_opt with
-      | Some name -> (
+      (* [group-hover/[]] is not a name Tailwind accepts. *)
+      | Some name when is_plain_ident name -> (
           match List.assoc_opt base group_state_modifiers with
           | Some m -> Some (make m name)
           | None -> None)
-      | None -> None
+      | Some _ | None -> None
     else None
   in
-  match try_match "not-group-" (fun m n -> Not_named_group (m, n)) with
-  | Some _ as r -> r
-  | None -> (
-      match try_match "has-group-" (fun m n -> Has_named_group (m, n)) with
-      | Some _ as r -> r
-      | None -> (
-          match try_match "in-group-" (fun m n -> In_named_group (m, n)) with
-          | Some _ as r -> r
-          | None -> try_match "group-peer-" (fun m n -> Group_peer_named (m, n))
-          ))
+  (* Longest prefix first: [group-peer-X/n] must not be read as [group-] with
+     the state [peer-X]. *)
+  List.find_map
+    (fun f -> f ())
+    [
+      (fun () -> try_match "not-group-" (fun m n -> Not_named_group (m, n)));
+      (fun () -> try_match "has-group-" (fun m n -> Has_named_group (m, n)));
+      (fun () -> try_match "in-group-" (fun m n -> In_named_group (m, n)));
+      (fun () -> try_match "group-peer-" (fun m n -> Group_peer_named (m, n)));
+      (fun () -> try_match "group-" (fun m n -> Named_group (m, n)));
+      (fun () -> try_match "peer-" (fun m n -> Named_peer (m, n)));
+    ]
 
 (* Try in-* pattern: in-[selector] or in-data-attr *)
 let try_in_modifier s =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -670,14 +670,22 @@ let _is_data_shorthand_name = function
 let route_data_bracket_modifier modifier base_class props =
   let kind, raw_str, name_opt =
     match modifier with
-    | Style.Data_bracket s -> (`Data, s, None)
+    | Style.Data_bracket s -> (`Data, "[" ^ s ^ "]", None)
     | Style.Group_data (s, n) -> (`Group_data, s, n)
     | Style.Peer_data (s, n) -> (`Peer_data, s, n)
     | _ -> failwith "Invalid data bracket modifier"
   in
-  let attr_name, attr_match, attr_flag = parse_data_expr raw_str in
+  (* [raw_str] is the spelling: [[state=open]] bracketed, [dragging] bare. The
+     expression to parse is the same either way. *)
+  let expr =
+    let n = String.length raw_str in
+    if n > 1 && raw_str.[0] = '[' && raw_str.[n - 1] = ']' then
+      String.sub raw_str 1 (n - 2)
+    else raw_str
+  in
+  let attr_name, attr_match, attr_flag = parse_data_expr expr in
   let open Css.Selector in
-  let class_part = "[" ^ raw_str ^ "]" in
+  let class_part = raw_str in
   let not_order = 20 in
   match kind with
   | `Data ->
@@ -1415,6 +1423,38 @@ let named_group_rel name pseudo =
     (compound [ where [ Class ("group/" ^ name) ]; pseudo ])
     Descendant universal
 
+(* [group-X/name] / [peer-X/name]: a state variant scoped to a named anchor. The
+   anchor's own [hover] must still gate on the pointer, so the rule carries
+   [has_hover] like a plain [group-hover] does. *)
+let named_anchor_rule ~anchor ~combinator inner name base_class props =
+  let open Css.Selector in
+  let modified_class =
+    String.concat ""
+      [ anchor; "-"; Modifiers.pp_modifier inner; "/"; name; ":"; base_class ]
+  in
+  let rel =
+    combine
+      (compound
+         [
+           where [ Class (anchor ^ "/" ^ name) ];
+           pseudo_selector_of_modifier inner;
+         ])
+      combinator universal
+  in
+  let sel = compound [ Class modified_class; is_ [ rel ] ] in
+  [
+    regular ~selector:sel ~props ~base_class:modified_class
+      ~has_hover:(Modifiers.is_hover inner) ();
+  ]
+
+let handle_named_group inner name base_class props =
+  named_anchor_rule ~anchor:"group" ~combinator:Css.Selector.Descendant inner
+    name base_class props
+
+let handle_named_peer inner name base_class props =
+  named_anchor_rule ~anchor:"peer" ~combinator:Css.Selector.Subsequent_sibling
+    inner name base_class props
+
 (** Handle not-group-STATE/name compound variant *)
 let named_group_modified_class prefix inner name base_class =
   let inner_str = Modifiers.pp_modifier inner in
@@ -1744,6 +1784,9 @@ let rec apply_modifier_to_rule ?theme modifier = function
           handle_group_not_modifier inner name_opt bc props
       | Style.Peer_not (inner, name_opt) ->
           handle_peer_not_modifier inner name_opt bc props
+      | Style.Named_group (inner, name) ->
+          handle_named_group inner name bc props
+      | Style.Named_peer (inner, name) -> handle_named_peer inner name bc props
       | Style.Not_named_group (inner, name) ->
           handle_not_named_group inner name bc props
       | Style.Has_named_group (inner, name) ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -222,6 +222,10 @@ type modifier =
       (** [group-aria-X/name] — group aria variant with optional name *)
   | Peer_aria of string * string option
       (** [peer-aria-X/name] — peer aria variant with optional name *)
+  | Named_group of modifier * string
+      (** [group-X/name] — a state variant on a named group *)
+  | Named_peer of modifier * string
+      (** [peer-X/name] — a state variant on a named peer *)
   | Not_named_group of modifier * string
       (** [not-group-X/name] — negate named group variant *)
   | Has_named_group of modifier * string
@@ -327,8 +331,8 @@ let rec container_size_name = function
   | Container_named (n, size) -> n ^ "/" ^ string_of_int size
   | Container_size (cmp, inner) ->
       container_cmp_prefix cmp ^ container_size_name inner
-  (* The raw bracket token, not the parsed length: [theme(--breakpoint-lg)]
-     must not come back as its resolved [64rem]. *)
+  (* The raw bracket token, not the parsed length: [theme(--breakpoint-lg)] must
+     not come back as its resolved [64rem]. *)
   | Container_len (raw, _) -> "[" ^ raw ^ "]"
   | Container_len_cmp (cmp, raw, _) ->
       container_cmp_prefix cmp ^ "[" ^ raw ^ "]"
@@ -605,12 +609,15 @@ let rec pp_modifier = function
   | Peer_not (inner, Some name) ->
       String.concat "" [ "peer-not-"; pp_modifier inner; "/"; name ]
   | Data_bracket expr -> "data-[" ^ expr ^ "]"
-  | Group_data (expr, None) -> "group-data-[" ^ expr ^ "]"
-  | Group_data (expr, Some name) ->
-      String.concat "" [ "group-data-["; expr; "]/"; name ]
-  | Peer_data (expr, None) -> "peer-data-[" ^ expr ^ "]"
-  | Peer_data (expr, Some name) ->
-      String.concat "" [ "peer-data-["; expr; "]/"; name ]
+  (* The spelling as written: [[dragging]] for the bracket form, [dragging] for
+     the bare shorthand. Both mean the same attribute, but the class names
+     differ. *)
+  | Group_data (spelling, None) -> "group-data-" ^ spelling
+  | Group_data (spelling, Some name) ->
+      String.concat "" [ "group-data-"; spelling; "/"; name ]
+  | Peer_data (spelling, None) -> "peer-data-" ^ spelling
+  | Peer_data (spelling, Some name) ->
+      String.concat "" [ "peer-data-"; spelling; "/"; name ]
   | Aria_bracket expr -> "aria-[" ^ expr ^ "]"
   | Group_aria (expr, None) -> "group-aria-" ^ expr
   | Group_aria (expr, Some name) ->
@@ -618,6 +625,10 @@ let rec pp_modifier = function
   | Peer_aria (expr, None) -> "peer-aria-" ^ expr
   | Peer_aria (expr, Some name) ->
       String.concat "" [ "peer-aria-"; expr; "/"; name ]
+  | Named_group (inner, name) ->
+      String.concat "" [ "group-"; pp_modifier inner; "/"; name ]
+  | Named_peer (inner, name) ->
+      String.concat "" [ "peer-"; pp_modifier inner; "/"; name ]
   | Not_named_group (inner, name) ->
       "not-group-" ^ pp_modifier inner ^ "/" ^ name
   | Has_named_group (inner, name) ->

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -232,6 +232,10 @@ type modifier =
       (** [group-aria-X/name] — group aria variant with optional name *)
   | Peer_aria of string * string option
       (** [peer-aria-X/name] — peer aria variant with optional name *)
+  | Named_group of modifier * string
+      (** [group-X/name] — a state variant on a named group *)
+  | Named_peer of modifier * string
+      (** [peer-X/name] — a state variant on a named peer *)
   | Not_named_group of modifier * string
       (** [not-group-X/name] — negate named group variant *)
   | Has_named_group of modifier * string

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -470,6 +470,35 @@ let test_has_state_shorthands () =
   check string "has-focus round-trips" "has-focus:flex"
     (Tw.pp (Result.get_ok (Tw.of_string "has-focus:flex")))
 
+(* A named anchor works on any state variant, not just the has/aria/data ones:
+   group-hover/edit scopes to .group\/edit. And a data variant takes the bare
+   attribute shorthand under group-/peer- too, keeping a class name distinct
+   from the bracket spelling. *)
+let test_named_anchor_and_bare_data () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "group-hover/edit:underline"
+    ".group-hover\\/edit\\:underline:is(:where(.group\\/edit):hover *)";
+  has "group-focus/option:underline"
+    ".group-focus\\/option\\:underline:is(:where(.group\\/option):focus *)";
+  has "peer-checked/draft:block"
+    ".peer-checked\\/draft\\:block:is(:where(.peer\\/draft):checked~*)";
+  has "group-data-modified:italic"
+    ".group-data-modified\\:italic:is(:where(.group)[data-modified] *)";
+  (* the bracket spelling keeps its own class name *)
+  has "group-data-[modified]:italic"
+    ".group-data-\\[modified\\]\\:italic:is(:where(.group)[data-modified] *)";
+  (* group-hover gates on the pointer, as a plain hover does *)
+  check bool "group-hover/edit keeps the pointer gate" true
+    (Astring.String.is_infix ~affix:"@media(hover:hover)"
+       (css "group-hover/edit:underline"))
+
 (* Test ARIA and data modifiers class names *)
 let test_aria_and_data_modifiers () =
   check string "aria-checked:p-4" "aria-checked:p-4"
@@ -618,6 +647,8 @@ let tests =
       test_case "container query min/max" `Quick test_container_query_min_max;
       test_case "apply bracketed has variants" `Quick test_apply_bracketed_has;
       test_case "has state shorthands" `Quick test_has_state_shorthands;
+      test_case "named anchor and bare data" `Quick
+        test_named_anchor_and_bare_data;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "before/after modifiers" `Quick test_before_after_modifiers;
       test_case "nested modifier class names" `Quick


### PR DESCRIPTION
`group-hover/edit` and `peer-checked/draft` were unknown classes: a named anchor only worked on the `has`/`aria`/`data` variants. `group-data-dragging` was unknown too, since the group and peer forms required the bracket spelling.

Both now go through the same state-name table as the rest, and the data variants keep the spelling they were written with so `group-data-dragging` and `group-data-[dragging]` stay distinct classes.
Stacked on #199. Merge in order; each PR is based on the one below it.
