### PR TITLE
reject an arbitrary value the property cannot take, part 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 - Read the `--theme(--x)` spelling of the theme lookup in a container query,
   alongside `theme(--x)`: `@min-[--theme(--breakpoint-sm)]:` was rejected
   (#236)
+- Reject an arbitrary value the property cannot take in seven more utilities:
+  `shadow-[...]`, `inset-shadow-[...]` and `drop-shadow-[...]` fell back to the
+  zero shadow, `font-[...]` quoted the text into a family name, and
+  `from-[...]`, `via-[...]` and `to-[...]` read it as the stop position `0%`
+  (#237)
 
 - Anchor an arbitrary-selector variant at the class's own position when an
   inner variant has moved the subject:

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1587,7 +1587,21 @@ module Handler = struct
         (String.sub s 0 i, Some (String.sub s (i + 1) (String.length s - i - 1)))
     | None -> (s, None)
 
+  (* A gradient stop bracket that is not a colour is a stop position: a
+     percentage, a length, or a var(). Anything else - the docs' [<value>]
+     placeholder included - is neither, and used to land as [0%]. *)
+
   (** Parse gradient color/position from token list for a given target *)
+  let is_gradient_position inner =
+    Parse.is_var inner
+    || (String.length inner > 11 && String.sub inner 0 11 = "percentage:")
+    || (String.length inner > 7 && String.sub inner 0 7 = "length:")
+    ||
+    let n = String.length inner in
+    String.ends_with ~suffix:"%" inner
+    && float_of_string_opt (String.sub inner 0 (n - 1)) <> None
+    || Css.parse_length inner <> None
+
   let parse_gradient_color ?theme target rest =
     let gc src = Ok (Gradient_color (target, src)) in
     let gp src = Ok (Gradient_stop_position (target, src)) in
@@ -1620,7 +1634,8 @@ module Handler = struct
             else if String.length inner > 0 && inner.[0] = '#' then
               gc (Gc_bracket_hex (String.sub inner 1 (String.length inner - 1)))
             else if Parse.is_var inner then gc (Gc_bracket_var inner)
-            else gp (Gp_bracket inner)
+            else if is_gradient_position inner then gp (Gp_bracket inner)
+            else Error (`Msg "Invalid gradient stop value")
         | Color.No_opacity ->
             Error (`Msg "Invalid gradient bracket with opacity")
         | opacity when Parse.is_bracket_value base ->
@@ -1654,7 +1669,8 @@ module Handler = struct
         else if Parse.is_var inner then gc (Gc_bracket_var inner)
         else if Color.parse_bracket_color inner <> None then
           gc (Gc_bracket_color inner)
-        else gp (Gp_bracket inner)
+        else if is_gradient_position inner then gp (Gp_bracket inner)
+        else Error (`Msg "Invalid gradient stop value")
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (
         match Color.shade_and_opacity_of_strings ?theme rest with

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -547,6 +547,14 @@ module Handler = struct
     | List shadows -> List (List.map (wrap_shadow_color ~color_var) shadows)
     | _ -> wrap_shadow_color ~color_var sh
 
+  (* A shadow bracket is a shadow list or a var(); anything else - the docs'
+     [<value>] placeholder included - is not one. *)
+  let is_shadow_bracket inner =
+    Parse.is_var inner
+    || parse_arbitrary_shadow inner <> None
+    || Css.parse_shadow (String.map (fun c -> if c = '_' then ' ' else c) inner)
+       <> None
+
   let shadow_arbitrary (arb : string) =
     let normalized = String.map (fun c -> if c = '_' then ' ' else c) arb in
     (* The reading below takes one shadow and no spread, so anything with a
@@ -2463,6 +2471,10 @@ module Handler = struct
           match opacity with
           | Color.No_opacity -> Ok (Shadow_bracket_color (inner, c))
           | _ -> Ok (Shadow_bracket_color_opacity (inner, c, opacity)))
+      | None when not (is_shadow_bracket inner) ->
+          (* Not a shadow, so not a utility: it used to fall back to the zero
+             shadow [0 0 #0000]. *)
+          err_not_utility
       | None -> (
           match opacity with
           | Color.No_opacity -> Ok (Shadow_arbitrary inner)
@@ -2493,6 +2505,7 @@ module Handler = struct
           match opacity with
           | Color.No_opacity -> Ok (Inset_shadow_bracket_color (inner, c))
           | _ -> Ok (Inset_shadow_bracket_color_opacity (inner, c, opacity)))
+      | None when not (is_shadow_bracket inner) -> err_not_utility
       | None -> (
           match opacity with
           | Color.No_opacity -> Ok (Inset_shadow_arbitrary inner)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1361,7 +1361,13 @@ module Handler = struct
     | [ "drop"; "shadow"; "transparent" ] ->
         Ok (Drop_shadow_keyword_color (Css.Transparent, "transparent"))
     | [ "drop"; "shadow"; s ] when Parse.is_bracket_value s ->
-        Ok (Drop_shadow_arbitrary s)
+        let inner = Parse.decode_arbitrary_value (Parse.bracket_inner s) in
+        (* A drop-shadow bracket is a shadow or a var(); the docs' [<value>]
+           placeholder is neither, and it used to reach the sheet as the colour
+           of an otherwise empty shadow. *)
+        if Parse.is_var inner || Css.parse_shadow inner <> None then
+          Ok (Drop_shadow_arbitrary s)
+        else err_not_utility
     | "drop" :: "shadow" :: rest -> (
         let full = String.concat "-" rest in
         let base, opacity = Color.parse_opacity_modifier ~theme full in

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -305,6 +305,20 @@ let is_feature_tag_list s =
   String.trim s = "normal"
   || (s <> "" && List.for_all entry (String.split_on_char ',' s))
 
+(* CSS Fonts 4 sec. 2.2: a family name is an identifier sequence or a quoted
+   string, and the list is comma-separated. *)
+let is_font_family_value s =
+  let entry e =
+    let e = String.trim e in
+    let n = String.length e in
+    if n = 0 then false
+    else if (e.[0] = '"' || e.[0] = '\'') && n > 1 then e.[n - 1] = e.[0]
+    else
+      String.split_on_char ' ' e |> List.filter (fun w -> w <> "") |> fun ws ->
+      ws <> [] && List.for_all Parse.is_ident ws
+  in
+  s <> "" && List.for_all entry (String.split_on_char ',' s)
+
 module Typography_early = struct
   open Style
   open Css
@@ -603,7 +617,12 @@ module Typography_early = struct
           | None ->
               if Parse.is_var inner then
                 Ok (Font_bracket_weight_var (inner, inner))
-              else Ok (Font_bracket_family_name (inner, inner)))
+                (* A family name is a list of idents or quoted strings; the
+                   docs' [<value>] placeholder is neither, and it used to be
+                   quoted into [font-family: "<value>"]. *)
+              else if is_font_family_value inner then
+                Ok (Font_bracket_family_name (inner, inner))
+              else err_not_utility)
     | [ "font"; "features"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         if Parse.is_var inner then Ok (Font_features_var inner)

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -254,9 +254,30 @@ let test_bg_var_opacity () =
        ~affix:"color-mix(in oklab, var(--x) 50%, transparent)"
        (css_of "bg-[var(--x)]/50"))
 
+(* A gradient stop bracket is a colour or a stop position; the docs' [<value>]
+   placeholder is neither, and it used to land as [0%]. *)
+let test_invalid_gradient_stop () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "from-[<value>]";
+  rejected "via-[<value>]";
+  rejected "to-[<value>]";
+  accepted "from-[25%]";
+  accepted "from-[var(--x)]";
+  accepted "from-[#0088cc]"
+
 let tests =
   [
     test_case "bg colors" `Quick test_bg_colors;
+    test_case "invalid gradient stop" `Quick test_invalid_gradient_stop;
     test_case "bg var color with opacity" `Quick test_bg_var_opacity;
     test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
     test_case "arbitrary rgba gradient stop" `Quick test_gradient_rgba_stop;

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -271,11 +271,30 @@ let test_arbitrary_shadow_list () =
        (css
           "shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)]"))
 
+(* An arbitrary shadow that is not a shadow is not a utility: it used to fall
+   back to the zero shadow. *)
+let test_invalid_arbitrary_shadow () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "shadow-[<value>]";
+  rejected "inset-shadow-[<value>]";
+  accepted "shadow-[0_1px_2px_#000]";
+  accepted "inset-shadow-[0_1px_2px_#000]"
+
 let tests =
   [
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;
+    test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;
     test_case "inset-shadow roundtrip" `Quick test_inset_shadow_roundtrip;

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -112,6 +112,7 @@ let test_invalid_arbitrary_amount () =
   rejected "brightness-[abc]";
   rejected "invert-[xyz]";
   rejected "backdrop-sepia-[nope]";
+  rejected "drop-shadow-[<value>]";
   check "brightness-[1.5]";
   check "saturate-[150%]";
   check "brightness-[var(--x)]"

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -464,9 +464,28 @@ let test_font_features_value () =
     (Astring.String.is_infix ~affix:"font-feature-settings:\"liga\" 0"
        (css "font-features-[\"liga\"_0]"))
 
+(* A font family is idents or quoted strings; the docs' [<value>] placeholder
+   used to be quoted into font-family: "<value>". *)
+let test_invalid_font_family () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "font-[<value>]";
+  accepted "font-[ui-sans-serif]";
+  accepted "font-[var(--x)]";
+  accepted "font-[600]"
+
 let tests =
   [
     test_case "bracket list-style" `Quick test_bracket_list_style;
+    test_case "invalid font family" `Quick test_invalid_font_family;
     test_case "font-features value" `Quick test_font_features_value;
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;


### PR DESCRIPTION
`shadow-[...]`, `inset-shadow-[...]` and `drop-shadow-[...]` fell back to the zero shadow when they could not read the bracket content; `font-[...]` quoted the text into a family name; and `from-[...]`, `via-[...]` and `to-[...]` read it as the stop position `0%`.

Same shape as #234 and #231, on the utilities those two missed because the coerced value was itself valid CSS.