### PR TITLE
modifiers: accept any variant as the argument of has-

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
   inner variant has moved the subject:
   `in-data-stack:[:last-child>&]:*:rounded-b-xl` put `:last-child >` in front
   of the whole selector rather than of the class (#233)
+- Accept any variant as the argument of `has-`, not only a state name or a
+  bracket: `has-peer-checked` and `group-not-has-peer-not-data-active` were
+  rejected as unknown modifiers (#232)
 
 - Reject an arbitrary value that is not what the property takes:
   `col-span-[<value>]`, `row-span-[<value>]`, `transition-[<value>]`,

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1027,6 +1027,7 @@ let rec pp_modifier = function
   (* A shorthand name is stored bare ([Has "focus"]), a bracket form with its
      CSS punctuation ([Has ":focus"]); only the latter renders brackets. *)
   | Has selector -> "has-" ^ has_part selector
+  | Has_variant m -> "has-" ^ pp_modifier m
   | Group_has (selector, None) -> "group-has-" ^ has_part selector
   | Group_has (selector, Some name) ->
       "group-has-" ^ has_part selector ^ "/" ^ name
@@ -2101,6 +2102,7 @@ let rec parse_modifier s : modifier option =
       (fun () -> try_bracketed_modifier s);
       (fun () -> try_aria_shorthand s);
       (fun () -> try_has_shorthand s);
+      (fun () -> try_has_variant s);
       (fun () -> try_numeric_nth s);
       (fun () -> try_compound_named_group s);
       (fun () -> try_in_modifier s);
@@ -2141,6 +2143,16 @@ and try_group_peer_not_variant s =
   match try_prefix "group-not-" (fun i n -> Group_not (i, n)) with
   | Some _ as r -> r
   | None -> try_prefix "peer-not-" (fun i n -> Peer_not (i, n))
+
+(* [has-<variant>]: the argument is any variant, and that variant's own selector
+   goes inside [:has()]. The shorthand reading only knows the state names and a
+   bracket, so [has-peer-checked] fell through. *)
+and try_has_variant s =
+  if String.length s > 4 && String.sub s 0 4 = "has-" then
+    match parse_modifier (String.sub s 4 (String.length s - 4)) with
+    | Some m when is_not_compatible m -> Some (Has_variant m)
+    | Some _ | None -> None
+  else None
 
 and try_not_of_modifier s =
   if not (String.length s > 4 && String.sub s 0 4 = "not-") then None
@@ -2217,7 +2229,7 @@ let not_variant_order = function
   | Disabled -> 3100
   | Inert -> 3200
   (* Block 2: complex selectors *)
-  | Has _ -> 3300
+  | Has _ | Has_variant _ -> 3300
   | Aria_selected -> 3340
   | Aria_checked -> 3350
   | Aria_expanded -> 3360

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1173,18 +1173,25 @@ let not_class_prefix inner_modifier =
 
 (** Extract the pseudo-class selector(s) from a modifier for use in :not().
     Returns a list of selectors that go inside :not(sel1, sel2, ...). *)
-let named_not_rel ~marker ~combinator ~name_opt conditions =
+let named_rel ~marker ~combinator ~name_opt extra =
   let marker_class =
     match name_opt with
     | Option.None -> Css.Selector.Class marker
     | Option.Some n -> Css.Selector.Class (marker ^ "/" ^ n)
   in
   Css.Selector.combine
-    (Css.Selector.compound
-       [ Css.Selector.where [ marker_class ]; Css.Selector.Not conditions ])
+    (Css.Selector.compound (Css.Selector.where [ marker_class ] :: extra))
     combinator Css.Selector.universal
 
-let rec extract_not_conditions inner_modifier base_class =
+let named_not_rel ~marker ~combinator ~name_opt conditions =
+  named_rel ~marker ~combinator ~name_opt [ Css.Selector.Not conditions ]
+
+let rec scoped_conditions ~marker ~combinator ~name_opt ~negated m base_class =
+  let inner = extract_not_conditions m base_class in
+  let extra = if negated then [ Css.Selector.Not inner ] else inner in
+  [ Css.Selector.is_ [ named_rel ~marker ~combinator ~name_opt extra ] ]
+
+and extract_not_conditions inner_modifier base_class =
   match inner_modifier with
   | Style.Hocus | Style.Device_hocus ->
       [ Css.Selector.Hover; Css.Selector.Focus ]
@@ -1194,26 +1201,22 @@ let rec extract_not_conditions inner_modifier base_class =
      [:not()] would negate - is what goes inside [:has()]. *)
   | Style.Has_variant m ->
       [ Css.Selector.Has (extract_not_conditions m base_class) ]
-  (* A scoped [not-] variant negates the whole relative selector, so that is
-     what an outer variant sees of it. *)
+  (* A scoped variant carries its own relative selector - negated for the [not-]
+     forms - and that is the whole of what an outer variant sees of it. *)
   | Style.Group_not (m, name_opt) ->
-      [
-        Css.Selector.is_
-          [
-            named_not_rel ~marker:"group" ~combinator:Css.Selector.Descendant
-              ~name_opt
-              (extract_not_conditions m base_class);
-          ];
-      ]
+      scoped_conditions ~marker:"group" ~combinator:Css.Selector.Descendant
+        ~name_opt ~negated:true m base_class
   | Style.Peer_not (m, name_opt) ->
-      [
-        Css.Selector.is_
-          [
-            named_not_rel ~marker:"peer"
-              ~combinator:Css.Selector.Subsequent_sibling ~name_opt
-              (extract_not_conditions m base_class);
-          ];
-      ]
+      scoped_conditions ~marker:"peer"
+        ~combinator:Css.Selector.Subsequent_sibling ~name_opt ~negated:true m
+        base_class
+  | Style.Named_group (m, name) ->
+      scoped_conditions ~marker:"group" ~combinator:Css.Selector.Descendant
+        ~name_opt:(Option.Some name) ~negated:false m base_class
+  | Style.Named_peer (m, name) ->
+      scoped_conditions ~marker:"peer"
+        ~combinator:Css.Selector.Subsequent_sibling ~name_opt:(Option.Some name)
+        ~negated:false m base_class
   (* [not-group-has-X] negates the whole scoped relative selector, not just its
      [:has()] part. *)
   | Style.Group_has (selector_str, name) ->

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1158,6 +1158,7 @@ let not_class_prefix inner_modifier =
     when String.length pseudo_str > 0 && pseudo_str.[0] = ':' ->
       "has-" ^ String.sub pseudo_str 1 (String.length pseudo_str - 1)
   | Style.Has shorthand_name -> "has-" ^ shorthand_name
+  | Style.Has_variant m -> "has-" ^ Modifiers.pp_modifier m
   | Style.Nth expr -> Style.pp_nth "nth" expr
   | Style.Nth_last expr -> Style.pp_nth "nth-last" expr
   | Style.Nth_of_type expr -> Style.pp_nth "nth-of-type" expr
@@ -1167,14 +1168,52 @@ let not_class_prefix inner_modifier =
       "supports-" ^ String.sub cond 0 prop_len
   | inner -> Modifiers.pp_modifier inner
 
+(* The relative selector a [group-not-]/[peer-not-] variant contributes:
+   [:where(.group):not(<conditions>) *]. *)
+
 (** Extract the pseudo-class selector(s) from a modifier for use in :not().
     Returns a list of selectors that go inside :not(sel1, sel2, ...). *)
-let extract_not_conditions inner_modifier base_class =
+let named_not_rel ~marker ~combinator ~name_opt conditions =
+  let marker_class =
+    match name_opt with
+    | Option.None -> Css.Selector.Class marker
+    | Option.Some n -> Css.Selector.Class (marker ^ "/" ^ n)
+  in
+  Css.Selector.combine
+    (Css.Selector.compound
+       [ Css.Selector.where [ marker_class ]; Css.Selector.Not conditions ])
+    combinator Css.Selector.universal
+
+let rec extract_not_conditions inner_modifier base_class =
   match inner_modifier with
   | Style.Hocus | Style.Device_hocus ->
       [ Css.Selector.Hover; Css.Selector.Focus ]
   | Style.Has selector_str ->
       [ Css.Selector.Has [ has_inner_selector selector_str ] ]
+  (* [has-<variant>] holds the variant itself, so its selector - the same one
+     [:not()] would negate - is what goes inside [:has()]. *)
+  | Style.Has_variant m ->
+      [ Css.Selector.Has (extract_not_conditions m base_class) ]
+  (* A scoped [not-] variant negates the whole relative selector, so that is
+     what an outer variant sees of it. *)
+  | Style.Group_not (m, name_opt) ->
+      [
+        Css.Selector.is_
+          [
+            named_not_rel ~marker:"group" ~combinator:Css.Selector.Descendant
+              ~name_opt
+              (extract_not_conditions m base_class);
+          ];
+      ]
+  | Style.Peer_not (m, name_opt) ->
+      [
+        Css.Selector.is_
+          [
+            named_not_rel ~marker:"peer"
+              ~combinator:Css.Selector.Subsequent_sibling ~name_opt
+              (extract_not_conditions m base_class);
+          ];
+      ]
   (* [not-group-has-X] negates the whole scoped relative selector, not just its
      [:has()] part. *)
   | Style.Group_has (selector_str, name) ->
@@ -1491,11 +1530,6 @@ let handle_named_not ~prefix ~base_marker_class ~combinator ~variant inner
   let nvo = Modifiers.not_variant_order (variant inner name_opt) in
   if is_media_inner_modifier inner then []
   else
-    let marker_class =
-      match name_opt with
-      | None -> Css.Selector.Class base_marker_class
-      | Some name -> Css.Selector.Class (base_marker_class ^ "/" ^ name)
-    in
     let not_conditions =
       match inner with
       | Style.Not_bracket content when content <> "" && content.[0] = ':' ->
@@ -1504,9 +1538,8 @@ let handle_named_not ~prefix ~base_marker_class ~combinator ~variant inner
     in
     let open Css.Selector in
     let rel =
-      combine
-        (compound [ where [ marker_class ]; Not not_conditions ])
-        combinator universal
+      named_not_rel ~marker:base_marker_class ~combinator ~name_opt
+        not_conditions
     in
     [
       regular ~not_order:nvo
@@ -1799,6 +1832,21 @@ let modified_selector_rule modifier base_class selector props =
   in
   regular ~selector:new_selector ~props ~base_class:modified_class ()
 
+(* [has-<variant>]: the inner variant's own selector goes inside [:has()]. *)
+let route_has_variant inner ~selector base_class props =
+  let modified_class =
+    "has-" ^ Modifiers.pp_modifier inner ^ ":" ^ base_class
+  in
+  let modified =
+    Css.Selector.compound
+      [
+        Css.Selector.Class modified_class;
+        Css.Selector.Has (extract_not_conditions inner base_class);
+      ]
+  in
+  route_regular ~selector ~base_class ~modified_class ~modified ~not_order:10
+    props
+
 let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
     selector props =
   match modifier with
@@ -1851,6 +1899,8 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
   (* :has() variants *)
   | Style.Has _ | Style.Group_has _ | Style.Peer_has _ ->
       route_has_modifier modifier ~selector base_class props
+  | Style.Has_variant inner ->
+      route_has_variant inner ~selector base_class props
   (* Aria bracket and group/peer aria variants *)
   | Style.Aria_bracket _ | Style.Group_aria _ | Style.Peer_aria _
   | Style.Aria_checked | Style.Aria_expanded | Style.Aria_selected

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -55,6 +55,7 @@ type modifier =
   | Container of container_query
   | Not of modifier
   | Has of string
+  | Has_variant of modifier
   | Group_has of string * string option
   | Peer_has of string * string option
   | Starting
@@ -480,6 +481,7 @@ let rec pp_modifier = function
   (* A shorthand name is stored bare ([Has "focus"]), a bracket form with its
      CSS punctuation ([Has ":focus"]); only the latter renders brackets. *)
   | Has s -> String.concat "" [ "has-"; has_part s ]
+  | Has_variant m -> String.concat "" [ "has-"; pp_modifier m ]
   | Group_has (s, None) -> String.concat "" [ "group-has-"; has_part s ]
   | Group_has (s, Some name) ->
       String.concat "" [ "group-has-"; has_part s; "/"; name ]

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -66,6 +66,9 @@ type modifier =
   | Container of container_query
   | Not of modifier
   | Has of string
+  | Has_variant of modifier
+      (** [has-<variant>]: any variant's own selector inside [:has()], as
+          [has-peer-checked] and [has-not-data-active] need. *)
   | Group_has of string * string option
   | Peer_has of string * string option
   | Starting

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -385,6 +385,26 @@ let test_arbitrary_anchor_over_child () =
        ~affix:":is(:last-child>:is(:where([data-stack]) .in-data-stack"
        (css "in-data-stack:[:last-child>&]:*:rounded-b-xl"))
 
+(* [has-<variant>] takes any variant, not only a state name or a bracket: its
+   own selector is what goes inside [:has()]. A scoped variant contributes its
+   whole relative selector, so it composes both ways. *)
+let test_has_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "has-peer-checked:underline" ":has(:is(:where(.peer):checked~*))";
+  has "group-not-has-peer-not-data-active:underline"
+    ":is(:where(.group):not(:has(:is(:where(.peer):not([data-active])~*))) *)";
+  (* a named group scopes on the marker class, and the whole relative selector
+     is what [:has()] sees *)
+  has "has-group-focus/name:underline"
+    ":has(:is(:where(.group\\/name):focus *))"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -413,6 +433,7 @@ let tests =
       test_in_variant_keeps_inner;
     test_case "arbitrary anchor over a child variant" `Quick
       test_arbitrary_anchor_over_child;
+    test_case "has- takes any variant" `Quick test_has_variant;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
`has-` only knew the state-name shorthands and a bracket, so `has-peer-checked` and `group-not-has-peer-not-data-active` were rejected as unknown modifiers. The argument is now any variant, and that variant's own selector goes inside `:has()`.

A scoped `not-` variant also had no selector of its own for an outer variant to read, so it resolved to the bare utility class; it now contributes its whole relative selector.