### PR TITLE
color: read an alpha from a var in every colour family

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -145,7 +145,7 @@ module Handler = struct
         in
         style ~rules:(Some [ supports_block ]) [ fallback_decl ]
     | Color.Opacity_var var_str ->
-        let bare = Parse.extract_var_name var_str in
+        let bare = Color.opacity_var_bare var_str in
         let srgb_fallback =
           Css.color_mix_var_percent ~in_space:Srgb ~var_name:bare color
             Css.Transparent
@@ -266,7 +266,7 @@ module Handler = struct
         else "/[" ^ Pp.float p ^ "%]"
     | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
     | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/[" ^ v ^ "]"
+    | Color.Opacity_var v -> "/" ^ v
 
   let to_class = function
     | Color_opacity { property; value; opacity } ->

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -210,7 +210,7 @@ module Handler = struct
         else "/[" ^ Pp.float p ^ "%]"
     | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
     | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/[" ^ v ^ "]"
+    | Color.Opacity_var v -> "/" ^ v
 
   let to_class (t : t) =
     match t with
@@ -995,11 +995,8 @@ module Handler = struct
   let bg_bracket_color_var_opacity' var_str opacity =
     let bare = Parse.extract_var_name var_str in
     let var_ref : Css.color Css.var = Var.bracket bare in
-    let percent = Color.opacity_to_percent opacity in
     let fallback_decl = Css.background_color (Var var_ref) in
-    let oklab_color =
-      Css.color_mix ~in_space:Oklab (Var var_ref) Transparent ~percent1:percent
-    in
+    let oklab_color = Color.mix_alpha opacity (Css.Var var_ref) in
     let oklab_decl = Css.background_color oklab_color in
     let supports_rule =
       Css.supports ~condition:Color.color_mix_supports_condition
@@ -1088,16 +1085,16 @@ module Handler = struct
            color-mix(...) } } 3. .from-X/N { --tw-gradient-stops: ... } To
            match, we put fallback in props, @supports in rules, and stops as
            separate rule in rules. *)
-        let hex_alpha = Color.hex_with_alpha hex_value percent in
+        let hex_alpha =
+          if Color.opacity_var_bare_of opacity <> None then hex_value
+          else Color.hex_with_alpha hex_value percent
+        in
         let d_fallback, _ = Var.binding set_var (Css.hex hex_alpha) in
 
         (* Theme variable for @supports block *)
         let color_var = Color.color_var color shade in
         let theme_decl, color_ref = Var.binding color_var (Css.hex hex_value) in
-        let oklab_color =
-          Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-            ~percent1:percent
-        in
+        let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
         let d_oklab, _ = Var.binding set_var oklab_color in
 
         (* Build @supports block with placeholder selector *)
@@ -1130,9 +1127,7 @@ module Handler = struct
         (* Non-scheme color: use color-mix directly *)
         let oklch = Color.to_oklch color shade in
         let color_value =
-          Css.color_mix ~in_space:Oklab
-            (Css.oklch oklch.l oklch.c oklch.h)
-            Css.Transparent ~percent1:percent
+          Color.mix_alpha opacity (Css.oklch oklch.l oklch.c oklch.h)
         in
         let d_var, _ = Var.binding set_var color_value in
         let declarations =
@@ -1845,28 +1840,7 @@ module Handler = struct
               decr depth;
               if !depth = 0 then close := i)
         done;
