### PR TITLE
color: expand a shorthand hex before appending the alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Expand a shorthand hex before appending the alpha byte: a colour with an
+  opacity modifier whose hex was three digits, as `ring-white/10`, produced the
+  five-digit `#fff1a` (#241)
+
 - Add the typed `divide` constructors: `divide_x`, `divide_y`,
   `divide_x_length`, `divide_y_length`, `divide_color`, `divide_transparent`,
   `divide_current`, `divide_inherit` and `divide_style`. Only the two reverse

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -288,6 +288,17 @@ let hex_with_alpha hex_str opacity_percent =
       String.sub hex_str 1 (String.length hex_str - 1)
     else hex_str
   in
+  (* The alpha byte is appended to the six RGB digits, so a shorthand has to be
+     expanded first: [#fff] would otherwise give the five-digit [#fff1a]. Any
+     alpha already present is the one being replaced. *)
+  let hex_clean =
+    let double c = String.make 2 c in
+    match String.length hex_clean with
+    | 3 | 4 ->
+        double hex_clean.[0] ^ double hex_clean.[1] ^ double hex_clean.[2]
+    | 8 -> String.sub hex_clean 0 6
+    | _ -> hex_clean
+  in
   (* Convert opacity percentage to 8-bit alpha value, with rounding *)
   let alpha = int_of_float ((opacity_percent /. 100.0 *. 255.0) +. 0.5) in
   let alpha_clamped = max 0 (min 255 alpha) in

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -400,6 +400,20 @@ let test_full_opacity_and_important () =
   has "bg-white/75!"
     "color-mix(in oklab,var(--color-white) 75%,transparent)!important"
 
+(* The alpha byte is appended to the six RGB digits, so a shorthand hex has to
+   be expanded first: [#fff] with 10% alpha gave the five-digit [#fff1a], which
+   cascade now rejects outright. *)
+let test_shorthand_hex_alpha () =
+  Alcotest.(check string)
+    "a three-digit hex expands before the alpha" "#ffffff1a"
+    (Tw.Color.hex_with_alpha "#fff" 10.);
+  Alcotest.(check string)
+    "an existing alpha is replaced" "#ffffff1a"
+    (Tw.Color.hex_with_alpha "#ffffffcc" 10.);
+  Alcotest.(check string)
+    "a six-digit hex is unchanged" "#0307121a"
+    (Tw.Color.hex_with_alpha "#030712" 10.)
+
 let tests =
   [
     ("Achromatic colour keeps a none hue", `Quick, test_achromatic_none_hue);
@@ -418,6 +432,7 @@ let tests =
     ("CSS modes with colors", `Quick, test_css_mode_with_colors);
     ("v4.3.3 colour families", `Quick, test_v433_color_families);
     ("Full opacity and important", `Quick, test_full_opacity_and_important);
+    ("Shorthand hex with alpha", `Quick, test_shorthand_hex_alpha);
   ]
 
 let suite = ("color", tests)


### PR DESCRIPTION
`hex_with_alpha` appends the alpha byte to what it assumes are six RGB digits, so a shorthand input produced a five-digit result: `ring-white/10` gave `#fff1a`.

cascade used to return black for a malformed hex and now rejects it (samoht/cascade#232), which turned this into a crash and is how it surfaced. Shorthand inputs now expand to six digits first, and an alpha already present is replaced rather than appended to.