### PR TITLE
modifiers: read has-data-* and let not- compose over any variant

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2043,7 +2043,7 @@ let try_container_query s =
       ]
 
 (* Parse a modifier string into a typed Style.modifier *)
-let parse_modifier s : modifier option =
+let rec parse_modifier s : modifier option =
   let fns =
     [
       (fun () -> List.assoc_opt s simple_modifiers);
@@ -2064,9 +2064,20 @@ let parse_modifier s : modifier option =
       (fun () -> try_prose_element s);
       (fun () -> try_custom_breakpoint s);
       (fun () -> try_custom_variant s);
+      (* Last: a [not-] over any other variant negates the selector it produces.
+         The readings above come first because several [not-] spellings need
+         their own handling. *)
+      (fun () -> try_not_of_modifier s);
     ]
   in
   List.find_map (fun f -> f ()) fns
+
+and try_not_of_modifier s =
+  if not (String.length s > 4 && String.sub s 0 4 = "not-") then None
+  else
+    match parse_modifier (String.sub s 4 (String.length s - 4)) with
+    | Some m when is_not_compatible m -> Some (Not m)
+    | Some _ | None -> None
 
 (* Apply a list of modifier strings to a base utility *)
 let apply modifiers base_utility =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -463,6 +463,42 @@ let preprocess_has_selector s =
   done;
   Buffer.contents buf
 
+(* The selector a has-shorthand name stands for. [has-<state>] takes the same
+   state names as the group/peer variants and matches what that state matches,
+   so most map straight to their pseudo-class. *)
+let resolve_has_shorthand = function
+  | "hocus" -> ":hover, :focus"
+  | "open" -> ":is([open], :popover-open, :open)"
+  | "inert" -> ":is([inert], [inert] *)"
+  | "odd" -> ":nth-child(odd)"
+  | "even" -> ":nth-child(even)"
+  | "first" -> ":first-child"
+  | "last" -> ":last-child"
+  | "only" -> ":only-child"
+  | s when Style.is_data_attr_name s -> "[" ^ s ^ "]"
+  | s -> ":" ^ s
+
+(* The [:has()] argument a has-variant matches, from the spelling the modifier
+   stored: a state name resolves to its pseudo-class, anything else is already a
+   selector. *)
+let has_inner_selector raw =
+  let str =
+    if Style.is_has_shorthand raw then resolve_has_shorthand raw else raw
+  in
+  Css.Selector.read_relative
+    (Cascade.Cursor.of_string (preprocess_has_selector str))
+
+(* The relative selector a group/peer has-variant scopes to:
+   [:where(.group):has(<inner>) *]. *)
+let has_anchor_rel ~anchor ~combinator ?name inner =
+  let open Css.Selector in
+  let anchor_class =
+    match name with Some n -> anchor ^ "/" ^ n | None -> anchor
+  in
+  combine
+    (compound [ where [ Class anchor_class ]; has [ inner ] ])
+    combinator universal
+
 let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
     selector_str base_class props =
   let open Css.Selector in
@@ -484,13 +520,9 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
       let class_name =
         "group-has-" ^ has_part selector_str ^ name_suffix ^ ":" ^ base_class
       in
-      let group_class =
-        match name with Some n -> "group/" ^ n | None -> "group"
-      in
       let rel =
-        combine
-          (compound [ where [ Class group_class ]; has [ parsed_selector ] ])
-          Descendant universal
+        has_anchor_rel ~anchor:"group" ~combinator:Descendant ?name
+          parsed_selector
       in
       let sel = compound [ Class class_name; is_ [ rel ] ] in
       regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
@@ -500,13 +532,9 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
       let class_name =
         "peer-has-" ^ has_part selector_str ^ name_suffix ^ ":" ^ base_class
       in
-      let peer_class =
-        match name with Some n -> "peer/" ^ n | None -> "peer"
-      in
       let rel =
-        combine
-          (compound [ where [ Class peer_class ]; has [ parsed_selector ] ])
-          Subsequent_sibling universal
+        has_anchor_rel ~anchor:"peer" ~combinator:Subsequent_sibling ?name
+          parsed_selector
       in
       let sel = compound [ Class class_name; is_ [ rel ] ] in
       regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
@@ -733,20 +761,6 @@ let route_data_bracket_modifier modifier base_class props =
       in
       let sel = compound [ Class class_name; is_ [ rel ] ] in
       regular ~selector:sel ~props ~base_class:class_name ~not_order ()
-
-(* The selector a has-shorthand name stands for. [has-<state>] takes the same
-   state names as the group/peer variants and matches what that state matches,
-   so most map straight to their pseudo-class. *)
-let resolve_has_shorthand = function
-  | "hocus" -> ":hover, :focus"
-  | "open" -> ":is([open], :popover-open, :open)"
-  | "inert" -> ":is([inert], [inert] *)"
-  | "odd" -> ":nth-child(odd)"
-  | "even" -> ":nth-child(even)"
-  | "first" -> ":first-child"
-  | "last" -> ":last-child"
-  | "only" -> ":only-child"
-  | s -> ":" ^ s
 
 (* Route :has() variants to appropriate handler *)
 let route_has_modifier modifier base_class props =
@@ -1051,20 +1065,27 @@ let extract_not_conditions inner_modifier base_class =
   | Style.Hocus | Style.Device_hocus ->
       [ Css.Selector.Hover; Css.Selector.Focus ]
   | Style.Has selector_str ->
