### PR TITLE
sizing, containers: px logical sizes, @container-size, and a bracket's own slash

### DIFF
--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -11,6 +11,7 @@ module Handler = struct
     | Layout_container (* .container - layout container with width:100% *)
     | Container (* @container - sets container-type: inline-size *)
     | Container_normal (* @container-normal - sets container-type: normal *)
+    | Container_size (* @container-size - sets container-type: size *)
     | Container_named of string (* @container/name *)
 
   type Utility.base += Self of t
@@ -24,6 +25,7 @@ module Handler = struct
     | Layout_container -> "container"
     | Container -> "@container"
     | Container_normal -> "@container-normal"
+    | Container_size -> "@container-size"
     | Container_named name -> "@container/" ^ name
 
   let layout_container_style =
@@ -52,6 +54,7 @@ module Handler = struct
 
   let container_query = style [ container_type Inline_size ]
   let container_normal_style = style [ container_type Normal ]
+  let container_size_style = style [ container_type Size ]
 
   (* Tailwind v4 emits the [container] shorthand ([container: <name> /
      inline-size]) rather than the longhand pair. *)
@@ -62,12 +65,14 @@ module Handler = struct
     | Layout_container -> layout_container_style
     | Container -> container_query
     | Container_normal -> container_normal_style
+    | Container_size -> container_size_style
     | Container_named name -> container_named_style name
 
   let suborder = function
     | Container_named _ -> 0
     | Container -> 1
     | Container_normal -> 2
+    | Container_size -> 3
     (* The .container utility (rank 15) sorts after grid_item's grid-column /
        grid-row utilities (priority 1, suborder up to ~2000), and after the
        @container query utilities above. *)
@@ -77,6 +82,7 @@ module Handler = struct
     | "container" -> Ok Layout_container
     | "@container" -> Ok Container
     | "@container-normal" -> Ok Container_normal
