### PR TITLE
theme: emit the remaining scales under theme(static)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 - Emit the shadow, inset-shadow, text-shadow and leading scales under
   `theme(static)`, and derive `--default-font-feature-settings` from the
   `--font-sans--font-feature-settings` a project declares (#231)
-- Drop the declaration of a token declared in an `@theme inline` block,
-  unless it refers to itself or another declaration still reads it (#231)
+- Drop the declaration of a token declared in an `@theme inline` block
+  unless something still reads it; the utility carries the value, with the
+  font-feature settings declared beside it, and a project override wins
+  over the built-in default (#231)
 
 - Honour `theme(static)` on the package import: the whole theme comes out,
   not only the variables a utility used (#230)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Write the keyword for `object-*`, `origin-*` and `perspective-origin-*`
+  when no `@theme` defines the token; they referenced a variable nothing
+  declared (#231)
+
 - Accept any CSS length in `mask-position-[...]`; only `px` and `%` were
   read, so `mask-position-[8rem_2rem]` fell back to `center` (#231)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Emit the shadow, inset-shadow, text-shadow and leading scales under
+  `theme(static)`, and derive `--default-font-feature-settings` from the
+  `--font-sans--font-feature-settings` a project declares (#231)
+- Drop the declaration of a token declared in an `@theme inline` block,
+  unless it refers to itself or another declaration still reads it (#231)
+
 - Honour `theme(static)` on the package import: the whole theme comes out,
   not only the variables a utility used (#230)
 - Emit a `@keyframes` declared inside a project's `@theme`; the animation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Write the keyword for `list-none`, `list-image-none` and `columns-auto`
+  when no `@theme` defines the token; they referenced a variable nothing
+  declared (#231)
+- Accept the `(--x)` shorthand in `list-image-(--x)` (#231)
+
 - Read `\_` in an arbitrary value as a literal underscore, not an escaped
   space: `content-['Hello\_World']` gave `"Hello World"` (#231)
 - Accept any CSS length in `bg-size-[...]`; only `px` and `%` were read,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Accept any CSS length in `mask-position-[...]`; only `px` and `%` were
+  read, so `mask-position-[8rem_2rem]` fell back to `center` (#231)
+
 - Write the keyword for `list-none`, `list-image-none` and `columns-auto`
   when no `@theme` defines the token; they referenced a variable nothing
   declared (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Read `\_` in an arbitrary value as a literal underscore, not an escaped
+  space: `content-['Hello\_World']` gave `"Hello World"` (#231)
+- Accept any CSS length in `bg-size-[...]`; only `px` and `%` were read,
+  so `bg-size-[8rem]` fell back to `auto` (#231)
+- Emit a plain `0px` for the zero spacing step, as Tailwind does (#231)
+
 - Emit the shadow, inset-shadow, text-shadow and leading scales under
   `theme(static)`, and derive `--default-font-feature-settings` from the
   `--font-sans--font-feature-settings` a project declares (#231)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -966,6 +966,47 @@ let hoist_layer_blocks stmts =
             | _ -> Some stmt))
       stmts
 
+(* A token the project declared in an [@theme inline] block has no declaration
+   of its own — the value goes into the utility instead. Two exceptions: one
+   that refers to itself, where inlining would leave the reference dangling, and
+   one some other rule still reads. That has to be judged over the whole
+   document: the typography plugin's [.prose code] reads [--font-mono] from the
+   components layer. *)
+let drop_unread_inline_tokens ~theme stmts =
+  if Tw.Scheme.(theme.inline_tokens) = [] then stmts
+  else
+    let rendered = Css.to_string ~minify:true (Css.v stmts) in
+    let reads name =
+      let needle = "var(" ^ name ^ ")" in
+      let nl = String.length needle and hl = String.length rendered in
+      let rec at i =
+        i + nl <= hl && (String.sub rendered i nl = needle || at (i + 1))
+      in
+      at 0
+    in
+    let keep decl =
+      match Css.custom_declaration_name decl with
+      | Some n when String.length n > 2 ->
+          let bare = String.sub n 2 (String.length n - 2) in
+          (not (Tw.Scheme.is_inline_token theme bare))
+          || String.trim (Css.declaration_value decl) = "var(" ^ n ^ ")"
+          || reads n
+      | _ -> true
+    in
+    let rec go stmts =
+      List.map
+        (fun stmt ->
+          match Css.as_layer stmt with
+          | Some (name, inner) -> Css.layer ?name (go inner)
+          | None -> (
+              match Css.as_rule stmt with
+              | Some (sel, decls, nested) ->
+                  Css.rule ~selector:sel ~nested (List.filter keep decls)
+              | None -> stmt))
+        stmts
+    in
+    go stmts
+
 let collect_properties_at_end stmts =
   let seen = Hashtbl.create 64 in
   let keep, props =
@@ -1026,6 +1067,7 @@ let splice_into_entrypoint ~theme ~path generated =
                   Css.statements generated
               | s -> [ s ])
           |> merge_named_layers |> hoist_layer_blocks
+          |> drop_unread_inline_tokens ~theme
           |> collect_properties_at_end |> Css.v)
 
 let eval_flag flag ~default =

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -635,34 +635,15 @@ module Handler = struct
   let bg_position' pos = style [ Css.background_position pos ]
 
   (* Parse a bracket size value like "120px_120px" or "120px" *)
+  (* [bg-size-[8rem]] and [bg-[length:120px_120px]] take any CSS length, so read
+     them with the value parser rather than a hand-rolled unit table. *)
   let parse_bracket_size inner =
     let parts =
       String.split_on_char '_' inner |> List.filter (fun s -> s <> "")
     in
     match parts with
     | [ w; h ] -> (
-        (* Two values: width height *)
-        let parse_len s =
-          if String.ends_with ~suffix:"px" s then
-            let n =
-              String.sub s 0 (String.length s - 2) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Css.Px f : Css.length)) n
-          else if String.ends_with ~suffix:"%" s then
-            let n =
-              String.sub s 0 (String.length s - 1) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Css.Pct f : Css.length)) n
-          else if String.ends_with ~suffix:"rem" s then
-            let n =
-              String.sub s 0 (String.length s - 3) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Css.Rem f : Css.length)) n
-          else None
-        in
-        let wl = parse_len w in
-        let hl = parse_len h in
-        match (wl, hl) with
+        match (Css.parse_length w, Css.parse_length h) with
         | Some w, Some h -> Some (Css.background_size (Size (w, h)))
         | _ -> None)
     | [ v ] -> (
@@ -674,20 +655,9 @@ module Handler = struct
         | "contain" -> Some (Css.background_size Contain)
         | "auto" -> Some (Css.background_size Auto)
         | _ ->
-            let parse_len s =
-              if String.ends_with ~suffix:"px" s then
-                let n =
-                  String.sub s 0 (String.length s - 2) |> float_of_string_opt
-                in
-                Option.map (fun f -> (Length (Px f) : Css.background_size)) n
-              else if String.ends_with ~suffix:"%" s then
-                let n =
-                  String.sub s 0 (String.length s - 1) |> float_of_string_opt
-                in
-                Option.map (fun f -> (Length (Pct f) : Css.background_size)) n
-              else None
-            in
-            Option.map Css.background_size (parse_len v))
+            Option.map
+              (fun l -> Css.background_size (Length l))
+              (Css.parse_length v))
     | _ -> None
 
   (* Parse a bracket position value like "120px_120px" or "120px" or "50%" *)

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -707,6 +707,29 @@ let referenced_theme_decls ~theme ~exclude selector_props =
             Some decl
         | _ -> Color.Handler.theme_color_decl ~theme bare)
 
+(* [--default-font-family] points at [--font-sans]. When the project declared
+   that token in an [@theme inline] block it has no declaration of its own, so
+   the default carries its value instead of a reference nothing resolves. *)
+let inline_default_family theme decl =
+  match Css.custom_declaration_name decl with
+  | Some name -> (
+      let token =
+        match name with
+        | "--default-font-family" -> Some "font-sans"
+        | "--default-mono-font-family" -> Some "font-mono"
+        | _ -> None
+      in
+      match token with
+      | Some t
+        when Scheme.is_inline_token theme t
+             && String.trim (Css.declaration_value decl) = "var(--" ^ t ^ ")"
+        -> (
+          match Scheme.theme_value (Some theme) t with
+          | Some v -> Css.custom_property ~layer:"theme" name v
+          | None -> decl)
+      | _ -> decl)
+  | None -> decl
+
 (* Tailwind derives the default font-feature settings from the sans and mono
    tokens the project declared. *)
 let derived_font_feature_decls ~theme ~have =
@@ -719,33 +742,6 @@ let derived_font_feature_decls ~theme ~have =
       | Some v when not (Strings.mem ("--" ^ name) have) ->
           Some (Css.custom_property ~layer:"theme" ("--" ^ name) v)
       | _ -> None)
-
-(* A token the project declared in an [@theme inline] block has no declaration
-   of its own — the value goes into the utility instead. A self-referential one
-   ([--font-a: var(--font-a)]) is the exception, and so is one another
-   declaration still reads: inlining either would leave a dangling reference. *)
-let drop_inline_tokens theme decls =
-  let reads n other =
-    let needle = "var(" ^ n ^ ")" in
-    let hay = Css.declaration_value other in
-    let nl = String.length needle and hl = String.length hay in
-    let rec at i =
-      i + nl <= hl && (String.sub hay i nl = needle || at (i + 1))
-    in
-    at 0
-  in
-  if theme.Scheme.inline_tokens = [] then decls
-  else
-    List.filter
-      (fun d ->
-        match Css.custom_declaration_name d with
-        | Some n when String.length n > 2 ->
-            let bare = String.sub n 2 (String.length n - 2) in
-            (not (Scheme.is_inline_token theme bare))
-            || String.trim (Css.declaration_value d) = "var(" ^ n ^ ")"
-            || List.exists (fun other -> other != d && reads n other) decls
-        | _ -> true)
-      decls
 
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
 let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
@@ -792,8 +788,12 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
       post_defaults
   in
 
+  (* A project [@theme] override wins wherever the declaration came from: the
+     built-in defaults carry the same token names as the extracted ones. *)
   pre @ extracted @ post
-  |> drop_inline_tokens theme |> sort_by_var_order |> theme_layer_rule ~layers
+  |> List.map (apply_token_override theme)
+  |> List.map (inline_default_family theme)
+  |> sort_by_var_order |> theme_layer_rule ~layers
 
 let theme_layer_of ?(default_decls = []) tw_classes =
   let selector_props = collect_selector_props tw_classes in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -707,6 +707,46 @@ let referenced_theme_decls ~theme ~exclude selector_props =
             Some decl
         | _ -> Color.Handler.theme_color_decl ~theme bare)
 
+(* Tailwind derives the default font-feature settings from the sans and mono
+   tokens the project declared. *)
+let derived_font_feature_decls ~theme ~have =
+  [
+    ("font-sans--font-feature-settings", "default-font-feature-settings");
+    ("font-mono--font-feature-settings", "default-mono-font-feature-settings");
+  ]
+  |> List.filter_map (fun (token, name) ->
+      match Scheme.theme_value (Some theme) token with
+      | Some v when not (Strings.mem ("--" ^ name) have) ->
+          Some (Css.custom_property ~layer:"theme" ("--" ^ name) v)
+      | _ -> None)
+
+(* A token the project declared in an [@theme inline] block has no declaration
+   of its own — the value goes into the utility instead. A self-referential one
+   ([--font-a: var(--font-a)]) is the exception, and so is one another
+   declaration still reads: inlining either would leave a dangling reference. *)
+let drop_inline_tokens theme decls =
+  let reads n other =
+    let needle = "var(" ^ n ^ ")" in
+    let hay = Css.declaration_value other in
+    let nl = String.length needle and hl = String.length hay in
+    let rec at i =
+      i + nl <= hl && (String.sub hay i nl = needle || at (i + 1))
+    in
+    at 0
+  in
+  if theme.Scheme.inline_tokens = [] then decls
+  else
+    List.filter
+      (fun d ->
+        match Css.custom_declaration_name d with
+        | Some n when String.length n > 2 ->
+            let bare = String.sub n 2 (String.length n - 2) in
+            (not (Scheme.is_inline_token theme bare))
+            || String.trim (Css.declaration_value d) = "var(" ^ n ^ ")"
+            || List.exists (fun other -> other != d && reads n other) decls
+        | _ -> true)
+      decls
+
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
 let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
     ?(default_decls = []) selector_props =
@@ -718,6 +758,9 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
     extracted
     @ referenced_theme_decls ~theme ~exclude:(names_set_of extracted)
         selector_props
+  in
+  let extracted =
+    extracted @ derived_font_feature_decls ~theme ~have:(names_set_of extracted)
   in
   (* [theme(static)] on the package import emits every theme variable, not only
      the ones a utility used. The palette is by far the biggest part of it. *)
@@ -749,7 +792,8 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
       post_defaults
   in
 
-  pre @ extracted @ post |> sort_by_var_order |> theme_layer_rule ~layers
+  pre @ extracted @ post
+  |> drop_inline_tokens theme |> sort_by_var_order |> theme_layer_rule ~layers
 
 let theme_layer_of ?(default_decls = []) tw_classes =
   let selector_props = collect_selector_props tw_classes in

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -74,7 +74,9 @@ module Handler = struct
               Css.custom_property ~layer:"theme" ("--" ^ var_name) value
             in
             style [ theme_decl; columns (Var ref) ]
-        | None -> style [ columns (Var ref) ])
+        (* Without a theme override Tailwind writes the keyword, not a reference
+           to a token nothing declares. *)
+        | None -> style [ columns Auto ])
     | Columns_count n -> style [ columns (Count n) ]
     | Columns_3xs -> columns_with_var Sizing.container_3xs (Rem 16.0)
     | Columns_2xs -> columns_with_var Sizing.container_2xs (Rem 18.0)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -367,6 +367,38 @@ module Handler = struct
     in
     match shadow_list with [ s ] -> s | _ -> List shadow_list
 
+  (* Publish the shadow scales through the theme-token registry, the way rule.ml
+     publishes the breakpoints, so [theme(static)] emits them. The utilities
+     inline the value into [--tw-shadow] rather than referencing a [--shadow-*]
+     token, so nothing else would put them in the sheet. *)
+  let () =
+    let render shadows =
+      Css.Pp.to_string ~minify:true
+        (Css.Pp.list
+           ~sep:(fun ctx () -> Css.Pp.string ctx ", ")
+           Css.Properties.pp_shadow)
+        shadows
+    in
+    List.iter
+      (fun (name, shape) ->
+        let shadows =
+          List.map
+            (fun (h_offset, v_offset, blur, spread, hex) ->
+              Css.shadow ~h_offset ~v_offset ?blur ?spread ~color:(Css.hex hex)
+                ())
+            (shadow_shape_data shape)
+        in
+        Scheme.register_default_token name (render shadows))
+      [
+        ("shadow-2xs", Two_xs);
+        ("shadow-xs", Xs);
+        ("shadow-sm", Sm);
+        ("shadow-md", Md);
+        ("shadow-lg", Lg);
+        ("shadow-xl", Xl);
+        ("shadow-2xl", Two_xl);
+      ]
+
   let shape_shadow_opacity_value shape opacity =
     let data = shadow_shape_data shape in
     let percent = Color.opacity_to_percent opacity in
@@ -843,6 +875,23 @@ module Handler = struct
     | Ish_2xs -> (Zero, Px 1., None, "#0000000d")
     | Ish_xs -> (Zero, Px 1., Some (Px 1.), "#0000000d")
     | Ish_sm -> (Zero, Px 2., Some (Px 4.), "#0000000d")
+
+  (* The inset-shadow scale, published the same way. *)
+  let () =
+    List.iter
+      (fun (name, shape) ->
+        let h_offset, v_offset, blur, hex = inset_shadow_shape_data shape in
+        let value =
+          Css.shadow ~inset:true ~h_offset ~v_offset ?blur ~color:(Css.hex hex)
+            ()
+        in
+        Scheme.register_default_token name
+          (Css.Pp.to_string ~minify:true Css.Properties.pp_shadow value))
+      [
+        ("inset-shadow-2xs", Ish_2xs);
+        ("inset-shadow-xs", Ish_xs);
+        ("inset-shadow-sm", Ish_sm);
+      ]
 
   (* Theme token name for a shape's scale value (matches the @theme keys, e.g.
      --inset-shadow-sm). *)

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -477,7 +477,7 @@ module Handler = struct
       | Object_bottom_left | Object_bottom_right | Object_left_bottom
       | Object_left_top | Object_right_bottom | Object_right_top
       | Object_top_left | Object_top_right ) as obj -> (
-        let name, (default : Css.position_value), default_css =
+        let name, (default : Css.position_value), _default_css =
           match obj with
           | Object_center -> ("object-position-center", Center, "center")
           | Object_top -> ("object-position-top", Top, "top")
@@ -507,11 +507,9 @@ module Handler = struct
             in
             let pos_ref : Css.position_value Css.var = Var.bracket name in
             style [ theme_decl; object_position (Var pos_ref) ]
-        | None ->
-            let v : Css.position_value =
-              Var (Var.theme_ref name ~default ~default_css)
-            in
-            style [ object_position v ])
+        (* Without a theme override Tailwind writes the keyword, not a reference
+           to a token nothing declares. *)
+        | None -> style [ object_position default ])
     | Object_arbitrary var_str ->
         let bare_name = Parse.extract_var_name var_str in
         let pos_ref : Css.position_value Css.var = Var.bracket bare_name in

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -277,35 +277,32 @@ module Handler = struct
           (parse_size_val v)
     | _ -> None
 
