### PR TITLE
mask: take a colour stop and any bracket image

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1771,6 +1771,12 @@ module Handler = struct
     | Some hex -> Css.hex hex
     | None -> to_css c (if is_base_color c then 500 else shade)
 
+  (* The theme-layer declaration for a palette colour together with the typed
+     reference to it, so a utility outside this module can both emit the token
+     and point at it. *)
+  let color_binding ?theme c shade =
+    Var.binding (color_var c shade) (get_color_value ?theme c shade)
+
   (* The theme-layer declaration for a colour token named like "color-red-500",
      or None when the name is not a catalogued colour token. [color_var]
      registers the token's canonical order and [get_color_value] supplies the

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -98,12 +98,19 @@ val neutral : color
 (** [neutral] is the base neutral color. *)
 
 val stone : color
+(** [stone] is the base stone color. *)
+
 val mauve : color
+(** [mauve] is the base mauve color. *)
+
 val olive : color
+(** [olive] is the base olive color. *)
+
 val mist : color
+(** [mist] is the base mist color. *)
 
 val taupe : color
-(** [stone] is the base stone color. *)
+(** [taupe] is the base taupe color. *)
 
 val red : color
 (** [red] is the base red color. *)

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -374,6 +374,12 @@ val suborder_with_shade : string -> int
 module Handler : sig
   include Utility.Handler
 
+  val color_binding :
+    ?theme:Scheme.t -> color -> int -> Css.declaration * Css.color Css.var
+  (** [color_binding ?theme color shade] is the [\@layer theme] declaration for
+      the palette token and the typed reference to it, for utilities that set a
+      colour var of their own from a palette entry. *)
+
   val theme_color_decl : ?theme:Scheme.t -> string -> Css.declaration option
   (** [theme_color_decl ?theme name] is the [\@layer theme] declaration for the
       colour token [name] (e.g. ["color-red-500"]), or [None] when [name] is not

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -64,6 +64,10 @@ module Handler = struct
       (* (--var) or (length:--var) → sets position to var(--var) *)
     | Mask_color_ref of direction * position_end * string
       (* (color:--var) → sets color to var(--var) *)
+    | Mask_stop_color of direction * position_end * Color.color * int
+      (* a palette entry as the stop colour *)
+    | Mask_stop_keyword of direction * position_end * Css.color * string
+      (* transparent / current as the stop colour *)
     | Mask_linear_angle of mask_angle
     | Mask_conic_angle of mask_angle
     | Mask_radial (* just mask-radial with no position *)
@@ -572,7 +576,7 @@ module Handler = struct
     style ~property_rules:conic_property_rules (decls @ composite_decls)
 
   (* Build directional var ref/color ref declarations for a single direction *)
-  let single_dir_var_decls dir_name pos_name prop var_name =
+  let single_dir_value_decls dir_name pos_name prop value =
     [
       custom_property ~layer:"utilities" ("--tw-mask-" ^ dir_name)
         (gradient_for_direction
@@ -584,8 +588,11 @@ module Handler = struct
            | d -> failwith ("unexpected direction " ^ d)));
       custom_property ~layer:"utilities"
         ("--tw-mask-" ^ dir_name ^ "-" ^ pos_name ^ "-" ^ prop)
-        ("var(" ^ var_name ^ ")");
+        value;
     ]
+
+  let single_dir_var_decls dir_name pos_name prop var_name =
+    single_dir_value_decls dir_name pos_name prop ("var(" ^ var_name ^ ")")
 
   (* Helper to get the stops + gradient decls for a gradient-type direction *)
   let stops_based_decls dir_name stops_decl gradient_decl =
@@ -656,38 +663,39 @@ module Handler = struct
     let common_decls = mask_image_decls @ linear_decl @ dir_decls in
     style ~merge_key ~property_rules (common_decls @ composite_decls)
 
-  (* Build the style for parenthesized var reference setting color *)
-  let build_color_ref_style dir pos_end var_name =
+  (* The stop colour, as a CSS value: [var(--color-black)] for a palette entry,
+     the keyword itself for [transparent] / [current]. *)
+  let build_color_value_style dir pos_end value =
     let pos_name = position_end_name pos_end in
     let property_rules = property_rules_for_direction dir in
     let dir_decls =
       match dir with
       | X ->
-          single_dir_var_decls "right" pos_name "color" var_name
-          @ single_dir_var_decls "left" pos_name "color" var_name
+          single_dir_value_decls "right" pos_name "color" value
+          @ single_dir_value_decls "left" pos_name "color" value
       | Y ->
-          single_dir_var_decls "top" pos_name "color" var_name
-          @ single_dir_var_decls "bottom" pos_name "color" var_name
+          single_dir_value_decls "top" pos_name "color" value
+          @ single_dir_value_decls "bottom" pos_name "color" value
       | Linear ->
           stops_based_decls "linear" linear_stops_decl linear_gradient_decl
           @ [
               custom_property ~layer:"utilities"
                 ("--tw-mask-linear-" ^ pos_name ^ "-color")
-                ("var(" ^ var_name ^ ")");
+                value;
             ]
       | Radial ->
           stops_based_decls "radial" radial_stops_decl radial_gradient_decl
           @ [
               custom_property ~layer:"utilities"
                 ("--tw-mask-radial-" ^ pos_name ^ "-color")
-                ("var(" ^ var_name ^ ")");
+                value;
             ]
       | Conic ->
           stops_based_decls "conic" conic_stops_decl conic_gradient_decl
           @ [
               custom_property ~layer:"utilities"
                 ("--tw-mask-conic-" ^ pos_name ^ "-color")
-                ("var(" ^ var_name ^ ")");
+                value;
             ]
       | _ ->
           let dir_name = direction_name dir in
@@ -696,7 +704,7 @@ module Handler = struct
               (gradient_for_direction dir);
             custom_property ~layer:"utilities"
               ("--tw-mask-" ^ dir_name ^ "-" ^ pos_name ^ "-color")
-              ("var(" ^ var_name ^ ")");
+              value;
           ]
     in
     let linear_decl =
