### PR TITLE
position, transforms: read a spacing step in both signs

### DIFF
--- a/lib/position.ml
+++ b/lib/position.ml
@@ -138,7 +138,7 @@ let parse_pos_spacing s : Style.spacing option =
 
 (* Resolve a spacing token to (optional --spacing binding, length), mirroring
    the padding family so the px and fractional steps render identically. *)
-let pos_spacing_to_len ?theme (s : Style.spacing) :
+let len_of_pos_spacing ?theme (s : Style.spacing) :
     Css.declaration option * Css.length =
   match s with
   | `Rem f ->
@@ -149,7 +149,29 @@ let pos_spacing_to_len ?theme (s : Style.spacing) :
   | `Named name -> (None, Css.Var (Var.theme_ref ("spacing-" ^ name)))
 
 let pos_spacing_style ?theme side (s : Style.spacing) =
-  let decl_opt, len = pos_spacing_to_len ?theme s in
+  let decl_opt, len = len_of_pos_spacing ?theme s in
+  let decls = Option.to_list decl_opt in
+  let body =
+    match side with
+    | P_top -> [ Css.top len ]
+    | P_right -> [ Css.right len ]
+    | P_bottom -> [ Css.bottom len ]
+    | P_left -> [ Css.left len ]
+    | P_inset -> [ Css.inset [ len ] ]
+    | P_inset_x -> [ Css.inset_inline [ len ] ]
+    | P_inset_y -> [ Css.inset_block [ len ] ]
+  in
+  Style.style (decls @ body)
+
+(* The same step, negated: [-inset-x-0.5]. The px step flips its sign directly,
+   the scale steps through the negated multiplier so the calc reads
+   [calc(var(--spacing) * -.5)] as Tailwind writes it. *)
+let neg_pos_spacing_style ?theme side (s : Style.spacing) =
+  let negated : Style.spacing =
+    match s with `Rem f -> `Rem (-.f) | other -> other
+  in
+  let decl_opt, len = len_of_pos_spacing ?theme negated in
+  let len = match s with `Px -> negate_length len | _ -> len in
   let decls = Option.to_list decl_opt in
   let body =
     match side with
@@ -217,6 +239,7 @@ module Handler = struct
     | Neg_inset_y_full
     | Inset_y_3_4
     | Pos_spacing of pside * Style.spacing
+    | Neg_pos_spacing of pside * Style.spacing
       (* fractional or px spacing step on a physical/axis inset side *)
     | Inset of int
     | Inset_arbitrary of string * Css.length
@@ -341,6 +364,7 @@ module Handler = struct
     | Neg_inset_y_full -> style [ Css.inset_block [ Pct (-100.0) ] ]
     | Inset_y_3_4 -> style [ Css.inset_block [ Pct 75.0 ] ]
     | Pos_spacing (side, sp) -> pos_spacing_style ~theme side sp
+    | Neg_pos_spacing (side, sp) -> neg_pos_spacing_style ~theme side sp
     | Inset n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset [ value ] ])
@@ -535,6 +559,21 @@ module Handler = struct
           match sp with `Rem f -> f /. 0.25 | `Px -> 0.05 | _ -> 0.
         in
         base + pos_off + int_of_float (scale *. 10.)
+    | Neg_pos_spacing (side, sp) ->
+        let base =
+          match side with
+          | P_top -> top
+          | P_right -> right
+          | P_bottom -> bottom
+          | P_left -> left
+          | P_inset -> inset
+          | P_inset_x -> inset_x
+          | P_inset_y -> inset_y
+        in
+        let scale =
+          match sp with `Rem f -> f /. 0.25 | `Px -> 0.05 | _ -> 0.
+        in
+        base + int_of_float (scale *. 10.)
     | Position_absolute -> 0
     | Position_fixed -> 1
     | Position_relative -> 2
@@ -704,8 +743,13 @@ module Handler = struct
                 | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "inset"; "x"; frac ] when frac_valid frac ->
         Ok (Neg_inset_x_fraction frac)
-    | [ ""; "inset"; "x"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset_x (-x))
+    | [ ""; "inset"; "x"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset_x (-x))
+        | Error _ -> (
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Neg_pos_spacing (P_inset_x, sp))
+            | None -> Error (`Msg "invalid")))
     | [ "inset"; "y"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_y x)
@@ -719,8 +763,13 @@ module Handler = struct
                   when Parse.is_valid_theme_name n && is_named_inset theme n ->
                     Ok (Inset_y_named n)
                 | Error _ -> Error (`Msg "invalid"))))
-    | [ ""; "inset"; "y"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset_y (-x))
+    | [ ""; "inset"; "y"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset_y (-x))
+        | Error _ -> (
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Neg_pos_spacing (P_inset_y, sp))
+            | None -> Error (`Msg "invalid")))
     (* inset-s = inset-inline-start *)
     | [ "inset"; "s"; "auto" ] -> Ok Inset_s_auto
     | [ "inset"; "s"; "full" ] -> Ok Inset_s_full
