### PR TITLE
typography: read a font family the project named in its @theme

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -62,10 +62,12 @@ let read_file path =
     ~finally:(fun () -> close_in ic)
     (fun () -> really_input_string ic (in_channel_length ic))
 
-(* Rewrite each Tailwind [@theme [modifiers] {] header to a [:root {] rule.
+(* Rewrite each Tailwind [@theme [modifiers] {] header to a rule selector.
    Cascade's parser accepts [@theme] but drops its body (it is not a standard
    at-rule), so this swaps only the at-rule keyword and its modifiers up to the
-   opening brace; the declarations themselves are left for the real parser. *)
+   opening brace; the declarations themselves are left for the real parser.
+   [@theme inline] becomes [:root inline] so the modifier survives as part of
+   the selector, which is all [theme_overrides_of_css] reads it for. *)
 let theme_blocks_as_root css =
   let len = String.length css in
   let buf = Buffer.create len in
@@ -78,7 +80,11 @@ let theme_blocks_as_root css =
         incr j
       done;
       if !j < len && css.[!j] = '{' then begin
-        Buffer.add_string buf ":root ";
+        let modifiers = String.sub css (!i + 6) (!j - !i - 6) in
+        let inline =
+          List.mem "inline" (String.split_on_char ' ' (String.trim modifiers))
+        in
+        Buffer.add_string buf (if inline then ":root inline " else ":root ");
         i := !j (* keep the '{' and the body verbatim *)
       end
       else begin
@@ -93,16 +99,17 @@ let theme_blocks_as_root css =
   done;
   Buffer.contents buf
 
-(* Extract @theme token overrides ([(bare-name, value)]) from a project CSS
-   entrypoint, so tw renders with the same tokens Tailwind reads from it. The
-   declarations are parsed by cascade (after the @theme -> :root header swap);
-   the resulting name/value strings feed Scheme.with_overrides. *)
+(* Extract @theme token overrides from a project CSS entrypoint, so tw renders
+   with the same tokens Tailwind reads from it: the [(bare-name, value)] pairs,
+   and the names among them that came from an [@theme inline] block. The
+   declarations are parsed by cascade (after the @theme header swap); the
+   resulting strings feed Scheme.with_overrides. *)
 let theme_overrides_of_css css =
   match Css.of_string (theme_blocks_as_root css) with
-  | Error _ -> []
+  | Error _ -> ([], [])
   | Ok parse ->
-      Css.rules_of_statements (Css.statements parse.Css.stylesheet)
-      |> List.concat_map (fun (_sel, decls) ->
+      let block (sel, decls) =
+        let names =
           List.filter_map
             (fun d ->
               match Css.custom_declaration_name d with
@@ -111,7 +118,19 @@ let theme_overrides_of_css css =
                     ( String.sub n 2 (String.length n - 2),
                       Css.declaration_value d )
               | _ -> None)
-            decls)
+            decls
+        in
+        let inline =
+          String.ends_with ~suffix:"inline"
+            (Cascade.Selector.to_string ~minify:true sel)
+        in
+        (names, if inline then List.map fst names else [])
+      in
+      let blocks =
+        List.map block
+          (Css.rules_of_statements (Css.statements parse.Css.stylesheet))
+      in
+      (List.concat_map fst blocks, List.concat_map snd blocks)
 
 (* [@import "tailwindcss"] (and its subpath forms) is the package entry, not a
    file on disk: it marks where the generated theme/base/utilities belong. *)
@@ -1092,7 +1111,8 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
     match css_content with
     | None -> Tw.Scheme.default
     | Some css ->
-        Tw.Scheme.with_overrides Tw.Scheme.default (theme_overrides_of_css css)
+        let overrides, inline = theme_overrides_of_css css in
+        Tw.Scheme.with_overrides ~inline Tw.Scheme.default overrides
   in
   let opts : gen_opts =
     {

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -41,6 +41,7 @@ type t = {
           When defined, responsive media queries use [@media (min-width: Xpx)]
           instead of rem-based values. *)
   token_overrides : (string * string) list;
+  inline_tokens : string list;
       (** Per-render theme token overrides (from a [@theme] block). Key is the
           variable name without the leading [--] (e.g. "text-shadow-2xs"), value
           is the CSS string. Threaded replacement for the global
@@ -70,6 +71,7 @@ let default : t =
     default_outline_width = 1;
     breakpoints = [];
     token_overrides = [];
+    inline_tokens = [];
   }
 
 let pp t =
@@ -135,5 +137,11 @@ let token scheme name =
 
 (** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
     on top of any existing token overrides (new entries win). *)
-let with_overrides scheme overrides =
-  { scheme with token_overrides = overrides @ scheme.token_overrides }
+let with_overrides ?(inline = []) scheme overrides =
+  {
+    scheme with
+    token_overrides = overrides @ scheme.token_overrides;
+    inline_tokens = inline @ scheme.inline_tokens;
+  }
+
+let is_inline_token scheme name = List.mem name scheme.inline_tokens

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -44,6 +44,10 @@ type t = {
       (** Per-render theme token overrides (from a [@theme] block). Key is the
           variable name without the leading [--]; value is the CSS string.
           Threaded replacement for the global [Var.theme_value_overrides]. *)
+  inline_tokens : string list;
+      (** Names of the tokens a project declared in an [\@theme inline] block.
+          Such a token has no declaration of its own: a utility reading it
+          inlines the value instead of referencing [var(--name)]. *)
 }
 (** Theme scheme configuration *)
 
@@ -74,9 +78,15 @@ val theme_value : t option -> string -> string option
 val token : t -> string -> string option
 (** [token t name] resolves a theme token: override (if any) else default. *)
 
-val with_overrides : t -> (string * string) list -> t
-(** [with_overrides t overrides] applies [overrides] on top of [t]'s existing
-    token overrides (new entries win). *)
+val with_overrides : ?inline:string list -> t -> (string * string) list -> t
+(** [with_overrides ?inline t overrides] applies [overrides] on top of [t]'s
+    existing token overrides (new entries win). [inline] names the tokens that
+    came from an [\@theme inline] block. *)
+
+val is_inline_token : t -> string -> bool
+(** [is_inline_token t name] is whether [name] was declared in an
+    [\@theme inline] block, so a utility reading it inlines the value rather
+    than referencing [var(--name)]. *)
 
 val color : t -> string -> color_value option
 (** [color t name] looks up a color in the scheme. *)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -204,7 +204,20 @@ let default_font_variant_theme : font_variant_theme =
     fraction = (fraction_decl, fraction_ref);
   }
 
-(* Font family theme variables *)
+(* Font family theme variables. A project [@theme] can name families of its own
+   ([--font-source]); order (1, 100) puts those after the three built-in
+   stacks. *)
+let font_named_cache : (string, Css.font_family Var.theme) Hashtbl.t =
+  Hashtbl.create 8
+
+let font_named_var name =
+  match Hashtbl.find_opt font_named_cache name with
+  | Some var -> var
+  | None ->
+      let var = Var.theme Css.Font_family ("font-" ^ name) ~order:(1, 100) in
+      Hashtbl.add font_named_cache name var;
+      var
+
 let font_sans_var = Var.theme Css.Font_family "font-sans" ~order:(1, 0)
 let font_serif_var = Var.theme Css.Font_family "font-serif" ~order:(1, 1)
 let font_mono_var = Var.theme Css.Font_family "font-mono" ~order:(1, 2)
@@ -312,6 +325,7 @@ module Typography_early = struct
       Font_sans
     | Font_serif
     | Font_mono
+    | Font_named of string (* font-source, from a --font-* theme token *)
     | (* Font styles *)
       Italic
     | Not_italic
@@ -508,7 +522,12 @@ module Typography_early = struct
           if List.mem s known_leading_names then Stdlib.Option.Some (Lh_named s)
           else Stdlib.Option.None
 
-  let of_class _theme class_name =
+  (* A font family the project named in its [@theme]. Gated on the token being
+     there so a stray source word (font-awesome) is not a utility. *)
+  let is_named_font theme n =
+    Scheme.theme_value (Some theme) ("font-" ^ n) <> None
+
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "text"; "xs" ] -> Ok Text_xs
@@ -578,6 +597,9 @@ module Typography_early = struct
     | [ "font"; "sans" ] -> Ok Font_sans
     | [ "font"; "serif" ] -> Ok Font_serif
     | [ "font"; "mono" ] -> Ok Font_mono
+    | "font" :: (_ :: _ as rest)
+      when is_named_font theme (String.concat "-" rest) ->
+        Ok (Font_named (String.concat "-" rest))
     | [ "italic" ] -> Ok Italic
     | [ "not"; "italic" ] -> Ok Not_italic
     | [ "text"; "left" ] -> Ok Text_left
@@ -661,6 +683,7 @@ module Typography_early = struct
     | Font_features_quoted raw -> "font-features-[" ^ raw ^ "]"
     | Font_features_var raw -> "font-features-[" ^ raw ^ "]"
     | Font_features_bare_var raw -> "font-features-" ^ raw
+    | Font_named name -> "font-" ^ name
     | Font_sans -> "font-sans"
     | Font_serif -> "font-serif"
     | Font_mono -> "font-mono"
@@ -705,6 +728,7 @@ module Typography_early = struct
     | Font_mono -> 1501
     | Font_sans -> 1502
     | Font_serif -> 1503
+    | Font_named _ -> 1504
     (* Bracket font-size with line-height modifier — before named sizes *)
     | Text_bracket_fs_lh _ -> 2000
     (* Font sizes come second - alphabetical order *)
@@ -903,6 +927,18 @@ module Typography_early = struct
            ])
     in
     style [ sans_decl; font_family (Css.Var sans_ref) ]