+    | "@container-size" -> Ok Container_size
     | n when String.starts_with ~prefix:"@container/" n ->
         let name = String.sub n 11 (String.length n - 11) in
         Ok (Container_named name)

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -928,6 +928,10 @@ module Handler = struct
   let err_invalid_value name value =
     Error (`Msg ("Invalid " ^ name ^ " value: " ^ value))
 
+  (* A [/] inside a bracket belongs to the value ([w-[calc(2px/2)]]), not to a
+     fraction. *)
+  let is_bracket v = String.length v > 0 && v.[0] = '['
+
   let parse_arbitrary s : (string * Css.length) option =
     (* Parse bracket values: [4px], [1rem], [calc(100vh-4rem)], etc. Uses
        Css.parse_length for full CSS length parsing including calc(). Returns
@@ -959,7 +963,7 @@ module Handler = struct
     | "lvw" -> Ok W_lvw
     | "svw" -> Ok W_svw
     | name when container_binding name <> None -> Ok (W_container name)
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (W_fraction frac)
         else err_invalid_value "width fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -986,7 +990,7 @@ module Handler = struct
     | "lvw" -> Ok H_lvw
     | "svw" -> Ok H_svw
     | "lh" -> Ok H_lh
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (H_fraction frac)
         else err_invalid_value "height fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1014,7 +1018,7 @@ module Handler = struct
     | "fit" -> Ok Min_w_fit
     | "auto" -> Ok Min_w_auto
     | name when container_binding name <> None -> Ok (Min_w_container name)
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Min_w_fraction frac)
         else err_invalid_value "min-width fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1042,7 +1046,7 @@ module Handler = struct
     | "lvw" -> Ok Min_h_lvw
     | "svw" -> Ok Min_h_svw
     | "lh" -> Ok Min_h_lh
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Min_h_fraction frac)
         else err_invalid_value "min-height fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1082,7 +1086,7 @@ module Handler = struct
     | "max" -> Ok Max_w_max
     | "fit" -> Ok Max_w_fit
     | "prose" -> Ok Max_w_prose
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Max_w_fraction frac)
         else err_invalid_value "max-width fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1117,7 +1121,7 @@ module Handler = struct
     | "lvw" -> Ok Max_h_lvw
     | "svw" -> Ok Max_h_svw
     | "lh" -> Ok Max_h_lh
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Max_h_fraction frac)
         else err_invalid_value "max-height fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1142,7 +1146,7 @@ module Handler = struct
     | "min" -> Ok Size_min
     | "max" -> Ok Size_max
     | "fit" -> Ok Size_fit
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Size_fraction frac)
         else err_invalid_value "size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1166,7 +1170,7 @@ module Handler = struct
     | "screen" -> Ok Inline_screen
     | "svw" -> Ok Inline_svw
     | name when container_binding name <> None -> Ok (Inline_container name)
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Inline_fraction frac)
         else err_invalid_value "inline-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1190,7 +1194,7 @@ module Handler = struct
     | "max" -> Ok Min_inline_max
     | "min" -> Ok Min_inline_min
     | name when container_binding name <> None -> Ok (Min_inline_container name)
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Min_inline_fraction frac)
         else err_invalid_value "min-inline-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1214,7 +1218,7 @@ module Handler = struct
     | "max" -> Ok Max_inline_max
     | "none" -> Ok Max_inline_none
     | name when container_binding name <> None -> Ok (Max_inline_container name)
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Max_inline_fraction frac)
         else err_invalid_value "max-inline-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1238,7 +1242,7 @@ module Handler = struct
     | "min" -> Ok Block_min
     | "screen" -> Ok Block_screen
     | "svh" -> Ok Block_svh
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Block_fraction frac)
         else err_invalid_value "block-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1262,7 +1266,7 @@ module Handler = struct
     | "min" -> Ok Min_block_min
     | "screen" -> Ok Min_block_screen
     | "svh" -> Ok Min_block_svh
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Min_block_fraction frac)
         else err_invalid_value "min-block-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (
@@ -1286,7 +1290,7 @@ module Handler = struct
     | "none" -> Ok Max_block_none
     | "screen" -> Ok Max_block_screen
     | "svh" -> Ok Max_block_svh
-    | frac when String.contains frac '/' ->
+    | frac when String.contains frac '/' && not (is_bracket frac) ->
         if fraction_pct frac <> None then Ok (Max_block_fraction frac)
         else err_invalid_value "max-block-size fraction" frac
     | v when String.length v > 0 && v.[0] = '[' -> (

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -158,6 +158,7 @@ module Handler = struct
     | Size_arbitrary of string * Css.length
     (* inline-size utilities *)
     | Inline_fraction of string
+    | Inline_px
     | Inline_spacing of float
     | Inline_arbitrary of string * Css.length
     | Inline_auto
@@ -202,6 +203,7 @@ module Handler = struct
     | Max_inline_container of string
     (* block-size utilities *)
     | Block_fraction of string
+    | Block_px
     | Block_spacing of float
     | Block_arbitrary of string * Css.length
     | Block_auto
@@ -790,6 +792,7 @@ module Handler = struct
         match fraction_pct f with
         | Some pct -> style [ inline_size (Pct pct) ]
         | None -> failwith ("Unknown inline-size fraction: " ^ f))
+    | Inline_px -> style [ inline_size (Px 1.) ]
     | Inline_spacing n -> spacing_utility inline_size n
     | Inline_arbitrary (_, len) -> style [ inline_size len ]
     | Inline_auto -> style [ inline_size Auto ]
@@ -863,6 +866,7 @@ module Handler = struct
         match fraction_pct f with
         | Some pct -> style [ block_size (Pct pct) ]
         | None -> failwith ("Unknown block-size fraction: " ^ f))
+    | Block_px -> style [ block_size (Px 1.) ]
     | Block_spacing n -> spacing_utility block_size n
     | Block_arbitrary (_, len) -> style [ block_size len ]
     | Block_auto -> style [ block_size Auto ]
@@ -1151,6 +1155,7 @@ module Handler = struct
         | _ -> err_invalid_value "size" v)
 
   let parse_inline = function
+    | "px" -> Ok Inline_px
     | "auto" -> Ok Inline_auto
     | "dvw" -> Ok Inline_dvw
     | "fit" -> Ok Inline_fit
@@ -1222,6 +1227,7 @@ module Handler = struct
         | _ -> err_invalid_value "max-inline-size" v)
 
   let parse_block = function
+    | "px" -> Ok Block_px
     | "auto" -> Ok Block_auto
     | "dvh" -> Ok Block_dvh
     | "fit" -> Ok Block_fit
@@ -1552,6 +1558,7 @@ module Handler = struct
     | Size_min -> size + keyword_off + 4
     (* inline-size *)
     | Inline_fraction f -> inline + fraction_value_order f
+    | Inline_px -> inline + keyword_off + 20
     | Inline_spacing n -> inline + spacing_value_order n
     | Inline_arbitrary _ -> inline + arbitrary_off
     | Inline_auto -> inline + keyword_off + 0
@@ -1598,6 +1605,7 @@ module Handler = struct
         max_inline + keyword_off + 4 + container_order name
     (* block-size *)
     | Block_fraction f -> block + fraction_value_order f
+    | Block_px -> block + keyword_off + 20
     | Block_spacing n -> block + spacing_value_order n
     | Block_arbitrary _ -> block + arbitrary_off
     | Block_auto -> block + keyword_off + 0
@@ -1798,6 +1806,7 @@ module Handler = struct
     | Size_arbitrary (raw, _) -> "size-[" ^ raw ^ "]"
     (* inline-size utilities *)
     | Inline_fraction f -> "inline-" ^ f
+    | Inline_px -> "inline-px"
     | Inline_spacing n -> "inline-" ^ class_float (n *. 4.)
     | Inline_arbitrary (raw, _) -> "inline-[" ^ raw ^ "]"
     | Inline_auto -> "inline-auto"
@@ -1842,6 +1851,7 @@ module Handler = struct
     | Max_inline_container name -> "max-inline-" ^ name
     (* block-size utilities *)
     | Block_fraction f -> "block-" ^ f
+    | Block_px -> "block-px"
     | Block_spacing n -> "block-" ^ class_float (n *. 4.)
     | Block_arbitrary (raw, _) -> "block-[" ^ raw ^ "]"
     | Block_auto -> "block-auto"

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -9,7 +9,8 @@ let check class_name =
 
 let test_container_types () =
   check "@container";
-  check "@container-normal"
+  check "@container-normal";
+  check "@container-size"
 
 let test_container_name () =
   check "@container/sidebar";

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -371,6 +371,17 @@ let test_any_fraction_denominator () =
     "a fraction of one or more is still rejected" true
     (Result.is_error (Tw.of_string "w-9/9"))
 
+(* A [/] inside a bracket belongs to the value, not to a fraction: the fraction
+   branch used to claim w-[calc(2px/2)] and reject it. *)
+let test_bracket_keeps_its_slash () =
+  Alcotest.(check bool)
+    "w-[calc(2px/2)] divides" true
+    (Astring.String.is_infix ~affix:"width: calc(2px / 2)"
+       (css_of "w-[calc(2px/2)]"));
+  Alcotest.(check bool)
+    "w-1/2 is still a fraction" true
+    (Astring.String.is_infix ~affix:"width: 50%" (css_of "w-1/2"))
+
 (* The px step exists on the logical sizes too: block-px and inline-px used to
    be unknown classes. *)
 let test_logical_px_step () =
@@ -385,6 +396,7 @@ let tests =
   [
     test_case "fractional spacing" `Quick test_fractional_spacing;
     test_case "logical px step" `Quick test_logical_px_step;
+    test_case "bracket keeps its slash" `Quick test_bracket_keeps_its_slash;
     test_case "any fraction denominator" `Quick test_any_fraction_denominator;
     test_case "general fractions" `Quick test_general_fractions;
     test_case "max-w-screen breakpoint var" `Quick test_max_w_screen;

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -371,9 +371,20 @@ let test_any_fraction_denominator () =
     "a fraction of one or more is still rejected" true
     (Result.is_error (Tw.of_string "w-9/9"))
 
+(* The px step exists on the logical sizes too: block-px and inline-px used to
+   be unknown classes. *)
+let test_logical_px_step () =
+  Alcotest.(check bool)
+    "block-px is 1px" true
+    (Astring.String.is_infix ~affix:"block-size: 1px" (css_of "block-px"));
+  Alcotest.(check bool)
+    "inline-px is 1px" true
+    (Astring.String.is_infix ~affix:"inline-size: 1px" (css_of "inline-px"))
+
 let tests =
   [
     test_case "fractional spacing" `Quick test_fractional_spacing;
+    test_case "logical px step" `Quick test_logical_px_step;
     test_case "any fraction denominator" `Quick test_any_fraction_denominator;
     test_case "general fractions" `Quick test_general_fractions;
     test_case "max-w-screen breakpoint var" `Quick test_max_w_screen;


### PR DESCRIPTION
`block-px`, `inline-px` and `@container-size` were unknown classes: the px step was missing from the logical size families and the `size` container-type had no utility.

The second commit fixes `w-[calc(2px/2)]`, where the fraction branch claimed any value containing a `/` so a division inside a bracket never reached the length parse. Cascade parses these fine — the loss was tw-side.

Stacked on #215. Merge in order; each PR is based on the one below it.