### PR TITLE
modifiers: accept an arbitrary variant with no ampersand anchor

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1277,6 +1277,16 @@ let try_has_shorthand s =
     if is_has_shorthand base then Some (Peer_has (base, name)) else None
   else None
 
+(* A bare arbitrary variant with no [&] anchor compounds onto the utility's own
+   class, so it has to be a single compound selector: [[code]] and [[.line]] are
+   fine, [[>img]] and [[@media_print]] are not. *)
+let is_compound_selector inner =
+  (match inner.[0] with
+    | 'a' .. 'z' | 'A' .. 'Z' | '.' | '#' | '[' | ':' | '*' -> true
+    | _ | (exception _) -> false)
+  && not
+       (String.exists (fun c -> c = '_' || c = '>' || c = '+' || c = '~') inner)
+
 (* A plain identifier: what a group/peer name or a bare data attribute may be
    spelled with. *)
 let is_plain_ident str =
@@ -1431,12 +1441,12 @@ let bracket_value_patterns s =
           if sel <> "" && String.contains sel '&' then Some sel else None)
         (fun sel -> Peer_arbitrary sel));
     (fun () ->
-      if
-        String.length s >= 3
-        && s.[0] = '['
-        && s.[String.length s - 1] = ']'
-        && String.contains s '&'
-      then Some (Arbitrary_selector (String.sub s 1 (String.length s - 2)))
+      if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']'
+      then
+        let inner = String.sub s 1 (String.length s - 2) in
+        if String.contains inner '&' || is_compound_selector inner then
+          Some (Arbitrary_selector inner)
+        else None
       else None);
   ]
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1531,7 +1531,18 @@ let arbitrary_selector_rule content base_class props =
           else Buffer.add_char buf c)
         s;
       Css.Selector.read (Cascade.Cursor.of_string (Buffer.contents buf)))
-    else Class modified_class
+    else
+      (* No anchor: the selector compounds onto the utility's own class. A type
+         selector cannot follow a class in a compound, so it goes in an [:is()];
+         anything else ([.line], [[data-x]], [:hover]) attaches directly. *)
+      let is_type_selector =
+        match s.[0] with
+        | 'a' .. 'z' | 'A' .. 'Z' -> true
+        | _ | (exception _) -> false
+      in
+      let inner = Css.Selector.read (Cascade.Cursor.of_string s) in
+      let inner = if is_type_selector then is_ [ inner ] else inner in
+      compound [ Class modified_class; inner ]
   in
   regular ~selector:sel ~props ~base_class:modified_class ()
 

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -182,10 +182,31 @@ let test_outer_variant_over_child_and_pseudo () =
   has "hover:*:underline" ":is(.hover\\:\\*\\:underline:hover>*)";
   has "*:*:grow" ":is(:is(.\\*\\:\\*\\:grow>*)>*)"
 
+(* An arbitrary variant with no [&] anchor compounds onto the utility's own
+   class: [[.line]] attaches directly, a type selector goes in an [:is()] since
+   it cannot follow a class. One that is not a single compound ([[>img]]) is not
+   a variant at all. *)
+let test_bare_arbitrary_selector_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "[.line]:block" ".\\[\\.line\\]\\:block.line";
+  has "[code]:pr-4" ".\\[code\\]\\:pr-4:is(code)";
+  has "**:[code]:pr-4" ":is(.\\*\\*\\:\\[code\\]\\:pr-4 *):is(code)";
+  check bool "[>img] is not a variant" true
+    (Result.is_error (Tw.of_string "[>img]:flex"))
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "bare arbitrary selector variant" `Quick
+      test_bare_arbitrary_selector_variant;
     test_case "outer variant over child and pseudo-element" `Quick
       test_outer_variant_over_child_and_pseudo;
     test_case "opacity color variant does not leak base rule" `Quick


### PR DESCRIPTION
`[code]:pr-4` and `[.line]:block` were unknown classes: an arbitrary variant had to spell its `&` anchor, so the bare form Tailwind also accepts was rejected. It now compounds onto the utility's own class, with a type selector wrapped in `:is()` since it cannot follow a class. A selector that is not a single compound stays rejected, as Tailwind rejects it too.
Stacked on #200. Merge in order; each PR is based on the one below it.