+
+  (* [font-source] reads --font-source from the theme; the token has to be
+     there, or a stray source word would parse as a utility. *)
+  let font_named theme name =
+    match Scheme.theme_value (Some theme) ("font-" ^ name) with
+    | None -> style []
+    | Some raw -> (
+        match Css.parse_font_family raw with
+        | None -> style []
+        | Some family ->
+            let decl, ref = Var.binding (font_named_var name) family in
+            style [ decl; font_family (Css.Var ref) ])
 
   let italic = style [ font_style Italic ]
   let not_italic = style [ font_style Normal ]
@@ -1204,6 +1240,7 @@ module Typography_early = struct
           Var.bracket bare_name
         in
         style [ font_feature_settings (Var var_ref) ]
+    | Font_named name -> font_named theme name
     | Font_sans -> font_sans
     | Font_serif -> font_serif
     | Font_mono -> font_mono

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -929,16 +929,30 @@ module Typography_early = struct
     style [ sans_decl; font_family (Css.Var sans_ref) ]
 
   (* [font-source] reads --font-source from the theme; the token has to be
-     there, or a stray source word would parse as a utility. *)
+     there, or a stray source word would parse as a utility.
+
+     An [@theme inline] token has no declaration of its own, so the utility
+     carries the value instead of a reference to it. A self-referential one
+     ([--font-a: var(--font-a)]) is the exception: inlining it would leave the
+     reference dangling, so the token keeps its declaration. *)
   let font_named theme name =
