### PR TITLE
divide: add the typed constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Add the typed `divide` constructors: `divide_x`, `divide_y`,
+  `divide_x_length`, `divide_y_length`, `divide_color`, `divide_transparent`,
+  `divide_current`, `divide_inherit` and `divide_style`. Only the two reverse
+  utilities were exposed, so the rest were reachable from a class string but
+  not from OCaml (#239, closes #5)
+
 - Reject an arbitrary value the property cannot take instead of falling back to
   a plausible one: `bg-position-[...]`, `bg-size-[...]`, `cursor-[...]`,
   `indent-[...]`, `mask-size-[...]`, `mask-position-[...]`, `object-[...]` and

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -557,3 +557,29 @@ let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
 let divide_x_reverse = utility Divide_x_reverse
 let divide_y_reverse = utility Divide_y_reverse
+
+(** {1 Divide Width Utilities} *)
+
+let divide_x n = utility (Divide_x n)
+let divide_y n = utility (Divide_y n)
+let divide_x_length w = utility (Divide_x_arb w)
+let divide_y_length w = utility (Divide_y_arb w)
+
+(** {1 Divide Colour Utilities} *)
+
+let divide_color ?opacity ?(shade = 500) color =
+  Color.check_shade ~utility:"divide_color" color shade;
+  match opacity with
+  | None -> utility (Divide_color (color, shade))
+  | Some pct ->
+      utility
+        (Divide_color_opacity
+           (color, shade, Color.Opacity_percent (float_of_int pct)))
+
+let divide_transparent = utility Divide_transparent
+let divide_current = utility Divide_current
+let divide_inherit = utility Divide_inherit
+
+(** {1 Divide Style Utilities} *)
+
+let divide_style s = utility (Divide_style s)

--- a/lib/divide.mli
+++ b/lib/divide.mli
@@ -3,6 +3,7 @@
     @see <https://tailwindcss.com/docs/divide-width>
       Tailwind CSS Divide Width documentation *)
 
+module Css = Cascade.Css
 open Utility
 
 (** {1 Divide Reverse Utilities} *)
@@ -13,5 +14,42 @@ val divide_x_reverse : t
 
 val divide_y_reverse : t
 (** [divide_y_reverse] reverses the direction of vertical divide borders. *)
+
+(** {1 Divide Width Utilities} *)
+
+val divide_x : int -> t
+(** [divide_x n] sets the border width between horizontal children, in pixels:
+    [divide_x 2] is [divide-x-2]. *)
+
+val divide_y : int -> t
+(** [divide_y n] sets the border width between vertical children. *)
+
+val divide_x_length : Css.border_width -> t
+(** [divide_x_length w] is [divide_x] with an arbitrary width, as
+    [divide-x-[3px]]. *)
+
+val divide_y_length : Css.border_width -> t
+(** [divide_y_length w] is [divide_y] with an arbitrary width. *)
+
+(** {1 Divide Colour Utilities} *)
+
+val divide_color : ?opacity:int -> ?shade:int -> Color.color -> t
+(** [divide_color color] sets the colour of the dividing borders. [shade]
+    defaults to 500; [opacity] is the alpha modifier (0-100). *)
+
+val divide_transparent : t
+(** [divide_transparent] makes the dividing borders transparent. *)
+
+val divide_current : t
+(** [divide_current] takes the dividing border colour from [currentColor]. *)
+
+val divide_inherit : t
+(** [divide_inherit] inherits the dividing border colour. *)
+
+(** {1 Divide Style Utilities} *)
+
+val divide_style : Css.border_style -> t
+(** [divide_style s] sets the style of the dividing borders, as [divide-dashed].
+*)
 
 module Handler : Utility.Handler

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3421,11 +3421,42 @@ val touch_pinch_zoom : t
 (** {2 Divide}
     @see <https://tailwindcss.com/docs/divide-width> Divide Width *)
 
+val divide_x : int -> t
+(** [divide_x n] sets the border width between horizontal children, in pixels:
+    [divide_x 2] is [divide-x-2]. *)
+
+val divide_y : int -> t
+(** [divide_y n] sets the border width between vertical children. *)
+
+val divide_x_length : Css.border_width -> t
+(** [divide_x_length w] is [divide_x] with an arbitrary width, as
+    [divide-x-[3px]]. *)
+
+val divide_y_length : Css.border_width -> t
+(** [divide_y_length w] is [divide_y] with an arbitrary width. *)
+
 val divide_x_reverse : t
 (** [divide_x_reverse] reverses horizontal divide borders for RTL layouts. *)
 
 val divide_y_reverse : t
 (** [divide_y_reverse] reverses vertical divide borders. *)
+
+val divide_color : ?opacity:int -> ?shade:int -> color -> t
+(** [divide_color color] sets the colour of the dividing borders. [shade]
+    defaults to 500; [opacity] is the alpha modifier (0-100). *)
+
+val divide_transparent : t
+(** [divide_transparent] makes the dividing borders transparent. *)
+
+val divide_current : t
+(** [divide_current] takes the dividing border colour from [currentColor]. *)
+
+val divide_inherit : t
+(** [divide_inherit] inherits the dividing border colour. *)
+
+val divide_style : Css.border_style -> t
+(** [divide_style s] sets the style of the dividing borders, as [divide-dashed].
+*)
 
 (** {2 Scroll Margin}
     @see <https://tailwindcss.com/docs/scroll-margin> Scroll Margin *)

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -20,7 +20,24 @@ let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide";
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-foo"
 
+(* Every divide utility the parser accepts also has a typed constructor, and the
+   two agree on the class name (issue #5). *)
+let test_typed () =
+  let open Tw in
+  Test_helpers.check_typed_class "divide-x-2" (divide_x 2);
+  Test_helpers.check_typed_class "divide-y-4" (divide_y 4);
+  Test_helpers.check_typed_class "divide-x-reverse" divide_x_reverse;
+  Test_helpers.check_typed_class "divide-y-reverse" divide_y_reverse;
+  Test_helpers.check_typed_class "divide-blue-500" (divide_color blue);
+  Test_helpers.check_typed_class "divide-gray-300"
+    (divide_color ~shade:300 gray);
+  Test_helpers.check_typed_class "divide-transparent" divide_transparent;
+  Test_helpers.check_typed_class "divide-current" divide_current;
+  Test_helpers.check_typed_class "divide-inherit" divide_inherit;
+  Test_helpers.check_typed_class "divide-dashed" (divide_style Dashed)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [ Alcotest.test_case "typed constructors" `Quick test_typed ]
 
 let suite = ("divide", tests)

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -856,9 +856,7 @@ let prose_element_variants_combined () =
     ]
 
 (* -- 3. Divide utilities -------------------------------------------------- *)
-(* divide-x and divide-y with width values are parseable by CLI but have no
-   typed API (only divide_x_reverse and divide_y_reverse are exposed).
-   divide-x/divide-y without explicit widths also exist. *)
+(* divide-x/divide-y also exist without an explicit width, defaulting to 1px. *)
 
 let divide_width () =
   (* Basic divide-x and divide-y (1px default) *)


### PR DESCRIPTION
Only `divide_x_reverse` and `divide_y_reverse` were exposed, so the widths, colours and styles were reachable from a class string but had no OCaml constructor. Adds `divide_x`, `divide_y`, `divide_x_length`, `divide_y_length`, `divide_color`, `divide_transparent`, `divide_current`, `divide_inherit` and `divide_style`, following the `border_*` shapes.

Closes #5.