-  let parse_bracket_position inner =
-    let parts =
-      String.split_on_char '_' inner |> List.filter (fun s -> s <> "")
+  (* A mask position is one or two components. Lengths go through the value
+     parser rather than a hand-rolled unit table, so every unit works. *)
+  let parse_bracket_position inner : Css.declaration list option =
+    let one entry : Css.position_value option =
+      match
+        String.split_on_char '_' entry |> List.filter (fun s -> s <> "")
+      with
+      | [ x; y ] -> (
+          match (Css.parse_length x, Css.parse_length y) with
+          | Some xv, Some yv -> Some (XY (xv, yv))
+          | _ -> None)
+      | [ v ] ->
+          Option.map
+            (fun (l : Css.length) : Css.position_value -> Single l)
+            (Css.parse_length v)
+      | _ -> None
     in
-    let parse_pos_val s : Css.position_value option =
-      if String.ends_with ~suffix:"px" s then
-        let n = String.sub s 0 (String.length s - 2) |> float_of_string_opt in
-        Option.map (fun f -> (Css.Single (Px f) : Css.position_value)) n
-      else if String.ends_with ~suffix:"%" s then
-        let n = String.sub s 0 (String.length s - 1) |> float_of_string_opt in
-        Option.map (fun f -> (Css.Single (Pct f) : Css.position_value)) n
-      else None
-    in
-    match parts with
-    | [ x; y ] -> (
-        match (parse_bracket_len x, parse_bracket_len y) with
-        | Some xv, Some yv ->
-            Some
-              [
-                Css.webkit_mask_position [ Css.XY (xv, yv) ];
-                Css.mask_position [ Css.XY (xv, yv) ];
-              ]
-        | _ -> None)
-    | [ v ] ->
-        Option.map
-          (fun pv ->
-            [ Css.webkit_mask_position [ pv ]; Css.mask_position [ pv ] ])
-          (parse_pos_val v)
-    | _ -> None
+    (* A comma-separated list of positions is valid CSS but [mask_position]
+       renders the list space-separated, so it would emit an invalid value;
+       leave it unparsed until cascade takes a list. *)
+    if String.contains inner ',' then None
+    else
+      Option.map
+        (fun pv ->
+          [ Css.webkit_mask_position [ pv ]; Css.mask_position [ pv ] ])
+        (one inner)
 
   let to_style _theme = function
     | Mask_none -> mask_none

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -75,7 +75,24 @@ let is_bracket_value s =
 let bracket_inner s =
   if is_bracket_value s then String.sub s 1 (String.length s - 2) else s
 
