### PR TITLE
modifiers: read --theme() in a container query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 - Keep the outer variant in the class name when an inner one has nested a
   media block of its own: `sm:motion-reduce:hover:translate-y-0` emitted the
   rule as `.motion-reduce\:hover\:translate-y-0`, without the `sm:` (#235)
+- Read the `--theme(--x)` spelling of the theme lookup in a container query,
+  alongside `theme(--x)`: `@min-[--theme(--breakpoint-sm)]:` was rejected
+  (#236)
 
 - Anchor an arbitrary-selector variant at the class's own position when an
   inner variant has moved the subject:

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2019,6 +2019,12 @@ let parse_container_length content =
   | Some _ as len -> len
   | None ->
       let s = String.trim content in
+      (* Tailwind spells the theme lookup [theme(--x)] and [--theme(--x)]. *)
+      let s =
+        if String.length s > 2 && String.sub s 0 2 = "--" then
+          String.sub s 2 (String.length s - 2)
+        else s
+      in
       let n = String.length s in
       if n > 7 && String.sub s 0 6 = "theme(" && s.[n - 1] = ')' then
         let inner = String.trim (String.sub s 6 (n - 7)) in

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -111,6 +111,19 @@ let test_scoped_container_variant () =
   has "@max-sm/main:hidden" "@container main not (width>=24rem)";
   has "@min-[400px]/sidebar:flex" "@container sidebar (width>=400px)"
 
+(* Tailwind spells the theme lookup both [theme(--x)] and [--theme(--x)]. *)
+let test_theme_fn_container_query () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "@min-[--theme(--breakpoint-sm)]:flex" "@container(width>=40rem)";
+  has "@min-[theme(--breakpoint-sm)]:flex" "@container(width>=40rem)"
+
 let tests =
   [
     test_case "types" `Quick test_container_types;
@@ -118,6 +131,8 @@ let tests =
     test_case "name" `Quick test_container_name;
     test_case "multiple named containers" `Quick test_multiple_named_containers;
     test_case "scoped container variant" `Quick test_scoped_container_variant;
+    test_case "theme() in a container query" `Quick
+      test_theme_fn_container_query;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "containers suborder matches Tailwind" `Quick
       suborder_matches_tailwind;


### PR DESCRIPTION
Tailwind spells the theme lookup in an arbitrary container query both `theme(--x)` and `--theme(--x)`. Only the first was read, so `@min-[--theme(--breakpoint-sm)]:-mx-8` was rejected as an unknown modifier.