-        let parse_opacity s =
-          if String.length s > 1 && s.[0] = '[' && s.[String.length s - 1] = ']'
-          then
-            let inner_o = String.sub s 1 (String.length s - 2) in
-            if String.ends_with ~suffix:"%" inner_o then
-              let num_s = String.sub inner_o 0 (String.length inner_o - 1) in
-              match float_of_string_opt num_s with
-              | Some f -> Some (Color.Opacity_bracket_percent f)
-              | None ->
-                  if Parse.is_var inner_o then Some (Color.Opacity_var inner_o)
-                  else None
-            else
-              match float_of_string_opt inner_o with
-              | Some f -> Some (Color.Opacity_arbitrary f)
-              | None ->
-                  if Parse.is_var inner_o then Some (Color.Opacity_var inner_o)
-                  else None
-          else
-            match float_of_string_opt s with
-            | Some f -> Some (Color.Opacity_percent f)
-            | None -> None
-        in
+        let parse_opacity s = Color.opacity_of_string ~theme s in
         if !close >= 0 && !close + 1 < len && bracket_stuff.[!close + 1] = '/'
         then
           (* Bracket with opacity: [color:var(--x)]/50 *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1567,7 +1567,50 @@ type opacity_modifier =
   | Opacity_bracket_percent of
       float (* e.g., /[50%] means 50% but preserves bracket form *)
   | Opacity_named of string (* e.g., /half, /custom - theme-defined names *)
-  | Opacity_var of string (* e.g., /[var(--x)] - var ref used as percentage *)
+  | Opacity_var of string
+(* the modifier as written: /[var(--x)] or the /(--x) shorthand *)
+
+(** Parse the modifier that follows the [/] in a colour class. *)
+let opacity_of_string ?theme opacity_str =
+  if
+    String.length opacity_str > 2
+    && opacity_str.[0] = '['
+    && opacity_str.[String.length opacity_str - 1] = ']'
+  then
+    (* Arbitrary value like [0.5] or [50%] or [var(--x)] *)
+    let inner = String.sub opacity_str 1 (String.length opacity_str - 2) in
+    if String.ends_with ~suffix:"%" inner then
+      let num_str = String.sub inner 0 (String.length inner - 1) in
+      match float_of_string_opt num_str with
+      | Some f -> Some (Opacity_bracket_percent f)
+      | None -> None
+    else
+      match float_of_string_opt inner with
+      | Some f -> Some (Opacity_arbitrary f)
+      | None ->
+          if Parse.is_var inner then Some (Opacity_var opacity_str) else None
+  else if
+    String.length opacity_str > 4
+    && opacity_str.[0] = '('
+    && opacity_str.[String.length opacity_str - 1] = ')'
+  then
+    (* The [(--x)] shorthand for [[var(--x)]]. *)
+    let inner = String.sub opacity_str 1 (String.length opacity_str - 2) in
+    if String.length inner > 2 && String.sub inner 0 2 = "--" then
+      Some (Opacity_var opacity_str)
+    else None
+  else
+    (* Numeric value like 50 or 2.5, or named opacity like half/custom *)
+    match float_of_string_opt opacity_str with
+    | Some f when f >= 0. -> Some (Opacity_percent f)
+    | _ ->
+        (* Not a number — check if it's a named opacity defined in the theme
+           (e.g., /half when --opacity-half exists) *)
+        if
+          Parse.is_valid_theme_name opacity_str
+          && Scheme.theme_value theme ("opacity-" ^ opacity_str) <> None
+        then Some (Opacity_named opacity_str)
+        else None
 
 (** Parse opacity modifier from a string that may contain /NN or /[N.N] *)
 let parse_opacity_modifier ?theme s =
@@ -1576,36 +1619,9 @@ let parse_opacity_modifier ?theme s =
   | Some idx -> (
       let base = String.sub s 0 idx in
       let opacity_str = String.sub s (idx + 1) (String.length s - idx - 1) in
-      if
-        String.length opacity_str > 2
-        && opacity_str.[0] = '['
-        && opacity_str.[String.length opacity_str - 1] = ']'
-      then
-        (* Arbitrary value like [0.5] or [50%] or [var(--x)] *)
-        let inner = String.sub opacity_str 1 (String.length opacity_str - 2) in
-        if String.ends_with ~suffix:"%" inner then
-          let num_str = String.sub inner 0 (String.length inner - 1) in
-          match float_of_string_opt num_str with
-          | Some f -> (base, Opacity_bracket_percent f)
-          | None -> (s, No_opacity)
-        else
-          match float_of_string_opt inner with
-          | Some f -> (base, Opacity_arbitrary f)
-          | None ->
-              if Parse.is_var inner then (base, Opacity_var inner)
-              else (s, No_opacity)
-      else
-        (* Numeric value like 50 or 2.5, or named opacity like half/custom *)
-        match float_of_string_opt opacity_str with
-        | Some f when f >= 0. -> (base, Opacity_percent f)
-        | _ ->
-            (* Not a number — check if it's a named opacity defined in the theme
-               (e.g., /half when --opacity-half exists) *)
-            if
-              Parse.is_valid_theme_name opacity_str
-              && Scheme.theme_value theme ("opacity-" ^ opacity_str) <> None
-            then (base, Opacity_named opacity_str)
-            else (s, No_opacity))
+      match opacity_of_string ?theme opacity_str with
+      | Some opacity -> (base, opacity)
+      | None -> (s, No_opacity))
 
 (* Parse color and shade from string list *)
 let shade_of_strings = function
@@ -2478,6 +2494,43 @@ module Handler = struct
         (* Named/var opacity requires variable lookup, default to 100% *)
         100.0
 
