### PR TITLE
rule: rename the class inside an inner media query's nested blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   `indent-[...]`, `mask-size-[...]`, `mask-position-[...]`, `object-[...]` and
   `text-shadow-[...]` emitted `center`, `auto`, `0px`, `none` or
   `var(--<value>)` for a value they could not read (#234)
+- Keep the outer variant in the class name when an inner one has nested a
+  media block of its own: `sm:motion-reduce:hover:translate-y-0` emitted the
+  rule as `.motion-reduce\:hover\:translate-y-0`, without the `sm:` (#235)
 
 - Anchor an arbitrary-selector variant at the class's own position when an
   inner variant has moved the subject:

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2007,9 +2007,31 @@ let arbitrary_selector_in_media content bc selector props ~inner_condition
       ]
   | other -> [ other ]
 
+(* An inner media query keeps its own nested blocks - a [hover:] rule carries an
+   [@media (hover:hover)] one - and those hold the utility's class too. Rename
+   it there as well, or the outer variant drops out of the class name. *)
+
 (** Apply a modifier to a Media_query rule by wrapping it in an outer media
     query. Handles media-like modifiers, responsive modifiers, and falls back to
     returning the rule unchanged. *)
+let rec rename_class_in_stmt ~old_class ~new_class stmt =
+  let recurse = rename_class_in_stmt ~old_class ~new_class in
+  match Css.as_rule stmt with
+  | Some (selector, decls, nested) ->
+      Css.rule
+        ~selector:
+          (Rules_selector.replace_class_in_selector ~old_class ~new_class
+             selector)
+        ~nested:(List.map recurse nested) decls
+  | None -> (
+      match Css.as_media stmt with
+      | Some (condition, stmts) -> Css.media ~condition (List.map recurse stmts)
+      | None -> (
+          match Css.as_supports stmt with
+          | Some (condition, stmts) ->
+              Css.supports ~condition (List.map recurse stmts)
+          | None -> stmt))
+
 let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
     ~props ~base_class ~nested =
   let bc = Option.value base_class ~default:"" in
@@ -2021,9 +2043,10 @@ let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
     Rules_selector.transform_selector_with_modifier modified_base_selector bc
       modified_class selector
   in
-  let inner_rule = Css.rule ~selector:new_selector props in
   let inner_media =
-    Css.media ~condition:inner_condition (inner_rule :: nested)
+    let rename = rename_class_in_stmt ~old_class:bc ~new_class:modified_class in
+    Css.media ~condition:inner_condition
+      (Css.rule ~selector:new_selector props :: List.map rename nested)
   in
   let wrap_in_media condition =
     (* Use the modified class (e.g. "dark:md:block") as the wrapped rule's base

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -405,6 +405,23 @@ let test_has_variant () =
   has "has-group-focus/name:underline"
     ":has(:is(:where(.group\\/name):focus *))"
 
+(* An inner media query's nested blocks hold the utility's class too, so an
+   outer responsive variant has to rename it there as well: [sm:] used to drop
+   out of the class name whenever [hover:] had wrapped the rule in its own media
+   block. *)
+let test_outer_media_renames_nested () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "sm:motion-reduce:hover:translate-y-0"
+    ".sm\\:motion-reduce\\:hover\\:translate-y-0:hover";
+  has "sm:dark:hover:underline" ".sm\\:dark\\:hover\\:underline:hover"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -434,6 +451,8 @@ let tests =
     test_case "arbitrary anchor over a child variant" `Quick
       test_arbitrary_anchor_over_child;
     test_case "has- takes any variant" `Quick test_has_variant;
+    test_case "outer media renames the nested class" `Quick
+      test_outer_media_renames_nested;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
A `hover:` rule carries its own `@media (hover:hover)` block. An outer responsive or media variant renamed the enclosing rule's selector but left that nested block alone, and since the nested rule is the one holding the declarations, the emitted class lost the outer variant: `sm:motion-reduce:hover:translate-y-0` came out as `.motion-reduce\:hover\:translate-y-0:hover`, inside the right media nest but under the wrong name.