### PR TITLE
source_scan: stop a candidate at the end of its line

### DIFF
--- a/lib/tools/source_scan.ml
+++ b/lib/tools/source_scan.ml
@@ -79,43 +79,48 @@ let read_candidate d start =
     if i >= len then i
     else
       let c = char_at d i in
-      match quote with
-      | Some q ->
-          if escaped then loop (i + 1) bracket_depth paren_depth quote false
-          else if c = 0x5c then
-            loop (i + 1) bracket_depth paren_depth quote true
-          else if c = q then loop (i + 1) bracket_depth paren_depth None false
-          else loop (i + 1) bracket_depth paren_depth quote false
-      | None when bracket_depth > 0 || paren_depth > 0 -> (
-          match c with
-          | 0x22 | 0x27 | 0x60 ->
-              loop (i + 1) bracket_depth paren_depth (Some c) false
-          | 0x5b -> loop (i + 1) (bracket_depth + 1) paren_depth None false
-          | 0x5d when bracket_depth > 0 ->
-              loop (i + 1) (bracket_depth - 1) paren_depth None false
-          | 0x28 -> loop (i + 1) bracket_depth (paren_depth + 1) None false
-          | 0x29 when paren_depth > 0 ->
-              loop (i + 1) bracket_depth (paren_depth - 1) None false
-          | _ -> loop (i + 1) bracket_depth paren_depth None false)
-      | None -> (
-          match c with
-          | c when is_whitespace c -> i
-          | 0x22 | 0x27 | 0x60 | 0x3c | 0x3e | 0x3d | 0x7b | 0x7d | 0x3b | 0x2c
-          | 0x23 ->
-              i
-          | 0x5b -> loop (i + 1) 1 0 None false
-          | 0x28 when i > start && char_at d (i - 1) = 0x2d ->
-              loop (i + 1) 0 1 None false
-          | 0x28 | 0x29 -> i
-          | 0x2e
-            when i > start
-                 && i + 1 < len
-                 && is_ascii_digit (char_at d (i - 1))
-                 && is_ascii_digit (char_at d (i + 1)) ->
-              loop (i + 1) 0 0 None false
-          | 0x2e -> i
-          | c when is_candidate_char c -> loop (i + 1) 0 0 None false
-          | _ -> i)
+      (* A candidate never spans a line, whatever is open. Without this an
+         unbalanced [[] or quote swallows the rest of the file into one
+         token. *)
+      if c = 0x0a || c = 0x0d then i
+      else
+        match quote with
+        | Some q ->
+            if escaped then loop (i + 1) bracket_depth paren_depth quote false
+            else if c = 0x5c then
+              loop (i + 1) bracket_depth paren_depth quote true
+            else if c = q then loop (i + 1) bracket_depth paren_depth None false
+            else loop (i + 1) bracket_depth paren_depth quote false
+        | None when bracket_depth > 0 || paren_depth > 0 -> (
+            match c with
+            | 0x22 | 0x27 | 0x60 ->
+                loop (i + 1) bracket_depth paren_depth (Some c) false
+            | 0x5b -> loop (i + 1) (bracket_depth + 1) paren_depth None false
+            | 0x5d when bracket_depth > 0 ->
+                loop (i + 1) (bracket_depth - 1) paren_depth None false
+            | 0x28 -> loop (i + 1) bracket_depth (paren_depth + 1) None false
+            | 0x29 when paren_depth > 0 ->
+                loop (i + 1) bracket_depth (paren_depth - 1) None false
+            | _ -> loop (i + 1) bracket_depth paren_depth None false)
+        | None -> (
+            match c with
+            | c when is_whitespace c -> i
+            | 0x22 | 0x27 | 0x60 | 0x3c | 0x3e | 0x3d | 0x7b | 0x7d | 0x3b
+            | 0x2c | 0x23 ->
+                i
+            | 0x5b -> loop (i + 1) 1 0 None false
+            | 0x28 when i > start && char_at d (i - 1) = 0x2d ->
+                loop (i + 1) 0 1 None false
+            | 0x28 | 0x29 -> i
+            | 0x2e
+              when i > start
+                   && i + 1 < len
+                   && is_ascii_digit (char_at d (i - 1))
+                   && is_ascii_digit (char_at d (i + 1)) ->
+                loop (i + 1) 0 0 None false
+            | 0x2e -> i
+            | c when is_candidate_char c -> loop (i + 1) 0 0 None false
+            | _ -> i)
   in
   loop start 0 0 None false
 

--- a/test/test_source_scan.ml
+++ b/test/test_source_scan.ml
@@ -56,8 +56,20 @@ let test_scan_bracket_before_whitespace () =
     [ "accent-current"; "accent-inherit" ]
     (known_classes source)
 
+(* A candidate never spans a line. An unbalanced bracket used to keep the
+   scanner reading to the end of the file, so every class after it was lost. *)
+let test_unbalanced_bracket_stops_at_newline () =
+  let src = "flex\nafter:content-[unbalanced\nblock\ngrid\n" in
+  let found = Tw_tools.Source_scan.candidates src in
+  List.iter
+    (fun cls ->
+      Alcotest.(check bool) (cls ^ " still scanned") true (List.mem cls found))
+    [ "flex"; "block"; "grid" ]
+
 let tests =
   [
+    test_case "unbalanced bracket stops at the newline" `Quick
+      test_unbalanced_bracket_stops_at_newline;
     test_case "split whitespace" `Quick test_split_whitespace;
     test_case "scan HTML plain text" `Quick test_scan_html_plain_text;
     test_case "scan JS static classes" `Quick test_scan_js_static_classes;


### PR DESCRIPTION
An unbalanced bracket or quote kept the scanner reading to the end of the file, so a single malformed token swallowed every class after it. A candidate never spans a line, whatever is open.
First in the stack. Merge in order; each PR is based on the one below it.