@@ -710,6 +718,18 @@ module Handler = struct
     in
     let common_decls = mask_image_decls @ linear_decl @ dir_decls in
     style ~property_rules (common_decls @ composite_decls)
+
+  (* A named stop colour points at its palette token, and carries the token's
+     own theme declaration along so the sheet defines what it references. *)
+  let build_stop_color_style ?theme dir pos_end c shade =
+    let decl, token = Color.Handler.color_binding ?theme c shade in
+    let value = Pp.to_string (Css.Values.pp_var Css.pp_color) token in
+    match build_color_value_style dir pos_end value with
+    | Style.Style st -> Style.Style { st with props = decl :: st.props }
+    | other -> other
+
+  let build_color_ref_style dir pos_end var_name =
+    build_color_value_style dir pos_end ("var(" ^ var_name ^ ")")
 
   let to_style theme =
     let build_directional_style dir pos_end value =
@@ -750,8 +770,14 @@ module Handler = struct
         build_var_ref_style dir pos_end var_name
     | Mask_color_ref (dir, pos_end, var_name) ->
         build_color_ref_style dir pos_end var_name
+    | Mask_stop_color (dir, pos_end, c, shade) ->
+        build_stop_color_style ~theme dir pos_end c shade
+    | Mask_stop_keyword (dir, pos_end, value, _) ->
+        build_color_value_style dir pos_end (Pp.to_string Css.pp_color value)
 
   let suborder = function
+    | Mask_stop_keyword (dir, pos_end, _, _)
+    | Mask_stop_color (dir, pos_end, _, _)
     | Mask_color_ref (dir, pos_end, _) ->
         let dir_offset =
           match dir with