-let decode_underscores s = String.map (fun c -> if c = '_' then ' ' else c) s
+(* In an arbitrary value [_] stands for a space, and [\_] for a literal
+   underscore — otherwise a value that needs one could not be written. *)
+let decode_underscores s =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec go i =
+    if i >= len then ()
+    else if s.[i] = '\\' && i + 1 < len && s.[i + 1] = '_' then begin
+      Buffer.add_char buf '_';
+      go (i + 2)
+    end
+    else begin
+      Buffer.add_char buf (if s.[i] = '_' then ' ' else s.[i]);
+      go (i + 1)
+    end
+  in
+  go 0;
+  Buffer.contents buf
 
 let function_name_before s i =
   let is_name_char = function

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -53,6 +53,10 @@ val bracket_inner : string -> string
 (** [bracket_inner s] extracts the inner content from ["[foo]"], returning
     ["foo"]. If [s] is not bracket-wrapped, returns [s] unchanged. *)
 
+val decode_underscores : string -> string
+(** [decode_underscores s] turns the [_] of an arbitrary value into a space, and
+    [\_] into a literal underscore. *)
+
 val decode_arbitrary_value : string -> string
 (** [decode_arbitrary_value s] decodes Tailwind arbitrary-value syntax into a
     CSS value string suitable for Cascade readers. This converts underscores to

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -155,6 +155,38 @@ module Handler = struct
           (Px 0., Px 4., Some (Px 8.), "#0000001a");
         ]
 
