### PR TITLE
rule: anchor an arbitrary-selector variant at the class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Anchor an arbitrary-selector variant at the class's own position when an
+  inner variant has moved the subject:
+  `in-data-stack:[:last-child>&]:*:rounded-b-xl` put `:last-child >` in front
+  of the whole selector rather than of the class (#233)
+
 - Reject an arbitrary value that is not what the property takes:
   `col-span-[<value>]`, `row-span-[<value>]`, `transition-[<value>]`,
   `will-change-[<value>]` and `font-features-[<value>]` emitted invalid CSS

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1705,9 +1705,12 @@ let arbitrary_selector_rule content base_class selector props =
     | Compound (Class cls :: rest) when String.equal cls base_class -> Some rest
     | _ -> None
   in
-  let rename replacement =
-    Rules_selector.replace_class_with ~old_class:base_class ~replacement
-      selector
+  (* With no decoration to lift, an inner variant has moved the subject, and the
+     variant's selector belongs at the class's own position inside what that
+     inner variant built - not wrapped around the whole of it. *)
+  let rebase modified =
+    Rules_selector.transform_selector_with_modifier modified base_class
+      modified_class selector
   in
   let anchored =
     if String.contains s '&' then (
@@ -1716,11 +1719,7 @@ let arbitrary_selector_rule content base_class selector props =
          ([&:hover]) and trailing anchors ([input&]) all flatten correctly. A
          naive split-on-[&] + Descendant combine mis-parses any remainder that
          starts with a combinator. *)
-      let anchor =
-        match decoration with
-        | Some _ -> Class modified_class
-        | None -> rename (Class modified_class)
-      in
+      let anchor = Class modified_class in
       let anchor_str = Css.Selector.to_string anchor in
       let buf = Buffer.create (String.length s + String.length anchor_str) in
       String.iter
@@ -1740,13 +1739,13 @@ let arbitrary_selector_rule content base_class selector props =
       in
       let inner = Css.Selector.read (Cascade.Cursor.of_string s) in
       let inner = if is_type_selector then is_ [ inner ] else inner in
-      let anchored = compound [ Class modified_class; inner ] in
-      match decoration with Some _ -> anchored | None -> rename anchored
+      compound [ Class modified_class; inner ]
   in
   let sel =
     match decoration with
-    | Some [] | None -> anchored
+    | Some [] -> anchored
     | Some extra -> attach_to_subject extra anchored
+    | None -> rebase anchored
   in
   regular ~selector:sel ~props ~base_class:modified_class ()
 

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -371,6 +371,20 @@ let test_in_variant_keeps_inner () =
   (* prose's own [:where(.prose > :last-child)] still only gets renamed *)
   has "hover:prose" ":where(.hover\\:prose>:last-child)"
 
+(* An arbitrary-selector variant anchors the utility's class, so when an inner
+   variant has already moved the subject the anchor belongs at the class's own
+   position - not wrapped around everything the inner variant built. *)
+let test_arbitrary_anchor_over_child () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check bool "the child variant's tail stays outermost" true
+    (Astring.String.is_infix
+       ~affix:":is(:last-child>:is(:where([data-stack]) .in-data-stack"
+       (css "in-data-stack:[:last-child>&]:*:rounded-b-xl"))
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -397,6 +411,8 @@ let tests =
       test_not_variant_keeps_inner;
     test_case "in- variant keeps the inner selector" `Quick
       test_in_variant_keeps_inner;
+    test_case "arbitrary anchor over a child variant" `Quick
+      test_arbitrary_anchor_over_child;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
When an inner variant has already moved the subject, the `&` anchor of an arbitrary-selector variant was substituted with everything that inner variant had built, rather than taking the class's own position inside it. `in-data-stack:[:last-child>&]:*:rounded-b-xl` came out as `:last-child > :is(… .cls > *)` — the child variant's `> *` trapped inside the anchor — instead of `:is(:last-child > :is(… .cls) > *)`.