@@ -869,11 +895,29 @@ module Handler = struct
     | None -> (
         match parse_value suffix with
         | Some value -> Ok (Mask_position (dir, pos_end, value))
-        | None ->
-            Error
-              (`Msg
-                 ("Invalid mask-" ^ direction_short dir ^ "-"
-                ^ position_end_name pos_end ^ " value")))
+        | None -> (
+            (* A stop is either a position or a colour, and the two share the
+               syntax slot, so a colour name is the last thing tried. *)
+            let keyword k =
+              Some (Mask_stop_keyword (dir, pos_end, k, String.concat "-" rest))
+            in
+            let stop =
+              match rest with
+              | [ "transparent" ] -> keyword Css.Transparent
+              | [ "current" ] -> keyword Css.current_color
+              | _ -> (
+                  match Color.shade_of_strings rest with
+                  | Ok (c, shade) ->
+                      Some (Mask_stop_color (dir, pos_end, c, shade))
+                  | Error _ -> None)
+            in
+            match stop with
+            | Some stop -> Ok stop
+            | None ->
+                Error
+                  (`Msg
+                     ("Invalid mask-" ^ direction_short dir ^ "-"
+                    ^ position_end_name pos_end ^ " value"))))
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
@@ -1031,6 +1075,13 @@ module Handler = struct
     | Mask_var_ref (dir, pos_end, Length_var, var_name) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end
         ^ "-(length:" ^ var_name ^ ")"
+    | Mask_stop_keyword (dir, pos_end, _, name) ->
+        "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end ^ "-"
+        ^ name
+    | Mask_stop_color (dir, pos_end, c, shade) ->
+        "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end ^ "-"
+        ^ Color.color_to_string c
+        ^ if Color.is_shadeless c then "" else "-" ^ string_of_int shade
     | Mask_color_ref (dir, pos_end, var_name) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end
         ^ "-(color:" ^ var_name ^ ")"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -65,7 +65,7 @@ module Handler = struct
     | Mask_bracket_url of string
     | Mask_bracket_url_var of string
     | Mask_bracket_var of string
-    | Mask_bracket_linear_gradient of string
+    | Mask_bracket_image of string
     (* Sub-property bracket notation: mask-position-[...], mask-size-[...] *)
     | Mask_position_bracket of string
     | Mask_position_bracket_var of string
@@ -401,7 +401,7 @@ module Handler = struct
             Css.webkit_mask_image (Var var_ref);
             Css.mask_image (Var var_ref);
           ]