+  (* Publish the scale through the theme-token registry, the way rule.ml
+     publishes the breakpoints, so [theme(static)] emits it. The utilities
+     inline the value rather than referencing a [--text-shadow-*] token, so
+     nothing else would put it in the sheet. The reference keeps the [px] on a
+     zero offset here, so render the lengths as written. *)
+  let () =
+    List.iter
+      (fun (name, shape) ->
+        let one (h, v, blur, hex) =
+          String.concat " "
+            ([
+               Css.Pp.to_string ~minify:true (Css.pp_length ~always:true) h;
+               Css.Pp.to_string ~minify:true (Css.pp_length ~always:true) v;
+             ]
+            @ (match blur with
+              | Some b ->
+                  [
+                    Css.Pp.to_string ~minify:true (Css.pp_length ~always:true) b;
+                  ]
+              | None -> [])
+            @ [ hex ])
+        in
+        Scheme.register_default_token name
+          (String.concat ", " (List.map one (shape_shadows shape))))
+      [
+        ("text-shadow-2xs", S_2xs);
+        ("text-shadow-xs", S_xs);
+        ("text-shadow-sm", S_sm);
+        ("text-shadow-md", S_md);
+        ("text-shadow-lg", S_lg);
+      ]
+
   (* Theme token name for a shape's scale value (matches the @theme keys, e.g.
      --text-shadow-2xs). *)
   let shape_token = function

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -82,7 +82,11 @@ let spacing_calc ?theme n : Css.declaration * Css.length =
          perform the equivalent calc(var(--spacing)) -> var(--spacing) rewrite,
          because it optimises arbitrary CSS and cannot assume that contract. *)
       let decl, spacing_ref = Var.binding spacing_var spacing_base in
