### PR TITLE
sizing: read a width fraction from any denominator

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -548,9 +548,9 @@ module Handler = struct
     match String.split_on_char '/' frac with
     | [ n; m ] -> (
         match (int_of_string_opt n, int_of_string_opt m) with
-        | Some n, Some m
-          when m > 0 && n > 0 && n < m && List.mem m [ 2; 3; 4; 5; 6; 10; 12 ]
-          ->
+        (* Any denominator: Tailwind reads [w-<number>/<number>] as a
+           percentage, not from a fixed scale. *)
+        | Some n, Some m when m > 0 && n > 0 && n < m ->
             let pct = float_of_int n /. float_of_int m *. 100. in
             let digits = 6. -. Float.ceil (Float.log10 pct) in
             let factor = 10. ** digits in

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -142,10 +142,10 @@ let of_string_invalid () =
   (* Missing value *)
   test_invalid [ "w"; "invalid" ];
   (* Invalid value *)
-  test_invalid [ "w"; "1/7" ];
-  (* Invalid fraction - 1/7 not supported *)
-  test_invalid [ "h"; "1/7" ];
-  (* Invalid fraction *)
+  test_invalid [ "w"; "1/0" ];
+  (* A zero denominator is not a percentage *)
+  test_invalid [ "h"; "9/9" ];
+  (* A fraction of one or more is not a width *)
   test_invalid [ "min" ];
   (* Missing dimension *)
   test_invalid [ "min"; "z"; "4" ];
@@ -336,7 +336,7 @@ let test_general_fractions () =
     | Error _ -> ()
     | Ok _ -> Alcotest.fail ("expected rejection of " ^ cls)
   in
-  rejected "w-1/7";
+  rejected "w-9/9";
   rejected "w-13/12"
 
 (* max-w-screen-* references the breakpoint theme var (like the v4 CLI), not an
@@ -358,9 +358,23 @@ let test_arbitrary_calc () =
     (Astring.String.is_infix ~affix:"width: calc(100vh - 4rem)"
        (css_of "w-[calc(100vh-4rem)]"))
 
+(* A width fraction is read as a percentage, from any denominator: Tailwind has
+   no fixed scale here, and w-3/8 used to be an unknown class. *)
+let test_any_fraction_denominator () =
+  Alcotest.(check bool)
+    "w-3/8 is 37.5%" true
+    (Astring.String.is_infix ~affix:"width: 37.5%" (css_of "w-3/8"));
+  Alcotest.(check bool)
+    "w-7/9 rounds like Tailwind" true
+    (Astring.String.is_infix ~affix:"width: 77.7778%" (css_of "w-7/9"));
+  Alcotest.(check bool)
+    "a fraction of one or more is still rejected" true
+    (Result.is_error (Tw.of_string "w-9/9"))
+
 let tests =
   [
     test_case "fractional spacing" `Quick test_fractional_spacing;
+    test_case "any fraction denominator" `Quick test_any_fraction_denominator;
     test_case "general fractions" `Quick test_general_fractions;
     test_case "max-w-screen breakpoint var" `Quick test_max_w_screen;
     test_case "widths" `Quick test_widths;


### PR DESCRIPTION
`w-3/8` was an unknown class: the fraction had to come from a fixed scale of denominators, but Tailwind reads `<number>/<number>` as a percentage.

Two tests asserting that `w-1/7` is rejected encoded the same wrong assumption and now cover the cases Tailwind really rejects.
Stacked on #202. Merge in order; each PR is based on the one below it.