-    | Mask_bracket_linear_gradient v -> (
+    | Mask_bracket_image v -> (
         let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
         match Css.parse_background_image css_str with
         | Some (img :: _) ->
@@ -444,7 +444,7 @@ module Handler = struct
 
   let suborder = function
     | Mask_bracket_image_var _ -> 100
-    | Mask_bracket_linear_gradient _ -> 101
+    | Mask_bracket_image _ -> 101
     | Mask_bracket_url _ -> 102
     | Mask_bracket_url_var _ -> 103
     | Mask_bracket_var _ -> 104
@@ -499,6 +499,15 @@ module Handler = struct
     | Mask_position_bracket_var _ -> 512
     | Mask_size_bracket _ -> 407
     | Mask_size_bracket_var _ -> 408
+
+  (* [mask-[<image>]] takes any background-image value, so what makes one is
+     whether the value parser accepts it, not which gradient function it
+     names. *)
+  let is_image_value inner =
+    let css_str = String.map (fun c -> if c = '_' then ' ' else c) inner in
+    match Css.parse_background_image css_str with
+    | Some (_ :: _) -> true
+    | _ -> false
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
@@ -586,11 +595,8 @@ module Handler = struct
         | _ when String.length inner > 4 && String.sub inner 0 4 = "url(" ->
             let url_content = String.sub inner 4 (String.length inner - 5) in
             Ok (Mask_bracket_url url_content)
-        | _
-          when String.length inner > 16
-               && String.sub inner 0 16 = "linear-gradient(" ->
-            Ok (Mask_bracket_linear_gradient inner)
         | _ when Parse.is_var inner -> Ok (Mask_bracket_var inner)
+        | _ when is_image_value inner -> Ok (Mask_bracket_image inner)
         | _ ->
             if parse_bracket_position inner <> None then
               Ok (Mask_bracket_position inner)
@@ -649,7 +655,7 @@ module Handler = struct
     | Mask_bracket_url url -> "mask-[url(" ^ url ^ ")]"
     | Mask_bracket_url_var v -> "mask-[url:" ^ v ^ "]"
     | Mask_bracket_var v -> "mask-[" ^ v ^ "]"
-    | Mask_bracket_linear_gradient v -> "mask-[" ^ v ^ "]"
+    | Mask_bracket_image v -> "mask-[" ^ v ^ "]"
     | Mask_position_bracket v -> "mask-position-[" ^ v ^ "]"
     | Mask_position_bracket_var v -> "mask-position-[" ^ v ^ "]"
     | Mask_size_bracket v -> "mask-size-[" ^ v ^ "]"

--- a/test/test_mask_gradient.ml
+++ b/test/test_mask_gradient.ml
@@ -35,11 +35,38 @@ let test_from_zero_keeps_unit () =
     "from-position is 0px, not bare 0" true
     (Astring.String.is_infix ~affix:"--tw-mask-top-from-position:0px" css)
 
+(* A stop takes a colour as well as a position. A palette entry points at its
+   theme token and brings the token's declaration with it; the transparent and
+   current keywords go in as themselves. *)
+let test_stop_colors () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " sets " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "mask-r-from-black" "--tw-mask-right-from-color:var(--color-black)";
+  has "mask-r-from-black" "--color-black:";
+  has "mask-b-to-red-500" "--tw-mask-bottom-to-color:var(--color-red-500)";
+  has "mask-radial-from-transparent" "--tw-mask-radial-from-color:transparent";
+  has "mask-r-from-current" "--tw-mask-right-from-color:currentcolor";
+  check "mask-r-from-black";
+  check "mask-y-to-white";
+  check "mask-conic-from-red-500";
+  check "mask-r-to-transparent";
+  check "mask-r-from-current"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "from-0 keeps its px unit" `Quick
         test_from_zero_keeps_unit;
+      Alcotest.test_case "colour stops" `Quick test_stop_colors;
     ]
 
 let suite = ("mask_gradient", tests)

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -45,8 +45,26 @@ let test_typed () =
   Test_helpers.check_typed_class "mask-cover" Tw.mask_cover;
   Test_helpers.check_typed_class "mask-type-alpha" Tw.mask_type_alpha
 
+(* [mask-[<image>]] takes any background-image, not only a linear-gradient. *)
+let test_bracket_image () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "radial-gradient reaches mask-image" true
+    (Astring.String.is_infix ~affix:"mask-image:radial-gradient(white,black)"
+       (css "mask-[radial-gradient(white,black)]"));
+  check "mask-[radial-gradient(white,black)]";
+  check "mask-[conic-gradient(white,black)]";
+  check "mask-[linear-gradient(white,black)]"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
-  @ [ Alcotest.test_case "typed constructors" `Quick test_typed ]
+  @ [
+      Alcotest.test_case "typed constructors" `Quick test_typed;
+      Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
+    ]
 
 let suite = ("masks", tests)


### PR DESCRIPTION
`mask-r-from-black`, `mask-radial-to-transparent` and `mask-[radial-gradient(...)]` were unknown classes: a gradient stop only accepted a position or a `(color:--var)` reference, and the bracket arm matched on the `linear-gradient(` prefix rather than asking the value parser.

Stacked on #221; the first commit is an unrelated doc fix merlint flags once `color.mli` is touched.