-      if n = 1 then (decl, (Css.Var spacing_ref : Css.length))
+      (* The zero step is a plain [0px], as Tailwind emits it: the scale factor
+         makes [calc(var(--spacing) * 0)] zero for any spacing, and only the
+         optimiser can see that once [--spacing] is a literal. *)
+      if n = 0 then (decl, (Px 0. : Css.length))
+      else if n = 1 then (decl, (Css.Var spacing_ref : Css.length))
       else
         let len : Css.length =
           Css.Calc

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -946,19 +946,9 @@ module Handler = struct
             (Var.theme_ref name ~default:(Css.Zero : Css.length) ~default_css)
         in
         style [ decl; perspective_origin ref; Css.perspective perspective_ref ]
-    | None ->
-        let v : Css.perspective_origin =
-          Var (Var.theme_ref name ~default ~default_css)
-        in
-        let perspective_ref : Css.length =
-          Css.Var
-            (Var.theme_ref name ~default:(Css.Zero : Css.length) ~default_css)
-        in
-        style
-          [
-            perspective_origin v;
-            Css.theme_guarded ~var_name:name (Css.perspective perspective_ref);
-          ]
+    (* Without a theme override Tailwind writes the keyword, not a reference to
+       a token nothing declares. *)
+    | None -> style [ perspective_origin default ]
 
   let perspective_origin_center ?theme () =
     po_with_ref ?theme "perspective-origin-center" Center "center" ()
