### PR TITLE
bin: keep a routed utility whose selector is not a bare class

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -388,13 +388,20 @@ let nest_on_ampersand sel =
       | ' ' | '.' | '#' | ':' | '[' | '>' | '+' | '~' | ')' | '*' -> i
       | _ -> class_end part (i + 1)
   in
+  (* The class does not always head the selector: [divide-*] wraps it in
+     [:where(.divide-x > :not(:last-child))], so look for it wherever it is. *)
   let rewrite part =
     let part = String.trim part in
     let n = String.length part in
-    if n = 0 || part.[0] <> '.' then part
-    else
-      let stop = min (class_end part 1) n in
-      String.concat "" [ "&"; String.sub part stop (n - stop) ]
+    let rec at i =
+      if i >= n then part
+      else if part.[i] = '.' && (i = 0 || part.[i - 1] <> '\\') then
+        let stop = min (class_end part (i + 1)) n in
+        String.concat ""
+          [ String.sub part 0 i; "&"; String.sub part stop (n - stop) ]
+      else at (i + 1)
+    in
+    at 0
   in
   Cascade.Selector.to_string ~minify:true sel
   |> selector_parts |> List.map rewrite |> String.concat ","
@@ -455,12 +462,16 @@ let nested_utilities ~theme names =
       in
       (* [to_css] also emits the theme block the utilities read from. It belongs
          at the top of the sheet, not inside the rule that applied them. *)
+      (* [to_css] also emits the theme block the utilities read from, whose
+         selector is [:root]. A utility's own rule names its class somewhere,
+         but not always first: [divide-*] wraps it in
+         [:where(.divide-x > :not(:last-child))]. *)
       let from_utility stmt =
         match Css.statement_selector stmt with
         | None -> true
         | Some sel ->
             let s = Cascade.Selector.to_string ~minify:true sel in
-            String.length s > 0 && s.[0] = '.'
+            String.contains s '.'
       in
       let hoisted, nestable =
         Css.statements sheet |> List.filter from_utility

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -93,3 +93,15 @@ An unknown token is left alone rather than guessed at:
   > EOF
   $ tw --minify --input-css un.css index.html | grep -c 'theme(--nope-not-a-token)'
   1
+
+A routed utility whose own selector is not a bare class survives too: the
+[divide-*] family wraps its class in a [:where(... > :not(:last-child))], and
+that class is the one the declared variant has to decorate.
+
+  $ cat > dv.html <<EOF
+  > <div class="dark:divide-gray-800"></div>
+  > EOF
+  $ tw --minify --input-css darkclass.css dv.html | grep -cF ':where(.dark\:divide-gray-800:where(.dark,.dark *)>:not(:last-child))'
+  1
+  $ tw --minify --input-css darkclass.css dv.html | grep -c 'divide-gray-800:where'
+  1


### PR DESCRIPTION
A candidate carrying a declared variant was dropped when its own rule did not head with its class: `divide-*` wraps it in a `:where(... > :not(:last-child))`, so the filter skipped the rule, and the ampersand rewrite missed the class and leaked the undecorated one instead.

Stacked on #220. Merge in order; each PR is based on the one below it.