### PR TITLE
modifiers: read a bracket argument to has- as a selector, not a state name

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2056,6 +2056,7 @@ let rec parse_modifier s : modifier option =
       (fun () -> try_in_modifier s);
       (fun () -> try_not_in_modifier s);
       (fun () -> try_group_peer_not s);
+      (fun () -> try_group_peer_not_variant s);
       (* Before [try_not_modifier]: a container variant handles its own [not-]
          (negating the structural condition), not the generic [Not] wrapper. *)
       (fun () -> try_container_variant s);
@@ -2071,6 +2072,25 @@ let rec parse_modifier s : modifier option =
     ]
   in
   List.find_map (fun f -> f ()) fns
+
+(* [group-not-has-[...]] and [peer-not-...]: the inner is any variant, read on
+   its own. The reading above only knows the simple state names and a bare
+   bracket. *)
+and try_group_peer_not_variant s =
+  let try_prefix prefix make =
+    let plen = String.length prefix in
+    if String.length s <= plen || String.sub s 0 plen <> prefix then None
+    else
+      let base, name =
+        split_name (String.sub s plen (String.length s - plen))
+      in
+      match parse_modifier base with
+      | Some m when is_not_compatible m -> Some (make m name)
+      | Some _ | None -> None
+  in
+  match try_prefix "group-not-" (fun i n -> Group_not (i, n)) with
+  | Some _ as r -> r
+  | None -> try_prefix "peer-not-" (fun i n -> Peer_not (i, n))
 
 and try_not_of_modifier s =
   if not (String.length s > 4 && String.sub s 0 4 = "not-") then None

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -485,8 +485,13 @@ let has_inner_selector raw =
   let str =
     if Style.is_has_shorthand raw then resolve_has_shorthand raw else raw
   in
-  Css.Selector.read_relative
-    (Cascade.Cursor.of_string (preprocess_has_selector str))
+  match
+    Css.Selector.read_relative
+      (Cascade.Cursor.of_string (preprocess_has_selector str))
+  with
+  | Css.Selector.List sels when not (Style.is_has_shorthand raw) ->
+      Css.Selector.is_ sels
+  | sel -> sel
 
 (* The relative selector a group/peer has-variant scopes to:
    [:where(.group):has(<inner>) *]. *)
@@ -504,7 +509,11 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
   let open Css.Selector in
   let processed = preprocess_has_selector selector_str in
   let parsed_selector =
-    Css.Selector.read_relative (Cascade.Cursor.of_string processed)
+    match Css.Selector.read_relative (Cascade.Cursor.of_string processed) with
+    (* A bracket list is one relative selector, so it goes in an [:is()]. The
+       [hocus] shorthand is genuinely two, and stays a list. *)
+    | List sels when shorthand = None -> is_ sels
+    | sel -> sel
   in
   let has_part s =
     match shorthand with Some sh -> sh | None -> "[" ^ s ^ "]"
@@ -771,18 +780,11 @@ let route_has_modifier modifier base_class props =
     | Style.Peer_has (s, name) -> (`Peer_has, s, name)
     | _ -> failwith "Invalid has modifier"
   in
-  (* Shorthand forms like "checked" are stored without colon prefix. Bracket
-     forms like ":checked" start with colon or other CSS chars. *)
-  let is_shorthand =
-    raw_str <> ""
-    && raw_str.[0] <> ':'
-    && raw_str.[0] <> '&'
-    && raw_str.[0] <> '+'
-    && raw_str.[0] <> '>'
-    && raw_str.[0] <> '~'
-    && raw_str.[0] <> '.'
-    && not (String.contains raw_str ' ')
-  in
+  (* A shorthand is one of the state names, spelled bare; anything else was
+     written in brackets and keeps them in the class name. Deciding this by
+     punctuation alone read a bare type selector like [has-[a]] as the state
+     name [a] and dropped the brackets. *)
+  let is_shorthand = Style.is_has_shorthand raw_str in
   let selector_str =
     if is_shorthand then resolve_has_shorthand raw_str else raw_str
   in

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -520,6 +520,28 @@ let test_has_data_and_not_composition () =
   has "not-peer-has-checked:opacity-0"
     ".not-peer-has-checked\\:opacity-0:not(:is(:where(.peer):has(:checked)~*))"
 
+(* A bracket [has-] argument is one relative selector, so a list inside it goes
+   in an [:is()]; a bare type selector keeps its brackets in the class name
+   rather than being read as a state name. And [group-not-] takes any variant as
+   its inner, not just the simple states. *)
+let test_has_bracket_arguments () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "has-[[data-a],[data-b]]:block" ":has(:is([data-a], [data-b]))";
+  has "has-[a]:block" ".has-\\[a\\]\\:block:has(a)";
+  has "group-has-[a]:block"
+    ".group-has-\\[a\\]\\:block:is(:where(.group):has(a) *)";
+  has "group-not-has-[[data-hover],[data-focus]]:block"
+    ":not(:has(:is([data-hover], [data-focus])))";
+  (* the hocus shorthand really is two selectors and stays a list *)
+  has "has-hocus:flex" ":has(:hover,:focus)"
+
 (* Test ARIA and data modifiers class names *)
 let test_aria_and_data_modifiers () =
   check string "aria-checked:p-4" "aria-checked:p-4"
@@ -672,6 +694,7 @@ let tests =
         test_named_anchor_and_bare_data;
       test_case "has-data and not- composition" `Quick
         test_has_data_and_not_composition;
+      test_case "has bracket arguments" `Quick test_has_bracket_arguments;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "before/after modifiers" `Quick test_before_after_modifiers;
       test_case "nested modifier class names" `Quick


### PR DESCRIPTION
`has-[a]` came out as the class `has-a` with the selector `:has(:a)`: the naming decided shorthand-vs-bracket by punctuation, so a bare type selector looked like a state name.

A list inside the brackets is one relative selector and goes in an `:is()`, and `group-not-` now takes any variant as its inner rather than only the simple states.
Stacked on #204. Merge in order; each PR is based on the one below it.