@@ -1030,11 +1020,7 @@ module Handler = struct
           Var.theme_ref name ~default ~default_css
         in
         style [ decl; transform_origin (Var ref) ]
-    | None ->
-        let v : Css.transform_origin =
-          Var (Var.theme_ref name ~default ~default_css)
-        in
-        style [ transform_origin v ]
+    | None -> style [ transform_origin default ]
 
   let origin_center ?theme () =
     origin_with_ref ?theme "transform-origin-center" Center "center" ()

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1695,6 +1695,10 @@ module Typography_late = struct
     | [ "list"; "image"; "none" ] -> Ok List_image_none
     | [ "list"; "image"; value ] when Parse.is_bracket_var value ->
         Ok (List_image_bracket_var (Parse.bracket_inner value))
+    (* The [(--x)] shorthand names a custom property, the same as
+       [list-image-[var(--x)]]. *)
+    | [ "list"; "image"; value ] when Parse.is_bare_var value ->
+        Ok (List_image_bracket_var value)
     | [ "list"; "image"; value ] when Parse.is_bracket_value value -> (
         let inner = Parse.bracket_inner value in
         match
@@ -1919,7 +1923,9 @@ module Typography_late = struct
     | List_inside -> "list-inside"
     | List_outside -> "list-outside"
     | List_image_none -> "list-image-none"
-    | List_image_bracket_var s -> "list-image-[" ^ s ^ "]"
+    | List_image_bracket_var s ->
+        if Parse.is_bare_var s then "list-image-" ^ s
+        else "list-image-[" ^ s ^ "]"
     | List_image_bracket (raw, _) -> "list-image-[" ^ raw ^ "]"
     | List_image_url url -> "list-image-" ^ url
     | Underline_offset_auto -> "underline-offset-auto"
@@ -2698,7 +2704,9 @@ module Typography_late = struct
           Css.custom_property ~layer:"theme" ("--" ^ var_name) value
         in
         style [ theme_decl; list_style_type (Var ref) ]
-    | None -> style [ list_style_type (Var ref) ]
+    (* Without a theme override Tailwind writes the keyword, not a reference to
+       a token nothing declares. *)
+    | None -> style [ list_style_type None ]
 
   let list_bracket_var s =
     let inner = Parse.extract_var_name s in
@@ -2711,7 +2719,15 @@ module Typography_late = struct
   let list_outside = style [ list_style_position Outside ]
 
   let list_image_bracket_var s =
-    let inner = Parse.extract_var_name s in
+    (* Written either as [[var(--x)]] or as the [(--x)] shorthand. *)
+    let inner =
+      if Parse.is_bare_var s then
+        let bare = Parse.bare_var_inner s in
+        if String.length bare > 2 && String.sub bare 0 2 = "--" then
+          String.sub bare 2 (String.length bare - 2)
+        else bare
+      else Parse.extract_var_name s
+    in
     let ref : Css.list_style_image Css.var = Var.bracket inner in
     style [ list_style_image (Var ref) ]
 
@@ -2728,7 +2744,7 @@ module Typography_late = struct
           Css.custom_property ~layer:"theme" ("--" ^ var_name) value
         in
         style [ theme_decl; list_style_image (Var ref) ]
-    | None -> style [ list_style_image (Var ref) ]
+    | None -> style [ list_style_image None ]
 
   let text_ellipsis = style [ text_overflow Ellipsis ]
   let text_clip = style [ text_overflow Clip ]

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1044,6 +1044,20 @@ module Typography_early = struct
       ("9xl", text_9xl_var, 8.0);
     ]
 