@@ -805,8 +854,13 @@ module Handler = struct
                     Ok (Inset_named n)
                 | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "inset"; frac ] when frac_valid frac -> Ok (Neg_inset_fraction frac)
-    | [ ""; "inset"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset (-x))
+    | [ ""; "inset"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset (-x))
+        | Error _ -> (
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Neg_pos_spacing (P_inset, sp))
+            | None -> Error (`Msg "invalid")))
     | [ "top"; frac ] when frac_valid frac -> Ok (Top_fraction frac)
     | [ "top"; "auto" ] -> Ok Top_auto
     | [ "top"; "full" ] -> Ok Top_full
@@ -825,8 +879,13 @@ module Handler = struct
                     Ok (Top_named n)
                 | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "top"; frac ] when frac_valid frac -> Ok (Neg_top_fraction frac)
-    | [ ""; "top"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Top (-x))
+    | [ ""; "top"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Top (-x))
+        | Error _ -> (
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Neg_pos_spacing (P_top, sp))
+            | None -> Error (`Msg "invalid")))
     | [ "right"; frac ] when frac_valid frac -> Ok (Right_fraction frac)
     | [ "right"; "auto" ] -> Ok Right_auto
     | [ "right"; "full" ] -> Ok Right_full
@@ -845,8 +904,13 @@ module Handler = struct
                     Ok (Right_named n)
                 | Error _ -> Error (`Msg "invalid"))))
     | [ ""; "right"; frac ] when frac_valid frac -> Ok (Neg_right_fraction frac)
-    | [ ""; "right"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Right (-x))
+    | [ ""; "right"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Right (-x))
+        | Error _ -> (
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Neg_pos_spacing (P_right, sp))
+            | None -> Error (`Msg "invalid")))
     | [ "bottom"; "3/4" ] -> Ok Bottom_3_4
     | [ "bottom"; "auto" ] -> Ok Bottom_auto
     | [ "bottom"; "full" ] -> Ok Bottom_full
@@ -864,8 +928,13 @@ module Handler = struct
                   when Parse.is_valid_theme_name n && is_named_inset theme n ->
                     Ok (Bottom_named n)
                 | Error _ -> Error (`Msg "invalid"))))
-    | [ ""; "bottom"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Bottom (-x))
+    | [ ""; "bottom"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Bottom (-x))
+        | Error _ -> (
+            match parse_pos_spacing n with
+            | Some sp -> Ok (Neg_pos_spacing (P_bottom, sp))
+            | None -> Error (`Msg "invalid")))
     | [ "left"; frac ] when frac_valid frac -> Ok (Left_fraction frac)
     | [ "left"; "auto" ] -> Ok Left_auto
     | [ "left"; "full" ] -> Ok Left_full
@@ -890,7 +959,10 @@ module Handler = struct
         | Error _ -> (
             match parse_neg_bracket_length n with
             | Some len -> Ok (Neg_left_arbitrary (n, len))
-            | None -> Error (`Msg "invalid")))
+            | None -> (
+                match parse_pos_spacing n with
+                | Some sp -> Ok (Neg_pos_spacing (P_left, sp))
+                | None -> Error (`Msg "invalid"))))
     | [ "start"; "3/4" ] -> Ok Start_3_4
     | [ "start"; "auto" ] -> Ok Start_auto
     | [ "start"; "full" ] -> Ok Start_full
@@ -931,6 +1003,8 @@ module Handler = struct
     | Inset_y_3_4 -> "inset-y-3/4"
     | Pos_spacing (side, sp) ->
         pside_name side ^ "-" ^ Spacing.pp_spacing_suffix sp
+    | Neg_pos_spacing (side, sp) ->
+        "-" ^ pside_name side ^ "-" ^ Spacing.pp_spacing_suffix sp
     | Inset n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-" ^ string_of_int (abs n)

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -21,10 +21,12 @@ module Handler = struct
     | Translate_x of int
     | Translate_x_full
     | Translate_x_px
+    | Translate_x_step of float
     | Translate_x_arbitrary of string * Css.length
     | Translate_y of int
     | Translate_y_full
     | Translate_y_px
+    | Translate_y_step of float
     | Translate_y_arbitrary of string * Css.length
     | Scale of int
     | Scale_x of int
@@ -439,6 +441,7 @@ module Handler = struct
        folding. *)
     let spacing_value : Css.length =
       if n = 0 then Css.Px 0.
