### PR TITLE
modifiers: read an at-rule in brackets as its own variant

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1197,6 +1197,7 @@ let rec pp_modifier = function
   | Group_peer_named (inner, name) ->
       "group-peer-" ^ pp_modifier inner ^ "/" ^ name
   | Arbitrary_selector content -> "[" ^ content ^ "]"
+  | At_rule content -> "[" ^ content ^ "]"
   | Custom_variant (token, _) -> token
   | Container_style (token, _) -> token
   | Prose_element name -> "prose-" ^ name
@@ -1369,6 +1370,18 @@ let is_valid_has_selector sel =
     true
   with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> false
 
+(* An at-rule in brackets is a variant too: [[@supports(display:grid)]] and
+   [[@starting-style]] wrap the utility rather than select it. *)
+let try_bracket_at_rule s =
+  if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']' then
+    let inner = String.sub s 1 (String.length s - 2) in
+    if
+      inner = "@starting-style"
+      || (String.length inner > 9 && String.sub inner 0 9 = "@supports")
+    then Some (At_rule inner)
+    else None
+  else None
+
 (* Try parsing a bracketed modifier, returning Some if matched *)
 (* Build the list of bracket pattern matchers for a given input string *)
 let bracket_named_patterns s =
@@ -1440,6 +1453,7 @@ let bracket_value_patterns s =
         (fun sel ->
           if sel <> "" && String.contains sel '&' then Some sel else None)
         (fun sel -> Peer_arbitrary sel));