-      let pseudo_str =
-        if String.length selector_str > 0 && selector_str.[0] = ':' then
-          String.sub selector_str 1 (String.length selector_str - 1)
-        else selector_str
-      in
-      let inner_sel =
-        match pseudo_str with
-        | "checked" -> Css.Selector.Checked
-        | "hover" -> Css.Selector.Hover
-        | "focus" -> Css.Selector.Focus
-        | "disabled" -> Css.Selector.Disabled
-        | _ -> Css.Selector.Class (":" ^ pseudo_str)
-      in
-      [ Css.Selector.Has [ inner_sel ] ]
+      [ Css.Selector.Has [ has_inner_selector selector_str ] ]
+  (* [not-group-has-X] negates the whole scoped relative selector, not just its
+     [:has()] part. *)
+  | Style.Group_has (selector_str, name) ->
+      [
+        Css.Selector.is_
+          [
+            has_anchor_rel ~anchor:"group" ~combinator:Css.Selector.Descendant
+              ?name
+              (has_inner_selector selector_str);
+          ];
+      ]
+  | Style.Peer_has (selector_str, name) ->
+      [
+        Css.Selector.is_
+          [
+            has_anchor_rel ~anchor:"peer"
+              ~combinator:Css.Selector.Subsequent_sibling ?name
+              (has_inner_selector selector_str);
+          ];
+      ]
   | Style.Data_custom (attr, "") ->
       [ Css.Selector.attribute ("data-" ^ attr) Presence ]
   | Style.Data_custom (attr, value) ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -380,8 +380,23 @@ let group_state_modifiers =
 
 (* Valid has-shorthand names. These are stored as-is (without : prefix) so they
    remain distinct from bracket forms like has-[:checked]. *)
+(* [has-data-lg] matches an attribute rather than a state, but spells itself the
+   same way, so it is a shorthand too. *)
+let is_data_attr_name name =
+  String.length name > 5
+  && String.sub name 0 5 = "data-"
+  && String.for_all
+       (fun c ->
+         (c >= 'a' && c <= 'z')
+         || (c >= 'A' && c <= 'Z')
+         || (c >= '0' && c <= '9')
+         || c = '-' || c = '_')
+       (String.sub name 5 (String.length name - 5))
+
 let is_has_shorthand name =
-  name = "hocus" || List.mem_assoc name group_state_modifiers
+  name = "hocus"
+  || List.mem_assoc name group_state_modifiers
+  || is_data_attr_name name
 
 let has_part selector =
   if is_has_shorthand selector then selector else "[" ^ selector ^ "]"

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -29,8 +29,8 @@ type container_query =
       (** [@min-<size>] / [@max-<size>]; the inner query is a bare named size.
       *)
   | Container_len of string * Css.length
-      (** [@[<len>]]: [width >= len]. Carries the raw bracket token so the
-          class name round-trips. *)
+      (** [@[<len>]]: [width >= len]. Carries the raw bracket token so the class
+          name round-trips. *)
   | Container_len_cmp of container_cmp * string * Css.length
       (** [@min-[<len>]] / [@max-[<len>]]. *)
 
@@ -291,13 +291,16 @@ val group_state_modifiers : (string * modifier) list
     modifier it stands for. Variants that take a state name — [group-*],
     [peer-*], [has-*] — share this table. *)
 
+val is_data_attr_name : string -> bool
+(** [is_data_attr_name name] is whether [name] is a [data-<attr>] shorthand. *)
+
 val is_has_shorthand : string -> bool
 (** [is_has_shorthand name] is whether [name] is a state name a [has-*] variant
     accepts, as opposed to a bracketed CSS selector. *)
 
 val has_part : string -> string
-(** [has_part s] is the class-name fragment a [has-*] variant spells [s] with:
-    a state name bare, a CSS selector in brackets. *)
+(** [has_part s] is the class-name fragment a [has-*] variant spells [s] with: a
+    state name bare, a CSS selector in brackets. *)
 
 val pp_modifier : modifier -> string
 (** [pp_modifier m] converts a modifier to its string representation. *)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -499,6 +499,27 @@ let test_named_anchor_and_bare_data () =
     (Astring.String.is_infix ~affix:"@media(hover:hover)"
        (css "group-hover/edit:underline"))
 
+(* [has-data-lg] matches an attribute rather than a state but spells itself the
+   same way, and [not-] composes over any variant, including a scoped
+   [group-has-]: the negation wraps the whole relative selector. *)
+let test_has_data_and_not_composition () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "has-data-lg:opacity-40" ".has-data-lg\\:opacity-40:has([data-lg])";
+  has "group-has-data-lg:opacity-40"
+    ".group-has-data-lg\\:opacity-40:is(:where(.group):has([data-lg]) *)";
+  has "not-group-has-data-lg:opacity-40"
+    ".not-group-has-data-lg\\:opacity-40:not(:is(:where(.group):has([data-lg]) \
+     *))";
+  has "not-peer-has-checked:opacity-0"
+    ".not-peer-has-checked\\:opacity-0:not(:is(:where(.peer):has(:checked)~*))"
+
 (* Test ARIA and data modifiers class names *)
 let test_aria_and_data_modifiers () =
   check string "aria-checked:p-4" "aria-checked:p-4"
@@ -649,6 +670,8 @@ let tests =
       test_case "has state shorthands" `Quick test_has_state_shorthands;
       test_case "named anchor and bare data" `Quick
         test_named_anchor_and_bare_data;
+      test_case "has-data and not- composition" `Quick
+        test_has_data_and_not_composition;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "before/after modifiers" `Quick test_before_after_modifiers;
       test_case "nested modifier class names" `Quick


### PR DESCRIPTION
`not-group-has-data-lg` and `not-peer-has-checked` were unknown classes: `not-` only knew a fixed set of inner spellings, and a `has-` variant could not match a data attribute.

`not-` now parses its inner as a modifier in its own right, and a scoped `has-` negates the whole relative selector rather than just its `:has()` part.
Stacked on #203. Merge in order; each PR is based on the one below it.