+      else if n = 1 then Css.Var spacing_ref
       else
         Css.Calc
           (Css.Calc.mul
@@ -451,6 +454,25 @@ module Handler = struct
 
   let translate_x n = translate_axis tw_translate_x_var n
   let translate_y n = translate_axis tw_translate_y_var n
+
+  (* A fractional spacing step ([translate-x-0.5]), signed so the negative form
+     goes through the same path. *)
+  let translate_axis_step axis_var f =
+    let spacing_decl, spacing_ref =
+      Var.binding Theme.spacing_var (Css.Rem 0.25)
+    in
+    let spacing_value : Css.length =
+      Css.Calc
+        (Css.Calc.mul
+           (Css.Calc.length (Css.Var spacing_ref))
+           (Css.Calc.float f))
+    in
+    let axis_decl, _ = Var.binding axis_var spacing_value in
+    style ~property_rules:translate_props
+      (spacing_decl :: axis_decl :: [ translate_xy_refs ])
+
+  let translate_x_step f = translate_axis_step tw_translate_x_var f
+  let translate_y_step f = translate_axis_step tw_translate_y_var f
 
   (** Helper to create a fraction percentage value: calc(n/d * 100%) *)
   let make_fraction_pct num denom : Css.length =
@@ -1204,11 +1226,13 @@ module Handler = struct
     | Translate_x n -> translate_x n
     | Translate_x_full -> translate_x_full
     | Translate_x_px -> translate_x_px
+    | Translate_x_step f -> translate_x_step f
     | Translate_x_arbitrary (_, len) -> translate_x_arbitrary len
     | Translate_x_fraction (num, denom) -> translate_x_fraction num denom
     | Translate_y n -> translate_y n
     | Translate_y_full -> translate_y_full
     | Translate_y_px -> translate_y_px
+    | Translate_y_step f -> translate_y_step f
     | Translate_y_arbitrary (_, len) -> translate_y_arbitrary len
     | Translate_y_fraction (num, denom) -> translate_y_fraction num denom
     | Translate n -> translate_spacing n
@@ -1358,6 +1382,7 @@ module Handler = struct
     | Translate_x_fraction _ -> 125
     | Translate_x_full -> 130
     | Translate_x_px -> 131
+    | Translate_x_step f -> 100 + int_of_float (f *. 10.)
     | Translate_x_arbitrary _ -> 199
     | Neg_translate_y_arbitrary _ -> 200
     | Neg_translate_y_full -> 201
@@ -1367,6 +1392,7 @@ module Handler = struct
     | Translate_y_fraction _ -> 225
     | Translate_y_full -> 230
     | Translate_y_px -> 231
+    | Translate_y_step f -> 200 + int_of_float (f *. 10.)
     | Translate_y_arbitrary _ -> 299
     | Neg_translate_z_arbitrary _ -> 299
     | Neg_translate_z_px -> 300
@@ -1462,8 +1488,16 @@ module Handler = struct
     | Origin_top_right -> 1708
     | Origin_arbitrary _ -> 1699
 
+  (* A fractional spacing step: [0.5], [2.5]. Integers keep the existing
+     path. *)
+
   (** Parse a fraction string like "1/2", "2/3", etc. Returns (numerator,
       denominator) or None. *)
+  let parse_spacing_step s =
+    match float_of_string_opt s with
+    | Some f when f > 0. && not (Float.is_integer f) -> Some f
+    | _ -> None
+
   let parse_fraction s =
     match String.split_on_char '/' s with
     | [ num_s; denom_s ] -> (
@@ -1516,6 +1550,8 @@ module Handler = struct
         match parse_fraction n with
         | Some (num, denom) -> Ok (Translate_x_fraction (num, denom))
         | None -> err_not_utility)
+    | [ "translate"; "x"; n ] when parse_spacing_step n <> None ->
+        Ok (Translate_x_step (Option.get (parse_spacing_step n)))
     | [ "translate"; "x"; n ] -> Parse.int_any n >|= fun n -> Translate_x n
     | [ "translate"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_bracket_length n with
@@ -1529,6 +1565,8 @@ module Handler = struct
         match parse_fraction n with
         | Some (num, denom) -> Ok (Translate_y_fraction (num, denom))
         | None -> err_not_utility)
+    | [ "translate"; "y"; n ] when parse_spacing_step n <> None ->
+        Ok (Translate_y_step (Option.get (parse_spacing_step n)))
     | [ "translate"; "y"; n ] -> Parse.int_any n >|= fun n -> Translate_y n
     | [ "translate"; "z"; "px" ] -> Ok Translate_z_px
     | [ "translate"; "z"; n ] -> Parse.int_any n >|= fun n -> Translate_z n
@@ -1578,6 +1616,8 @@ module Handler = struct
         match parse_fraction n with
         | Some (num, denom) -> Ok (Neg_translate_x_fraction (num, denom))
         | None -> err_not_utility)
