### PR TITLE
bin, theme: fix six entrypoint gaps (variants, layers, keyframes, theme(static))

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Honour `theme(static)` on the package import: the whole theme comes out,
+  not only the variables a utility used (#230)
+- Emit a `@keyframes` declared inside a project's `@theme`; the animation
+  it defines was dropped (#230)
 - Emit one `@property` per custom property, beside the utilities rather
   than inside each rule that applied them: a sheet using `@apply` carried
   the same `@property` once per applying rule (#228)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 ## Unreleased
 
+- Emit one `@property` per custom property, beside the utilities rather
+  than inside each rule that applied them: a sheet using `@apply` carried
+  the same `@property` once per applying rule (#228)
+- Expand every built-in `@variant` in author CSS, not just `dark`:
+  `@variant sm { ... }` was dropped along with the declarations it
+  guarded (#229)
+- `@apply` puts the utilities it pulls in into one rule instead of one
+  rule per utility (#226)
+- Read an alpha from a custom property in every colour family:
+  `bg-cyan-400/(--my-alpha)` and `bg-cyan-400/[var(--my-alpha)]` kept the
+  colour but dropped the alpha (#225)
+- Resolve `theme()` with a v3 dotted path, such as `theme("fontSize.sm")`
+  (#227)
+- Read a font family the project named in its own `@theme`, including
+  `@theme inline` semantics: `font-source` was an unknown class (#223)
+- Stack an arbitrary-selector variant with the variants beside it:
+  `[svg]:first:size-4` lost its `:first-child`, and `[svg]:sm:size-4`
+  lost the arbitrary selector (#224)
+- Take a colour as a mask gradient stop (`mask-r-from-black`) and any
+  image in a mask bracket (`mask-[radial-gradient(...)]`) (#222)
 - Reject shades the palette does not define: `bg ~shade:250 gray` raises
   `Invalid_argument` when the value is constructed, and the CLI reports
   `bg-gray-250` as an unknown class instead of failing with an internal

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -68,6 +68,72 @@ let read_file path =
    opening brace; the declarations themselves are left for the real parser.
    [@theme inline] becomes [:root inline] so the modifier survives as part of
    the selector, which is all [theme_overrides_of_css] reads it for. *)
+(* A project can declare [@keyframes] inside its [@theme] block, beside the
+   [--animate-*] token that names it. The theme block is not CSS — it becomes a
+   [:root] rule — and a nested [@keyframes] there is invalid, so it went out
+   with the rewrite. Lift them to the top level, where Tailwind emits them. *)
+let hoist_theme_keyframes css =
+  let len = String.length css in
+  let buf = Buffer.create len in
+  let lifted = Buffer.create 0 in
+  let block_end from =
+    let rec scan j depth =
+      if j >= len then j
+      else
+        match css.[j] with
+        | '{' -> scan (j + 1) (depth + 1)
+        | '}' -> if depth = 1 then j + 1 else scan (j + 1) (depth - 1)
+        | _ -> scan (j + 1) depth
+    in
+    scan from 0
+  in
+  let rec go i inside_theme =
+    if i >= len then ()
+    else if inside_theme && i + 10 <= len && String.sub css i 10 = "@keyframes"
+    then
+      begin match String.index_from_opt css i '{' with
+      | None ->
+          Buffer.add_char buf css.[i];
+          go (i + 1) inside_theme
+      | Some brace ->
+          let stop = block_end brace in
+          Buffer.add_string lifted (String.sub css i (stop - i));
+          go stop inside_theme
+      end
+    else if i + 6 <= len && String.sub css i 6 = "@theme" then
+      begin match String.index_from_opt css i '{' with
+      | None ->
+          Buffer.add_char buf css.[i];
+          go (i + 1) inside_theme
+      | Some brace ->
+          let stop = block_end brace in
+          Buffer.add_string buf (String.sub css i (brace + 1 - i));
+          go_theme (brace + 1) stop
+      end
+    else begin
+      Buffer.add_char buf css.[i];
+      go (i + 1) inside_theme
+    end
+  and go_theme i stop =
+    if i >= stop then go i false
+    else if i + 10 <= stop && String.sub css i 10 = "@keyframes" then (
+      match String.index_from_opt css i '{' with
+      | None ->
+          Buffer.add_char buf css.[i];
+          go_theme (i + 1) stop
+      | Some brace ->
+          let k_end = block_end brace in
+          Buffer.add_string lifted (String.sub css i (k_end - i));
+          go_theme k_end stop)
+    else begin
+      Buffer.add_char buf css.[i];
+      go_theme (i + 1) stop
+    end
+  in
+  go 0 false;
+  Buffer.add_string buf (Buffer.contents lifted);
+  Buffer.contents buf
+
 let theme_blocks_as_root css =
   let len = String.length css in
   let buf = Buffer.create len in
@@ -916,7 +982,10 @@ let splice_into_entrypoint ~theme ~path generated =
   match read_file path with
   | exception Sys_error _ -> generated
   | raw -> (
-      let css = apply_variants ~theme (strip_tailwind_import_options raw) in
+      let css =
+        apply_variants ~theme
+          (hoist_theme_keyframes (strip_tailwind_import_options raw))
+      in
       match Css.of_string css with
       | Error _ -> generated
       | Ok p ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -165,6 +165,16 @@ let theme_blocks_as_root css =
   done;
   Buffer.contents buf
 
+(* [@import "tailwindcss" theme(static)] asks for the whole theme, not only the
+   variables a utility used. The option is stripped before parsing, so it is
+   read from the raw text. *)
+let imports_static_theme css =
+  let len = String.length css in
+  let rec go i =
+    i + 13 <= len && (String.sub css i 13 = "theme(static)" || go (i + 1))
+  in
+  go 0
+
 (* Extract @theme token overrides from a project CSS entrypoint, so tw renders
    with the same tokens Tailwind reads from it: the [(bare-name, value)] pairs,
    and the names among them that came from an [@theme inline] block. The
@@ -1420,7 +1430,12 @@ let tw_main single_class base_flag ~css_mode ~minify ~optimize ~quiet ~backend
     | None -> Tw.Scheme.default
     | Some css ->
         let overrides, inline = theme_overrides_of_css css in
-        Tw.Scheme.with_overrides ~inline Tw.Scheme.default overrides
+        let base =
+          if imports_static_theme css then
+            { Tw.Scheme.default with static_theme = true }
+          else Tw.Scheme.default
+        in
+        Tw.Scheme.with_overrides ~inline base overrides
   in
   let opts : gen_opts =
     {

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -680,12 +680,67 @@ let expand_apply ~theme ~defs ?(udefs = []) css =
   Buffer.add_buffer buf hoisted;
   Buffer.contents buf
 
+(* The names an [@variant NAME {] header uses inside a body. *)
+let variant_names_in css =
+  let len = String.length css in
+  let rec go i acc =
+    if i >= len then List.rev acc
+    else
+      match at_rule_header css i "@variant" with
+      | Some (name, brace) when name <> "" -> go (brace + 1) (name :: acc)
+      | _ -> go (i + 1) acc
+  in
+  go 0 []
+
+(* Replace the first occurrence of [needle] in [hay]. *)
+let replace_first ~needle ~by hay =
+  let n = String.length needle and h = String.length hay in
+  let rec at i =
+    if i + n > h then None
+    else if String.sub hay i n = needle then Some i
+    else at (i + 1)
+  in
+  match at 0 with
+  | None -> None
+  | Some i ->
+      Some
+        (String.concat ""
+           [ String.sub hay 0 i; by; String.sub hay (i + n) (h - i - n) ])
+
+(* The [@variant] body a built-in variant expands to. [Tw.of_string] knows the
+   variants, but only as part of a whole utility, so derive the wrapper from
+   what it emits around a probe with a single declaration and put [@slot] where
+   that declaration was. This is what lets a project's [@utility] carry a
+   built-in prefix, which the [@variant] machinery otherwise only has templates
+   for when the project declared it. *)
+let builtin_variant_template ~theme name =
+  let body, _ = nested_utilities ~theme [ name ^ ":float-none" ] in
+  if body = "" then None
+  else
+    (* A media variant wraps the probe in a bare [&], which would add a nesting
+       level the utility's own body cannot survive: its [@variant before] and
+       the [@supports] an opacity colour emits end up three deep and the sheet
+       no longer parses. Drop that level by putting the slot in its place. *)
+    match replace_first ~needle:"&{float:none}" ~by:"@slot;" body with
+    | Some t -> Some t
+    | None -> replace_first ~needle:"float:none" ~by:"@slot;" body
+
 let apply_variants ?(extra_defs = []) ?(udefs = []) ~theme css =
   let css, _ = take_custom_utilities css in
   let css, defs = take_custom_variants css in
   let defs = defs @ extra_defs in
-  (* A project declaration wins over the built-in of the same name. *)
-  let defs = defs @ builtin_variants in
+  (* A project declaration wins over the built-in of the same name. Any other
+     built-in the CSS names has its template derived from tw's own output for a
+     probe utility, so [@variant sm] is not silently dropped along with the
+     declarations it guards. *)
+  let derived =
+    variant_names_in css
+    |> List.sort_uniq String.compare
+    |> List.filter (fun n -> not (List.mem_assoc n defs))
+    |> List.filter_map (fun n ->
+        Option.map (fun t -> (n, t)) (builtin_variant_template ~theme n))
+  in
+  let defs = defs @ builtin_variants @ derived in
   (* A declared utility's body may [@apply] another one, so keep expanding until
      nothing is left (bounded, in case two reference each other). *)
   let rec expand depth css =
@@ -1000,18 +1055,6 @@ let entry_defs take = function
 let entry_variant_defs = entry_defs take_custom_variants
 let entry_utility_defs = entry_defs take_custom_utilities
 
-(* The names an [@variant NAME {] header uses inside a body. *)
-let variant_names_in css =
-  let len = String.length css in
-  let rec go i acc =
-    if i >= len then List.rev acc
-    else
-      match at_rule_header css i "@variant" with
-      | Some (name, brace) when name <> "" -> go (brace + 1) (name :: acc)
-      | _ -> go (i + 1) acc
-  in
-  go 0 []
-
 (* The escaped class with its declarations under the [@variant]s that wrap
    it. *)
 let wrapped_block cls variants body =
@@ -1022,39 +1065,6 @@ let wrapped_block cls variants body =
       variants body
   in
   String.concat "" [ class_sel; "{"; wrapped; "}" ]
-
-(* Replace the first occurrence of [needle] in [hay]. *)
-let replace_first ~needle ~by hay =
-  let n = String.length needle and h = String.length hay in
-  let rec at i =
-    if i + n > h then None
-    else if String.sub hay i n = needle then Some i
-    else at (i + 1)
-  in
-  match at 0 with
-  | None -> None
-  | Some i ->
-      Some
-        (String.concat ""
-           [ String.sub hay 0 i; by; String.sub hay (i + n) (h - i - n) ])
-
-(* The [@variant] body a built-in variant expands to. [Tw.of_string] knows the
-   variants, but only as part of a whole utility, so derive the wrapper from
-   what it emits around a probe with a single declaration and put [@slot] where
-   that declaration was. This is what lets a project's [@utility] carry a
-   built-in prefix, which the [@variant] machinery otherwise only has templates
-   for when the project declared it. *)
-let builtin_variant_template ~theme name =
-  let body, _ = nested_utilities ~theme [ name ^ ":float-none" ] in
-  if body = "" then None
-  else
-    (* A media variant wraps the probe in a bare [&], which would add a nesting
-       level the utility's own body cannot survive: its [@variant before] and
-       the [@supports] an opacity colour emits end up three deep and the sheet
-       no longer parses. Drop that level by putting the slot in its place. *)
-    match replace_first ~needle:"&{float:none}" ~by:"@slot;" body with
-    | Some t -> Some t
-    | None -> replace_first ~needle:"float:none" ~by:"@slot;" body
 
 (* A candidate the project's own declarations govern: it carries a declared
    variant, or it is a declared utility. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -791,6 +791,62 @@ let preload_imports ~transform ~base_url stylesheet =
    redundant. Keep the first, and put them all at the end of the document, where
    Tailwind emits them: spliced at the [@import] instead, they sit ahead of the
    author's own rules and shift every one of them. *)
+(* A named layer appears once in Tailwind's output. The generated sheet and the
+   [@layer properties] blocks each applied utility hoists arrive separately, so
+   fold every repeat of a name into the first, dropping content the first
+   already has. *)
+let merge_named_layers stmts =
+  let name_of stmt =
+    match Css.as_layer stmt with Some (Some name, _) -> Some name | _ -> None
+  in
+  let inner stmt =
+    match Css.as_layer stmt with Some (_, inner) -> inner | None -> []
+  in
+  let repeated =
+    let counts = Hashtbl.create 8 in
+    List.iter
+      (fun stmt ->
+        match name_of stmt with
+        | Some n ->
+            Hashtbl.replace counts n
+              (1 + Option.value ~default:0 (Hashtbl.find_opt counts n))
+        | None -> ())
+      stmts;
+    Hashtbl.fold (fun n c acc -> if c > 1 then n :: acc else acc) counts []
+  in
+  if repeated = [] then stmts
+  else
+    let merged = Hashtbl.create 8 in
+    List.iter
+      (fun n ->
+        let seen = Hashtbl.create 64 in
+        let body =
+          List.concat_map
+            (fun stmt -> if name_of stmt = Some n then inner stmt else [])
+            stmts
+          |> List.filter (fun st ->
+              let key = Css.to_string ~minify:true (Css.v [ st ]) in
+              if Hashtbl.mem seen key then false
+              else begin
+                Hashtbl.add seen key ();
+                true
+              end)
+        in
+        Hashtbl.add merged n body)
+      repeated;
+    let emitted = Hashtbl.create 8 in
+    List.filter_map
+      (fun stmt ->
+        match name_of stmt with
+        | Some n when List.mem n repeated ->
+            if Hashtbl.mem emitted n then None
+            else begin
+              Hashtbl.add emitted n ();
+              Some (Css.layer ~name:n (Hashtbl.find merged n))
+            end
+        | _ -> Some stmt)
+      stmts
+
 let collect_properties_at_end stmts =
   let seen = Hashtbl.create 64 in
   let keep, props =
@@ -842,7 +898,7 @@ let splice_into_entrypoint ~theme ~path generated =
                 ->
                   Css.statements generated
               | s -> [ s ])
-          |> collect_properties_at_end |> Css.v)
+          |> merge_named_layers |> collect_properties_at_end |> Css.v)
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -847,13 +847,58 @@ let merge_named_layers stmts =
         | _ -> Some stmt)
       stmts
 
+(* [@layer components;] on its own declares the layer's slot; the block that
+   fills it can come much later, from an imported file. Tailwind emits the block
+   in the slot, so move it there. The declared order already makes this
+   cascade-neutral; it is the document shape that differs. *)
+let hoist_layer_blocks stmts =
+  let declared_name stmt =
+    match Css.as_layer stmt with
+    | Some _ -> None
+    | None -> (
+        let s = Css.to_string ~minify:true (Css.v [ stmt ]) in
+        match String.index_opt s ';' with
+        | Some semi
+          when String.length s > 7
+               && String.sub s 0 7 = "@layer "
+               && semi = String.length s - 1 ->
+            let name = String.sub s 7 (semi - 7) in
+            if String.contains name ',' || name = "" then None else Some name
+        | _ -> None)
+  in
+  let block_name stmt =
+    match Css.as_layer stmt with Some (Some n, _) -> Some n | _ -> None
+  in
+  let slots =
+    List.filter_map declared_name stmts |> List.sort_uniq String.compare
+  in
+  let movable =
+    List.filter
+      (fun n -> List.exists (fun st -> block_name st = Some n) stmts)
+      slots
+  in
+  if movable = [] then stmts
+  else
+    let block_for n = List.find_opt (fun st -> block_name st = Some n) stmts in
+    List.filter_map
+      (fun stmt ->
+        match declared_name stmt with
+        | Some n when List.mem n movable -> block_for n
+        | _ -> (
+            match block_name stmt with
+            | Some n when List.mem n movable -> None
+            | _ -> Some stmt))
+      stmts
+
 let collect_properties_at_end stmts =
   let seen = Hashtbl.create 64 in
   let keep, props =
     List.partition_map
       (fun stmt ->
         match Css.as_property stmt with
-        | None -> Left (Some stmt)
+        | None ->
+            if Css.as_keyframes stmt <> None then Right stmt
+            else Left (Some stmt)
         | Some (Css.Property_info { name; _ }) ->
             if Hashtbl.mem seen name then Left None
             else begin
@@ -862,7 +907,10 @@ let collect_properties_at_end stmts =
             end)
       stmts
   in
-  List.filter_map Fun.id keep @ props
+  let at_end, keyframes =
+    List.partition (fun st -> Css.as_keyframes st = None) props
+  in
+  List.filter_map Fun.id keep @ at_end @ keyframes
 
 let splice_into_entrypoint ~theme ~path generated =
   match read_file path with
@@ -898,7 +946,8 @@ let splice_into_entrypoint ~theme ~path generated =
                 ->
                   Css.statements generated
               | s -> [ s ])
-          |> merge_named_layers |> collect_properties_at_end |> Css.v)
+          |> merge_named_layers |> hoist_layer_blocks
+          |> collect_properties_at_end |> Css.v)
 
 let eval_flag flag ~default =
   match flag with `Enable -> true | `Disable -> false | `Default -> default

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -719,6 +719,25 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
     @ referenced_theme_decls ~theme ~exclude:(names_set_of extracted)
         selector_props
   in
+  (* [theme(static)] on the package import emits every theme variable, not only
+     the ones a utility used. The palette is by far the biggest part of it. *)
+  let extracted =
+    if not theme.Scheme.static_theme then extracted
+    else
+      let have = names_set_of extracted in
+      let registered =
+        Scheme.all_default_tokens ()
+        |> List.map (fun (name, css) ->
+            Css.custom_property ~layer:"theme" ("--" ^ name) css)
+      in
+      extracted
+      @ List.filter
+          (fun d ->
+            match Css.custom_declaration_name d with
+            | Some n -> not (Strings.mem n have)
+            | None -> true)
+          (Color.Handler.all_palette_declarations ~theme () @ registered)
+  in
   let pre_defaults, post_defaults = split_defaults default_decls in
 
   (* Filter defaults to remove duplicates of extracted vars *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1793,6 +1793,49 @@ module Handler = struct
   let color_binding ?theme c shade =
     Var.binding (color_var c shade) (get_color_value ?theme c shade)
 
+  (* Every colour the palette defines, in theme order. [\@import "tailwindcss"
+     theme(static)] emits the whole theme rather than only the tokens a utility
+     used, so the sheet needs them all. *)
+  let palette_names =
+    [
+      "red";
+      "orange";
+      "amber";
+      "yellow";
+      "lime";
+      "green";
+      "emerald";
+      "teal";
+      "cyan";
+      "sky";
+      "blue";
+      "indigo";
+      "violet";
+      "purple";
+      "fuchsia";
+      "pink";
+      "rose";
+      "slate";
+      "gray";
+      "zinc";
+      "neutral";
+      "stone";
+      "mauve";
+      "olive";
+      "mist";
+      "taupe";
+      "black";
+      "white";
+    ]
+
+  let all_palette_declarations ?theme () =
+    List.concat_map
+      (fun name ->
+        let c = of_string_exn name in
+        let shades = if is_base_color c then [ 500 ] else palette_shades in
+        List.map (fun sh -> fst (color_binding ?theme c sh)) shades)
+      palette_names
+
   (* The theme-layer declaration for a colour token named like "color-red-500",
      or None when the name is not a catalogued colour token. [color_var]
      registers the token's canonical order and [get_color_value] supplies the

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -393,6 +393,12 @@ val suborder_with_shade : string -> int
 module Handler : sig
   include Utility.Handler
 
+  val all_palette_declarations : ?theme:Scheme.t -> unit -> Css.declaration list
+  (** [all_palette_declarations ?theme ()] is the [\@layer theme] declaration
+      for every colour the palette defines, in theme order. [theme(static)] on
+      the package import emits the whole theme, not only the tokens a utility
+      used. *)
+
   val color_binding :
     ?theme:Scheme.t -> color -> int -> Css.declaration * Css.color Css.var
   (** [color_binding ?theme color shade] is the [\@layer theme] declaration for

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -42,6 +42,7 @@ type t = {
           instead of rem-based values. *)
   token_overrides : (string * string) list;
   inline_tokens : string list;
+  static_theme : bool;
       (** Per-render theme token overrides (from a [@theme] block). Key is the
           variable name without the leading [--] (e.g. "text-shadow-2xs"), value
           is the CSS string. Threaded replacement for the global
@@ -59,6 +60,9 @@ let default_tokens : (string, string) Hashtbl.t = Hashtbl.create 64
 let register_default_token name css = Hashtbl.replace default_tokens name css
 let token_default name = Hashtbl.find_opt default_tokens name
 
+let all_default_tokens () =
+  Hashtbl.fold (fun k v acc -> (k, v) :: acc) default_tokens []
+
 (** Default scheme - uses oklch colors and calc-based spacing (matches Tailwind
     v4 default) *)
 let default : t =
@@ -72,6 +76,7 @@ let default : t =
     breakpoints = [];
     token_overrides = [];
     inline_tokens = [];
+    static_theme = false;
   }
 
 let pp t =

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -48,6 +48,9 @@ type t = {
       (** Names of the tokens a project declared in an [\@theme inline] block.
           Such a token has no declaration of its own: a utility reading it
           inlines the value instead of referencing [var(--name)]. *)
+  static_theme : bool;
+      (** Whether the package was imported with [theme(static)], which emits
+          every theme variable rather than only the ones a utility used. *)
 }
 (** Theme scheme configuration *)
 
@@ -62,6 +65,10 @@ val register_default_token : string -> string -> unit
 (** [register_default_token name css] registers the v4.3.1 baseline default CSS
     for theme token [name] (without [--]) in the process-global registry. Called
     once at module-init by the utility that owns the token. *)
+
+val all_default_tokens : unit -> (string * string) list
+(** [all_default_tokens ()] is every token a family has published through
+    {!register_default_token}. [theme(static)] emits them all. *)
 
 val token_default : string -> string option
 (** [token_default name] returns the registered baseline default for [name]. *)

--- a/test/cli/apply.t
+++ b/test/cli/apply.t
@@ -98,3 +98,12 @@ at the [@import] it was spliced into:
   $ tw --minify --input-css props.css index.html | grep -oE '\.two\{[^}]*\}|@property' | head -2
   .two{border-bottom-style:var(--tw-border-style);border-bottom-width:1px;--tw-border-style:dotted;border-style:dotted}
   @property
+
+The [@layer properties] block each applied utility brings holds initial values
+on the universal selector. Tailwind emits one; hoisting them per [@apply] used
+to leave a block per distinct set:
+
+  $ tw --minify --input-css props.css index.html | grep -oF '@layer properties' | grep -c .
+  1
+  $ tw --minify --input-css props.css index.html | grep -oF '@layer utilities' | grep -c .
+  1

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -145,3 +145,24 @@ token that names it. The theme block becomes a [:root] rule, where a nested
   $ tw --minify --input-css kf.css index.html | grep -c ':root{[^}]*@keyframes'
   0
   [1]
+
+[@import "tailwindcss" theme(static)] asks for the whole theme, not only the
+variables a utility used, so the palette comes out even for colours nothing
+references:
+
+  $ cat > static.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > EOF
+  $ tw --minify --input-css static.css index.html | grep -c -- '--color-fuchsia-300:'
+  1
+  $ tw --minify --input-css static.css index.html | grep -c -- '--breakpoint-sm:'
+  1
+
+Without it only what the sheet uses is emitted:
+
+  $ cat > dynamic.css <<EOF
+  > @import "tailwindcss";
+  > EOF
+  $ tw --minify --input-css dynamic.css index.html | grep -c -- '--color-fuchsia-300:'
+  0
+  [1]

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -105,3 +105,23 @@ An unknown namespace is left alone, the same as an unknown token:
   > EOF
   $ tw --minify --input-css v3bad.css index.html | grep -c 'theme("nope.not-a-namespace")'
   1
+
+An imported file's [@layer components { ... }] fills the slot the generated
+sheet declared, and the [@keyframes] the utilities bring go at the end of the
+document, both the way Tailwind emits them:
+
+  $ cat > comp.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @import "./card.css";
+  > .after { color: red }
+  > EOF
+  $ cat > card.css <<EOF
+  > @layer components { .card { padding: 1rem } }
+  > EOF
+  $ cat > comp.html <<EOF
+  > <div class="animate-spin after"></div>
+  > EOF
+  $ tw --minify --input-css comp.css comp.html | grep -oE '@layer components\{\.card\{padding:1rem\}\}|\.after\{color:red\}|@keyframes spin' | head -3
+  @layer components{.card{padding:1rem}}
+  .after{color:red}
+  @keyframes spin

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -125,3 +125,23 @@ document, both the way Tailwind emits them:
   @layer components{.card{padding:1rem}}
   .after{color:red}
   @keyframes spin
+
+A project can declare [@keyframes] inside its [@theme], beside the [--animate-*]
+token that names it. The theme block becomes a [:root] rule, where a nested
+[@keyframes] would be invalid, so it is lifted to the top level:
+
+  $ cat > kf.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @theme {
+  >   --animate-flash: flash 2s forwards;
+  >   @keyframes flash {
+  >     0% { opacity: 1 }
+  >     100% { opacity: 0 }
+  >   }
+  > }
+  > EOF
+  $ tw --minify --input-css kf.css index.html | grep -cF '@keyframes flash{0%{opacity:1}to{opacity:0}}'
+  1
+  $ tw --minify --input-css kf.css index.html | grep -c ':root{[^}]*@keyframes'
+  0
+  [1]

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -105,3 +105,28 @@ that class is the one the declared variant has to decorate.
   1
   $ tw --minify --input-css darkclass.css dv.html | grep -c 'divide-gray-800:where'
   1
+
+Only [dark] had a built-in template, so every other built-in [@variant] used in
+author CSS was dropped along with the declarations it guarded. The template is
+derived from tw's own output for the named variant, so a responsive one wraps
+its body in the breakpoint's media query:
+
+  $ cat > sm.css <<EOF
+  > @import "tailwindcss";
+  > .box { color: red; @variant sm { font-size: 0.875rem } }
+  > EOF
+  $ tw --minify --input-css sm.css index.html | grep -cF '@media(min-width:40rem){.box{font-size:.875rem}}'
+  1
+  $ tw --minify --input-css sm.css index.html | grep -cF '.box{color:red}'
+  1
+
+A variant that names nothing tw knows leaves the block alone rather than
+guessing:
+
+  $ cat > nope.css <<EOF
+  > @import "tailwindcss";
+  > .box { @variant not-a-variant { color: red } }
+  > EOF
+  $ tw --minify --input-css nope.css index.html | grep -c 'color:red'
+  0
+  [1]

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -340,6 +340,7 @@ let scheme_from_expected_css expected : Tw.Scheme.t =
     breakpoints;
     token_overrides = [];
     inline_tokens = [];
+    static_theme = false;
   }
 
 let setup_scheme_for_test expected =


### PR DESCRIPTION
Six independent gaps in how the entrypoint's author CSS is expanded and assembled, all found by comparing top-level statement shapes between the raw sheets and reading the canonical diff in full rather than its summary line.

`builtin_variants` had one entry, so an author `@variant sm { ... }` matched nothing and was dropped along with the declarations it guarded — the tailwindcss.com sheet was missing `@media (min-width:40rem){.DocSearch-Input{font-size:.875rem}}` entirely. Templates now derive from tw's own output for the named variant.

`theme(static)` on the package import was ignored: only the variables a utility used came out, leaving 145 theme tokens missing, 122 of them palette colours. A `@keyframes` declared inside a project's `@theme` was dropped too, since the theme block becomes a `:root` rule where nesting it is invalid.

Repeated named layers fold into one, an imported file's `@layer components` block fills the slot the generated sheet declared, and the `@keyframes` go at the end of the document. Stacked on #228.