### PR TITLE
modifiers: scope in- to an ancestor in a given state

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1177,6 +1177,7 @@ let rec pp_modifier = function
   | Peer_not (inner, Some name) -> "peer-not-" ^ pp_modifier inner ^ "/" ^ name
   | In_bracket content -> "in-[" ^ content ^ "]"
   | In_data attr -> "in-data-" ^ attr
+  | In_state (_, name) -> "in-" ^ name
   | Data_bracket expr -> "data-[" ^ expr ^ "]"
   | Group_data (spelling, None) -> "group-data-" ^ spelling
   | Group_data (spelling, Some name) -> "group-data-" ^ spelling ^ "/" ^ name
@@ -1865,7 +1866,12 @@ let try_in_modifier s =
       | _ -> None
     else if String.length rest > 5 && String.sub rest 0 5 = "data-" then
       Some (In_data (String.sub rest 5 (String.length rest - 5)))
-    else None
+    else
+      (* [in-focus]: an ancestor in that state, the same state names the other
+         variants take. *)
+      match List.assoc_opt rest group_state_modifiers with
+      | Some m -> Some (In_state (m, rest))
+      | None -> None
 
 (* Try not-in-[...] pattern *)
 let try_not_in_modifier s =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1528,6 +1528,21 @@ let handle_named_peer inner name base_class props =
   named_anchor_rule ~anchor:"peer" ~combinator:Css.Selector.Subsequent_sibling
     inner name base_class props
 
+(* [in-focus]: an ancestor in that state. Same shape as [in-data-X], with the
+   state's pseudo-class in place of the attribute. *)
+let handle_in_state inner name base_class props =
+  let modified_class = "in-" ^ name ^ ":" ^ base_class in
+  let sel =
+    Css.Selector.combine
+      (Css.Selector.Where [ pseudo_selector_of_modifier inner ])
+      Css.Selector.Descendant (Css.Selector.Class modified_class)
+  in
+  [
+    (* [in-hover] gates on the pointer just as [hover] itself does. *)
+    regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in"
+      ~has_hover:(Modifiers.is_hover inner) ~not_order:250 ();
+  ]
+
 (** Handle not-group-STATE/name compound variant *)
 let named_group_modified_class prefix inner name base_class =
   let inner_str = Modifiers.pp_modifier inner in
@@ -1880,6 +1895,7 @@ let rec apply_modifier_to_rule ?theme modifier = function
       | Style.Not_bracket content -> handle_not_bracket content bc props
       | Style.In_bracket content -> handle_in_bracket content bc props
       | Style.In_data attr -> handle_in_data attr bc props
+      | Style.In_state (inner, name) -> handle_in_state inner name bc props
       | Style.Group_not (inner, name_opt) ->
           handle_group_not_modifier inner name_opt bc props
       | Style.Peer_not (inner, name_opt) ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -204,6 +204,9 @@ type modifier =
       *)
   | In_data of string
       (** [in-data-X] — element must be descendant of [data-X] *)
+  | In_state of modifier * string
+      (** [in-focus] — element must be a descendant of one in that state; the
+          string is the state name, for the class *)
   | Group_not of modifier * string option
       (** [group-not-X/name] — inner modifier + optional group name *)
   | Peer_not of modifier * string option
@@ -618,6 +621,7 @@ let rec pp_modifier = function
   | Not_bracket content -> "not-[" ^ content ^ "]"
   | In_bracket content -> "in-[" ^ content ^ "]"
   | In_data attr -> "in-data-" ^ attr
+  | In_state (_, name) -> "in-" ^ name
   | Group_not (inner, None) ->
       String.concat "" [ "group-not-"; pp_modifier inner ]
   | Group_not (inner, Some name) ->

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -214,6 +214,9 @@ type modifier =
       *)
   | In_data of string
       (** [in-data-X] — element must be descendant of [data-X] *)
+  | In_state of modifier * string
+      (** [in-focus] — element must be a descendant of one in that state; the
+          string is the state name, for the class *)
   | Group_not of modifier * string option
       (** [group-not-X/name] — inner modifier + optional group name *)
   | Peer_not of modifier * string option

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -255,10 +255,28 @@ let test_bracketed_at_rule_variant () =
   (* an unprefixed property stays a single test *)
   has "supports-[display:grid]:flex" "@supports(display:grid)"
 
+(* [in-focus] scopes to an ancestor in that state, the same state names the
+   group and peer variants take. It used to be an unknown class: only the
+   bracket and data spellings were read. *)
+let test_in_state_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "in-focus:opacity-100" ":where(:focus) .in-focus\\:opacity-100";
+  has "in-checked:flex" ":where(:checked) .in-checked\\:flex";
+  (* in-hover gates on the pointer, as hover itself does *)
+  has "in-hover:flex" "@media(hover:hover)"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "in-state variant" `Quick test_in_state_variant;
     test_case "bracketed at-rule variant" `Quick test_bracketed_at_rule_variant;
     test_case "opacity @supports under a variant" `Quick
       test_opacity_supports_under_variant;


### PR DESCRIPTION
`in-focus` was an unknown class: the `in-` variant only read a bracket selector or a data attribute. It now takes the same state names as the group and peer variants, and `in-hover` gates on the pointer as `hover` itself does.

Stacked on #214. Merge in order; each PR is based on the one below it.