### PR TITLE
bin: resolve theme() with a v3 dotted path

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -337,6 +337,47 @@ let expand_spacing_fn css =
   go 0;
   Buffer.contents buf
 
+(* [theme()] also takes the dotted path of a v3 config ([theme(fontSize.sm)]),
+   which names the same token under its old namespace. *)
+let v3_theme_namespaces =
+  [
+    ("fontSize", "text");
+    ("lineHeight", "leading");
+    ("letterSpacing", "tracking");
+    ("fontWeight", "font-weight");
+    ("fontFamily", "font");
+    ("colors", "color");
+    ("borderRadius", "radius");
+    ("boxShadow", "shadow");
+    ("dropShadow", "drop-shadow");
+    ("screens", "breakpoint");
+    ("spacing", "spacing");
+    ("transitionTimingFunction", "ease");
+    ("animation", "animate");
+    ("blur", "blur");
+  ]
+
+let v3_theme_token theme path =
+  let unquote s =
+    let n = String.length s in
+    if n >= 2 && (s.[0] = '"' || s.[0] = '\'') && s.[n - 1] = s.[0] then
+      String.sub s 1 (n - 2)
+    else s
+  in
+  match String.split_on_char '.' (unquote path) with
+  | [] | [ _ ] -> None
+  | ns :: rest -> (
+      match List.assoc_opt ns v3_theme_namespaces with
+      | None -> None
+      | Some prefix -> (
+          let key = String.concat "-" rest in
+          match Tw.Scheme.token theme (prefix ^ "-" ^ key) with
+          | Some _ as v -> v
+          | None -> (
+              match (ns, float_of_string_opt key) with
+              | ("spacing" | "lineHeight"), Some n -> Tw.Theme.spacing_times n
+              | _ -> None)))
+
 (* Tailwind's [theme(--token)] inlines the token's value. It is not CSS, and it
    appears in places a [var()] could not stand anyway, such as a media query
    condition. An unknown token is left alone rather than guessed at. *)
@@ -353,7 +394,11 @@ let resolve_theme_fn ~theme css =
           String.sub name 2 (String.length name - 2)
         else name
       in
-      match Tw.Scheme.token theme bare with
+      match
+        match Tw.Scheme.token theme bare with
+        | Some _ as v -> v
+        | None -> v3_theme_token theme name
+      with
       | Some value ->
           Buffer.add_string buf value;
           go next

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -22,6 +22,23 @@ let spacing_var = Var.theme Css.Length "spacing" ~runtime:true ~order:(3, 0)
 (* The base spacing value: 0.25rem *)
 let spacing_base : Css.length = Rem 0.25
 
+(* Publish the spacing step through the theme-token registry, the way rule.ml
+   publishes the breakpoints, so [theme()] in a project's CSS resolves against
+   the same value the utilities use. *)
+let () =
+  Scheme.register_default_token "spacing"
+    (Css.Pp.to_string Css.pp_length spacing_base)
+
+(* The spacing step times [n], rendered. Tailwind's v3 [spacing] and
+   [lineHeight] scales are both that product, and v4 keeps no token per step, so
+   a [theme(spacing.4)] has to be computed rather than looked up. *)
+let spacing_times n =
+  match spacing_base with
+  | Css.Rem v -> Some (Css.Pp.to_string Css.pp_length (Css.Rem (v *. n)))
+  | Css.Px v -> Some (Css.Pp.to_string Css.pp_length (Css.Px (v *. n)))
+  | Css.Em v -> Some (Css.Pp.to_string Css.pp_length (Css.Em (v *. n)))
+  | _ -> None
+
 (* Create a spacing variable for explicit spacing values (e.g., --spacing-4) *)
 let spacing_n_var n = Var.theme Css.Length ("spacing-" ^ Pp.int n) ~order:(3, n)
 

--- a/lib/theme.mli
+++ b/lib/theme.mli
@@ -6,6 +6,12 @@ val spacing_var : Css.length Var.theme
 (** [spacing_var] is the shared [--spacing] variable used across padding,
     margin, positioning, etc. *)
 
+val spacing_times : float -> string option
+(** [spacing_times n] is the spacing step times [n], rendered, or
+    {!constructor-None} when the step is in a unit this cannot scale. Tailwind's
+    v3 [spacing] and [lineHeight] scales are both that product, and v4 keeps no
+    token per step, so [theme(spacing.4)] is computed rather than looked up. *)
+
 val spacing_base : Css.length
 (** [spacing_base] is the base spacing value ([0.25rem]). *)
 

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1044,6 +1044,16 @@ module Typography_early = struct
       ("9xl", text_9xl_var, 8.0);
     ]
 
+  (* Publish the text scale through the theme-token registry, the way rule.ml
+     publishes the breakpoints, so [theme()] in a project's CSS resolves against
+     the same values the utilities use. *)
+  let () =
+    List.iter
+      (fun (name, _var, rem) ->
+        Scheme.register_default_token ("text-" ^ name)
+          (Css.Pp.to_string Css.pp_length (Css.Rem rem)))
+      text_size_data
+
   (** Convert a line-height modifier to (extra_declarations, line_height_value).
   *)
   let lh_modifier_to_css = function

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -82,3 +82,26 @@ leave the reference dangling.
   [1]
   $ tw --minify --input-css inline.css inline.html | grep -cF -- '--font-a:var(--font-a)'
   1
+
+[theme()] also takes the dotted path of a v3 config, which names the same
+token under its old namespace. The [spacing] and [lineHeight] scales are the
+spacing step times the key, which v4 keeps no token for, so those are computed:
+
+  $ cat > v3.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > .a { font-size: theme("fontSize.sm"); line-height: theme("lineHeight.6") }
+  > .b { margin: theme(spacing.4); width: theme("screens.sm") }
+  > EOF
+  $ tw --minify --input-css v3.css index.html | grep -cF '.a{font-size:.875rem;line-height:1.5rem}'
+  1
+  $ tw --minify --input-css v3.css index.html | grep -cF '.b{margin:1rem;width:40rem}'
+  1
+
+An unknown namespace is left alone, the same as an unknown token:
+
+  $ cat > v3bad.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > .u { color: theme("nope.not-a-namespace") }
+  > EOF
+  $ tw --minify --input-css v3bad.css index.html | grep -c 'theme("nope.not-a-namespace")'
+  1


### PR DESCRIPTION
`theme("fontSize.sm")` was left in the declaration, which then dropped as invalid CSS. It resolves through a namespace map onto the v4 token, and the `spacing` / `lineHeight` scales are computed from the spacing step since v4 keeps no token per step.