### PR TITLE
bin: put the utilities one @apply pulls in into a single rule

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -496,11 +496,25 @@ let nested_utilities ~theme names =
         Css.statements sheet |> List.filter from_utility
         |> List.partition (fun stmt -> Css.as_layer stmt <> None)
       in
+      (* One [@apply] pulls in several utilities, each with a rule of its own.
+         They all decorate the same [&], so they belong in one rule, the way
+         Tailwind emits them; left apart, each is a rule of the author's
+         selector holding one declaration. *)
+      let rec merge_same_selector = function
+        | a :: b :: rest -> (
+            match (Css.as_rule a, Css.as_rule b) with
+            | Some (sa, da, []), Some (sb, db, [])
+              when Cascade.Selector.to_string ~minify:true sa
+                   = Cascade.Selector.to_string ~minify:true sb ->
+                merge_same_selector (Css.rule ~selector:sa (da @ db) :: rest)
+            | _ -> a :: merge_same_selector (b :: rest))
+        | stmts -> stmts
+      in
       let render stmts =
         stmts
         |> Css.map (fun sel decls ->
             Css.rule ~selector:(nest_on_ampersand sel) decls)
-        |> Css.v |> Css.to_string ~minify:true
+        |> merge_same_selector |> Css.v |> Css.to_string ~minify:true
       in
       (render nestable, Css.to_string ~minify:true (Css.v hoisted))
 
@@ -564,7 +578,38 @@ let expand_apply ~theme ~defs ?(udefs = []) css =
           List.iter (fun _ -> Buffer.add_char buf '}') variants
         end
       in
-      List.iter emit names;
+      (* A utility with no declared variant and no body of its own decorates the
+         applying rule's [&] directly. A run of those renders in one call, so
+         their declarations land in a single rule the way Tailwind emits them,
+         rather than one rule of the author's selector per utility. *)
+      let plain name =
+        match split_declared_variants defs name with
+        | [], bare when not (List.mem_assoc bare udefs) -> Some bare
+        | _ -> None
+      in
+      let rec emit_all = function
+        | [] -> ()
+        | name :: tl as all -> (
+            match plain name with
+            | None ->
+                emit name;
+                emit_all tl
+            | Some _ ->
+                let run, rest =
+                  let rec span acc = function
+                    | n :: tl when plain n <> None -> span (n :: acc) tl
+                    | rest -> (List.rev acc, rest)
+                  in
+                  span [] all
+                in
+                let body, top =
+                  nested_utilities ~theme (List.filter_map plain run)
+                in
+                add_once hoisted seen top;
+                Buffer.add_string buf body;
+                emit_all rest)
+      in
+      emit_all names;
       go (if !stop < len && css.[!stop] = ';' then !stop + 1 else !stop)
     end
     else begin

--- a/test/cli/apply.t
+++ b/test/cli/apply.t
@@ -62,3 +62,17 @@ An unknown utility is skipped rather than aborting the sheet:
   > EOF
   $ tw --minify --input-css bad.css index.html | grep -c '\.x{color:red}'
   1
+
+One [@apply] names several utilities, and they all decorate the same rule, so
+their declarations belong together the way Tailwind emits them rather than in
+one rule of the author's selector per utility. A variant among them still gets
+a rule of its own, since it carries a selector the others do not:
+
+  $ cat > many.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > .title { @apply truncate leading-6 text-gray-700 dark:text-gray-400; }
+  > EOF
+  $ tw --minify --input-css many.css index.html | grep -cF '.title{text-overflow:ellipsis;white-space:nowrap;overflow:hidden;--tw-leading:calc(var(--spacing)*6);line-height:calc(var(--spacing)*6);color:var(--color-gray-700)}'
+  1
+  $ tw --minify --input-css many.css index.html | grep -cF '.title{color:var(--color-gray-400)}'
+  1

--- a/test/cli/utility.t
+++ b/test/cli/utility.t
@@ -23,7 +23,7 @@ and its own declarations kept:
 
   $ tw --minify --input-css app.css index.html | grep -c '\.line-t{border-color:red}'
   1
-  $ tw --minify --input-css app.css index.html | grep -cF '.line-t{--tw-border-style:dashed;border-style:dashed}'
+  $ tw --minify --input-css app.css index.html | grep -cF '.line-t{border-top-style:var(--tw-border-style);border-top-width:1px;--tw-border-style:dashed;border-style:dashed}'
   1
   $ tw --minify --input-css app.css index.html | grep -cF '.line-y{border-block-style:var(--tw-border-style);border-block-width:1px}'
   1


### PR DESCRIPTION
Each applied utility was rendered by its own `nested_utilities` call, so an author rule that applied four utilities came out as four rules of its selector holding one declaration each, where Tailwind emits one. On the tailwindcss.com sheet this takes the canonical diff from 15 modified rules to 6.