+  (* The leading scale, published the same way. *)
+  let () =
+    List.iter
+      (fun (name, value) ->
+        Scheme.register_default_token ("leading-" ^ name)
+          (Css.Pp.to_string ~minify:true Css.Properties.pp_line_height value))
+      [
+        ("tight", (Num 1.25 : Css.line_height));
+        ("snug", Num 1.375);
+        ("normal", Num 1.5);
+        ("relaxed", Num 1.625);
+        ("loose", Num 2.0);
+      ]
+
   (* Publish the text scale through the theme-token registry, the way rule.ml
      publishes the breakpoints, so [theme()] in a project's CSS resolves against
      the same values the utilities use. *)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2658,9 +2658,9 @@ module Typography_late = struct
     style ~property_rules (content_decl @ [ Css.content c ])
 
   let content_squote s =
-    (* Single-quoted arbitrary content (content-['x']) keeps the single
-       quote. *)
-    let value = String.map (fun c -> if c = '_' then ' ' else c) s in
+    (* Single-quoted arbitrary content (content-['x']) keeps the single quote.
+       [_] is a space and [\_] a literal underscore. *)
+    let value = Parse.decode_underscores s in
     let quoted : Css.content =
       Css.Quoted { value; quote = '\''; repr = None }
     in

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -935,24 +935,34 @@ module Typography_early = struct
      carries the value instead of a reference to it. A self-referential one
      ([--font-a: var(--font-a)]) is the exception: inlining it would leave the
      reference dangling, so the token keeps its declaration. *)