+    | [ ""; "translate"; "x"; n ] when parse_spacing_step n <> None ->
+        Ok (Translate_x_step (-.Option.get (parse_spacing_step n)))
     | [ ""; "translate"; "x"; n ] ->
         Parse.int_pos ~name:"translate-x" n >|= fun n -> Translate_x (-n)
     | [ ""; "translate"; "y"; value ] when Parse.is_bracket_value value ->
@@ -1589,6 +1629,8 @@ module Handler = struct
         match parse_fraction n with
         | Some (num, denom) -> Ok (Neg_translate_y_fraction (num, denom))
         | None -> err_not_utility)
+    | [ ""; "translate"; "y"; n ] when parse_spacing_step n <> None ->
+        Ok (Translate_y_step (-.Option.get (parse_spacing_step n)))
     | [ ""; "translate"; "y"; n ] ->
         Parse.int_pos ~name:"translate-y" n >|= fun n -> Translate_y (-n)
     | [ ""; "translate"; "z"; value ] when Parse.is_bracket_value value ->
@@ -1801,6 +1843,18 @@ module Handler = struct
     in
     "[" ^ s ^ "]"
 
+  (* [translate-x-0.5], and [-translate-x-0.5] for the negative step. Tailwind
+     writes the fraction as the author did, so keep the trailing digits. *)
+  let step_class prefix f =
+    let digits = Float.to_string (Float.abs f) in
+    (* [Float.to_string 0.5] is ["0.5"]; drop a trailing dot from ["2."]. *)
+    let digits =
+      let n = String.length digits in
+      if n > 0 && digits.[n - 1] = '.' then String.sub digits 0 (n - 1)
+      else digits
+    in
+    (if f < 0. then "-" else "") ^ prefix ^ "-" ^ digits
+
   let to_class = function
     | Rotate n -> neg_class "rotate-" n
     | Rotate_arbitrary a -> "rotate-" ^ pp_angle_bracket a
@@ -1821,12 +1875,14 @@ module Handler = struct
     | Translate_x n -> neg_class "translate-x-" n
     | Translate_x_full -> "translate-x-full"
     | Translate_x_px -> "translate-x-px"
+    | Translate_x_step f -> step_class "translate-x" f
     | Translate_x_arbitrary (raw, _) -> "translate-x-[" ^ raw ^ "]"
     | Translate_x_fraction (num, denom) ->
         "translate-x-" ^ string_of_int num ^ "/" ^ string_of_int denom
     | Translate_y n -> neg_class "translate-y-" n
     | Translate_y_full -> "translate-y-full"
     | Translate_y_px -> "translate-y-px"
+    | Translate_y_step f -> step_class "translate-y" f
     | Translate_y_arbitrary (raw, _) -> "translate-y-[" ^ raw ^ "]"
     | Translate_y_fraction (num, denom) ->
         "translate-y-" ^ string_of_int num ^ "/" ^ string_of_int denom

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -172,8 +172,28 @@ let test_translate_spacing () =
     (Astring.String.is_infix
        ~affix:"--tw-translate-x: calc(var(--spacing) * -4)" (css "-translate-4"))
 
+(* A fractional spacing step on translate, in both signs: translate-x-0.5 and
+   -translate-y-0.5 used to be unknown classes since the axis took an int. The
+   unit step folds to the bare variable, as Tailwind writes it. *)
+let test_translate_spacing_steps () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "translate-x-0.5" "--tw-translate-x:calc(var(--spacing)*.5)";
+  has "-translate-y-0.5" "--tw-translate-y:calc(var(--spacing)*-.5)";
+  has "translate-x-1" "--tw-translate-x:var(--spacing)";
+  Alcotest.(check string)
+    "-translate-y-0.5 round-trips" "-translate-y-0.5"
+    (Tw.pp (Result.get_ok (Tw.of_string "-translate-y-0.5")))
+
 let tests =
   [
+    test_case "translate spacing steps" `Quick test_translate_spacing_steps;
     test_case "translate zero keeps its unit" `Quick
       test_translate_zero_keeps_unit;
     test_case "translate spacing (both axes)" `Quick test_translate_spacing;


### PR DESCRIPTION
`-inset-x-0.5` and `-top-2.5` were unknown classes: only the positive side of each inset read a fractional or px step. `translate` took an int on either sign, so `translate-x-0.5` was unknown too.

The unit translate step now folds to the bare variable (`--tw-translate-x: var(--spacing)`), which is how Tailwind writes it.
Stacked on #205. Merge in order; each PR is based on the one below it.