-    match Scheme.theme_value (Some theme) ("font-" ^ name) with
+    let token = "font-" ^ name in
+    match Scheme.theme_value (Some theme) token with
     | None -> style []
     | Some raw -> (
         match Css.parse_font_family raw with
         | None -> style []
         | Some family ->
-            let decl, ref = Var.binding (font_named_var name) family in
-            style [ decl; font_family (Css.Var ref) ])
+            let self_referential =
+              match family with
+              | Css.Var v -> Css.var_name v = token
+              | _ -> false
+            in
+            if Scheme.is_inline_token theme token && not self_referential then
+              style [ font_family family ]
+            else
+              let decl, ref = Var.binding (font_named_var name) family in
+              style [ decl; font_family (Css.Var ref) ])
 
   let italic = style [ font_style Italic ]
   let not_italic = style [ font_style Normal ]

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -42,3 +42,21 @@ theme, so an animate-* utility uses the project's --animate-* value:
 
   $ tw --minify --input-css anim.css page.html | grep -c '\.animate-wiggle{animation:var(--animate-wiggle)}'
   1
+
+A project [@theme] can name font families of its own, and [font-<name>] reads
+the token it declared:
+
+  $ cat > font.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @theme {
+  >   --font-source: Georgia, serif;
+  > }
+  > EOF
+  $ cat > font.html <<EOF
+  > <div class="font-source font-awesome"></div>
+  > EOF
+  $ tw --minify --input-css font.css font.html | grep -cF '.font-source{font-family:var(--font-source)}'
+  1
+  $ tw --minify --input-css font.css font.html | grep -c 'font-awesome'
+  0
+  [1]

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -60,3 +60,25 @@ the token it declared:
   $ tw --minify --input-css font.css font.html | grep -c 'font-awesome'
   0
   [1]