+  (* [opacity_to_percent] answers 100 for an opacity it cannot resolve (a var or
+     a theme name), so a caller cannot use that to mean "fully opaque". *)
+  (* The bare custom-property name inside an opacity modifier, written either
+     as [[var(--x)]] or as the [(--x)] shorthand. *)
+  let opacity_var_bare v =
+    let inner =
+      if Parse.is_bracket_value v then Parse.bracket_inner v
+      else if String.length v > 2 && v.[0] = '(' then
+        String.sub v 1 (String.length v - 2)
+      else v
+    in
+    let name = Parse.extract_var_name inner in
+    if String.length name > 2 && String.sub name 0 2 = "--" then
+      String.sub name 2 (String.length name - 2)
+    else name
+
+  (* The custom property an opacity modifier reads its percentage from, when it
+     names one rather than giving a number. *)
+  let opacity_var_name = function
+    | Opacity_var v -> Some (opacity_var_bare v)
+    | Opacity_named name -> Some ("opacity-" ^ Parse.extract_var_name name)
+    | _ -> None
+
+  let is_fully_opaque = function
+    | Opacity_named _ | Opacity_var _ -> false
+    | opacity -> opacity_to_percent opacity >= 100.
+
+  (* The colour with the modifier's alpha applied: a percentage folds in, an
+     alpha read from a var is referenced by name. *)
+  let mix_alpha ?(in_space : Css.color_space = Oklab) opacity color =
+    match opacity_var_name opacity with
+    | Some var_name ->
+        Css.color_mix_var_percent ~in_space ~var_name color Css.Transparent
+    | None ->
+        Css.color_mix ~in_space color Css.Transparent
+          ~percent1:(opacity_to_percent opacity)
+
   (** Condition for progressive enhancement with color-mix in oklab *)
   let color_mix_supports_condition =
     Css.Supports.property "color" "color-mix(in lab, red, red)"
@@ -2494,7 +2547,9 @@ module Handler = struct
       shade opacity =
     let property_decls value = List.map (fun set -> set value) properties in
     let percent = opacity_to_percent opacity in
-    if is_custom_color c then
+    if is_custom_color c && opacity_var_name opacity <> None then
+      style ?merge_key (property_decls (mix_alpha opacity (to_css c shade)))
+    else if is_custom_color c then
       (* Custom/arbitrary colors (hex, rgb): output oklab() directly. No theme
          variables, no @supports, no hex+alpha fallback. *)
       let ok_l, ok_a, ok_b =
@@ -2557,16 +2612,26 @@ module Handler = struct
             | Stdlib.Option.None ->
                 to_css c (if is_base_color c then 500 else shade)
           in
-          (* Fallback: hex+alpha from converted value *)
-          let oklch = to_oklch c shade in
-          let rgb = oklch_to_rgb oklch in
-          let hex_value = rgb_to_hex rgb in
-          let hex_with_alpha_str = hex_with_alpha hex_value percent in
-          let fallback_decls = property_decls (Css.hex hex_with_alpha_str) in
           let theme_decl, color_ref = Var.binding color_var color_value in
+          (* An opacity read from a var has no percentage to fold into a hex
+             fallback, so the fallback is the colour at full opacity. *)
+          let fallback_decls =
+            match opacity_var_name opacity with
+            | Some _ -> property_decls (Css.Var color_ref)
+            | None ->
+                let oklch = to_oklch c shade in
+                let rgb = oklch_to_rgb oklch in
+                let hex_value = rgb_to_hex rgb in
+                property_decls (Css.hex (hex_with_alpha hex_value percent))
+          in
           let oklab_color =
-            Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-              ~percent1:percent
+            match opacity_var_name opacity with
+            | Some var_name ->
+                Css.color_mix_var_percent ~in_space:Oklab ~var_name
+                  (Css.Var color_ref) Css.Transparent
+            | None ->
+                Css.color_mix ~in_space:Oklab (Css.Var color_ref)
+                  Css.Transparent ~percent1:percent
           in
           let supports_block =
             Css.supports ~condition:color_mix_supports_condition
@@ -2692,7 +2757,7 @@ module Handler = struct
           | Opacity_arbitrary f -> "/[" ^ string_of_float f ^ "]"
           | Opacity_bracket_percent p -> "/[" ^ string_of_float p ^ "%]"
           | Opacity_named n -> "/" ^ n
-          | Opacity_var v -> "/[" ^ v ^ "]"
+          | Opacity_var v -> "/" ^ v
         in
         "outline-[" ^ inner ^ "]" ^ opacity_tag
     in
