### PR TITLE
reject an arbitrary value the property cannot take

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Reject an arbitrary value the property cannot take instead of falling back to
+  a plausible one: `bg-position-[...]`, `bg-size-[...]`, `cursor-[...]`,
+  `indent-[...]`, `mask-size-[...]`, `mask-position-[...]`, `object-[...]` and
+  `text-shadow-[...]` emitted `center`, `auto`, `0px`, `none` or
+  `var(--<value>)` for a value they could not read (#234)
+
 - Anchor an arbitrary-selector variant at the class's own position when an
   inner variant has moved the subject:
   `in-data-stack:[:last-child>&]:*:rounded-b-xl` put `:last-child >` in front

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1801,10 +1801,16 @@ module Handler = struct
         Ok (Bg_radial_bracket inner)
     (* bg-position-[...] bracket notation *)
     | [ "bg"; "position"; bracket ] when Parse.is_bracket_value bracket ->
-        Ok (Bg_position_bracket (Parse.bracket_inner bracket))
+        let inner = Parse.bracket_inner bracket in
+        if parse_bracket_position inner = None && not (Parse.is_var inner) then
+          Error (`Msg "Invalid background-position value")
+        else Ok (Bg_position_bracket inner)
     (* bg-size-[...] bracket notation *)
     | [ "bg"; "size"; bracket ] when Parse.is_bracket_value bracket ->
-        Ok (Bg_size_bracket (Parse.bracket_inner bracket))
+        let inner = Parse.bracket_inner bracket in
+        if parse_bracket_size inner = None && not (Parse.is_var inner) then
+          Error (`Msg "Invalid background-size value")
+        else Ok (Bg_size_bracket inner)
     (* Bracket notation: bg-[...] and bg-[...]/opacity *)
     | [ "bg"; bracket_stuff ]
       when String.length bracket_stuff > 1 && bracket_stuff.[0] = '[' -> (

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -160,7 +160,10 @@ module Handler = struct
     | [ "cursor"; value ] when Parse.is_bracket_var value ->
         Ok (Cursor_bracket_var (Parse.bracket_inner value))
     | [ "cursor"; name ] when not (List.mem_assoc cls of_class_map) ->
-        if Parse.is_valid_theme_name name then Ok (Cursor_theme name)
+        (* A theme token name is an identifier: [cursor-[<value>]] is not
+           one. *)
+        if Parse.is_valid_theme_name name && Parse.is_ident name then
+          Ok (Cursor_theme name)
         else Error (`Msg "Not a cursor utility")
     | _ -> (
         match List.assoc_opt cls of_class_map with

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -665,7 +665,12 @@ module Handler = struct
     | [ "object"; "top"; "left" ] -> Ok Object_top_left
     | [ "object"; "top"; "right" ] -> Ok Object_top_right
     | [ "object"; value ] when Parse.is_bracket_value value ->
-        Ok (Object_arbitrary (Parse.bracket_inner value))
+        let inner = Parse.bracket_inner value in
+        (* Only a var() reference names a variable; anything the position parser
+           rejects is not a utility. *)
+        if parse_object_position inner = None && not (Parse.is_var inner) then
+          Error (`Msg ("Invalid object-position value: " ^ inner))
+        else Ok (Object_arbitrary inner)
     | [ "float"; "left" ] -> Ok Float_left
     | [ "float"; "right" ] -> Ok Float_right
     | [ "float"; "none" ] -> Ok Float_none

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -556,10 +556,14 @@ module Handler = struct
     | [ "mask"; "position"; bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
         if Parse.is_var inner then Ok (Mask_position_bracket_var inner)
+        else if parse_bracket_position inner = None then
+          Error (`Msg "Invalid mask-position value")
         else Ok (Mask_position_bracket inner)
     | [ "mask"; "size"; bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
         if Parse.is_var inner then Ok (Mask_size_bracket_var inner)
+        else if parse_bracket_size inner = None then
+          Error (`Msg "Invalid mask-size value")
         else Ok (Mask_size_bracket inner)
     (* Bracket notation: mask-[...] *)
     | [ "mask"; bracket ] when Parse.is_bracket_value bracket -> (

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -703,6 +703,10 @@ module Handler = struct
               match opacity with
               | Color.No_opacity -> Ok (Text_shadow_bracket_hex hex)
               | op -> Ok (Text_shadow_bracket_hex_opacity (hex, op))
+            else if parse_arbitrary_shadow inner = Stdlib.Option.None then
+              (* Not a shadow, so not a utility: it used to fall back to
+                 [text-shadow: none]. *)
+              err_not_utility
             else
               match opacity with
               | Color.No_opacity -> Ok (Text_shadow_arbitrary inner)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1393,6 +1393,32 @@ module Typography_late = struct
   open Style
   open Css
 
+  let parse_length_value str : Css.length option =
+    let len = String.length str in
+    if len = 0 then None
+    else
+      let num_end = ref 0 in
+      while
+        !num_end < len
+        &&
+        let c = str.[!num_end] in
+        (c >= '0' && c <= '9') || c = '.' || c = '-'
+      do
+        incr num_end
+      done;
+      let num_str = String.sub str 0 !num_end in
+      let unit_str = String.sub str !num_end (len - !num_end) in
+      match float_of_string_opt num_str with
+      | Some n -> (
+          match unit_str with
+          | "px" -> Some (Px n)
+          | "rem" -> Some (Rem n)
+          | "em" -> Some (Em n)
+          | "%" -> Some (Pct n)
+          | "" when n = 0.0 -> Some Zero
+          | _ -> None)
+      | None -> None
+
   type t =
     | (* Decoration color *)
       Decoration_color of Color.color * int option
@@ -1814,9 +1840,13 @@ module Typography_late = struct
     | [ "indent"; "px" ] -> Ok Indent_px
     | [ ""; "indent"; "px" ] -> Ok Indent_neg_px
     | [ "indent"; n ] when Parse.is_bracket_value n ->
-        Ok (Indent_arbitrary (Parse.bracket_inner n))
+        let inner = Parse.bracket_inner n in
+        if parse_length_value inner = None then err_not_utility
+        else Ok (Indent_arbitrary inner)
     | [ ""; "indent"; n ] when Parse.is_bracket_value n ->
-        Ok (Indent_neg_arbitrary (Parse.bracket_inner n))
+        let inner = Parse.bracket_inner n in
+        if parse_length_value inner = None then err_not_utility
+        else Ok (Indent_neg_arbitrary inner)
     | [ "indent"; n ] -> (
         match Parse.spacing_value ~name:"indent" n with
         | Ok f -> Ok (Indent f)
@@ -2551,32 +2581,6 @@ module Typography_late = struct
     style [ webkit_font_smoothing Auto; moz_osx_font_smoothing Auto ]
 
   let list_image_url url = style [ list_style_image (Url url) ]
-
-  let parse_length_value str : Css.length option =
-    let len = String.length str in
-    if len = 0 then None
-    else
-      let num_end = ref 0 in
-      while
-        !num_end < len
-        &&
-        let c = str.[!num_end] in
-        (c >= '0' && c <= '9') || c = '.' || c = '-'
-      do
-        incr num_end
-      done;
-      let num_str = String.sub str 0 !num_end in
-      let unit_str = String.sub str !num_end (len - !num_end) in
-      match float_of_string_opt num_str with
-      | Some n -> (
-          match unit_str with
-          | "px" -> Some (Px n)
-          | "rem" -> Some (Rem n)
-          | "em" -> Some (Em n)
-          | "%" -> Some (Pct n)
-          | "" when n = 0.0 -> Some Zero
-          | _ -> None)
-      | None -> None
 
   let text_indent_length length =
     text_indent (Indent { length; hanging = false; each_line = false })

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -188,6 +188,10 @@ let test_object_and_z_values () =
   has "object-[50%]" "object-position:50%";
   has "object-[10px_20px]" "object-position:10px 20px";
   has "object-[var(--x)]" "object-position:var(--x)";
+  (* not a position and not a var: not a utility *)
+  (match Tw.of_string "object-[<value>]" with
+  | Ok _ -> Alcotest.fail "expected object-[<value>] to be rejected"
+  | Error _ -> ());
   has "z-auto" "z-index:auto"
 
 let tests =

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -78,6 +78,17 @@ let test_bracket_layer_list () =
     (Astring.String.is_infix ~affix:"mask-position:30% 50%,70% 50%"
        (css "mask-position-[30%_50%,70%_50%]"))
 
+(* An arbitrary value the property cannot take is not a utility: these used to
+   fall back to [auto] / [center] and emit a plausible-looking declaration. *)
+let test_invalid_bracket_value () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "mask-size-[<value>]";
+  rejected "mask-position-[<value>]"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -85,6 +96,8 @@ let tests =
       Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
       Alcotest.test_case "arbitrary mask layer list" `Quick
         test_bracket_layer_list;
+      Alcotest.test_case "invalid bracket value" `Quick
+        test_invalid_bracket_value;
     ]
 
 let suite = ("masks", tests)


### PR DESCRIPTION
`bg-position-[…]`, `bg-size-[…]`, `cursor-[…]`, `indent-[…]`, `mask-size-[…]`, `mask-position-[…]`, `object-[…]` and `text-shadow-[…]` each fell back to a plausible value — `center`, `auto`, `0px`, `none`, or a `var()` named after the bracket text — when they could not read the content. An unreadable value became a silently wrong declaration rather than a rejected class.

Follow-up to #231, which fixed the same shape in five other utilities.