+
+An [@theme inline] token has no declaration of its own: the utility carries
+the value. A self-referential one is the exception, since inlining it would
+leave the reference dangling.
+
+  $ cat > inline.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @theme inline {
+  >   --font-a: var(--font-a);
+  >   --font-b: var(--font-ext), system-ui;
+  > }
+  > EOF
+  $ cat > inline.html <<EOF
+  > <div class="font-a font-b"></div>
+  > EOF
+  $ tw --minify --input-css inline.css inline.html | grep -cF '.font-b{font-family:var(--font-ext),system-ui}'
+  1
+  $ tw --minify --input-css inline.css inline.html | grep -c -- '--font-b:'
+  0
+  [1]
+  $ tw --minify --input-css inline.css inline.html | grep -cF -- '--font-a:var(--font-a)'
+  1

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -213,6 +213,28 @@ let test_content_named_requires_theme () =
   | Ok _ -> ()
   | Error (`Msg m) -> Alcotest.failf "content-slash with theme rejected: %s" m
 
+(* A project @theme can name font families of its own. The token gates the
+   parse, so a stray source word (font-awesome) stays an unknown class; an
+   @theme inline token carries its value into the utility rather than a
+   reference, except when the value refers back to the token itself. *)
+let test_named_font_family () =
+  (match Tw.of_string "font-awesome" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "font-awesome should be rejected without a token");
+  let css theme cls =
+    match Tw.of_string ~theme cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u -> Tw.Css.pp ~minify:true (Tw.to_css ~base:false ~theme [ u ])
+  in
+  let themed =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("font-source", "Georgia, serif") ]
+  in
+  Alcotest.(check bool)
+    "font-source references its token" true
+    (Astring.String.is_infix ~affix:"font-family:var(--font-source)"
+       (css themed "font-source"))
+
 (* text-[<value>] accepts values that CSS font-size accepts: lengths with a
    unit, percentages, font-size keywords (larger/smaller/xxx-large/...),
    clamp(...), and var(...). Bare identifiers without a unit are rejected --
@@ -441,6 +463,7 @@ let tests =
       test_text_bracket_size_invalid;
     test_case "text-[--spacing()/--alpha()] functions" `Quick
       test_text_bracket_functions;
+    test_case "named font family from the theme" `Quick test_named_font_family;
     test_case "typography of_string - invalid values" `Quick of_string_invalid;
     test_case "typography suborder matches Tailwind" `Quick
       suborder_matches_tailwind;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -233,7 +233,21 @@ let test_named_font_family () =
   Alcotest.(check bool)
     "font-source references its token" true
     (Astring.String.is_infix ~affix:"font-family:var(--font-source)"
-       (css themed "font-source"))
+       (css themed "font-source"));
+  let inline =
+    Tw.Scheme.with_overrides
+      ~inline:[ "font-source"; "font-self" ]
+      Tw.Scheme.default
+      [ ("font-source", "Georgia, serif"); ("font-self", "var(--font-self)") ]
+  in
+  Alcotest.(check bool)
+    "an inline token is inlined" true
+    (Astring.String.is_infix ~affix:"font-family:Georgia,serif"
+       (css inline "font-source"));
+  Alcotest.(check bool)
+    "a self-referential inline token keeps its declaration" true
+    (Astring.String.is_infix ~affix:"--font-self:var(--font-self)"
+       (css inline "font-self"))
 
 (* text-[<value>] accepts values that CSS font-size accepts: lengths with a
    unit, percentages, font-size keywords (larger/smaller/xxx-large/...),

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -339,6 +339,7 @@ let scheme_from_expected_css expected : Tw.Scheme.t =
     default_outline_width;
     breakpoints;
     token_overrides = [];
+    inline_tokens = [];
   }
 
 let setup_scheme_for_test expected =


### PR DESCRIPTION
`font-source` and `font-ubuntu-mono` were unknown classes: only `sans`, `serif` and `mono` reached a font family, so a `--font-*` token declared in the project's own `@theme` had no utility.

The second commit adds `@theme inline` semantics, where the token has no declaration of its own and the utility carries its value. Stacked on #222; uses the font-family value parser from cascade#202.