### PR TITLE
rule: declare the pseudo-element content once

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -903,12 +903,20 @@ let handle_fallback_modifier ?(inner_has_hover = false) modifier base_class
    selector and prefix its own name in turn. *)
 let handle_pseudo_element_modifier modifier base_class props =
   let sel = Modifiers.to_selector modifier base_class in
-  let content_decl = Css.content (Var (Var.reference Typography.content_var)) in
   let modified_class =
     Rules_selector.extract_modified_class_name sel base_class
   in
-  regular ~selector:sel ~props:(content_decl :: props)
-    ~base_class:modified_class ()
+  (* [before:]/[after:] need a [content], but a [content-*] utility already
+     brings its own; adding a second one leaves it declared twice. *)
+  let reads_content_var d =
+    Css.declaration_name d = "content"
+    && Css.declaration_value d = "var(--tw-content)"
+  in
+  let props =
+    if List.exists reads_content_var props then props
+    else Css.content (Var (Var.reference Typography.content_var)) :: props
+  in
+  regular ~selector:sel ~props ~base_class:modified_class ()
 
 (* Whether every [(] in [s] closes: a compound condition keeps its own parens,
    so unwrapping one pair only makes sense when what is left is balanced. *)

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -272,10 +272,36 @@ let test_in_state_variant () =
   (* in-hover gates on the pointer, as hover itself does *)
   has "in-hover:flex" "@media(hover:hover)"
 
+(* [before:]/[after:] add the content declaration the pseudo-element needs, but
+   a content-* utility already brings its own: adding a second one left it
+   declared twice. A utility that sets content to something else (content-none)
+   still gets the var indirection. *)
+let test_pseudo_element_content_once () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let occurrences sub str =
+    let n = String.length sub in
+    let rec go i acc =
+      if i + n > String.length str then acc
+      else if String.sub str i n = sub then go (i + n) (acc + 1)
+      else go (i + 1) acc
+    in
+    go 0 0
+  in
+  check int "content declared once" 1
+    (occurrences "content:var(--tw-content)" (css "after:content-['x']"));
+  check int "a plain utility still gets one" 1
+    (occurrences "content:var(--tw-content)" (css "after:underline"))
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "pseudo-element content once" `Quick
+      test_pseudo_element_content_once;
     test_case "in-state variant" `Quick test_in_state_variant;
     test_case "bracketed at-rule variant" `Quick test_bracketed_at_rule_variant;
     test_case "opacity @supports under a variant" `Quick


### PR DESCRIPTION
`before:`/`after:` add the `content` declaration the pseudo-element needs, but a `content-*` utility already brings its own, so it came out declared twice. A utility that sets `content` to something else (`content-none`) keeps the var indirection.

Stacked on #219. Merge in order; each PR is based on the one below it.