### PR TITLE
parse: expand --spacing() inside an arbitrary value

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -684,7 +684,20 @@ let referenced_theme_decls ~theme ~exclude selector_props =
       then None
       else
         let bare = String.sub full 2 (String.length full - 2) in
-        Color.Handler.theme_color_decl ~theme bare)
+        match bare with
+        (* An arbitrary value may name the spacing scale directly, as
+           [p-[calc(--spacing(2)+1px)]] does. *)
+        | "spacing" ->
+            let decl, _ =
+              Var.binding Theme.spacing_var
+                (Option.value
+                   (Option.bind
+                      (Scheme.theme_value (Some theme) "spacing")
+                      Css.parse_length)
+                   ~default:Theme.spacing_base)
+            in
+            Some decl
+        | _ -> Color.Handler.theme_color_decl ~theme bare)
 
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
 let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -142,7 +142,7 @@ module Handler = struct
       else
         (* Full length grammar (percent, container units, calc), raw kept for
            round-trip. *)
-        match Css.parse_length (Parse.normalize_css_math_operators inner) with
+        match Css.parse_length (Parse.decode_arbitrary_value inner) with
         | Some l -> Some (Arbitrary (inner, l))
         | None -> None
     else None

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -165,8 +165,37 @@ let normalize_css_math_operators s =
   done;
   Buffer.contents buf
 
+(* Tailwind's [--spacing(N)] shorthand: the spacing scale as a function. It is
+   not CSS, so a value holding it fails to parse and the utility drops out. *)
+let expand_spacing_fn s =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec close_paren i depth =
+    if i >= len then (len, len)
+    else
+      match s.[i] with
+      | '(' -> close_paren (i + 1) (depth + 1)
+      | ')' when depth = 1 -> (i, i + 1)
+      | ')' -> close_paren (i + 1) (depth - 1)
+      | _ -> close_paren (i + 1) depth
+  in
+  let rec go i =
+    if i >= len then ()
+    else if i + 10 <= len && String.sub s i 10 = "--spacing(" then (
+      let stop, next = close_paren (i + 9) 0 in
+      let n = String.sub s (i + 10) (stop - i - 10) in
+      Buffer.add_string buf
+        (String.concat "" [ "calc(var(--spacing) * "; n; ")" ]);
+      go next)
+    else (
+      Buffer.add_char buf s.[i];
+      go (i + 1))
+  in
+  go 0;
+  Buffer.contents buf
+
 let decode_arbitrary_value s =
-  s |> decode_underscores |> normalize_css_math_operators
+  s |> decode_underscores |> expand_spacing_fn |> normalize_css_math_operators
 
 (** Check if a string starts with "var(" — works on inner bracket content *)
 let is_var s = String.length s > 4 && String.sub s 0 4 = "var("

--- a/test/test_padding.ml
+++ b/test/test_padding.ml
@@ -95,8 +95,27 @@ let test_arbitrary_length_grammar () =
   check "px-[50%]";
   check "p-[calc(var(--spacing-6)-1px)]"
 
+(* Tailwind's [--spacing(N)] shorthand can appear inside an arbitrary value; it
+   is not CSS, so the whole utility used to drop out. Expanding it also has to
+   pull [--spacing] into the theme layer, which only colour tokens reached. *)
+let test_arbitrary_spacing_fn () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let s = css "py-[calc(--spacing(2)+1px)]" in
+  Alcotest.(check bool)
+    "expands to the spacing scale" true
+    (Astring.String.is_infix
+       ~affix:"padding-block:calc(calc(var(--spacing)*2) + 1px)" s);
+  Alcotest.(check bool)
+    "declares --spacing" true
+    (Astring.String.is_infix ~affix:"--spacing:.25rem" s)
+
 let tests =
   [
+    test_case "arbitrary --spacing()" `Quick test_arbitrary_spacing_fn;
     test_case "padding of_string - valid values" `Quick of_string_valid;
     test_case "padding of_string - invalid values" `Quick of_string_invalid;
     test_case "padding suborder matches Tailwind" `Quick


### PR DESCRIPTION
`py-[calc(--spacing(2)+1px)]` was an unknown class: the shorthand is not CSS, so the value failed to parse and the utility dropped out. It now expands to the spacing scale before the value is read.

An arbitrary value naming `--spacing` also has to pull the token into the theme layer, which until now only colour tokens reached.
Stacked on #207. Merge in order; each PR is based on the one below it.
