### PR TITLE
rule, color: fix variant composition and full-opacity colours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Reject an arbitrary value that is not what the property takes:
+  `col-span-[<value>]`, `row-span-[<value>]`, `transition-[<value>]`,
+  `will-change-[<value>]` and `font-features-[<value>]` emitted invalid CSS
+  (#231)
+- Read the underscore in `font-features-["liga"_0]` as a space (#231)
+
 - Sort the `@container` utilities and `pointer-events-*` before the layout
   group, where Tailwind's utility order puts them (#231)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Fix `not-in-data-*`, which negated the utility's own class instead of the
+  ancestor relation, and keep the inner variant's selector under `not-*`
+  (#231)
+
 - Keep the inner variant's selector under an `aria-*`, `data-*` or `has-*`
   variant: `aria-selected:hover:underline` lost its `:hover`,
   `data-[closed]:data-[enter]:` its second attribute (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Read a comma-separated layer list in `mask-[...]` and `mask-position-[...]`;
+  two `url()` layers collapsed into one malformed `url()`, and a position list
+  fell back to `center` (#231)
+
 - Resolve Tailwind's `--alpha(C/P)` in an arbitrary value, and render a
   reference to a palette token from the palette so the fallback carries a
   colour instead of the bare reference (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Reject an arbitrary filter amount that is not a number, a percentage or a
+  var; `brightness-[abc]` emitted `brightness(0)` (#231)
+
 - `shadow-inner` sets `--tw-shadow` and composes like the other shadow
   shapes; it wrote `box-shadow` directly, so a ring or inset shadow beside it
   was dropped and its `@property` rules were missing (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Declare `--container-*` in `@layer theme` for `basis-sm` and friends; the
+  utility read a variable nothing declared (#231)
+
 - Write the keyword for `object-*`, `origin-*` and `perspective-origin-*`
   when no `@theme` defines the token; they referenced a variable nothing
   declared (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Read a shadow list in `shadow-[...]`; the single-shadow reading dropped the
+  spread and swallowed the second layer (#231)
+
 - Keep the inner variant's selector under `in-*`, `not-*` and the named
   group/peer variants: `in-data-stack:[:first-child>&]:rounded-t-xl` lost its
   anchor (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Keep the inner variant's selector under an `aria-*`, `data-*` or `has-*`
+  variant: `aria-selected:hover:underline` lost its `:hover`,
+  `data-[closed]:data-[enter]:` its second attribute (#231)
+- Keep the `@media (hover:hover)` gate when an outer variant wraps `hover:`,
+  as in `disabled:hover:bg-indigo-500` (#231)
+
 - Support the `@sm/main:` container-query variant, which aims a size query at a
   named container instead of the nearest one (#231)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- `shadow-inner` sets `--tw-shadow` and composes like the other shadow
+  shapes; it wrote `box-shadow` directly, so a ring or inset shadow beside it
+  was dropped and its `@property` rules were missing (#231)
+- Read `--spacing(1)` as `var(--spacing)`, the form Tailwind writes (#231)
+
 - Write the colour itself for a `/100` modifier, which emitted a no-op
   `color-mix` and its `@supports` fallback (#231)
 - Apply `!` inside the `@supports` colour override, so `bg-white/75!` no longer

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+- Write the colour itself for a `/100` modifier, which emitted a no-op
+  `color-mix` and its `@supports` fallback (#231)
+- Apply `!` inside the `@supports` colour override, so `bg-white/75!` no longer
+  has its fallback outrank the modern value (#231)
+- Emit the fallback and `@supports` pair for a gradient stop with opacity, as
+  in `from-white/10` (#231)
+
 - Read `object-[50%]` as a position; it emitted `object-position: var(--50)`
   (#231)
 - Write `z-index: auto` for `z-auto`, which referenced a variable nothing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Read `calc()` and `var()` in `rounded-[...]`; anything but a plain length
+  silently became `border-radius: 0` (#231)
+
 - Declare `--container-*` in `@layer theme` for `basis-sm` and friends; the
   utility read a variable nothing declared (#231)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Support the `@sm/main:` container-query variant, which aims a size query at a
+  named container instead of the nearest one (#231)
+
 - Read `calc()` and `var()` in `rounded-[...]`; anything but a plain length
   silently became `border-radius: 0` (#231)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Sort the `@container` utilities and `pointer-events-*` before the layout
+  group, where Tailwind's utility order puts them (#231)
+
 - Read a shadow list in `shadow-[...]`; the single-shadow reading dropped the
   spread and swallowed the second layer (#231)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+- Read `object-[50%]` as a position; it emitted `object-position: var(--50)`
+  (#231)
+- Write `z-index: auto` for `z-auto`, which referenced a variable nothing
+  declares (#231)
+- Expand Tailwind's `--spacing(N)` in an arbitrary property value, as in
+  `[--gap:--spacing(10)]` (#231)
+
 - Fix `not-in-data-*`, which negated the utility's own class instead of the
   ancestor relation, and keep the inner variant's selector under `not-*`
   (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Keep the inner variant's selector under `in-*`, `not-*` and the named
+  group/peer variants: `in-data-stack:[:first-child>&]:rounded-t-xl` lost its
+  anchor (#231)
+
 - Read a comma-separated layer list in `mask-[...]` and `mask-position-[...]`;
   two `url()` layers collapsed into one malformed `url()`, and a position list
   fell back to `center` (#231)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Resolve Tailwind's `--alpha(C/P)` in an arbitrary value, and render a
+  reference to a palette token from the palette so the fallback carries a
+  colour instead of the bare reference (#231)
+- Read the position in `mask-radial-at-[30%_30%]`; it reached the sheet with
+  its underscore (#231)
+
 - Reject an arbitrary filter amount that is not a number, a percentage or a
   var; `brightness-[abc]` emitted `brightness(0)` (#231)
 

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -216,20 +216,6 @@ module Handler = struct
 
   (* Arbitrary values use [_] for spaces (Tailwind); a literal underscore is
      escaped as [\_]. *)
-  let unescape_value value =
-    let b = Buffer.create (String.length value) in
-    let n = String.length value in
-    let i = ref 0 in
-    while !i < n do
-      if value.[!i] = '\\' && !i + 1 < n && value.[!i + 1] = '_' then (
-        Buffer.add_char b '_';
-        incr i)
-      else if value.[!i] = '_' then Buffer.add_char b ' '
-      else Buffer.add_char b value.[!i];
-      incr i
-    done;
-    Buffer.contents b
-
   let to_style theme t =
     match t with
     | Parsed_decl { property; value } -> (
@@ -238,7 +224,7 @@ module Handler = struct
            filter drops layerless custom properties). *)
         match
           Css.parse_declaration ~layer:"utilities" property
-            (Parse.normalize_css_math_operators (unescape_value value))
+            (Parse.decode_arbitrary_value value)
         with
         | Some decl -> style [ decl ]
         | None -> style [])
@@ -367,7 +353,7 @@ module Handler = struct
                    parse becomes a typed declaration. *)
                 match
                   Css.parse_declaration property
-                    (Parse.normalize_css_math_operators (unescape_value value))
+                    (Parse.decode_arbitrary_value value)
                 with
                 | Some _ -> Ok (Parsed_decl { property; value })
                 | None -> err_not_utility))

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -48,6 +48,25 @@ let color_property_of_name = function
   | "stroke" -> Some (fun c -> Css.stroke (Css.Color c : Css.svg_paint))
   | _ -> None
 
+(* Tailwind's [--alpha(<color>/<percentage>)]: the colour and the alpha it is
+   mixed with. The separating slash is the last one, so a colour that carries
+   its own (as [oklch(1 0 0 / 50%)] does) still reads. *)
+let alpha_fn value =
+  let n = String.length value in
+  let prefix = "--alpha(" in
+  let plen = String.length prefix in
+  if n > plen + 1 && String.sub value 0 plen = prefix && value.[n - 1] = ')'
+  then
+    let inner = String.sub value plen (n - plen - 1) in
+    match String.rindex_opt inner '/' with
+    | Some i ->
+        Some
+          ( String.trim (String.sub inner 0 i),
+            String.trim (String.sub inner (i + 1) (String.length inner - i - 1))
+          )
+    | None -> None
+  else None
+
 module Handler = struct
   open Style
 
@@ -56,6 +75,9 @@ module Handler = struct
         property : string;
         value : string;
         opacity : Color.opacity_modifier;
+        spelling : string option;
+            (** The [--alpha(...)] the class was written with, when the opacity
+                came from that function rather than a [/] modifier. *)
       }
     | Parsed_decl of { property : string; value : string }
   (* Plain [property:value] (no /opacity), parsed by cascade into a typed,
@@ -171,35 +193,44 @@ module Handler = struct
   let color_var_opacity_style theme (emit : Css.color -> Css.declaration) value
       opacity =
     let bare = Parse.extract_var_name value in
-    let var_ref : Css.color Css.var = Var.bracket bare in
-    let percent = Color.opacity_to_percent opacity in
-    let oklab_decl =
-      emit
-        (Css.color_mix ~in_space:Oklab (Css.Var var_ref) Css.Transparent
-           ~percent1:percent)
-    in
-    (* The srgb fallback inlines the resolved theme colour when known (matching
-       Tailwind), else keeps the raw var. Emitting the referenced [--token] into
-       @layer theme needs the registering theme-var mechanism (see
-       [Color.color_var]); arbitrary references via [Var.bracket] don't trigger
-       it, so theme-var-referencing values still differ in the theme layer (the
-       same gap as [backgrounds.ml]'s bg-[color:var(--token)]). *)
-    let fallback =
-      match Scheme.theme_value (Some theme) bare with
-      | Some v -> (
-          match Css.parse_color (String.trim v) with
-          | Some c ->
-              emit
-                (Css.color_mix ~in_space:Srgb c Css.Transparent
-                   ~percent1:percent)
-          | None -> emit (Css.Var var_ref : Css.color))
-      | None -> emit (Css.Var var_ref : Css.color)
-    in
-    let supports =
-      Css.supports ~condition:Color.color_mix_supports_condition
-        [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-    in
-    style ~rules:(Some [ supports ]) [ fallback ]
+    match Color.Handler.theme_color_of_name bare with
+    (* A reference to a palette token renders from the palette, which is what
+       puts the token in [@layer theme] and gives the fallback a colour rather
+       than the bare reference. *)
+    | Some (c, shade) ->
+        Color.Handler.colors_with_opacity_style ~theme ~properties:[ emit ] c
+          shade opacity
+    | None ->
+        let var_ref : Css.color Css.var = Var.bracket bare in
+        let percent = Color.opacity_to_percent opacity in
+        let oklab_decl =
+          emit
+            (Css.color_mix ~in_space:Oklab (Css.Var var_ref) Css.Transparent
+               ~percent1:percent)
+        in
+        (* The srgb fallback inlines the resolved theme colour when known
+           (matching Tailwind), else keeps the raw var. Emitting the referenced
+           [--token] into @layer theme needs the registering theme-var mechanism
+           (see [Color.color_var]); arbitrary references via [Var.bracket] don't
+           trigger it, so theme-var-referencing values still differ in the theme
+           layer (the same gap as [backgrounds.ml]'s
+           bg-[color:var(--token)]). *)
+        let fallback =
+          match Scheme.theme_value (Some theme) bare with
+          | Some v -> (
+              match Css.parse_color (String.trim v) with
+              | Some c ->
+                  emit
+                    (Css.color_mix ~in_space:Srgb c Css.Transparent
+                       ~percent1:percent)
+              | None -> emit (Css.Var var_ref : Css.color))
+          | None -> emit (Css.Var var_ref : Css.color)
+        in
+        let supports =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
+        in
+        style ~rules:(Some [ supports ]) [ fallback ]
 
   (* Place a colour on the declaration's target property: a known colour
      property uses its typed constructor; a custom property ([--name]) uses the
@@ -228,7 +259,7 @@ module Handler = struct
         with
         | Some decl -> style [ decl ]
         | None -> style [])
-    | Color_opacity { property; value; opacity } -> (
+    | Color_opacity { property; value; opacity; _ } -> (
         match color_emitter property with
         (* of_class only accepts renderable colour declarations; defensive. *)
         | None -> style []
@@ -255,7 +286,10 @@ module Handler = struct
     | Color.Opacity_var v -> "/" ^ v
 
   let to_class = function
-    | Color_opacity { property; value; opacity } ->
+    | Color_opacity { property; opacity; spelling = Some raw; _ } ->
+        ignore opacity;
+        "[" ^ property ^ ":" ^ raw ^ "]"
+    | Color_opacity { property; value; opacity; spelling = None } ->
         "[" ^ property ^ ":" ^ value ^ "]" ^ opacity_suffix opacity
     | Parsed_decl { property; value } -> "[" ^ property ^ ":" ^ value ^ "]"
 
@@ -287,9 +321,26 @@ module Handler = struct
           | None -> err_not_utility
           | Some colon_pos -> (
               let property = String.sub inner 0 colon_pos in
-              let value =
+              let raw_value =
                 String.sub inner (colon_pos + 1)
                   (String.length inner - colon_pos - 1)
+              in
+              (* [--alpha(C/P)] is the [/opacity] form spelled as a function, so
+                 it resolves to the same fallback and [@supports] pair. *)
+              let value, fn_opacity =
+                match alpha_fn raw_value with
+                | Some (c, p) -> (
+                    (* [--alpha()] writes the alpha as a percentage; the [/]
+                       modifier writes the bare number. *)
+                    let bare =
+                      if String.ends_with ~suffix:"%" p then
+                        String.sub p 0 (String.length p - 1)
+                      else p
+                    in
+                    match Color.opacity_of_string ~theme bare with
+                    | Some op -> (c, op)
+                    | None -> (raw_value, Color.No_opacity))
+                | None -> (raw_value, Color.No_opacity)
               in
               (* Parse opacity modifier after ] *)
               let opacity_str =
@@ -335,7 +386,7 @@ module Handler = struct
                              <> None
                         then Color.Opacity_named op_part
                         else Color.No_opacity
-                else Color.No_opacity
+                else fn_opacity
               in
               let is_colour_value =
                 Parse.is_var value || parse_css_color value <> None
@@ -346,7 +397,15 @@ module Handler = struct
                    a colour value. Non-colour cases are rejected (Tailwind
                    blindly color-mixes them, which is meaningless). *)
                 if color_emitter property <> None && is_colour_value then
-                  Ok (Color_opacity { property; value; opacity })
+                  Ok
+                    (Color_opacity
+                       {
+                         property;
+                         value;
+                         opacity;
+                         spelling =
+                           (if raw_value == value then None else Some raw_value);
+                       })
                 else err_not_utility
               else
                 (* Plain [property:value]: any property whose value cascade can

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1047,7 +1047,16 @@ module Handler = struct
       |> Css.concat
     in
 
-    match Scheme.hex_color scheme color_name with
+    (* Without a scheme override the palette still has a hex for the colour, and
+       Tailwind emits the same fallback + [@supports] pair either way. *)
+    let hex_of_palette () =
+      Color.rgb_to_hex (Color.oklch_to_rgb (Color.to_oklch color shade))
+    in
+    match
+      match Scheme.hex_color scheme color_name with
+      | Some _ as h -> h
+      | None -> Some (hex_of_palette ())
+    with
     | Some hex_value ->
         (* Scheme color: generate fallback + @supports + stops (same as
            Tailwind) Tailwind outputs: 1. .from-X/N { --tw-gradient-from:

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -52,7 +52,7 @@ type rounded_size =
   | Rsz_3xl
   | Rsz_4xl
   | Rsz_full
-  | Rsz_arbitrary of string
+  | Rsz_arbitrary of string * Css.length
 
 module Handler = struct
   open Style
@@ -388,32 +388,11 @@ module Handler = struct
   let border_transparent' = style [ Css.border_color (Css.hex "#0000") ]
   let border_current' = style [ Css.border_color Current ]
 
-  (* Create radius theme variables with fallback values for inline mode *)
+  (* Arbitrary radii go through the same normalisation as the other arbitrary
+     length utilities, so calc() and var() references parse. *)
   let parse_length str : length option =
-    let len = String.length str in
-    if len >= 1 then (
-      let num_end = ref 0 in
-      while
-        !num_end < len
-        && (str.[!num_end] = '-'
-           || str.[!num_end] = '.'
-           || (str.[!num_end] >= '0' && str.[!num_end] <= '9'))
-      do
-        incr num_end
-      done;
-      let num_str = String.sub str 0 !num_end in
-      let unit_str = String.sub str !num_end (len - !num_end) in
-      match float_of_string_opt num_str with
-      | Some n -> (
-          match unit_str with
-          | "px" -> Some (Px n)
-          | "rem" -> Some (Rem n)
-          | "em" -> Some (Em n)
-          | "%" -> Some (Pct n)
-          | "" when n = 0.0 -> Some Zero
-          | _ -> None)
-      | None -> None)
-    else None
+    Css.parse_length
+      (Parse.normalize_css_math_operators (Parse.decode_arbitrary_value str))
 
   let radius_none_var = Var.theme Css.Length "radius-none" ~order:(7, 0)
   let radius_full_var = Var.theme Css.Length "radius-full" ~order:(7, 1)
@@ -509,11 +488,7 @@ module Handler = struct
     | Rsz_2xl -> sized_radius radius_2xl_var (Css.Rem 1.0) pos
     | Rsz_3xl -> sized_radius radius_3xl_var (Css.Rem 1.5) pos
     | Rsz_4xl -> sized_radius radius_4xl_var (Css.Rem 2.0) pos
-    | Rsz_arbitrary value ->
-        let len =
-          match parse_length value with Some len -> len | None -> Css.Px 0.
-        in
-        style (radius_decls_for_position pos len)
+    | Rsz_arbitrary (_, len) -> style (radius_decls_for_position pos len)
 
   (* Outline style variable - used by outline utilities that set the style *)
   let outline_style_var =
@@ -955,8 +930,11 @@ module Handler = struct
        all corners; [rounded-<pos>] / [rounded-<pos>-<size>] target a side or
        corner. Sizes and positions are disjoint token sets. *)
     | [ "rounded" ] -> Ok (Rounded (Rp_all, Rsz_default))
-    | [ "rounded"; v ] when Parse.is_bracket_value v ->
-        Ok (Rounded (Rp_all, Rsz_arbitrary (Parse.bracket_inner v)))
+    | [ "rounded"; v ] when Parse.is_bracket_value v -> (
+        let inner = Parse.bracket_inner v in
+        match parse_length inner with
+        | Some len -> Ok (Rounded (Rp_all, Rsz_arbitrary (inner, len)))
+        | None -> err_not_utility)
     | [ "rounded"; tok ] -> (
         match rounded_size_of_string tok with
         | Some size -> Ok (Rounded (Rp_all, size))
@@ -965,9 +943,10 @@ module Handler = struct
             | Some pos -> Ok (Rounded (pos, Rsz_default))
             | None -> err_not_utility))
     | [ "rounded"; pos; v ] when Parse.is_bracket_value v -> (
-        match rounded_position_of_string pos with
-        | Some pos -> Ok (Rounded (pos, Rsz_arbitrary (Parse.bracket_inner v)))
-        | None -> err_not_utility)
+        let inner = Parse.bracket_inner v in
+        match (rounded_position_of_string pos, parse_length inner) with
+        | Some pos, Some len -> Ok (Rounded (pos, Rsz_arbitrary (inner, len)))
+        | _ -> err_not_utility)
     | [ "rounded"; pos; size ] -> (
         match (rounded_position_of_string pos, rounded_size_of_string size) with
         | Some pos, Some size -> Ok (Rounded (pos, size))
@@ -1113,7 +1092,7 @@ module Handler = struct
           | Rsz_3xl -> "-3xl"
           | Rsz_4xl -> "-4xl"
           | Rsz_full -> "-full"
-          | Rsz_arbitrary value -> "-[" ^ value ^ "]"
+          | Rsz_arbitrary (raw, _) -> "-[" ^ raw ^ "]"
         in
         "rounded" ^ pos_str ^ size_str
     | Outline -> "outline"

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1842,6 +1842,16 @@ module Handler = struct
      typed value, so the result matches what a colour utility would emit. Used
      to emit tokens that arbitrary values reference via var() but that no colour
      utility set. *)
+  (* The palette colour a [--color-*] token names, so a value that references
+     the token can be rendered from the palette. *)
+  let theme_color_of_name name =
+    if String.length name <= 6 || String.sub name 0 6 <> "color-" then None
+    else
+      let rest = String.sub name 6 (String.length name - 6) in
+      match shade_of_strings (String.split_on_char '-' rest) with
+      | Ok (c, shade) when not (is_custom_color c) -> Some (c, shade)
+      | _ -> None
+
   let theme_color_decl ?theme name =
     if String.length name <= 6 || String.sub name 0 6 <> "color-" then None
     else

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2590,7 +2590,15 @@ module Handler = struct
       shade opacity =
     let property_decls value = List.map (fun set -> set value) properties in
     let percent = opacity_to_percent opacity in
-    if is_custom_color c && opacity_var_name opacity <> None then
+    if is_fully_opaque opacity && not (is_custom_color c) then
+      (* At 100% the mix is a no-op, so Tailwind writes the colour itself and
+         needs neither the fallback nor the [@supports] pair. *)
+      let theme_decl, color_ref =
+        Var.binding (color_var c shade) (to_css c shade)
+      in
+      let value : Css.color = Var color_ref in
+      style ?merge_key (theme_decl :: property_decls value)
+    else if is_custom_color c && opacity_var_name opacity <> None then
       style ?merge_key (property_decls (mix_alpha opacity (to_css c shade)))
     else if is_custom_color c then
       (* Custom/arbitrary colors (hex, rgb): output oklab() directly. No theme
@@ -3415,7 +3423,14 @@ let generic_color_with_opacity ?theme ~property c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   let alpha_var = opacity_var_name opacity <> None in
-  if is_custom_color c then
+  if is_fully_opaque opacity && not (is_custom_color c) then
+    (* At 100% the mix is a no-op, so Tailwind writes the colour itself. *)
+    let theme_decl, color_ref =
+      Var.binding (color_var c shade) (to_css c shade)
+    in
+    let value : Css.color = Var color_ref in
+    Style.style [ theme_decl; property value ]
+  else if is_custom_color c then
     if alpha_var then
       Style.style [ property (mix_alpha opacity (to_css c shade)) ]
     else
@@ -3524,7 +3539,14 @@ let divide_with_opacity_selector ?theme ~selector c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   let alpha_var = opacity_var_name opacity <> None in
-  if is_custom_color c then
+  if is_fully_opaque opacity && not (is_custom_color c) then
+    let theme_decl, color_ref =
+      Var.binding (color_var c shade) (to_css c shade)
+    in
+    let value : Css.color = Var color_ref in
+    let rule = Css.rule ~selector [ Css.border_color value ] in
+    Style.style ~rules:(Some [ rule ]) [ theme_decl ]
+  else if is_custom_color c then
     let value =
       if alpha_var then mix_alpha opacity (to_css c shade)
       else

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -405,6 +405,23 @@ module Handler : sig
       the palette token and the typed reference to it, for utilities that set a
       colour var of their own from a palette entry. *)
 
+  val colors_with_opacity_style :
+    ?theme:Scheme.t ->
+    properties:(Css.color -> Css.declaration) list ->
+    ?property_prefix:string ->
+    ?merge_key:string ->
+    color ->
+    int ->
+    opacity_modifier ->
+    Style.t
+  (** [colors_with_opacity_style ~properties color shade opacity] sets every
+      declaration in [properties] to [color] at [opacity]: the srgb fallback
+      plus the [@supports] colour-mix override Tailwind emits. *)
+
+  val theme_color_of_name : string -> (color * int) option
+  (** [theme_color_of_name name] is the palette colour and shade a [color-*]
+      token names, or {!constructor-None} when it names none. *)
+
   val theme_color_decl : ?theme:Scheme.t -> string -> Css.declaration option
   (** [theme_color_decl ?theme name] is the [\@layer theme] declaration for the
       colour token [name] (e.g. ["color-red-500"]), or [None] when [name] is not

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -17,7 +17,12 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "containers"
-  let priority _ = 1
+
+  (* Tailwind's utility order opens with the container utilities; the layout
+     [.container] keeps its own place by its width property. *)
+  let priority = function
+    | Layout_container -> 1
+    | Container | Container_normal | Container_size | Container_named _ -> -2
   (* Tailwind orders .container by its width property: after the position group
      (inset, z-index) and before margin. *)
 

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -142,7 +142,7 @@ let container_size_rem = function
   | Style.Container_6xl -> Some 72.
   | Style.Container_7xl -> Some 80.
   | Style.Container_named _ | Style.Container_size _ | Style.Container_len _
-  | Style.Container_len_cmp _ ->
+  | Style.Container_len_cmp _ | Style.Container_scoped _ ->
       None
 
 (* A [(width <op> len)] container feature query, matching Tailwind v4's range
@@ -162,7 +162,7 @@ let width_cond cmp len =
   | Style.Cq_max -> Css.Container.Not (width_range Css.Media.Ge len)
 
 (** Convert a container query modifier to a structured Container.t condition *)
-let container_query_to_condition q =
+let rec container_query_to_condition q =
   let geq len = width_range Css.Media.Ge len in
   let rem r : Css.length = Css.Values.Rem r in
   match q with
@@ -187,6 +187,8 @@ let container_query_to_condition q =
       width_cond cmp (rem (Option.value ~default:0. (container_size_rem inner)))
   | Style.Container_len (_, len) -> geq len
   | Style.Container_len_cmp (cmp, _, len) -> width_cond cmp len
+  | Style.Container_scoped (name, inner) ->
+      Css.Container.Named (name, container_query_to_condition inner)
 
 let container_query_to_class_prefix = function
   | Style.Container_3xs -> "@3xs"
@@ -205,6 +207,6 @@ let container_query_to_class_prefix = function
   | Style.Container_named ("", width) -> "@" ^ string_of_int width ^ "px"
   | Style.Container_named (name, width) ->
       "@" ^ name ^ "/" ^ string_of_int width
-  | (Style.Container_size _ | Style.Container_len _ | Style.Container_len_cmp _)
-    as q ->
+  | ( Style.Container_size _ | Style.Container_len _ | Style.Container_len_cmp _
+    | Style.Container_scoped _ ) as q ->
       "@" ^ Style.container_size_name q

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -16,7 +16,17 @@ module Handler = struct
     let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
     if a = 255 then rgb else rgb ^ hex_byte a
 
-  type shadow_shape = Two_xs | Xs | Sm | Default | Md | Lg | Xl | Two_xl
+  type shadow_shape =
+    | Two_xs
+    | Xs
+    | Sm
+    | Default
+    | Md
+    | Lg
+    | Xl
+    | Two_xl
+    | Inner
+
   type inset_shadow_shape = Ish_2xs | Ish_xs | Ish_sm
 
   (* Color in an arbitrary shadow value *)
@@ -326,6 +336,7 @@ module Handler = struct
       list =
     match shape with
     | Two_xs -> [ (Zero, Px 1., None, None, "#0000000d") ]
+    | Inner -> [ (Zero, Px 2., Some (Px 4.), Some Zero, "#0000000d") ]
     | Xs -> [ (Zero, Px 1., Some (Px 2.), Some Zero, "#0000000d") ]
     | Sm ->
         [
@@ -354,15 +365,20 @@ module Handler = struct
         ]
     | Two_xl -> [ (Zero, Px 25., Some (Px 50.), Some (Px (-12.)), "#00000040") ]
 
+  (* Only [shadow-inner] draws inside the box. *)
+  let shape_is_inset = function Inner -> true | _ -> false
+
   let shape_shadow_value shape =
     let data = shadow_shape_data shape in
+    let inset = shape_is_inset shape in
     let shadow_list =
       List.map
         (fun (h_offset, v_offset, blur, spread, fallback_hex) ->
           let color_ref =
             Var.reference_with_fallback shadow_color_var (Css.hex fallback_hex)
           in
-          Css.shadow ~h_offset ~v_offset ?blur ?spread ~color:(Var color_ref) ())
+          Css.shadow ~inset ~h_offset ~v_offset ?blur ?spread
+            ~color:(Var color_ref) ())
         data
     in
     match shadow_list with [ s ] -> s | _ -> List shadow_list
@@ -450,31 +466,7 @@ module Handler = struct
   let shadow_lg = shadow_shape_style Lg
   let shadow_xl = shadow_shape_style Xl
   let shadow_2xl = shadow_shape_style Two_xl
-
-  let shadow_inner =
-    (* Define inset shadow variable *)
-    let inset_shadow_value =
-      Css.shadow ~inset:true ~h_offset:(Px 0.) ~v_offset:(Px 2.) ~blur:(Px 4.)
-        ()
-    in
-    (* Create the box-shadow declaration with the shadow value *)
-    let box_shadow_decl = Css.box_shadow inset_shadow_value in
-
-    let d_inset, _ = Var.binding inset_shadow_var inset_shadow_value in
-    let d_inset_ring, _ =
-      Var.binding inset_ring_shadow_var
-        (Css.shadow ~h_offset:Zero ~v_offset:Zero ~color:(Css.hex "#0000") ())
-    in
-    let d_ring_offset, _ =
-      Var.binding ring_offset_shadow_var
-        (Css.shadow ~h_offset:Zero ~v_offset:Zero ~color:(Css.hex "#0000") ())
-    in
-    let d_ring, _ =
-      Var.binding ring_shadow_var
-        (Css.shadow ~h_offset:Zero ~v_offset:Zero ~color:(Css.hex "#0000") ())
-    in
-    style
-      (d_inset :: d_inset_ring :: d_ring_offset :: d_ring :: [ box_shadow_decl ])
+  let shadow_inner = shadow_shape_style Inner
 
   (* Parse arbitrary shadow value like "12px_12px_#0088cc" *)
   let parse_arbitrary_shadow (s : string) :
@@ -2804,7 +2796,8 @@ module Handler = struct
           | Md -> "shadow-md"
           | Lg -> "shadow-lg"
           | Xl -> "shadow-xl"
-          | Two_xl -> "shadow-2xl")
+          | Two_xl -> "shadow-2xl"
+          | Inner -> "shadow-inner")
         ^ "/" ^ Color.pp_opacity op
     | Shadow_color (c, s) -> "shadow-" ^ color_shade c s
     | Shadow_color_opacity (c, s, op) ->

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -549,7 +549,13 @@ module Handler = struct
 
   let shadow_arbitrary (arb : string) =
     let normalized = String.map (fun c -> if c = '_' then ' ' else c) arb in
-    match parse_arbitrary_shadow arb with
+    (* The reading below takes one shadow and no spread, so anything with a
+       comma - a layer list, or a colour function carrying one - goes to the
+       value parser instead. *)
+    match
+      if String.contains arb ',' then Option.None
+      else parse_arbitrary_shadow arb
+    with
     | Some (h_offset, v_offset, blur, Var v) ->
         (* A trailing var() is the colour, not the blur (Tailwind). *)
         let color_ref =

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -368,21 +368,28 @@ module Handler = struct
           | _ -> Option.None)
 
   (* Parse bracket content for number_percentage values *)
-  let parse_bracket_numpct inner : Css.number_percentage =
+  let parse_bracket_numpct_opt inner : Css.number_percentage option =
     if Parse.is_var inner then
       let bare = Parse.extract_var_name inner in
-      Var (Var.bracket bare)
+      Option.Some (Css.Var (Var.bracket bare) : Css.number_percentage)
     else
       let len = String.length inner in
       if len > 1 && inner.[len - 1] = '%' then
-        let num_s = String.sub inner 0 (len - 1) in
-        match Float.of_string_opt num_s with
-        | Option.Some f -> Pct f
-        | Option.None -> Num 0.
+        Option.map
+          (fun f : Css.number_percentage -> Pct f)
+          (Float.of_string_opt (String.sub inner 0 (len - 1)))
       else
-        match Float.of_string_opt inner with
-        | Option.Some f -> Num f
-        | Option.None -> Num 0.
+        Option.map
+          (fun f : Css.number_percentage -> Num f)
+          (Float.of_string_opt inner)
+
+  (* An arbitrary filter amount is a number, a percentage or a var: anything
+     else is not CSS, and the class is not a utility. *)
+  let is_numpct_bracket s =
+    parse_bracket_numpct_opt (Parse.bracket_inner s) <> Option.None
+
+  let parse_bracket_numpct inner : Css.number_percentage =
+    Option.value (parse_bracket_numpct_opt inner) ~default:(Num 0.)
 
   let blur_arbitrary s =
     match parse_bracket_length s with
@@ -1293,27 +1300,30 @@ module Handler = struct
     | [ "blur"; "2xl" ] -> Ok Blur_2xl
     | [ "blur"; "3xl" ] -> Ok Blur_3xl
     | [ "blur"; s ] when Parse.is_bracket_value s -> Ok (Blur_arbitrary s)
-    | [ "brightness"; s ] when Parse.is_bracket_value s ->
+    | [ "brightness"; s ] when Parse.is_bracket_value s && is_numpct_bracket s
+      ->
         Ok (Brightness_arbitrary s)
     | [ "brightness"; n ] ->
         Parse.int_pos ~name:"brightness" n >|= fun x -> Brightness x
-    | [ "contrast"; s ] when Parse.is_bracket_value s ->
+    | [ "contrast"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Contrast_arbitrary s)
     | [ "contrast"; n ] ->
         Parse.int_pos ~name:"contrast" n >|= fun x -> Contrast x
-    | [ "grayscale"; s ] when Parse.is_bracket_value s ->
+    | [ "grayscale"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Grayscale_arbitrary s)
     | [ "grayscale"; n ] ->
         Parse.int_pos ~name:"grayscale" n >|= fun x -> Grayscale x
     | [ "grayscale" ] -> Ok (Grayscale 100)
-    | [ "saturate"; s ] when Parse.is_bracket_value s ->
+    | [ "saturate"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Saturate_arbitrary s)
     | [ "saturate"; n ] ->
         Parse.int_pos ~name:"saturate" n >|= fun x -> Saturate x
-    | [ "sepia"; s ] when Parse.is_bracket_value s -> Ok (Sepia_arbitrary s)
+    | [ "sepia"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
+        Ok (Sepia_arbitrary s)
     | [ "sepia"; n ] -> Parse.int_pos ~name:"sepia" n >|= fun x -> Sepia x
     | [ "sepia" ] -> Ok (Sepia 100)
-    | [ "invert"; s ] when Parse.is_bracket_value s -> Ok (Invert_arbitrary s)
+    | [ "invert"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
+        Ok (Invert_arbitrary s)
     | [ "invert"; n ] -> Parse.int_pos ~name:"invert" n >|= fun x -> Invert x
     | [ "invert" ] -> Ok (Invert 100)
     | [ "hue"; "rotate"; s ] when Parse.is_bracket_value s -> (
@@ -1391,39 +1401,46 @@ module Handler = struct
     | [ "backdrop"; "blur"; "3xl" ] -> Ok Backdrop_blur_3xl
     | [ "backdrop"; "blur"; s ] when Parse.is_bracket_value s ->
         Ok (Backdrop_blur_arbitrary s)
-    | [ "backdrop"; "brightness"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "brightness"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_brightness_arbitrary s)
     | [ "backdrop"; "brightness"; n ] ->
         Parse.int_pos ~name:"backdrop-brightness" n >|= fun x ->
         Backdrop_brightness x
-    | [ "backdrop"; "contrast"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "contrast"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_contrast_arbitrary s)
     | [ "backdrop"; "contrast"; n ] ->
         Parse.int_pos ~name:"backdrop-contrast" n >|= fun x ->
         Backdrop_contrast x
-    | [ "backdrop"; "opacity"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "opacity"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_opacity_arbitrary s)
     | [ "backdrop"; "opacity"; n ] -> (
         match float_of_string_opt n with
         | Some f when f >= 0. -> Ok (Backdrop_opacity f)
         | _ -> err_not_utility)
-    | [ "backdrop"; "saturate"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "saturate"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_saturate_arbitrary s)
     | [ "backdrop"; "saturate"; n ] ->
         Parse.int_pos ~name:"backdrop-saturate" n >|= fun x ->
         Backdrop_saturate x
-    | [ "backdrop"; "grayscale"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "grayscale"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_grayscale_arbitrary s)
     | [ "backdrop"; "grayscale"; n ] ->
         Parse.int_pos ~name:"backdrop-grayscale" n >|= fun x ->
         Backdrop_grayscale x
     | [ "backdrop"; "grayscale" ] -> Ok (Backdrop_grayscale 100)
-    | [ "backdrop"; "invert"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "invert"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_invert_arbitrary s)
     | [ "backdrop"; "invert"; n ] ->
         Parse.int_pos ~name:"backdrop-invert" n >|= fun x -> Backdrop_invert x
     | [ "backdrop"; "invert" ] -> Ok (Backdrop_invert 100)
-    | [ "backdrop"; "sepia"; s ] when Parse.is_bracket_value s ->
+    | [ "backdrop"; "sepia"; s ]
+      when Parse.is_bracket_value s && is_numpct_bracket s ->
         Ok (Backdrop_sepia_arbitrary s)
     | [ "backdrop"; "sepia"; n ] ->
         Parse.int_pos ~name:"backdrop-sepia" n >|= fun x -> Backdrop_sepia x

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -121,13 +121,25 @@ module Handler = struct
             ~default_css:"0px"
         in
         style [ decl; flex_basis (Var ref) ]
-    | None ->
-        let ref : Css.flex_basis Css.var =
-          Var.theme_ref var_name
-            ~default:(Css.Zero : Css.flex_basis)
-            ~default_css:"0px"
-        in
-        style [ flex_basis (Var ref) ]
+    (* Without an override the container scale still declares its own default,
+       so the token the utility reads is in the sheet. *)
+    | None -> (
+        match Sizing.container_binding name with
+        | Some (v, d) ->
+            let decl, _ = Var.binding v d in
+            let ref : Css.flex_basis Css.var =
+              Var.theme_ref var_name
+                ~default:(Css.Zero : Css.flex_basis)
+                ~default_css:"0px"
+            in
+            style [ decl; flex_basis (Var ref) ]
+        | None ->
+            let ref : Css.flex_basis Css.var =
+              Var.theme_ref var_name
+                ~default:(Css.Zero : Css.flex_basis)
+                ~default_css:"0px"
+            in
+            style [ flex_basis (Var ref) ])
 
   (* Order *)
   let order_style n = style [ order (Int n) ]

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -120,6 +120,11 @@ module Handler = struct
 
   let col_span n = style [ grid_column (Span n, Span n) ]
 
+  (* [col-span-[N]] is a count, [col-span-[name]] a named line: anything else -
+     the docs' [<value>] placeholder included - is not a grid line. *)
+  let is_span_value s =
+    int_of_string_opt s <> None || Parse.is_var s || Parse.is_ident s
+
   let col_span_arbitrary s =
     let gl =
       match int_of_string_opt s with Some n -> Span n | None -> Span_name s
@@ -297,8 +302,8 @@ module Handler = struct
     | [ "col"; "span"; "full" ] -> Ok Col_span_full
     | [ "col"; "span"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_arbitrary n with
-        | Some v -> Ok (Col_span_arbitrary v)
-        | None -> err_not_utility)
+        | Some v when is_span_value v -> Ok (Col_span_arbitrary v)
+        | _ -> err_not_utility)
     | [ "col"; "span"; n ] -> (
         match Parse.int_pos ~name:"col-span" n with
         | Ok i -> Ok (Col_span i)
@@ -361,8 +366,8 @@ module Handler = struct
     | [ "row"; "span"; "full" ] -> Ok Row_span_full
     | [ "row"; "span"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_arbitrary n with
-        | Some v -> Ok (Row_span_arbitrary v)
-        | None -> err_not_utility)
+        | Some v when is_span_value v -> Ok (Row_span_arbitrary v)
+        | _ -> err_not_utility)
     | [ "row"; "span"; n ] -> (
         match Parse.int_pos ~name:"row-span" n with
         | Ok i -> Ok (Row_span i)

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -298,7 +298,20 @@ module Handler = struct
     | [ "will"; "change"; "contents" ] -> Ok Will_change_contents
     | [ "will"; "change"; "transform" ] -> Ok Will_change_transform
     | [ "will"; "change"; value ] when Parse.is_bracket_value value ->
-        Ok (Will_change_arbitrary (Parse.bracket_inner value))
+        let inner = Parse.bracket_inner value in
+        (* [will-change] takes property names, so anything that is not an
+           identifier - the docs' [<value>] placeholder included - is not
+           one. *)
+        if
+          Parse.is_var inner
+          || String.split_on_char ',' inner
+             |> List.map String.trim
+             |> List.for_all (fun p ->
+                 Parse.is_ident
+                   (String.map (fun c -> if c = '_' then ' ' else c) p
+                   |> String.trim))
+        then Ok (Will_change_arbitrary inner)
+        else err_not_utility
     | [ "group" ] -> Ok Group
     | [ "peer" ] -> Ok Peer
     | [ "scheme"; "dark" ] -> Ok Scheme_dark

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -74,6 +74,9 @@ module Handler = struct
     | Resize | Resize_none | Resize_x | Resize_y | Appearance_auto
     | Appearance_none ->
         11
+    (* Tailwind's utility order opens with the container utilities and then
+       pointer-events, before the layout group. *)
+    | Pointer_events_none | Pointer_events_auto -> -1
     | _ -> 31
 
   let select_none_s = style [ webkit_user_select None; user_select None ]

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -85,15 +85,24 @@ let z_auto_style ?theme () =
       in
       let decl, ref = Var.binding z_index_auto_var z_value in
       Style.style [ decl; Css.z_index (Var ref) ]
-  | None ->
-      Style.style
-        [
-          Css.z_index
-            (Var
-               (Var.theme_ref "z-index-auto"
-                  ~default:(Auto : Css.z_index)
-                  ~default_css:"auto"));
-        ]
+  (* Without a theme override Tailwind writes the keyword, not a reference to a
+     token nothing declares. *)
+  | None -> Style.style [ Css.z_index Auto ]
+
+(* An [object-[...]] value that is not a var() reference is a position: one or
+   two lengths, with [_] for the space. *)
+let parse_object_position raw : Css.position_value option =
+  let decoded = Parse.decode_arbitrary_value raw in
+  match String.split_on_char ' ' decoded |> List.filter (fun s -> s <> "") with
+  | [ x; y ] -> (
+      match (Css.parse_length x, Css.parse_length y) with
+      | Some xv, Some yv -> Some (XY (xv, yv))
+      | _ -> None)
+  | [ v ] ->
+      Option.map
+        (fun (l : Css.length) : Css.position_value -> Single l)
+        (Css.parse_length v)
+  | _ -> None
 
 module Handler = struct
   open Style
@@ -510,10 +519,15 @@ module Handler = struct
         (* Without a theme override Tailwind writes the keyword, not a reference
            to a token nothing declares. *)
         | None -> style [ object_position default ])
-    | Object_arbitrary var_str ->
-        let bare_name = Parse.extract_var_name var_str in
-        let pos_ref : Css.position_value Css.var = Var.bracket bare_name in
-        style [ object_position (Var pos_ref) ]
+    | Object_arbitrary raw -> (
+        (* Only a var() reference names a variable; anything else is a position
+           value, which [object-[50%]] used to turn into [var(--50)]. *)
+        match parse_object_position raw with
+        | Some pos -> style [ object_position pos ]
+        | None ->
+            let bare_name = Parse.extract_var_name raw in
+            let pos_ref : Css.position_value Css.var = Var.bracket bare_name in
+            style [ object_position (Var pos_ref) ])
     | Float_left -> style [ Css.float Left ]
     | Float_right -> style [ Css.float Right ]
     | Float_none -> style [ Css.float None ]

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -435,10 +435,32 @@ module Handler = struct
      Tailwind *)
   let build_radial_base_style = style []
 
+  (* An arbitrary [mask-radial-at-[30%_30%]] is a position value, so it goes
+     through the value printer rather than reaching the sheet as written. *)
+  let radial_at_position raw : Css.position_value option =
+    match
+      String.split_on_char ' ' (Parse.decode_arbitrary_value raw)
+      |> List.filter (fun s -> s <> "")
+    with
+    | [ x; y ] -> (
+        match (Css.parse_length x, Css.parse_length y) with
+        | Some xv, Some yv -> Some (XY (xv, yv))
+        | _ -> None)
+    | [ v ] ->
+        Option.map
+          (fun (l : Css.length) : Css.position_value -> Single l)
+          (Css.parse_length v)
+    | _ -> None
+
   (* Build the style for mask-radial-at-* - only sets the position variable *)
   let build_radial_at_style pos =
     let position_str =
-      match pos with At_keyword s -> s | At_arbitrary s -> s
+      match pos with
+      | At_keyword s -> s
+      | At_arbitrary s -> (
+          match radial_at_position s with
+          | Some p -> Cascade.Pp.to_string Css.Properties.pp_position_value p
+          | None -> s)
     in
     let decls =
       [
@@ -989,7 +1011,9 @@ module Handler = struct
           && position.[String.length position - 1] = ']'
         then
           let inner = String.sub position 1 (String.length position - 2) in
-          Ok (Mask_radial_at (At_arbitrary inner))
+          if radial_at_position inner = None then
+            Error (`Msg ("Invalid mask-radial-at position: " ^ position))
+          else Ok (Mask_radial_at (At_arbitrary inner))
         else
           (* Validate keyword positions: top, bottom, left, right, center and
              combinations *)

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -294,15 +294,13 @@ module Handler = struct
             (Css.parse_length v)
       | _ -> None
     in
-    (* A comma-separated list of positions is valid CSS but [mask_position]
-       renders the list space-separated, so it would emit an invalid value;
-       leave it unparsed until cascade takes a list. *)
-    if String.contains inner ',' then None
+    (* One position per mask layer, comma-separated. *)
+    let entries = String.split_on_char ',' inner |> List.map String.trim in
+    let positions = List.map one entries in
+    if List.exists Option.is_none positions then None
     else
-      Option.map
-        (fun pv ->
-          [ Css.webkit_mask_position [ pv ]; Css.mask_position [ pv ] ])
-        (one inner)
+      let positions = List.filter_map Fun.id positions in
+      Some [ Css.webkit_mask_position positions; Css.mask_position positions ]
 
   let to_style _theme = function
     | Mask_none -> mask_none
@@ -589,11 +587,14 @@ module Handler = struct
             Ok
               (Mask_bracket_url_var
                  (String.sub inner 4 (String.length inner - 4)))
+        (* Before the single-[url(...)] reading below, which takes everything
+           between the first [(] and the last [)] and so swallows the comma of a
+           layer list. *)
+        | _ when is_image_value inner -> Ok (Mask_bracket_image inner)
         | _ when String.length inner > 4 && String.sub inner 0 4 = "url(" ->
             let url_content = String.sub inner 4 (String.length inner - 5) in
             Ok (Mask_bracket_url url_content)
         | _ when Parse.is_var inner -> Ok (Mask_bracket_var inner)
-        | _ when is_image_value inner -> Ok (Mask_bracket_image inner)
         | _ ->
             if parse_bracket_position inner <> None then
               Ok (Mask_bracket_position inner)

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2029,7 +2029,9 @@ let parse_container_length content =
         Option.bind (Scheme.token_default name) Css.parse_length
       else None
 
-let try_container_query s =
+(* [@sm/main] aims a size query at the container named [main]. The name is the
+   tail after the last [/]; the head is any other container-query spelling. *)
+let rec try_container_query s =
   (* Match ["<prefix>[<len>]"] and build a modifier from the parsed length. *)
   let bracketed prefix mk =
     let plen = String.length prefix and slen = String.length s in
@@ -2071,7 +2073,24 @@ let try_container_query s =
               Container (Container_len_cmp (Cq_max, raw, len))));
         (fun () -> sized "@min-" Cq_min);
         (fun () -> sized "@max-" Cq_max);
+        (fun () -> try_scoped_container_query s);
       ]
+
+and try_scoped_container_query s =
+  match String.rindex_opt s '/' with
+  | None -> None
+  | Some i -> (
+      let name = String.sub s (i + 1) (String.length s - i - 1) in
+      if name = "" then None
+      else
+        let head = String.sub s 0 i in
+        match
+          match List.assoc_opt head simple_modifiers with
+          | Some _ as m -> m
+          | None -> try_container_query head
+        with
+        | Some (Container q) -> Some (Container (Container_scoped (name, q)))
+        | _ -> None)
 
 (* Parse a modifier string into a typed Style.modifier *)
 let rec parse_modifier s : modifier option =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -217,6 +217,22 @@ let expand_spacing_fn s =
 let decode_arbitrary_value s =
   s |> decode_underscores |> expand_spacing_fn |> normalize_css_math_operators
 
+(* A CSS identifier, which is what a custom-ident or a property name written in
+   an arbitrary value has to be. The docs pages carry [<value>] placeholders
+   that are not CSS, and passing one through emits an invalid declaration. *)
+let is_ident s =
+  s <> ""
+  && (match s.[0] with
+    | 'a' .. 'z' | 'A' .. 'Z' | '_' -> true
+    | '-' -> String.length s > 1
+    | c -> Char.code c >= 0x80)
+  && String.for_all
+       (fun c ->
+         match c with
+         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
+         | c -> Char.code c >= 0x80)
+       s
+
 (** Check if a string starts with "var(" — works on inner bracket content *)
 let is_var s = String.length s > 4 && String.sub s 0 4 = "var("
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -201,8 +201,11 @@ let expand_spacing_fn s =
     else if i + 10 <= len && String.sub s i 10 = "--spacing(" then (
       let stop, next = close_paren (i + 9) 0 in
       let n = String.sub s (i + 10) (stop - i - 10) in
-      Buffer.add_string buf
-        (String.concat "" [ "calc(var(--spacing) * "; n; ")" ]);
+      (* [--spacing(1)] is the scale itself; only a multiplier needs calc. *)
+      if String.trim n = "1" then Buffer.add_string buf "var(--spacing)"
+      else
+        Buffer.add_string buf
+          (String.concat "" [ "calc(var(--spacing) * "; n; ")" ]);
       go next)
     else (
       Buffer.add_char buf s.[i];

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -68,6 +68,10 @@ val normalize_css_math_operators : string -> string
     (calc/min/max/...) require around binary [+] and [-], e.g.
     [calc(var(--a)-var(--b))] becomes [calc(var(--a) - var(--b))]. *)
 
+val is_ident : string -> bool
+(** [is_ident s] is [true] when [s] is a CSS identifier, as a custom-ident or a
+    property name written in an arbitrary value has to be. *)
+
 val is_var : string -> bool
 (** [is_var s] returns [true] if [s] starts with ["var("]. Works on inner
     bracket content (without surrounding brackets). *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -509,8 +509,21 @@ let has_anchor_rel ~anchor ~combinator ?name inner =
     (compound [ where [ Class anchor_class ]; has [ inner ] ])
     combinator universal
 
+(* Rebuild [selector] around the [modified] selector a route builds for the bare
+   class, so an inner variant's own work survives: [aria-selected:hover:X] keeps
+   its [:hover]. With no inner variant [selector] is the bare class and the
+   result is [modified] itself. *)
+let route_regular ~selector ~base_class ~modified_class ~modified ?has_hover
+    ~not_order props =
+  let sel =
+    Rules_selector.transform_selector_with_modifier modified base_class
+      modified_class selector
+  in
+  regular ~selector:sel ~props ~base_class:modified_class ?has_hover ~not_order
+    ()
+
 let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
-    selector_str base_class props =
+    ~selector selector_str base_class props =
   let open Css.Selector in
   let processed = preprocess_has_selector selector_str in
   let parsed_selector =
@@ -526,9 +539,9 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
   match kind with
   | `Has ->
       let class_name = "has-" ^ has_part selector_str ^ ":" ^ base_class in
-      let sel = compound [ class_ class_name; has [ parsed_selector ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
-        ()
+      let modified = compound [ class_ class_name; has [ parsed_selector ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~has_hover ~not_order props
   | `Group_has ->
       let name_suffix = match name with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -538,9 +551,9 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
         has_anchor_rel ~anchor:"group" ~combinator:Descendant ?name
           parsed_selector
       in
-      let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
-        ()
+      let modified = compound [ Class class_name; is_ [ rel ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~has_hover ~not_order props
   | `Peer_has ->
       let name_suffix = match name with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -550,9 +563,9 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
         has_anchor_rel ~anchor:"peer" ~combinator:Subsequent_sibling ?name
           parsed_selector
       in
-      let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~has_hover ~not_order
-        ()
+      let modified = compound [ Class class_name; is_ [ rel ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~has_hover ~not_order props
 
 (* Pseudo-class modifiers: transform the base selector and mark hover when
    needed. *)
@@ -709,7 +722,7 @@ let _is_data_shorthand_name = function
   | _ -> false
 
 (* Route data bracket variants to appropriate handler *)
-let route_data_bracket_modifier modifier base_class props =
+let route_data_bracket_modifier modifier ~selector base_class props =
   let kind, raw_str, name_opt =
     match modifier with
     | Style.Data_bracket s -> (`Data, "[" ^ s ^ "]", None)
@@ -732,11 +745,12 @@ let route_data_bracket_modifier modifier base_class props =
   match kind with
   | `Data ->
       let class_name = "data-" ^ class_part ^ ":" ^ base_class in
-      let sel =
+      let modified =
         compound
           [ class_ class_name; attribute ?flag:attr_flag attr_name attr_match ]
       in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~not_order props
   | `Group_data ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -754,8 +768,9 @@ let route_data_bracket_modifier modifier base_class props =
              ])
           Descendant universal
       in
-      let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      let modified = compound [ Class class_name; is_ [ rel ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~not_order props
   | `Peer_data ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -773,11 +788,12 @@ let route_data_bracket_modifier modifier base_class props =
              ])
           Subsequent_sibling universal
       in
-      let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      let modified = compound [ Class class_name; is_ [ rel ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~not_order props
 
 (* Route :has() variants to appropriate handler *)
-let route_has_modifier modifier base_class props =
+let route_has_modifier modifier ~selector base_class props =
   let kind, raw_str, name =
     match modifier with
     | Style.Has s -> (`Has, s, None)
@@ -805,8 +821,8 @@ let route_has_modifier modifier base_class props =
     else 30
   in
   let not_order = base_order in
-  has_like_selector kind ?name ?shorthand ~has_hover ~not_order selector_str
-    base_class props
+  has_like_selector kind ?name ?shorthand ~has_hover ~not_order ~selector
+    selector_str base_class props
 
 (* Parse an aria expression string into an attribute name and match. "modal" →
    ("aria-modal", Presence) "valuenow=1" → ("aria-valuenow", Exact "1")
@@ -832,7 +848,7 @@ let parse_aria_expr expr =
       ("aria-" ^ attr, Css.Selector.Exact value)
 
 (* Route aria variants to appropriate handler *)
-let route_aria_modifier modifier base_class props =
+let route_aria_modifier modifier ~selector base_class props =
   let kind, raw_str, name_opt =
     match modifier with
     | Style.Aria_bracket s -> (`Aria, s, None)
@@ -851,10 +867,11 @@ let route_aria_modifier modifier base_class props =
   match kind with
   | `Aria ->
       let class_name = "aria-" ^ class_part ^ ":" ^ base_class in
-      let sel =
+      let modified =
         compound [ class_ class_name; attribute aria_attr aria_match ]
       in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~not_order props
   | `Group_aria ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -869,8 +886,9 @@ let route_aria_modifier modifier base_class props =
              [ where [ Class group_class ]; attribute aria_attr aria_match ])
           Descendant universal
       in
-      let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      let modified = compound [ Class class_name; is_ [ rel ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~not_order props
   | `Peer_aria ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -885,8 +903,9 @@ let route_aria_modifier modifier base_class props =
              [ where [ Class peer_class ]; attribute aria_attr aria_match ])
           Subsequent_sibling universal
       in
-      let sel = compound [ Class class_name; is_ [ rel ] ] in
-      regular ~selector:sel ~props ~base_class:class_name ~not_order ()
+      let modified = compound [ Class class_name; is_ [ rel ] ] in
+      route_regular ~selector ~base_class ~modified_class:class_name ~modified
+        ~not_order props
 
 (* Handle fallback for unmatched modifiers. Must extract modified_class so that
    outer modifiers like dark: can properly transform the selector. *)
@@ -1735,8 +1754,8 @@ let modified_selector_rule modifier base_class selector props =
   in
   regular ~selector:new_selector ~props ~base_class:modified_class ()
 
-let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
-    base_class selector props =
+let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
+    selector props =
   match modifier with
   (* Data modifiers *)
   | Style.Data_state _ | Style.Data_variant _ ->
@@ -1786,7 +1805,7 @@ let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
       regular ~selector ~props ~base_class ()
   (* :has() variants *)
   | Style.Has _ | Style.Group_has _ | Style.Peer_has _ ->
-      route_has_modifier modifier base_class props
+      route_has_modifier modifier ~selector base_class props
   (* Aria bracket and group/peer aria variants *)
   | Style.Aria_bracket _ | Style.Group_aria _ | Style.Peer_aria _
   | Style.Aria_checked | Style.Aria_expanded | Style.Aria_selected
@@ -1799,10 +1818,10 @@ let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
         | Style.Aria_disabled -> Style.Aria_bracket "disabled"
         | m -> m
       in
-      route_aria_modifier modifier base_class props
+      route_aria_modifier modifier ~selector base_class props
   (* Data bracket and group/peer data variants *)
   | Style.Data_bracket _ | Style.Group_data _ | Style.Peer_data _ ->
-      route_data_bracket_modifier modifier base_class props
+      route_data_bracket_modifier modifier ~selector base_class props
   (* Starting style - selector includes starting: prefix *)
   | Style.Starting ->
       let modified_class = "starting:" ^ base_class in
@@ -1845,6 +1864,19 @@ let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
   | _ ->
       handle_fallback_modifier ~inner_has_hover modifier base_class selector
         props
+
+(* An outer modifier must not swallow the [@media (hover:hover)] gate the inner
+   [hover:] carries: [disabled:hover:X] and [has-checked:hover:X] keep it. Only
+   the routes that build a media query of their own consume the flag. *)
+let modifier_to_rule_themed ?theme ?(inner_has_hover = false) modifier
+    base_class selector props =
+  let rule =
+    dispatch_modifier ?theme ~inner_has_hover modifier base_class selector props
+  in
+  match rule with
+  | Output.Regular r when inner_has_hover && not r.has_hover ->
+      Output.Regular { r with has_hover = true }
+  | rule -> rule
 
 let modifier_to_rule ?inner_has_hover modifier base_class selector props =
   modifier_to_rule_themed ?inner_has_hover modifier base_class selector props

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -149,6 +149,15 @@ module Rules_selector = struct
     in
     Option.value (find modified_base_selector) ~default:base_class
 
+  (* A selector carrying a combinator cannot stand on the right of another one,
+     nor inside a compound, so it goes in [:is()] there - the same rule CSS
+     Nesting applies when substituting [&]. *)
+  let rec is_complex_selector = function
+    | Css.Selector.Combined _ -> true
+    | Css.Selector.Compound sels | Css.Selector.List sels ->
+        List.exists is_complex_selector sels
+    | _ -> false
+
   (* Transform selector by applying modifier to base class and updating
      descendants. *)
   let transform_selector_with_modifier modified_base_selector base_class
@@ -156,27 +165,43 @@ module Rules_selector = struct
     let replace_in_children =
       replace_class_in_selector ~old_class:base_class ~new_class:modified_class
     in
-    let rec transform = function
+    let substitute ~enclose =
+      if enclose && is_complex_selector modified_base_selector then
+        Css.Selector.is_ [ modified_base_selector ]
+      else modified_base_selector
+    in
+    (* [descendant] marks the right of a combinator. A [:where] there holds the
+       utility's own zero-specificity self-reference (as prose's [:where(.prose
+       > :last-child)] does), which only wants the new class name. An [:is] is
+       where the child and descendant variants bury the class, so an outer
+       variant has to reach into it. *)
+    let rec transform ~enclose ~descendant = function
       | Css.Selector.Class cls when String.equal cls base_class ->
-          modified_base_selector
+          substitute ~enclose
       | Css.Selector.Combined (base_sel, combinator, complex_sel) ->
           Css.Selector.Combined
-            (transform base_sel, combinator, replace_in_children complex_sel)
+            ( transform ~enclose ~descendant base_sel,
+              combinator,
+              transform ~enclose:true ~descendant:true complex_sel )
       | Css.Selector.Compound selectors ->
-          Css.Selector.Compound (List.map transform selectors)
+          Css.Selector.Compound
+            (List.map (transform ~enclose:true ~descendant) selectors)
       | Css.Selector.List selectors ->
-          Css.Selector.List (List.map transform selectors)
-      (* The child and descendant variants bury the class inside an [:is], so an
-         outer variant has to reach into it to prefix the class in place. *)
+          Css.Selector.List
+            (List.map (transform ~enclose ~descendant) selectors)
       | Css.Selector.Is selectors ->
-          Css.Selector.Is (List.map transform selectors)
-      | Css.Selector.Where selectors ->
-          Css.Selector.Where (List.map transform selectors)
+          Css.Selector.Is
+            (List.map (transform ~enclose:false ~descendant:false) selectors)
+      | Css.Selector.Where selectors when not descendant ->
+          Css.Selector.Where
+            (List.map (transform ~enclose:false ~descendant) selectors)
+      | Css.Selector.Where _ as sel -> replace_in_children sel
       | Css.Selector.Relative (comb, sel) ->
-          Css.Selector.Relative (comb, transform sel)
+          Css.Selector.Relative
+            (comb, transform ~enclose:true ~descendant:true sel)
       | other -> other
     in
-    transform selector
+    transform ~enclose:false ~descendant:false selector
 end
 
 let resolve_scheme = function Some s -> s | None -> Scheme.default
@@ -1994,11 +2019,36 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
               ~base_class:modified_class ~nested ();
           ])
 
+(* The multi-rule routes below build their selector from the bare class, so an
+   outer variant would discard whatever an inner one already did. Rebuild each
+   rule they produce around the incoming selector; with no inner variant that
+   selector is the bare class and this changes nothing. *)
+let rebase_on_selector ~base_class ~selector rules =
+  match selector with
+  | Css.Selector.Class cls when String.equal cls base_class -> rules
+  | _ ->
+      List.map
+        (fun rule ->
+          match rule with
+          | Output.Regular ({ base_class = Some modified_class; _ } as r) ->
+              Output.Regular
+                {
+                  r with
+                  selector =
+                    Rules_selector.transform_selector_with_modifier r.selector
+                      base_class modified_class selector;
+                }
+          | rule -> rule)
+        rules
+
 (* Extract selector and properties from a single Utility *)
 (* Apply modifier to extracted rule *)
 let rec apply_modifier_to_rule ?theme modifier = function
   | Regular { selector; props; base_class; has_hover; _ } -> (
       let bc = Option.value base_class ~default:"" in
+      let rebase ~selector rules =
+        rebase_on_selector ~base_class:bc ~selector rules
+      in
       match modifier with
       | Style.Pseudo_marker ->
           let open Css.Selector in
@@ -2014,25 +2064,29 @@ let rec apply_modifier_to_rule ?theme modifier = function
           | Style.In_bracket content -> handle_not_in_bracket content bc props
           | Style.In_data attr -> handle_not_in_data attr bc props
           | _ -> handle_not_modifier ?theme inner_modifier bc selector props)
-      | Style.Not_bracket content -> handle_not_bracket content bc props
-      | Style.In_bracket content -> handle_in_bracket content bc props
-      | Style.In_data attr -> handle_in_data attr bc props
-      | Style.In_state (inner, name) -> handle_in_state inner name bc props
+      | Style.Not_bracket content ->
+          rebase ~selector (handle_not_bracket content bc props)
+      | Style.In_bracket content ->
+          rebase ~selector (handle_in_bracket content bc props)
+      | Style.In_data attr -> rebase ~selector (handle_in_data attr bc props)
+      | Style.In_state (inner, name) ->
+          rebase ~selector (handle_in_state inner name bc props)
       | Style.Group_not (inner, name_opt) ->
-          handle_group_not_modifier inner name_opt bc props
+          rebase ~selector (handle_group_not_modifier inner name_opt bc props)
       | Style.Peer_not (inner, name_opt) ->
-          handle_peer_not_modifier inner name_opt bc props
+          rebase ~selector (handle_peer_not_modifier inner name_opt bc props)
       | Style.Named_group (inner, name) ->
-          handle_named_group inner name bc props
-      | Style.Named_peer (inner, name) -> handle_named_peer inner name bc props
+          rebase ~selector (handle_named_group inner name bc props)
+      | Style.Named_peer (inner, name) ->
+          rebase ~selector (handle_named_peer inner name bc props)
       | Style.Not_named_group (inner, name) ->
-          handle_not_named_group inner name bc props
+          rebase ~selector (handle_not_named_group inner name bc props)
       | Style.Has_named_group (inner, name) ->
-          handle_has_named_group inner name bc props
+          rebase ~selector (handle_has_named_group inner name bc props)
       | Style.In_named_group (inner, name) ->
-          handle_in_named_group inner name bc props
+          rebase ~selector (handle_in_named_group inner name bc props)
       | Style.Group_peer_named (inner, name) ->
-          handle_group_peer_named inner name bc props
+          rebase ~selector (handle_group_peer_named inner name bc props)
       | _ -> (
           try
             [

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1189,17 +1189,24 @@ let extract_not_conditions inner_modifier base_class =
       match sel with
       | Css.Selector.Compound (Css.Selector.Class _ :: rest) when rest <> [] ->
           rest
+      (* A descendant-style variant anchors the class under an ancestor.
+         Negating it negates the ancestor relation, so the class's own position
+         becomes a universal: [not-in-data-open] negates [:where([data-open]) *]
+         rather than the class itself. *)
+      | Css.Selector.Combined (ancestor, comb, Css.Selector.Class c)
+        when String.equal c base_class ->
+          [ Css.Selector.Combined (ancestor, comb, Css.Selector.universal) ]
       | _ -> [ sel ])
 
 (** Build a regular rule with :not() selector for a not-* modifier. *)
 let not_selector_rule ?(not_order = 0) inner_modifier modified_class base_class
-    props =
+    ~selector props =
   let conditions = extract_not_conditions inner_modifier base_class in
   let not_sel = Css.Selector.Not conditions in
-  regular ~not_order
-    ~selector:
-      (Css.Selector.compound [ Css.Selector.Class modified_class; not_sel ])
-    ~props ~base_class:modified_class ()
+  let modified =
+    Css.Selector.compound [ Css.Selector.Class modified_class; not_sel ]
+  in
+  route_regular ~selector ~base_class ~modified_class ~modified ~not_order props
 
 (* Create a single not-media rule *)
 let not_media_rule ~nvo ~condition modified_class props =
@@ -1212,14 +1219,14 @@ let not_media_rule ~nvo ~condition modified_class props =
 (** Handle :not() pseudo-class modifier: dispatches to the right rule type based
     on the inner modifier. Returns a list of rules since some modifiers (like
     hover) produce both a selector rule and a media rule. *)
-let handle_not_modifier ?theme inner_modifier base_class _selector props =
+let handle_not_modifier ?theme inner_modifier base_class selector props =
   let modified_class =
     "not-" ^ not_class_prefix inner_modifier ^ ":" ^ base_class
   in
   let nvo = Modifiers.not_variant_order inner_modifier in
   let sel_rule () =
     not_selector_rule ~not_order:nvo inner_modifier modified_class base_class
-      props
+      ~selector props
   in
   let not_hover_media () =
     not_media_rule ~nvo ~condition:(negate_media hover_media) modified_class
@@ -1357,10 +1364,9 @@ let handle_in_data attr base_class props =
       ~not_order:200 ();
   ]
 
-(** Handle not-in-[...] bracket modifier. Returns a list of rules. *)
-let handle_not_in_bracket content base_class props =
-  let modified_class = "not-in-[" ^ content ^ "]:" ^ base_class in
-  let ancestor = in_bracket_ancestor content in
+(* [not-in-*] negates the ancestor relation rather than the class, so the
+   class's own position in the negated selector is a universal. *)
+let not_in_rule ~modified_class ~ancestor props =
   let sel =
     Css.Selector.compound
       [
@@ -1376,6 +1382,21 @@ let handle_not_in_bracket content base_class props =
     regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in"
       ~not_order:100 ();
   ]
+
+(** Handle not-in-[...] bracket modifier. Returns a list of rules. *)
+let handle_not_in_bracket content base_class props =
+  not_in_rule
+    ~modified_class:("not-in-[" ^ content ^ "]:" ^ base_class)
+    ~ancestor:(in_bracket_ancestor content)
+    props
+
+(** Handle the not-in-data-* modifier. Returns a list of rules. *)
+let handle_not_in_data attr base_class props =
+  not_in_rule
+    ~modified_class:("not-in-data-" ^ attr ^ ":" ^ base_class)
+    ~ancestor:
+      (Css.Selector.Attribute (None, Data attr, Css.Selector.Presence, None))
+    props
 
 (** Handle not-[...] bracket modifier. Returns a list of rules. *)
 let handle_not_bracket content base_class props =
@@ -1991,6 +2012,7 @@ let rec apply_modifier_to_rule ?theme modifier = function
       | Style.Not inner_modifier -> (
           match inner_modifier with
           | Style.In_bracket content -> handle_not_in_bracket content bc props
+          | Style.In_data attr -> handle_not_in_data attr bc props
           | _ -> handle_not_modifier ?theme inner_modifier bc selector props)
       | Style.Not_bracket content -> handle_not_bracket content bc props
       | Style.In_bracket content -> handle_in_bracket content bc props

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -2085,6 +2085,7 @@ let order (u : Utility.base) =
   match u with Self x -> Some (priority x, suborder x) | _ -> None
 
 (* Export container theme variables for use by other modules (e.g., Columns) *)
+let container_binding = Handler.container_binding
 let container_3xs = Handler.container_3xs
 let container_2xs = Handler.container_2xs
 let container_xs = Handler.container_xs

--- a/lib/sizing.mli
+++ b/lib/sizing.mli
@@ -342,3 +342,8 @@ val container_6xl : Css.length Var.theme
 
 val container_7xl : Css.length Var.theme
 (** [container_7xl] is the theme variable for 7xl container width (80rem). *)
+
+val container_binding : string -> (Css.length Var.theme * Css.length) option
+(** [container_binding name] is the theme variable and default for a container
+    scale step ["sm"], or {!constructor-None} when [name] is not one. The scale
+    doubles as the named width scale in v4. *)

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -23,6 +23,7 @@ type container_query =
   | Container_size of container_cmp * container_query
   | Container_len of string * Css.length
   | Container_len_cmp of container_cmp * string * Css.length
+  | Container_scoped of string * container_query
 
 type modifier =
   | Hover
@@ -342,6 +343,7 @@ let rec container_size_name = function
   | Container_len (raw, _) -> "[" ^ raw ^ "]"
   | Container_len_cmp (cmp, raw, _) ->
       container_cmp_prefix cmp ^ "[" ^ raw ^ "]"
+  | Container_scoped (name, inner) -> container_size_name inner ^ "/" ^ name
 
 (* Convert modifier to string prefix *)
 (* Map of simple state names to base modifiers for compound variant parsing *)

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -300,7 +300,22 @@ let rec important_stmt stmt =
       Css.rule ~selector
         ~nested:(List.map important_stmt nested)
         (List.map mark_important_decl decls)
-  | None -> stmt
+  | None -> (
+      (* An at-rule holds the declarations the [!] has to reach: the colour
+         utilities put their modern-syntax value behind [@supports], and it has
+         to outrank the fallback the same way. *)
+      match Css.as_supports stmt with
+      | Some (condition, stmts) ->
+          Css.supports ~condition (List.map important_stmt stmts)
+      | None -> (
+          match Css.as_media stmt with
+          | Some (condition, stmts) ->
+              Css.media ~condition (List.map important_stmt stmts)
+          | None -> (
+              match Css.as_container stmt with
+              | Some (name, condition, stmts) ->
+                  Css.container ?name ?condition (List.map important_stmt stmts)
+              | None -> stmt)))
 
 let rec map_important = function
   | Style s ->

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -10,6 +10,7 @@ type container_cmp =
       (** Container-query direction: [Cq_min] is [width >= v], [Cq_max] is
           [width < v]. *)
 
+(** [@min-[<len>]] / [@max-[<len>]]. *)
 type container_query =
   | Container_3xs
   | Container_2xs
@@ -32,7 +33,8 @@ type container_query =
       (** [@[<len>]]: [width >= len]. Carries the raw bracket token so the class
           name round-trips. *)
   | Container_len_cmp of container_cmp * string * Css.length
-      (** [@min-[<len>]] / [@max-[<len>]]. *)
+  | Container_scoped of string * container_query
+      (** [@sm/main]: a size query aimed at the container named [main]. *)
 
 type modifier =
   | Hover

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -562,7 +562,17 @@ module Handler = struct
     | [ "transition"; "normal" ] -> Ok Transition_behavior_normal
     | [ "transition"; "discrete" ] -> Ok Transition_behavior_allow_discrete
     | [ "transition"; value ] when Parse.is_bracket_value value ->
-        Ok (Transition_arbitrary (Parse.bracket_inner value))
+        let inner = Parse.bracket_inner value in
+        (* [transition-property] takes property names, so anything that is not
+           an identifier - the docs' [<value>] placeholder included - is not
+           one. *)
+        if
+          Parse.is_var inner
+          || String.split_on_char ',' inner
+             |> List.map String.trim
+             |> List.for_all Parse.is_ident
+        then Ok (Transition_arbitrary inner)
+        else Error (`Msg "Invalid transition property")
     | [ "transition" ] -> Ok Transition
     | [ "duration"; n ] when String.length n > 0 && n.[0] = '[' ->
         (* Arbitrary duration: duration-[300ms] *)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -279,7 +279,32 @@ let default_font_family_declarations =
   in
   [ sans_decl; mono_decl; default_font_decl; default_mono_decl ]
 
+(* CSS Fonts 4 sec. 6.4: [font-feature-settings] is [normal] or a comma list of
+   [<opentype-tag> [<integer> | on | off]?], the tag being a quoted
+   four-character string. The docs' [<value>] placeholder is neither. *)
+
 (** Early typography handler - comes before color utilities (priority 22) *)
+let is_feature_tag_list s =
+  let s = Parse.decode_underscores s in
+  let entry e =
+    match
+      String.split_on_char ' ' (String.trim e) |> List.filter (( <> ) "")
+    with
+    | [] -> false
+    | tag :: rest -> (
+        let n = String.length tag in
+        n = 6
+        && (tag.[0] = '"' || tag.[0] = '\'')
+        && tag.[n - 1] = tag.[0]
+        &&
+        match rest with
+        | [] -> true
+        | [ x ] -> x = "on" || x = "off" || int_of_string_opt x <> None
+        | _ -> false)
+  in
+  String.trim s = "normal"
+  || (s <> "" && List.for_all entry (String.split_on_char ',' s))
+
 module Typography_early = struct
   open Style
   open Css
@@ -582,7 +607,8 @@ module Typography_early = struct
     | [ "font"; "features"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         if Parse.is_var inner then Ok (Font_features_var inner)
-        else Ok (Font_features_quoted inner)
+        else if is_feature_tag_list inner then Ok (Font_features_quoted inner)
+        else err_not_utility
     | [ "font"; "features"; v ] when Parse.is_bare_var v ->
         Ok (Font_features_bare_var v)
     | [ "font"; "thin" ] -> Ok Font_thin
@@ -1265,8 +1291,8 @@ module Typography_early = struct
     | Font_features_quoted s ->
         (* Normalize comma spacing: "c2sc","smcp" → "c2sc", "smcp" *)
         let normalized =
-          String.split_on_char ',' s |> List.map String.trim
-          |> String.concat ", "
+          String.split_on_char ',' (Parse.decode_underscores s)
+          |> List.map String.trim |> String.concat ", "
         in
         style [ font_feature_settings (Feature_list normalized) ]
     | Font_features_var var_str ->

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -101,12 +101,21 @@ let test_no_crash () =
       "[mask-type:luminance]";
     ]
 
+(* Tailwind's [--spacing(N)] shorthand reads the spacing scale, so it has to be
+   expanded here too: the value used to reach the sheet verbatim. *)
+let test_property_spacing_fn () =
+  Alcotest.(check bool)
+    "[--gap:--spacing(10)] reads the spacing scale" true
+    (Astring.String.is_infix ~affix:"--gap: calc(var(--spacing) * 10)"
+       (css "[--gap:--spacing(10)]"))
+
 let tests =
   [
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
     test_case "arbitrary of_string - invalid values" `Quick of_string_invalid;
     test_case "property value calc operators" `Quick
       test_property_calc_operators;
+    test_case "property value --spacing()" `Quick test_property_spacing_fn;
     test_case "theme() dot-notation" `Quick test_theme_dot_notation;
     test_case "var-valued colour with opacity" `Quick test_var_color_opacity;
     test_case "custom property with opacity" `Quick test_custom_prop_opacity;

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -109,6 +109,25 @@ let test_property_spacing_fn () =
     (Astring.String.is_infix ~affix:"--gap: calc(var(--spacing) * 10)"
        (css "[--gap:--spacing(10)]"))
 
+(* Tailwind's [--alpha(C/P)] is the [/opacity] form written as a function, and a
+   reference to a palette token renders from the palette, so the fallback is a
+   colour rather than the bare reference. *)
+let test_alpha_fn () =
+  let out = css "[--checkered-bg:--alpha(var(--color-gray-950)/10%)]" in
+  Alcotest.(check bool)
+    "fallback resolves the palette colour" true
+    (Astring.String.is_infix ~affix:"--checkered-bg: #0307121a" out);
+  Alcotest.(check bool)
+    "@supports keeps the token reference" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, var(--color-gray-950) 10%, transparent)" out);
+  Alcotest.(check string)
+    "the --alpha() spelling round-trips"
+    "[--checkered-bg:--alpha(var(--color-gray-950)/10%)]"
+    (Tw.pp
+       (Result.get_ok
+          (Tw.of_string "[--checkered-bg:--alpha(var(--color-gray-950)/10%)]")))
+
 let tests =
   [
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
@@ -116,6 +135,7 @@ let tests =
     test_case "property value calc operators" `Quick
       test_property_calc_operators;
     test_case "property value --spacing()" `Quick test_property_spacing_fn;
+    test_case "property value --alpha()" `Quick test_alpha_fn;
     test_case "theme() dot-notation" `Quick test_theme_dot_notation;
     test_case "var-valued colour with opacity" `Quick test_var_color_opacity;
     test_case "custom property with opacity" `Quick test_custom_prop_opacity;

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -376,6 +376,30 @@ let test_v433_color_families () =
   has "border-mist-200" "var(--color-mist-200)";
   has "bg-taupe-950" "var(--color-taupe-950)"
 
+(* A [/100] modifier is a no-op mix, so the colour itself is the value: the
+   color-mix and its @supports fallback used to be emitted anyway. And [!] has
+   to reach inside that @supports, or the fallback outranks the modern value. *)
+let test_full_opacity_and_important () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  let lacks cls affix =
+    Alcotest.(check bool)
+      (cls ^ " without " ^ affix)
+      false
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "text-blue-600/100" "color:var(--color-blue-600)";
+  lacks "text-blue-600/100" "color-mix";
+  lacks "divide-gray-200/100" "color-mix";
+  has "bg-white/75!"
+    "color-mix(in oklab,var(--color-white) 75%,transparent)!important"
+
 let tests =
   [
     ("Achromatic colour keeps a none hue", `Quick, test_achromatic_none_hue);
@@ -393,6 +417,7 @@ let tests =
     ("Color accuracy", `Quick, accuracy);
     ("CSS modes with colors", `Quick, test_css_mode_with_colors);
     ("v4.3.3 colour families", `Quick, test_v433_color_families);
+    ("Full opacity and important", `Quick, test_full_opacity_and_important);
   ]
 
 let suite = ("color", tests)

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -95,12 +95,29 @@ let test_container_variant_composition () =
   has "@sm:@max-md:flex-col"
     "@container(width>=24rem){@container not (width>=28rem)"
 
+(* [@sm/main] aims the size query at the container named [main] rather than the
+   nearest one. *)
+let test_scoped_container_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "@sm/main:flex-col" "@container main (width>=24rem)";
+  has "@sm/main:flex-col" ".\\@sm\\/main\\:flex-col";
+  has "@max-sm/main:hidden" "@container main not (width>=24rem)";
+  has "@min-[400px]/sidebar:flex" "@container sidebar (width>=400px)"
+
 let tests =
   [
     test_case "types" `Quick test_container_types;
     test_case "variant composition" `Quick test_container_variant_composition;
     test_case "name" `Quick test_container_name;
     test_case "multiple named containers" `Quick test_multiple_named_containers;
+    test_case "scoped container variant" `Quick test_scoped_container_variant;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "containers suborder matches Tailwind" `Quick
       suborder_matches_tailwind;

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -253,10 +253,29 @@ let test_shadow_inner () =
        ~affix:"box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow)"
        out)
 
+(* A shadow list is one shadow per layer. The single-shadow reading also drops
+   the spread, so anything with a comma goes to the value parser. *)
+let test_arbitrary_shadow_list () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "both layers survive with their spread" true
+    (Astring.String.is_infix
+       ~affix:
+         "--tw-shadow:-5px 10px 15px -3px \
+          var(--tw-shadow-color,var(--shadow-color)),-5px 4px 6px -4px \
+          var(--tw-shadow-color,var(--shadow-color))"
+       (css
+          "shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)]"))
+
 let tests =
   [
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;
+    test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;
     test_case "inset-shadow roundtrip" `Quick test_inset_shadow_roundtrip;

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -235,9 +235,28 @@ let test_shadeless_shadow_colors () =
   has "inset-shadow-white/20"
     ".inset-shadow-white\\/20{--tw-inset-shadow-color:#fff3}"
 
+(* shadow-inner is a shadow shape like the others: it sets --tw-shadow and
+   composes, rather than writing box-shadow directly. *)
+let test_shadow_inner () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let out = css "shadow-inner" in
+  Alcotest.(check bool)
+    "shadow-inner sets --tw-shadow" true
+    (Astring.String.is_infix ~affix:"--tw-shadow:inset 0 2px 4px 0 " out);
+  Alcotest.(check bool)
+    "shadow-inner composes box-shadow" true
+    (Astring.String.is_infix
+       ~affix:"box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow)"
+       out)
+
 let tests =
   [
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
+    test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;
     test_case "inset-shadow roundtrip" `Quick test_inset_shadow_roundtrip;

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -101,11 +101,27 @@ let test_drop_shadow_keyword_and_alpha () =
     (Astring.String.is_infix ~affix:"--drop-shadow-xl:"
        (css "drop-shadow-xl/25"))
 
+(* An arbitrary filter amount that is not a number, a percentage or a var used
+   to be coerced to zero, so brightness-[abc] emitted brightness(0). *)
+let test_invalid_arbitrary_amount () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "brightness-[abc]";
+  rejected "invert-[xyz]";
+  rejected "backdrop-sepia-[nope]";
+  check "brightness-[1.5]";
+  check "saturate-[150%]";
+  check "brightness-[var(--x)]"
+
 let tests =
   [
     test_case "drop-shadow keyword color and alpha" `Quick
       test_drop_shadow_keyword_and_alpha;
     test_case "blur" `Quick test_blur;
+    test_case "invalid arbitrary amount" `Quick test_invalid_arbitrary_amount;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;
     test_case "drop-shadow color (default theme)" `Quick test_drop_shadow_color;
     test_case "drop-shadow fractional alpha" `Quick

--- a/test/test_grid_item.ml
+++ b/test/test_grid_item.ml
@@ -93,10 +93,31 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"grid_item suborder matches Tailwind" shuffled
 
+(* An arbitrary span is a count, a named line or a var(). The docs pages carry a
+   [<value>] placeholder, which is none of those and emitted an invalid
+   grid-column. *)
+let test_invalid_arbitrary_span () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "col-span-[<value>]";
+  rejected "row-span-[<value>]";
+  accepted "col-span-[3]";
+  accepted "col-span-[mycol]";
+  accepted "col-span-[var(--my-variable)]"
+
 let tests =
   [
     test_case "grid_item of_string - valid values" `Quick of_string_valid;
     test_case "grid_item of_string - invalid values" `Quick of_string_invalid;
+    test_case "invalid arbitrary span" `Quick test_invalid_arbitrary_span;
     test_case "grid_item suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
   ]

--- a/test/test_interactivity.ml
+++ b/test/test_interactivity.ml
@@ -82,6 +82,17 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"interactivity suborder matches Tailwind" shuffled
 
+(* Tailwind's utility order opens with the container utilities and then
+   pointer-events, before the layout group. *)
+let pointer_events_sorts_first () =
+  let open Tw in
+  let shuffled =
+    Test_helpers.shuffle
+      [ absolute; pointer_events_none; flex; at_container; pointer_events_auto ]
+  in
+  Test_helpers.check_ordering_matches
+    ~test_name:"pointer-events sorts before the layout group" shuffled
+
 let tests =
   [
     test_case "select" `Quick test_select;
@@ -89,6 +100,7 @@ let tests =
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "interactivity suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "pointer-events sorts first" `Quick pointer_events_sorts_first;
   ]
 
 let suite = ("interactivity", tests)

--- a/test/test_interactivity.ml
+++ b/test/test_interactivity.ml
@@ -93,6 +93,24 @@ let pointer_events_sorts_first () =
   Test_helpers.check_ordering_matches
     ~test_name:"pointer-events sorts before the layout group" shuffled
 
+(* [will-change] takes property names, so the docs' [<value>] placeholder is not
+   one; it used to reach the sheet as will-change: <value>. *)
+let test_invalid_arbitrary_will_change () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "will-change-[<value>]";
+  accepted "will-change-[opacity]";
+  accepted "will-change-[opacity,transform]";
+  accepted "will-change-[var(--x)]"
+
 let tests =
   [
     test_case "select" `Quick test_select;
@@ -101,6 +119,8 @@ let tests =
     test_case "interactivity suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "pointer-events sorts first" `Quick pointer_events_sorts_first;
+    test_case "invalid arbitrary will-change" `Quick
+      test_invalid_arbitrary_will_change;
   ]
 
 let suite = ("interactivity", tests)

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -173,6 +173,23 @@ let test_typed () =
   Test_helpers.check_typed_class "break-before-column" Tw.break_before_column;
   Test_helpers.check_typed_class "break-inside-avoid" Tw.break_inside_avoid
 
+(* [object-[50%]] is a position, not a variable name: it used to come out as
+   [object-position: var(--50)]. [z-auto] writes the keyword, since no theme
+   declares [--z-index-auto]. *)
+let test_object_and_z_values () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "object-[50%]" "object-position:50%";
+  has "object-[10px_20px]" "object-position:10px 20px";
+  has "object-[var(--x)]" "object-position:var(--x)";
+  has "z-auto" "z-index:auto"
+
 let tests =
   [
     test_case "display utilities" `Quick test_display_utilities;
@@ -180,6 +197,8 @@ let tests =
     test_case "box-decoration-break" `Quick test_box_decoration_break;
     test_case "typed constructors" `Quick test_typed;
     test_case "z-index" `Quick test_z_index;
+    test_case "object-position and z-auto values" `Quick
+      test_object_and_z_values;
     test_case "overflow" `Quick test_overflow;
     test_case "screen reader utilities" `Quick test_screen_reader;
     test_case "sr-only declaration order" `Quick test_sr_only_declaration_order;

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -60,11 +60,31 @@ let test_bracket_image () =
   check "mask-[conic-gradient(white,black)]";
   check "mask-[linear-gradient(white,black)]"
 
+(* A mask takes one image and one position per layer, comma-separated. The
+   single-[url(...)] reading used to swallow the comma, and a position list was
+   rejected outright. *)
+let test_bracket_layer_list () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "two url layers stay two" true
+    (Astring.String.is_infix ~affix:"mask-image:url(/a.png),url(/b.png)"
+       (css "mask-[url(/a.png),url(/b.png)]"));
+  Alcotest.(check bool)
+    "two positions stay two" true
+    (Astring.String.is_infix ~affix:"mask-position:30% 50%,70% 50%"
+       (css "mask-position-[30%_50%,70%_50%]"))
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
+      Alcotest.test_case "arbitrary mask layer list" `Quick
+        test_bracket_layer_list;
     ]
 
 let suite = ("masks", tests)

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -337,6 +337,23 @@ let test_attribute_variant_keeps_inner () =
   has "disabled:hover:bg-indigo-500" "(hover:hover)";
   has "has-checked:hover:bg-indigo-500" "(hover:hover)"
 
+(* [not-] over a variant that anchors the class under an ancestor negates the
+   ancestor relation, and over an inner variant it keeps that variant's own
+   selector work. *)
+let test_not_variant_keeps_inner () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "not-in-data-open:hidden" ":not(:where([data-open]) *)";
+  has "not-checked:before:hidden" ":not(:checked):before";
+  has "not-data-focus:not-has-checked:ring-inset"
+    ":not([data-focus]):not(:has(:checked))"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -359,6 +376,8 @@ let tests =
       test_hover_dark_media_wrapper;
     test_case "attribute variant keeps the inner selector" `Quick
       test_attribute_variant_keeps_inner;
+    test_case "not- variant keeps the inner selector" `Quick
+      test_not_variant_keeps_inner;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -354,6 +354,23 @@ let test_not_variant_keeps_inner () =
   has "not-data-focus:not-has-checked:ring-inset"
     ":not([data-focus]):not(:has(:checked))"
 
+(* The in-/named-group/peer routes build their selector from the bare class too,
+   so an outer one used to drop the anchor an inner arbitrary selector had put
+   in place. *)
+let test_in_variant_keeps_inner () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "in-data-stack:[:first-child>&]:underline"
+    ":first-child>:is(:where([data-stack]) .in-data-stack";
+  (* prose's own [:where(.prose > :last-child)] still only gets renamed *)
+  has "hover:prose" ":where(.hover\\:prose>:last-child)"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -378,6 +395,8 @@ let tests =
       test_attribute_variant_keeps_inner;
     test_case "not- variant keeps the inner selector" `Quick
       test_not_variant_keeps_inner;
+    test_case "in- variant keeps the inner selector" `Quick
+      test_in_variant_keeps_inner;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -317,6 +317,26 @@ let test_pseudo_element_content_once () =
   check int "a plain utility still gets one" 1
     (occurrences "content:var(--tw-content)" (css "after:underline"))
 
+(* An attribute-style variant (aria/data/has) builds its own selector, so it
+   used to discard whatever an inner variant had already done: the [:hover], the
+   child combinator, the second attribute. *)
+let test_attribute_variant_keeps_inner () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "aria-selected:hover:underline" "[aria-selected=true]:hover";
+  has "data-[closed]:data-[enter]:-translate-x-8" "[data-closed][data-enter]";
+  has "has-checked:hover:bg-indigo-500" ":has(:checked):hover";
+  has "aria-selected:*:font-medium" "[aria-selected=true]>*";
+  (* the inner [hover:] keeps its own @media gate under an outer variant *)
+  has "disabled:hover:bg-indigo-500" "(hover:hover)";
+  has "has-checked:hover:bg-indigo-500" "(hover:hover)"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -337,6 +357,8 @@ let tests =
       test_opacity_color_variant_no_leak;
     test_case "hover:dark keeps hover media wrapper" `Quick
       test_hover_dark_media_wrapper;
+    test_case "attribute variant keeps the inner selector" `Quick
+      test_attribute_variant_keeps_inner;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -44,8 +44,30 @@ let test_initial_resets () =
     "ease-initial sets --tw-ease:initial" true
     (Astring.String.is_infix ~affix:"--tw-ease:initial" (css "ease-initial"))
 
+(* [transition-[...]] takes property names, so the docs' [<value>] placeholder
+   is not one; it used to reach the sheet as transition-property: <value>. *)
+let test_invalid_arbitrary_property () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "transition-[<value>]";
+  accepted "transition-[opacity]";
+  accepted "transition-[opacity,transform]";
+  accepted "transition-[var(--x)]"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
-  @ [ Alcotest.test_case "initial resets" `Quick test_initial_resets ]
+  @ [
+      Alcotest.test_case "initial resets" `Quick test_initial_resets;
+      Alcotest.test_case "invalid arbitrary property" `Quick
+        test_invalid_arbitrary_property;
+    ]
 
 let suite = ("transitions", tests)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -444,9 +444,30 @@ let test_bracket_list_style () =
     "an unknown counter style is rejected" true
     (Result.is_error (Tw.of_string "list-[nonsense-style]"))
 
+(* CSS Fonts 4 sec. 6.4: a feature setting is a quoted four-character tag with
+   an optional integer / on / off, so the docs' [<value>] placeholder is not
+   one; the underscore in [font-features-["liga"_0]] is a space. *)
+let test_font_features_value () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "font-features-[<value>]";
+  Alcotest.(check bool)
+    "the underscore is a space" true
+    (Astring.String.is_infix ~affix:"font-feature-settings:\"liga\" 0"
+       (css "font-features-[\"liga\"_0]"))
+
 let tests =
   [
     test_case "bracket list-style" `Quick test_bracket_list_style;
+    test_case "font-features value" `Quick test_font_features_value;
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;
     test_case "leading-none inline" `Quick test_leading_none_inline;


### PR DESCRIPTION
Stacking a variant on top of another dropped the inner one's work: the aria/data/has routes rebuilt the selector from the bare class, so `aria-selected:hover:underline` lost its `:hover` and `data-[closed]:data-[enter]:` its second attribute, and an outer variant swallowed the inner `hover:`'s `@media (hover:hover)` gate. The `not-` routes had the same problem, and `not-in-data-*` negated the utility's own class rather than the ancestor relation.

The colour commit also fixes a correctness bug rather than a cosmetic one: `!` never reached inside the `@supports` override a colour utility emits, so on `bg-white/75!` the srgb fallback outranked the modern value.