-  let font_named theme name =
+  (* A family the project declared also carries the [--font-<name>--font-
+     feature-settings] beside it, the way Tailwind emits it. *)
+  let font_feature_decls theme token =
+    match
+      Scheme.theme_value (Some theme) (token ^ "--font-feature-settings")
+    with
+    | None -> []
+    | Some v -> [ font_feature_settings (Css.Feature_list v) ]
+
+  let font_named ?fallback theme name =
     let token = "font-" ^ name in
     match Scheme.theme_value (Some theme) token with
-    | None -> style []
+    | None -> ( match fallback with Some s -> s | None -> style [])
     | Some raw -> (
         match Css.parse_font_family raw with
-        | None -> style []
+        | None -> ( match fallback with Some s -> s | None -> style [])
         | Some family ->
             let self_referential =
               match family with
               | Css.Var v -> Css.var_name v = token
               | _ -> false
             in
+            let features = font_feature_decls theme token in
             if Scheme.is_inline_token theme token && not self_referential then
-              style [ font_family family ]
+              style (font_family family :: features)
             else
               let decl, ref = Var.binding (font_named_var name) family in
-              style [ decl; font_family (Css.Var ref) ])
+              style (decl :: font_family (Css.Var ref) :: features))
 
   let italic = style [ font_style Italic ]
   let not_italic = style [ font_style Normal ]
@@ -1279,9 +1289,9 @@ module Typography_early = struct
         in
         style [ font_feature_settings (Var var_ref) ]
     | Font_named name -> font_named theme name
-    | Font_sans -> font_sans
-    | Font_serif -> font_serif
-    | Font_mono -> font_mono
+    | Font_sans -> font_named ~fallback:font_sans theme "sans"
+    | Font_serif -> font_named ~fallback:font_serif theme "serif"
+    | Font_mono -> font_named ~fallback:font_mono theme "mono"
     | Italic -> italic
     | Not_italic -> not_italic
     | Text_left -> text_left

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -166,3 +166,20 @@ Without it only what the sheet uses is emitted:
   $ tw --minify --input-css dynamic.css index.html | grep -c -- '--color-fuchsia-300:'
   0
   [1]
+
+The shadow, text-shadow and leading scales come out under [theme(static)] too,
+and the default font-feature settings are derived from the sans and mono tokens
+the project declared:
+
+  $ cat > scales.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @theme {
+  >   --font-sans--font-feature-settings: "cv02";
+  > }
+  > EOF
+  $ tw --minify --input-css scales.css index.html | grep -c -- '--shadow-md:0 4px 6px -1px'
+  1
+  $ tw --minify --input-css scales.css index.html | grep -c -- '--text-shadow-sm:'
+  1
+  $ tw --minify --input-css scales.css index.html | grep -cF -- '--default-font-feature-settings:"cv02"'
+  1

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -183,3 +183,25 @@ the project declared:
   1
   $ tw --minify --input-css scales.css index.html | grep -cF -- '--default-font-feature-settings:"cv02"'
   1
+
+An [@theme inline] token gets no declaration of its own unless something still
+reads it: the utility carries the value instead, along with the font-feature
+settings declared beside it. A project override wins over the built-in default:
+
+  $ cat > inl.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @theme inline {
+  >   --font-sans: var(--font-inter), system-ui;
+  >   --font-sans--font-feature-settings: "cv02";
+  > }
+  > EOF
+  $ cat > inl.html <<EOF
+  > <div class="font-sans"></div>
+  > EOF
+  $ tw --minify --input-css inl.css inl.html | grep -cF '.font-sans{font-family:var(--font-inter),system-ui;font-feature-settings:"cv02"}'
+  1
+  $ tw --minify --input-css inl.css inl.html | grep -c -- '--font-sans:'
+  0
+  [1]
+  $ tw --minify --input-css inl.css inl.html | grep -cF -- '--default-font-family:var(--font-inter),system-ui'
+  1


### PR DESCRIPTION
Follow-up to #229, which taught tw to honour `theme(static)` and closed 128 of the 145 theme tokens the tailwindcss.com sheet was missing.

The rest are scales whose utilities inline the value rather than referencing a token, so nothing put them in the sheet: `--shadow-*`, `--inset-shadow-*`, `--text-shadow-*` and `--leading-*`. They now publish through the same registry `lib/rule.ml` uses for the breakpoints. `--default-font-feature-settings` and its mono sibling are derived from the `--font-*--font-feature-settings` a project declares, and a token declared in an `@theme inline` block no longer gets a declaration of its own unless it refers to itself or another declaration still reads it.

The sheet's theme layer now has every token the reference has.