### PR TITLE
rule: keep the inner selector under an at-rule variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   zero shadow, `font-[...]` quoted the text into a family name, and
   `from-[...]`, `via-[...]` and `to-[...]` read it as the stop position `0%`
   (#237)
+- Keep the inner variant's selector under `starting:` and a bracketed at-rule
+  variant: `starting:open:opacity-0` lost `open:`'s
+  `:is([open], :popover-open, :open)` (#238)
 
 - Anchor an arbitrary-selector variant at the class's own position when an
   inner variant has moved the subject:

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1788,9 +1788,12 @@ let arbitrary_selector_rule content base_class selector props =
 (* An at-rule written in brackets: [[@supports(display:grid)]] wraps the utility
    in that query, [[@starting-style]] in [@starting-style]. The class name keeps
    the brackets, so it cannot go through the [supports-] spelling. *)
-let at_rule_variant content base_class props =
+let at_rule_variant content ~selector base_class props =
   let modified_class = "[" ^ content ^ "]:" ^ base_class in
-  let selector = Css.Selector.Class modified_class in
+  let selector =
+    Rules_selector.transform_selector_with_modifier
+      (Css.Selector.Class modified_class) base_class modified_class selector
+  in
   if content = "@starting-style" then
     starting_style ~selector ~props ~base_class:modified_class ()
   else
@@ -1923,8 +1926,13 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
   (* Starting style - selector includes starting: prefix *)
   | Style.Starting ->
       let modified_class = "starting:" ^ base_class in
-      starting_style ~selector:(Css.Selector.Class modified_class) ~props
-        ~base_class:modified_class ()
+      (* Rebuilding the selector from the bare class would drop what an inner
+         variant put on it, as [open:]'s [:is([open], :popover-open, :open)]. *)
+      let new_selector =
+        Rules_selector.transform_selector_with_modifier
+          (Css.Selector.Class modified_class) base_class modified_class selector
+      in
+      starting_style ~selector:new_selector ~props ~base_class:modified_class ()
   (* Interactive pseudo-classes *)
   | Style.Hover | Style.Focus | Style.Active | Style.Focus_within
   | Style.Focus_visible | Style.Disabled ->
@@ -1935,7 +1943,7 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
       handle_pseudo_element_modifier modifier base_class props
   | Style.Arbitrary_selector content ->
       arbitrary_selector_rule content base_class selector props
-  | Style.At_rule content -> at_rule_variant content base_class props
+  | Style.At_rule content -> at_rule_variant content ~selector base_class props
   | Style.Custom_variant (token, template) ->
       custom_variant_rule token template base_class props
   | Style.Container_style (token, condition) ->

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -405,22 +405,30 @@ let test_has_variant () =
   has "has-group-focus/name:underline"
     ":has(:is(:where(.group\\/name):focus *))"
 
+let variant_css cls =
+  match Tw.of_string cls with
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+let variant_has cls affix =
+  check bool cls true (Astring.String.is_infix ~affix (variant_css cls))
+
 (* An inner media query's nested blocks hold the utility's class too, so an
    outer responsive variant has to rename it there as well: [sm:] used to drop
    out of the class name whenever [hover:] had wrapped the rule in its own media
    block. *)
 let test_outer_media_renames_nested () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "sm:motion-reduce:hover:translate-y-0"
+  variant_has "sm:motion-reduce:hover:translate-y-0"
     ".sm\\:motion-reduce\\:hover\\:translate-y-0:hover";
-  has "sm:dark:hover:underline" ".sm\\:dark\\:hover\\:underline:hover"
+  variant_has "sm:dark:hover:underline" ".sm\\:dark\\:hover\\:underline:hover"
+
+(* [starting:] and the bracketed at-rule variant wrap the utility in an at-rule,
+   and rebuilding the selector from the bare class dropped whatever an inner
+   variant had put on it. *)
+let test_at_rule_keeps_inner () =
+  variant_has "starting:open:opacity-0" ":is([open],:popover-open,:open)";
+  variant_has "[@starting-style]:open:opacity-0"
+    ":is([open],:popover-open,:open)"
 
 let tests =
   [
@@ -453,6 +461,8 @@ let tests =
     test_case "has- takes any variant" `Quick test_has_variant;
     test_case "outer media renames the nested class" `Quick
       test_outer_media_renames_nested;
+    test_case "at-rule variant keeps the inner selector" `Quick
+      test_at_rule_keeps_inner;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
`starting:` and the bracketed at-rule variant (`[@starting-style]:`, `[@supports(...)]:`) rebuilt their selector from the bare utility class, discarding whatever an inner variant had put on it. `starting:open:opacity-0` lost `open:`'s `:is([open], :popover-open, :open)` and matched every element instead.

Same shape as #231's aria/data/has routes.