@@ -2770,8 +2835,8 @@ module Handler = struct
     | Bg (color, shade) -> bg' color shade
     | Bg_opacity (color, shade, opacity) ->
         (* 100% opacity: same as base color, no @supports needed *)
-        if opacity_to_percent opacity >= 100. && not (is_custom_color color)
-        then bg' color shade
+        if is_fully_opaque opacity && not (is_custom_color color) then
+          bg' color shade
         else bg_with_opacity color shade opacity
     | Bg_transparent -> bg_transparent
     | Bg_current -> bg_current
@@ -2892,8 +2957,8 @@ module Handler = struct
     | Placeholder (color, shade) ->
         with_pseudo Css.Selector.Placeholder (text' color shade)
     | Placeholder_opacity (color, shade, opacity) ->
-        if opacity_to_percent opacity >= 100. && not (is_custom_color color)
-        then with_pseudo Css.Selector.Placeholder (text' color shade)
+        if is_fully_opaque opacity && not (is_custom_color color) then
+          with_pseudo Css.Selector.Placeholder (text' color shade)
         else
           with_pseudo Css.Selector.Placeholder
             (text_with_opacity color shade opacity)
@@ -3053,7 +3118,7 @@ module Handler = struct
         else "/[" ^ pp_float p ^ "%]"
     | Opacity_arbitrary f -> "/[" ^ pp_float f ^ "]"
     | Opacity_named name -> "/" ^ name
-    | Opacity_var v -> "/[" ^ v ^ "]"
+    | Opacity_var v -> "/" ^ v
 
   let to_class = function
     | Bg (c, shade) ->
@@ -3225,6 +3290,8 @@ let scheme_color_name = Handler.scheme_color_name
 let property_color_var = Handler.property_color_var
 let property_color_value = Handler.property_color_value
 let opacity_to_percent = Handler.opacity_to_percent
+let opacity_var_bare = Handler.opacity_var_bare
+let opacity_var_bare_of = Handler.opacity_var_name
 
 let pp_opacity = function
   | No_opacity -> ""
@@ -3240,7 +3307,7 @@ let pp_opacity = function
       else "[" ^ Pp.float pct ^ "%]"
   | Opacity_arbitrary f -> "[" ^ string_of_float f ^ "]"
   | Opacity_named name -> name
-  | Opacity_var v -> "[" ^ v ^ "]"
+  | Opacity_var v -> v
 
 let shorten_hex_str = shorten_hex_str
 let bracket_color_to_custom = Handler.bracket_color_to_custom
@@ -3290,14 +3357,13 @@ let color_mix_supports ~decls =
 let color_mix_supports_stmts ~stmts =
   Css.supports ~condition:color_mix_supports_condition stmts
 
-let oklab_with_supports ~property ~fallback_decl c shade percent =
+let mix_alpha = Handler.mix_alpha
+
+let oklab_with_supports ~property ~fallback_decl c shade opacity =
   let cvar = color_var c shade in
   let color_value = to_css c (if is_base_color c then 500 else shade) in
   let theme_decl, color_ref = Var.binding cvar color_value in
-  let oklab_color =
-    Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-      ~percent1:percent
-  in
+  let oklab_color = mix_alpha opacity (Css.Var color_ref) in
   let oklab_decl = property oklab_color in
   let supports_block = color_mix_supports ~decls:[ theme_decl; oklab_decl ] in
   Style.style ~rules:(Some [ supports_block ]) [ fallback_decl ]
@@ -3305,34 +3371,36 @@ let oklab_with_supports ~property ~fallback_decl c shade percent =
 let generic_color_with_opacity ?theme ~property c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
+  let alpha_var = opacity_var_name opacity <> None in
   if is_custom_color c then
-    let ok_l, ok_a, ok_b = custom_color_to_oklab c in
-    let alpha = percent /. 100.0 in
-    let oklab_value = Css.oklaba ok_l ok_a ok_b alpha in
-    Style.style [ property oklab_value ]
+    if alpha_var then
+      Style.style [ property (mix_alpha opacity (to_css c shade)) ]
+    else
+      let ok_l, ok_a, ok_b = custom_color_to_oklab c in
+      let oklab_value = Css.oklaba ok_l ok_a ok_b (percent /. 100.0) in
+      Style.style [ property oklab_value ]
   else
     let color_name = scheme_color_name c shade in
     match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex_value ->
         let fallback_decl =
-          property (Css.hex (hex_with_alpha hex_value percent))
+          if alpha_var then property (Css.hex hex_value)
+          else property (Css.hex (hex_with_alpha hex_value percent))
         in
-        oklab_with_supports ~property ~fallback_decl c shade percent
+        oklab_with_supports ~property ~fallback_decl c shade opacity
     | None ->
         let oklch = to_oklch c shade in
         let fallback_color =
-          Css.color_mix ~in_space:Srgb (css_color_of_oklch oklch)
-            Css.Transparent ~percent1:percent
+          if alpha_var then css_color_of_oklch oklch
+          else
+            Css.color_mix ~in_space:Srgb (css_color_of_oklch oklch)
+              Css.Transparent ~percent1:percent
         in
         oklab_with_supports ~property ~fallback_decl:(property fallback_color) c
-          shade percent
+          shade opacity
 
 let generic_current_with_opacity ?merge_key ~fallback_decl ~property opacity =
-  let open Handler in
-  let percent = opacity_to_percent opacity in
-  let oklab_color =
-    Css.color_mix ~in_space:Oklab Css.Current Css.Transparent ~percent1:percent
-  in
+  let oklab_color = mix_alpha opacity Css.Current in
   let oklab_decl = property oklab_color in
   let supports_block =
     Css.supports ~condition:color_mix_supports_condition
@@ -3363,7 +3431,7 @@ let stroke_current_with_opacity opacity =
     ~property:(fun color -> Css.stroke (Css.Color color))
     opacity
 
-let divide_opacity_via_property ?theme ~selector c shade percent =
+let divide_opacity_via_property ?theme ~selector c shade opacity =
   let cvar =
     property_color_var ?theme ~property_prefix:"border-color" c shade
   in
@@ -3372,35 +3440,38 @@ let divide_opacity_via_property ?theme ~selector c shade percent =
   in
   let hex_alpha =
     let oklch = to_oklch c shade in
-    hex_with_alpha (rgb_to_hex (oklch_to_rgb oklch)) percent
+    let hex = rgb_to_hex (oklch_to_rgb oklch) in
+    if Handler.opacity_var_name opacity <> None then hex
+    else hex_with_alpha hex (Handler.opacity_to_percent opacity)
   in
   let fallback_rule =
     Css.rule ~selector [ Css.border_color (Css.hex hex_alpha) ]
   in
   let theme_decl, color_ref = Var.binding cvar color_value in
-  let oklab_color =
-    Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-      ~percent1:percent
-  in
+  let oklab_color = mix_alpha opacity (Css.Var color_ref) in
   let supports_rule =
     Css.rule ~selector [ theme_decl; Css.border_color oklab_color ]
   in
   let supports_block = color_mix_supports_stmts ~stmts:[ supports_rule ] in
   Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
 
-let bg_opacity_via_property c shade percent =
+let bg_opacity_via_property c shade opacity =
   let cvar = color_var c shade in
   let color_value = to_css c (if is_base_color c then 500 else shade) in
-  let hex_alpha =
-    let oklch = to_oklch c shade in
-    hex_with_alpha (rgb_to_hex (oklch_to_rgb oklch)) percent
-  in
-  let fallback_decl = Css.background_color (Css.hex hex_alpha) in
   let theme_decl, color_ref = Var.binding cvar color_value in
+  (* An opacity read from a var has no percentage to fold into the fallback, so
+     that is the colour at full opacity, as Tailwind emits. *)
+  let fallback_decl =
+    match Handler.opacity_var_name opacity with
+    | Some _ -> Css.background_color (Css.Var color_ref)
+    | None ->
+        let oklch = to_oklch c shade in
+        let hex = rgb_to_hex (oklch_to_rgb oklch) in
+        Css.background_color
+          (Css.hex (hex_with_alpha hex (Handler.opacity_to_percent opacity)))
+  in
   let oklab_decl =
-    Css.background_color
-      (Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-         ~percent1:percent)
+    Css.background_color (mix_alpha opacity (Css.Var color_ref))
   in
   let supports_block = color_mix_supports ~decls:[ theme_decl; oklab_decl ] in
   Style.style ~rules:(Some [ supports_block ]) [ fallback_decl ]
@@ -3409,26 +3480,29 @@ let bg_opacity_via_property c shade percent =
 let divide_with_opacity_selector ?theme ~selector c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
+  let alpha_var = opacity_var_name opacity <> None in
   if is_custom_color c then
-    let ok_l, ok_a, ok_b = custom_color_to_oklab c in
-    let alpha = percent /. 100.0 in
-    let oklab_value = Css.oklaba ok_l ok_a ok_b alpha in
-    let rule = Css.rule ~selector [ Css.border_color oklab_value ] in
+    let value =
+      if alpha_var then mix_alpha opacity (to_css c shade)
+      else
+        let ok_l, ok_a, ok_b = custom_color_to_oklab c in
+        Css.oklaba ok_l ok_a ok_b (percent /. 100.0)
+    in
+    let rule = Css.rule ~selector [ Css.border_color value ] in
     Style.style ~rules:(Some [ rule ]) []
   else
     let color_name = scheme_color_name c shade in
     match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex_value ->
-        let hex_alpha = hex_with_alpha hex_value percent in
+        let hex_alpha =
+          if alpha_var then hex_value else hex_with_alpha hex_value percent
+        in
         let fallback_rule =
           Css.rule ~selector [ Css.border_color (Css.hex hex_alpha) ]
         in
         let cvar = color_var c shade in
         let _theme_decl, color_ref = Var.binding cvar (Css.hex hex_value) in
-        let oklab_color =
-          Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-            ~percent1:percent
-        in
+        let oklab_color = mix_alpha opacity (Css.Var color_ref) in
         let supports_rule =
           Css.rule ~selector [ Css.border_color oklab_color ]
         in
@@ -3436,7 +3510,7 @@ let divide_with_opacity_selector ?theme ~selector c shade opacity =
           color_mix_supports_stmts ~stmts:[ supports_rule ]
         in
         Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
-    | None -> divide_opacity_via_property ?theme ~selector c shade percent
+    | None -> divide_opacity_via_property ?theme ~selector c shade opacity
 
 let divide_with_opacity ?theme c shade opacity selector =
   divide_with_opacity_selector ?theme ~selector c shade opacity
@@ -3463,7 +3537,7 @@ let divide_current_with_opacity opacity selector =
 let bg_with_opacity ?theme c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
-  if percent >= 100.0 then
+  if is_fully_opaque opacity then
     (* 100% opacity = no transparency. Tailwind outputs the plain color var
        reference, identical to the no-opacity case. *)
     let cvar = color_var c shade in
@@ -3471,28 +3545,32 @@ let bg_with_opacity ?theme c shade opacity =
     let _d, color_ref = Var.binding cvar color_value in
     Style.style [ Css.background_color (Var color_ref) ]
   else if is_custom_color c then
-    let ok_l, ok_a, ok_b = custom_color_to_oklab c in
-    let alpha = percent /. 100.0 in
-    let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
-    Style.style [ Css.background_color oklab_value ]
+    let value =
+      if opacity_var_name opacity <> None then
+        mix_alpha opacity (to_css c shade)
+      else
+        let ok_l, ok_a, ok_b = custom_color_to_oklab c in
+        Css.oklaba_none_zeros ok_l ok_a ok_b (percent /. 100.0)
+    in
+    Style.style [ Css.background_color value ]
   else
     let color_name = scheme_color_name c shade in
     match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex_value ->
-        let fallback_decl =
-          Css.background_color (Css.hex (hex_with_alpha hex_value percent))
-        in
         let cvar = color_var c shade in
         let theme_decl, color_ref = Var.binding cvar (Css.hex hex_value) in
+        let fallback_decl =
+          if opacity_var_name opacity <> None then
+            Css.background_color (Css.Var color_ref)
+          else Css.background_color (Css.hex (hex_with_alpha hex_value percent))
+        in
         let oklab_decl =
-          Css.background_color
-            (Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-               ~percent1:percent)
+          Css.background_color (mix_alpha opacity (Css.Var color_ref))
         in
         let supports_block = color_mix_supports ~decls:[ oklab_decl ] in
         Style.style ~rules:(Some [ supports_block ])
           [ theme_decl; fallback_decl ]
-    | None -> bg_opacity_via_property c shade percent
+    | None -> bg_opacity_via_property c shade opacity
 
 (** Determine the appropriate fallback for an opacity theme variable. If the
     theme defines a concrete value (e.g., "0.5"), use [Fallback (Num f)]. If the
@@ -3530,7 +3608,7 @@ let bg_current_with_opacity ?theme opacity =
         Css.color_mix_var_pct_fallback ~in_space:Oklab ~var_name ~fallback
           Css.Current Css.Transparent
     | Opacity_var var_str ->
-        let bare = Parse.extract_var_name var_str in
+        let bare = Handler.opacity_var_bare var_str in
         Css.color_mix_var_percent ~in_space:Oklab ~var_name:bare Css.Current
           Css.Transparent
     | _ ->

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -336,6 +336,25 @@ type opacity_modifier =
   | Opacity_var of string
       (** e.g., /[var(--x)] - var ref used directly as percentage *)
 
+val opacity_var_bare : string -> string
+(** [opacity_var_bare v] is the bare custom-property name inside an opacity
+    modifier, written either as ["[var(--x)]"] or as the ["(--x)"] shorthand. *)
+
+val opacity_var_bare_of : opacity_modifier -> string option
+(** [opacity_var_bare_of opacity] is the custom property the modifier reads its
+    percentage from, when it names one rather than giving a number. *)
+
+val mix_alpha :
+  ?in_space:Css.color_space -> opacity_modifier -> Css.color -> Css.color
+(** [mix_alpha ?in_space opacity color] is [color] with the modifier's alpha
+    applied: a percentage folds into the [color-mix], an alpha read from a var
+    is referenced by name. *)
+
+val opacity_of_string : ?theme:Scheme.t -> string -> opacity_modifier option
+(** [opacity_of_string ?theme s] parses the modifier that follows the [/] in a
+    colour class: a percentage, a bracket value, the [(--x)] shorthand, or a
+    theme-defined name. *)
+
 val parse_opacity_modifier :
   ?theme:Scheme.t -> string -> string * opacity_modifier
 (** [parse_opacity_modifier ?theme s] parses an opacity modifier from a string.

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -232,9 +232,14 @@ module Handler = struct
     if String.length inner > 0 && inner.[0] = '#' then
       match Color.hex_to_rgb (String.sub inner 1 (String.length inner - 1)) with
       | Some rgb ->
-          let ok_l, ok_a, ok_b = Color.rgb_to_oklab rgb in
-          let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
-          let rule = Css.rule ~selector [ Css.border_color oklab_value ] in
+          let value =
+            if Color.opacity_var_bare_of opacity <> None then
+              Color.mix_alpha opacity (Css.hex inner)
+            else
+              let ok_l, ok_a, ok_b = Color.rgb_to_oklab rgb in
+              Css.oklaba_none_zeros ok_l ok_a ok_b alpha
+          in
+          let rule = Css.rule ~selector [ Css.border_color value ] in
           style ~rules:(Some [ rule ]) []
       | None ->
           let rule = Css.rule ~selector [ Css.border_color (Css.hex "#000") ] in
@@ -309,7 +314,7 @@ module Handler = struct
         else "/[" ^ pp_float p ^ "%]"
     | Color.Opacity_arbitrary f -> "/[" ^ pp_float f ^ "]"
     | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/[" ^ v ^ "]"
+    | Color.Opacity_var v -> "/" ^ v
 
   (* Divide color with opacity using Color helpers *)
   let divide_color_opacity_style ?theme color shade opacity =

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -82,7 +82,7 @@ module Handler = struct
         else "/[" ^ Pp.float p ^ "%]"
     | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
     | Color.Opacity_named n -> "/" ^ n
-    | Color.Opacity_var v -> "/[" ^ v ^ "]"
+    | Color.Opacity_var v -> "/" ^ v
 
   let spec_class = function
     | Theme (color, shade, op) ->

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -60,7 +60,7 @@ module Handler = struct
         else "/[" ^ Pp.float p ^ "%]"
     | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
     | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/[" ^ v ^ "]"
+    | Color.Opacity_var v -> "/" ^ v
 
   (* Fill color style with scheme support *)
   let fill_color_style ?theme color shade =

--- a/lib/tools/source_scan.ml
+++ b/lib/tools/source_scan.ml
@@ -64,6 +64,11 @@ let is_candidate_char = function
   | 0x2d | 0x5f | 0x3a | 0x2f | 0x25 | 0x40 | 0x21 | 0x2a -> true
   | _ -> false
 
+(* A [(] opens a group only where a utility can hold one: after the [-] of
+   [bg-(--x)] or the [/] of an alpha shorthand. Elsewhere it ends the token, so
+   a call in the source is not read as a class. *)
+let opens_paren_group prev = prev = 0x2d || prev = 0x2f
+
 let trim_candidate s =
   let len = String.length s in
   let rec stop i =
@@ -109,7 +114,7 @@ let read_candidate d start =
             | 0x2c | 0x23 ->
                 i
             | 0x5b -> loop (i + 1) 1 0 None false
-            | 0x28 when i > start && char_at d (i - 1) = 0x2d ->
+            | 0x28 when i > start && opens_paren_group (char_at d (i - 1)) ->
                 loop (i + 1) 0 1 None false
             | 0x28 | 0x29 -> i
             | 0x2e

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -277,6 +277,38 @@ let test_border_side_color_opacity () =
     "border-b-white/5 round-trips" "border-b-white/5"
     (Tw.pp (Result.get_ok (Tw.of_string "border-b-white/5")))
 
+(* An alpha can name a custom property to read the percentage from, written
+   either as [/[var(--x)]] or as the [/(--x)] shorthand. The percentage is not
+   known at build time, so it goes into the [color-mix] as a reference; before,
+   an unresolved alpha counted as 100% and the modifier was dropped. *)
+let test_alpha_from_a_var () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "bg-cyan-400/(--a)"
+    "color-mix(in oklab,var(--color-cyan-400) var(--a),transparent)";
+  has "bg-cyan-400/[var(--a)]"
+    "color-mix(in oklab,var(--color-cyan-400) var(--a),transparent)";
+  has "text-red-500/(--a)"
+    "color-mix(in oklab,var(--color-red-500) var(--a),transparent)";
+  has "fill-red-500/(--a)"
+    "color-mix(in oklab,var(--color-red-500) var(--a),transparent)";
+  has "bg-[#0088cc]/(--a)" "color-mix(in oklab,#08c var(--a),transparent)";
+  (* the fallback is the colour at full opacity, with no alpha folded in *)
+  has "bg-cyan-400/(--a)" "background-color:var(--color-cyan-400)";
+  (* both spellings round-trip *)
+  Alcotest.(check string)
+    "the shorthand round-trips" "bg-cyan-400/(--a)"
+    (Tw.pp (Result.get_ok (Tw.of_string "bg-cyan-400/(--a)")));
+  Alcotest.(check string)
+    "the bracket form round-trips" "bg-cyan-400/[var(--a)]"
+    (Tw.pp (Result.get_ok (Tw.of_string "bg-cyan-400/[var(--a)]")))
+
 (* A bracket colour is read as CSS first and only then as a palette name, so a
    system colour or a light-dark() both work. The fallback used to admit only
    colour functions, which left [bg-[Field]] an unknown class. *)
@@ -351,6 +383,7 @@ let tests =
     ("Border color var", `Quick, test_border_color_var);
     ("Border side color opacity", `Quick, test_border_side_color_opacity);
     ("Bracket CSS colors", `Quick, test_bracket_css_colors);
+    ("Alpha from a var", `Quick, test_alpha_from_a_var);
     ("Invalid shades", `Quick, test_invalid_shade);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);

--- a/test/test_source_scan.ml
+++ b/test/test_source_scan.ml
@@ -66,6 +66,22 @@ let test_unbalanced_bracket_stops_at_newline () =
       Alcotest.(check bool) (cls ^ " still scanned") true (List.mem cls found))
     [ "flex"; "block"; "grid" ]
 
+(* A [(] belongs to the candidate where a utility can hold one: after the [-] of
+   [bg-(--x)] and after the [/] of an alpha shorthand. Elsewhere it ends the
+   token, so a call in the source is not read as a class. *)
+let test_scan_paren_shorthands () =
+  let source =
+    {|<div class="bg-(--brand) bg-cyan-400/(--alpha) p-4">x</div>
+const f = fn(arg)|}
+  in
+  let found = Tw_tools.Source_scan.candidates source in
+  List.iter
+    (fun cls ->
+      Alcotest.(check bool) (cls ^ " scanned") true (List.mem cls found))
+    [ "bg-(--brand)"; "bg-cyan-400/(--alpha)"; "p-4" ];
+  Alcotest.(check bool)
+    "a call is not a candidate" false (List.mem "fn(arg)" found)
+
 let tests =
   [
     test_case "unbalanced bracket stops at the newline" `Quick
@@ -77,6 +93,8 @@ let tests =
     test_case "Tw.str splits HTML whitespace" `Quick test_tw_str_html_space;
     test_case "bracket before whitespace is not a candidate" `Quick
       test_scan_bracket_before_whitespace;
+    test_case "paren shorthands stay in the candidate" `Quick
+      test_scan_paren_shorthands;
   ]
 
 let suite = ("source_scan", tests)


### PR DESCRIPTION
`bg-cyan-400/(--my-alpha-value)` was an unknown class, and `bg-cyan-400/[var(--x)]` silently dropped its alpha: an opacity that names a custom property has no percentage at build time, and `opacity_to_percent` answers 100 for one, so every caller treated it as fully opaque.

Stacked on #224. The gradient stops still differ from Tailwind on which colour they mix (a literal rather than `var(--color-*)`), which is a separate pre-existing divergence.