### PR TITLE
grid_template: accept a var or --spacing() in an arbitrary track

### DIFF
--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -186,9 +186,10 @@ module Handler = struct
           else if value = "min-content" then Some Min_content
           else if value = "max-content" then Some Max_content
           else
-            (* A math-function track (min()/max()/clamp()/calc()) is a length,
-               which the suffix-based parse above does not recognise. *)
-            match Css.parse_length value with
+            (* A math-function track (min()/max()/clamp()/calc()), a var() or
+               the [--spacing()] shorthand: all lengths the suffix-based parse
+               above does not recognise. *)
+            match Css.parse_length (Parse.decode_arbitrary_value value) with
             | Some l -> Some (Length l)
             | None -> None)
 
@@ -224,7 +225,11 @@ module Handler = struct
           | n -> (
               match int_of_string_opt n with
               | Some i -> Some (Css.Count i)
-              | None -> None)
+              | None ->
+                  (* [repeat(var(--columns), ...)]: the count can be a var. *)
+                  if Parse.is_var n then
+                    Some (Css.Var (Var.bracket (Parse.extract_var_name n)))
+                  else None)
         in
         (* The track list after the count is space-separated (underscores in the
            bracket); commas only separated count from the list. *)
@@ -258,11 +263,31 @@ module Handler = struct
     | Some v -> v
     | None -> invalid_arg ("Unparseable grid template: " ^ s)
 
+  (* A track written with the [--spacing()] shorthand reads the scale, so the
+     token has to be declared alongside it. *)
+  let spacing_decls s =
+    let has_spacing_fn =
+      let n = String.length "--spacing(" in
+      let rec at i =
+        i + n <= String.length s
+        && (String.sub s i n = "--spacing(" || at (i + 1))
+      in
+      at 0
+    in
+    if has_spacing_fn then
+      let decl, _ = Var.binding Theme.spacing_var Theme.spacing_base in
+      [ decl ]
+    else []
+
   let grid_cols_arbitrary s =
-    style [ Css.grid_template_columns (parse_arbitrary_grid_template_exn s) ]
+    style
+      (spacing_decls s
+      @ [ Css.grid_template_columns (parse_arbitrary_grid_template_exn s) ])
 
   let grid_rows_arbitrary s =
-    style [ Css.grid_template_rows (parse_arbitrary_grid_template_exn s) ]
+    style
+      (spacing_decls s
+      @ [ Css.grid_template_rows (parse_arbitrary_grid_template_exn s) ])
 
   let grid_rows n =
     if n < 1 || n > 999 then

--- a/test/test_grid_template.ml
+++ b/test/test_grid_template.ml
@@ -144,8 +144,26 @@ let test_grid_functions_css () =
   has "grid-cols-[fit-content(200px)]"
     "grid-template-columns:fit-content(200px)"
 
+(* An arbitrary track can name the spacing scale or hold a var(), including as
+   the repeat() count. The token has to be declared alongside the value. *)
+let test_arbitrary_track_values () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "grid-cols-[repeat(auto-fit,--spacing(42))]"
+    "grid-template-columns:repeat(auto-fit,calc(var(--spacing)*42))";
+  has "grid-cols-[repeat(auto-fit,--spacing(42))]" "--spacing:.25rem";
+  has "grid-cols-[repeat(var(--columns),var(--width))]"
+    "grid-template-columns:repeat(var(--columns),var(--width))"
+
 let tests =
   [
+    test_case "arbitrary track values" `Quick test_arbitrary_track_values;
     test_case "grid_template of_string - valid values" `Quick of_string_valid;
     test_case "grid_template of_string - invalid values" `Quick
       of_string_invalid;


### PR DESCRIPTION
`grid-cols-[repeat(auto-fit,--spacing(42))]` and a `var()` repeat count were unknown classes: the track reader has its own length parse that knew neither. A track naming the spacing scale also declares the token.
Stacked on #206. Merge in order; each PR is based on the one below it.