+    (fun () -> try_bracket_at_rule s);
     (fun () ->
       if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']'
       then

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -910,8 +910,45 @@ let handle_pseudo_element_modifier modifier base_class props =
   regular ~selector:sel ~props:(content_decl :: props)
     ~base_class:modified_class ()
 
+(* Whether every [(] in [s] closes: a compound condition keeps its own parens,
+   so unwrapping one pair only makes sense when what is left is balanced. *)
+let is_balanced s =
+  let rec go i depth =
+    if i >= String.length s then depth = 0
+    else
+      match s.[i] with
+      | '(' -> go (i + 1) (depth + 1)
+      | ')' when depth = 0 -> false
+      | ')' -> go (i + 1) (depth - 1)
+      | _ -> go (i + 1) depth
+  in
+  go 0 0
+
+(* Properties whose [@supports] test Tailwind also runs against the prefixed
+   spelling, so a browser that only ships the prefix still matches. The set is
+   its browser-support data; these are the entries observed against v4.3.3.
+   [text-size-adjust] additionally carries the [-moz-] spelling. *)
+
 (** Normalize a supports condition string into a valid CSS [@supports]
     condition. Converts underscores to spaces and wraps in parens as needed. *)
+let supports_vendor_prefixes = function
+  | "backdrop-filter" | "background-clip" | "box-decoration-break" | "hyphens"
+  | "mask" | "mask-image" | "mask-origin" | "mask-size" | "print-color-adjust"
+  | "text-decoration-skip-ink" | "user-select" ->
+      [ "-webkit-" ]
+  | "text-size-adjust" -> [ "-webkit-"; "-moz-" ]
+  | _ -> []
+
+(* [(prop: value)] as Tailwind writes it: one test per prefixed spelling, the
+   unprefixed one last, joined with [or]. *)
+let supports_property_test prop value =
+  let one p = String.concat "" [ "("; p; prop; ":"; value; ")" ] in
+  match supports_vendor_prefixes prop with
+  | [] -> one ""
+  | prefixes ->
+      String.concat ""
+        [ "("; String.concat " or " (List.map one prefixes @ [ one "" ]); ")" ]
+
 let normalize_supports_condition condition_str =
   (* Convert underscores to spaces (Tailwind bracket notation) *)
   let cond = String.map (fun c -> if c = '_' then ' ' else c) condition_str in
@@ -923,12 +960,25 @@ let normalize_supports_condition condition_str =
   then
     (* Bare custom property: --test → (--test: var(--tw)) *)
     "(" ^ cond ^ ": var(--tw))"
-  else if cond <> "" && cond.[0] = '(' then
-    (* Already wrapped in parens *)
-    cond
+  else if cond <> "" && cond.[0] = '(' && cond.[String.length cond - 1] = ')'
+  then
+    (* Already wrapped. A single [(prop: value)] still has to go through the
+       prefix expansion, so unwrap it and rebuild; anything else (a compound
+       condition, a [not]) is left as written. *)
+    let inner = String.sub cond 1 (String.length cond - 2) in
+    if is_balanced inner && String.contains inner ':' then
+      let i = String.index inner ':' in
+      supports_property_test
+        (String.trim (String.sub inner 0 i))
+        (String.trim (String.sub inner (i + 1) (String.length inner - i - 1)))
+    else cond
   else if String.contains cond ':' then
-    (* Property: value → wrap in parens *)
-    "(" ^ cond ^ ")"
+    let i = String.index cond ':' in
+    let prop = String.trim (String.sub cond 0 i) in
+    let value =
+      String.trim (String.sub cond (i + 1) (String.length cond - i - 1))
+    in
+    supports_property_test prop value
   else if String.contains cond '(' then
     (* Function call like font-format(opentype) or var(--test) *)
     cond
@@ -1569,6 +1619,21 @@ let arbitrary_selector_rule content base_class props =
   in
   regular ~selector:sel ~props ~base_class:modified_class ()
 
+(* An at-rule written in brackets: [[@supports(display:grid)]] wraps the utility
+   in that query, [[@starting-style]] in [@starting-style]. The class name keeps
+   the brackets, so it cannot go through the [supports-] spelling. *)
+let at_rule_variant content base_class props =
+  let modified_class = "[" ^ content ^ "]:" ^ base_class in
+  let selector = Css.Selector.Class modified_class in
+  if content = "@starting-style" then
+    starting_style ~selector ~props ~base_class:modified_class ()
+  else
+    let cond = String.trim (String.sub content 9 (String.length content - 9)) in
+    let condition =
+      Css.Supports.of_string (normalize_supports_condition cond)
+    in
+    supports_query ~condition ~selector ~props ~base_class:modified_class ()
+
 (* A [matchVariant]-registered custom variant. The class name is the token
    ([is-data-foo]); the selector is the template with [&] replaced by the
    element's own class, e.g. [&:is([data-foo])] -> [.is-data-foo\:flex:is(...)].
@@ -1687,6 +1752,7 @@ let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
       handle_pseudo_element_modifier modifier base_class props
   | Style.Arbitrary_selector content ->
       arbitrary_selector_rule content base_class props
+  | Style.At_rule content -> at_rule_variant content base_class props
   | Style.Custom_variant (token, template) ->
       custom_variant_rule token template base_class props
   | Style.Container_style (token, condition) ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -237,6 +237,9 @@ type modifier =
   | Arbitrary_selector of string
       (** [[&_p]] — arbitrary selector variant, [&] is replaced by the element's
           own class selector *)
+  | At_rule of string
+      (** [[@supports(...)]] / [[@starting-style]] — an at-rule in brackets,
+          kept as written so the class name round-trips *)
   | Custom_variant of string * string
       (** [is-data-foo:] — a [matchVariant]-registered variant. First field is
           the class-name token (e.g. [is-data-foo]); second is the resolved
@@ -652,6 +655,7 @@ let rec pp_modifier = function
   | Group_peer_named (inner, name) ->
       "group-peer-" ^ pp_modifier inner ^ "/" ^ name
   | Arbitrary_selector content -> "[" ^ content ^ "]"
+  | At_rule content -> "[" ^ content ^ "]"
   | Custom_variant (token, _) -> token
   | Container_style (token, _) -> token
   | Prose_element name -> "prose-" ^ name

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -245,6 +245,9 @@ type modifier =
   | Group_peer_named of modifier * string
       (** [group-peer-X/name] — peer-X within named group *)
   | Arbitrary_selector of string  (** [[&_p]] — arbitrary selector variant *)
+  | At_rule of string
+      (** [[@supports(...)]] / [[@starting-style]] — an at-rule in brackets,
+          kept as written so the class name round-trips *)
   | Custom_variant of string * string
       (** [is-data-foo:] — a [matchVariant]-registered variant: the class-name
           token and the resolved selector template ([&] is the own class). *)

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -232,10 +232,34 @@ let test_opacity_supports_under_variant () =
   check bool "the @supports block follows the fallback" true
     (idx "#fb2c3680" < idx "@supports")
 
+(* An at-rule written in brackets wraps the utility rather than selecting it,
+   and keeps its own spelling in the class name: reading it as the [supports-]
+   variant gave a class the HTML would not match. A property test also runs
+   against the prefixed spellings, as Tailwind's browser data has it. *)
+let test_bracketed_at_rule_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "[@starting-style]:opacity-0"
+    "@starting-style{.\\[\\@starting-style\\]\\:opacity-0";
+  has "[@supports(display:grid)]:grid" "@supports(display:grid)";
+  has "[@supports(display:grid)]:grid"
+    ".\\[\\@supports\\(display\\:grid\\)\\]\\:grid";
+  has "[@supports(backdrop-filter:blur(0))]:backdrop-blur"
+    "@supports(-webkit-backdrop-filter:blur(0))or (backdrop-filter:blur(0))";
+  (* an unprefixed property stays a single test *)
+  has "supports-[display:grid]:flex" "@supports(display:grid)"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "bracketed at-rule variant" `Quick test_bracketed_at_rule_variant;
     test_case "opacity @supports under a variant" `Quick
       test_opacity_supports_under_variant;
     test_case "bare arbitrary selector variant" `Quick


### PR DESCRIPTION
`[@supports(display:grid)]:grid` and `[@starting-style]:X` were unknown classes, and reading them as the `supports-`/`starting-` spellings would have given a class name the HTML does not match. They now keep the brackets.

A property test also runs against the prefixed spellings (`(-webkit-backdrop-filter:…) or (backdrop-filter:…)`), as Tailwind's browser data has it. The table covers the entries verified against v4.3.3.