### PR TITLE
rule: keep an opacity color's @supports block correct under a variant

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -208,7 +208,15 @@ let rec filter_theme_from_statements statements =
                       | Some (name, condition, content) ->
                           Css.container ?name ?condition
                             (filter_theme_from_statements content)
-                      | None -> stmt)))))
+                      | None -> (
+                          (* An opacity colour's progressive-enhancement block
+                             carries the same theme declaration as the rule it
+                             sits beside; without this it is declared twice. *)
+                          match Css.as_supports stmt with
+                          | Some (condition, content) ->
+                              Css.supports ~condition
+                                (filter_theme_from_statements content)
+                          | None -> stmt))))))
     statements
 
 (* Compute merge key from a base class name as a fallback when the utility

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1895,13 +1895,16 @@ and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
   in
   apply_modifier_to_rule ?theme modifier inner
   |> List.map (function
-    | Regular { selector; props; base_class; has_hover; _ } ->
+    | Regular { selector; props; base_class; has_hover; not_order; _ } ->
         (* A bare hover: rule carries [has_hover] instead of an outer media;
            wrap the @supports in @media (hover:hover) to match. *)
         if has_hover then
           wrap_supports_in_media hover_media selector props base_class []
         else
-          supports_query ~condition ~selector ~props ?base_class ?merge_key ()
+          (* Keep the variant's own order: without it the block sorts before the
+             rule it enhances, and the plain fallback wins instead. *)
+          supports_query ~condition ~selector ~props ?base_class ?merge_key
+            ~not_order ()
     | Media_query { condition = outer; selector; props; base_class; nested; _ }
       ->
         wrap_supports_in_media outer selector props base_class nested

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -201,10 +201,43 @@ let test_bare_arbitrary_selector_variant () =
   check bool "[>img] is not a variant" true
     (Result.is_error (Tw.of_string "[>img]:flex"))
 
+(* An opacity colour emits a progressive-enhancement @supports block beside its
+   fallback. Under a variant the block used to carry the theme declaration a
+   second time, and for the variants that set an order of their own it sorted
+   ahead of the rule it enhances, so the fallback won. *)
+let test_opacity_supports_under_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let s = css "hover:bg-red-500/50" in
+  let occurrences sub str =
+    let n = String.length sub in
+    let rec go i acc =
+      if i + n > String.length str then acc
+      else if String.sub str i n = sub then go (i + n) (acc + 1)
+      else go (i + 1) acc
+    in
+    go 0 0
+  in
+  (* once in @layer theme, not again inside the @supports block *)
+  check int "the theme token is declared once" 1
+    (occurrences "--color-red-500:oklch" s);
+  (* the enhancement has to come after the fallback to win *)
+  let d = css "aria-selected:bg-red-500/50" in
+  let idx affix =
+    Option.get (Astring.String.find_sub ~sub:affix d) |> fun (i : int) -> i
+  in
+  check bool "the @supports block follows the fallback" true
+    (idx "#fb2c3680" < idx "@supports")
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "opacity @supports under a variant" `Quick
+      test_opacity_supports_under_variant;
     test_case "bare arbitrary selector variant" `Quick
       test_bare_arbitrary_selector_variant;
     test_case "outer variant over child and pseudo-element" `Quick


### PR DESCRIPTION
An opacity colour emits a progressive-enhancement `@supports` block beside its fallback. Under a variant that block carried the theme declaration a second time, because the statement filter walked media, layer and container but not `@supports`.

It also lost the variant's own sort order, so for the variants that set one (`aria-*`, `group-data-*`) it landed ahead of the rule it enhances and the plain fallback won.
Stacked on #211. Merge in order; each PR is based on the one below it.
