### PR TITLE
sort: order container variants by their width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Fall back to a plain hex for `drop-shadow-<color>/<opacity>`. The fallback
+  was itself a `color-mix`, so a browser without `color-mix` had nothing to
+  read (#244)
+
 - Order container variants by width like breakpoints: `@max-*` first and widest
   first, then ascending. They were compared alphabetically by class prefix, so
   `@2xl:` landed before `@sm:` (#243)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Order container variants by width like breakpoints: `@max-*` first and widest
+  first, then ascending. They were compared alphabetically by class prefix, so
+  `@2xl:` landed before `@sm:` (#243)
+
 - Keep a colour's `@supports` color-mix rule next to the hex fallback it
   enhances. Under a variant the two drifted apart and the fallback could end up
   winning in browsers that support color-mix (#242)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -764,15 +764,17 @@ module Handler = struct
     let color_name = Color.scheme_color_name c shade in
     let scheme = match theme with Some t -> t | None -> Scheme.default in
     let percent = Color.opacity_to_percent opacity in
-    (* srgb fallback: a scheme hex gets a hex+alpha; without one (the default
-       scheme) mix the resolved colour in srgb, matching Tailwind. The old path
-       raised when the scheme had no hex. *)
+    (* The fallback is what a browser without color-mix reads, so it has to be a
+       plain hex. [Scheme.hex_color] only holds the hexes a project declared, so
+       resolve the palette colour when it has none. *)
     let fallback_color =
-      match Scheme.hex_color scheme color_name with
-      | Option.Some hex -> Css.hex (Color.hex_with_alpha hex percent)
-      | Option.None ->
-          Css.color_mix ~in_space:Srgb (Color.to_css c shade) Css.Transparent
-            ~percent1:percent
+      let hex =
+        match Scheme.hex_color scheme color_name with
+        | Option.Some hex -> hex
+        | Option.None ->
+            Color.rgb_to_hex (Color.oklch_to_rgb (Color.to_oklch c shade))
+      in
+      Css.hex (Color.hex_with_alpha hex percent)
     in
     let color_ref : Css.color Css.var = Var.bracket ("color-" ^ color_name) in
     let supports_decl =

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -215,12 +215,43 @@ let extract_media_sort_key = function
   | `Media cond -> Css.Media.group_order (Css.Media.kind cond)
   | _ -> (0, 0.)
 
+(* Tailwind orders container variants exactly like breakpoints, and every
+   container condition it emits is a width range wrapped in an optional
+   container name and an optional negation. Project one onto the media query it
+   is equivalent to, so the breakpoint ordering applies unchanged: [@max-sm] is
+   a negated lower bound, which is the [not all and (...)] shape media already
+   classifies as an upper bound. The name plays no part -- Tailwind interleaves
+   a named container with the unnamed ones at its width. *)
+let rec container_media_projection (c : Css.Container.t) =
+  match c with
+  | Css.Container.Named (_, inner) -> container_media_projection inner
+  | Css.Container.Feature_query q -> Some q
+  | Css.Container.Not inner -> (
+      match container_media_projection inner with
+      | Some (Css.Media.Cond cond) ->
+          Some
+            (Css.Media.Type
+               {
+                 prefix = Some Css.Media.Not;
+                 type_ = Css.Media.All;
+                 trailing = Some cond;
+               })
+      | _ -> None)
+  | Css.Container.Min_width_rem _ | Css.Container.Min_width_px _
+  | Css.Container.And _ | Css.Container.Or _ | Css.Container.Style _
+  | Css.Container.Scroll_state _ ->
+      None
+
 (* Precompute the sort keys for a rule's own and nested media conditions, so the
    comparators use [Css.Media.compare_keys] (cheap) instead of re-serializing
    the query on every comparison. See [media_key]/[nested_media_key]. *)
 let media_sort_keys rule_type nested =
   let media_key =
-    match rule_type with `Media c -> Some (Css.Media.sort_key c) | _ -> None
+    match rule_type with
+    | `Media c -> Some (Css.Media.sort_key c)
+    | `Container c ->
+        Stdlib.Option.map Css.Media.sort_key (container_media_projection c)
+    | _ -> None
   in
   let nested_media_key =
     match nested with
@@ -991,6 +1022,33 @@ let nested_order rule_type nested =
       | _ -> 1 (* other nested: last *))
   | _ -> 1 (* multiple nested: last *)
 
+(* Last resort for two rules that share a variant group, a breakpoint and a
+   prefix: the utility's own priority, then the selector. *)
+let compare_variant_tail r1 r2 =
+  let p1, s1 = r1.order and p2, s2 = r2.order in
+  let prio_cmp = Int.compare p1 p2 in
+  if prio_cmp <> 0 then prio_cmp
+  else
+    let sub_cmp = Int.compare s1 s2 in
+    if sub_cmp <> 0 then sub_cmp
+    else
+      match (r1.selector_kind, r2.selector_kind) with
+      | Simple, Simple ->
+          (* Same priority/suborder simple rules (e.g. two arbitrary bg colors)
+             break ties by selector like the regular layer, matching Tailwind's
+             alphabetical order. *)
+          natural_compare r1.selector_str r2.selector_str
+      | _ ->
+          (* Complex rules (prose's descendant selectors) keep base class +
+             source order so a component stays one block. Arbitrary values in a
+             variant, e.g. hover:from-[rgba(5,...)] vs
+             hover:from-[rgba(14,...)], share a prefix and differ only in the
+             numeric part, so order those numerically like Tailwind. Identical
+             base classes (prose's :where rules all key on "prose") tie at 0 and
+             fall back to source order, unchanged. *)
+          let class_cmp = natural_compare r1.base_class_key r2.base_class_key in
+          if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
+
 let compare_variant_ordered r1 r2 =
   match (r1.rule_type, r2.rule_type) with
   | `Supports _, `Supports _
@@ -998,7 +1056,7 @@ let compare_variant_ordered r1 r2 =
          && is_modifier_supports r1.base_class
          && is_modifier_supports r2.base_class ->
       compare_supports_by_key r1 r2
-  | _ -> (
+  | _ ->
       let list_cmp =
         compare_variant_order_lists r1.variant_orders r2.variant_orders
       in
@@ -1026,36 +1084,15 @@ let compare_variant_ordered r1 r2 =
           in
           if media_cmp <> 0 then media_cmp
           else
-            let prefix_cmp = compare_bracket_prefixes p1_prefix p2_prefix in
-            if prefix_cmp <> 0 then prefix_cmp
-            else
-              let p1, s1 = r1.order and p2, s2 = r2.order in
-              let prio_cmp = Int.compare p1 p2 in
-              if prio_cmp <> 0 then prio_cmp
-              else
-                let sub_cmp = Int.compare s1 s2 in
-                if sub_cmp <> 0 then sub_cmp
-                else
-                  match (r1.selector_kind, r2.selector_kind) with
-                  | Simple, Simple ->
-                      (* Same priority/suborder simple rules (e.g. two arbitrary
-                         bg colors) break ties by selector like the regular
-                         layer, matching Tailwind's alphabetical order. *)
-                      natural_compare r1.selector_str r2.selector_str
-                  | _ ->
-                      (* Complex rules (prose's descendant selectors) keep base
-                         class + source order so a component stays one block.
-                         Arbitrary values in a variant, e.g.
-                         hover:from-[rgba(5,...)] vs hover:from-[rgba(14,...)],
-                         share a prefix and differ only in the numeric part, so
-                         order those numerically like Tailwind. Identical base
-                         classes (prose's :where rules all key on "prose") tie
-                         at 0 and fall back to source order, unchanged. *)
-                      let class_cmp =
-                        natural_compare r1.base_class_key r2.base_class_key
-                      in
-                      if class_cmp <> 0 then class_cmp
-                      else Int.compare r1.index r2.index)
+            (* Two container variants at the same width are already fully
+               ordered: what remains is the utility's own priority, so the
+               prefix must not step in and group @sm/main away from @sm. *)
+            let prefix_cmp =
+              match (r1.rule_type, r2.rule_type) with
+              | `Container _, `Container _ -> 0
+              | _ -> compare_bracket_prefixes p1_prefix p2_prefix
+            in
+            if prefix_cmp <> 0 then prefix_cmp else compare_variant_tail r1 r2
 
 (* Compare two Supports rules *)
 let compare_supports_rules r1 r2 =

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -56,9 +56,11 @@ type indexed_rule = {
       (** The rule's base class ([""] when it has none), used by
           [compare_indexed_rules] as the lexicographic sort key. *)
   media_key : Css.Media.key option;
-      (** Precomputed sort key of the rule's own media condition (the [`Media]
-          case of {!field-rule_type}), [None] otherwise. Comparisons use this
-          instead of re-serializing the query on every call. *)
+      (** Precomputed sort key of the rule's own breakpoint condition: the
+          [`Media] case of {!field-rule_type}, or the [`Container] case
+          projected onto the media query it is equivalent to. [None] otherwise.
+          Comparisons use this instead of re-serializing the query on every
+          call. *)
   nested_media_key : Css.Media.key option;
       (** Precomputed sort key of a single nested media condition. *)
 }

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -124,9 +124,62 @@ let test_theme_fn_container_query () =
   has "@min-[--theme(--breakpoint-sm)]:flex" "@container(width>=40rem)";
   has "@min-[theme(--breakpoint-sm)]:flex" "@container(width>=40rem)"
 
+let test_variant_width_order () =
+  (* Tailwind orders container variants like breakpoints: the @max-* negated
+     lower bounds first and largest first, then the plain ones ascending, with a
+     named container interleaved at its own width. The variant order alone gave
+     every @-prefixed variant the same key, so they fell through to an
+     alphabetical comparison of the class prefix. *)
+  let classes =
+    [
+      "@md:flex";
+      "@sm:flex";
+      "@lg:flex";
+      "@xs:flex";
+      "@max-sm:flex";
+      "@max-lg:flex";
+      "@sm/main:flex";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css =
+    Cascade.Css.to_string ~minify:true (Tw.to_css ~base:false utilities)
+  in
+  let expected =
+    [
+      "@container not (width>=32rem)";
+      "@container not (width>=24rem)";
+      "@container(width>=20rem)";
+      "@container main (width>=24rem)";
+      "@container(width>=24rem)";
+      "@container(width>=28rem)";
+      "@container(width>=32rem)";
+    ]
+  in
+  let positions =
+    List.map
+      (fun needle ->
+        let n = String.length needle and h = String.length css in
+        let rec go i =
+          if i + n > h then -1
+          else if String.sub css i n = needle then i
+          else go (i + 1)
+        in
+        go 0)
+      expected
+  in
+  Alcotest.check Alcotest.bool "every container condition is emitted" true
+    (List.for_all (fun p -> p >= 0) positions);
+  Alcotest.check
+    (Alcotest.list Alcotest.int)
+    "container variants are emitted widest-negated first, then ascending"
+    (List.sort Int.compare positions)
+    positions
+
 let tests =
   [
     test_case "types" `Quick test_container_types;
+    test_case "variant width order" `Quick test_variant_width_order;
     test_case "variant composition" `Quick test_container_variant_composition;
     test_case "name" `Quick test_container_name;
     test_case "multiple named containers" `Quick test_multiple_named_containers;

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -25,9 +25,10 @@ let test_drop_shadow_xs () =
     "emits --drop-shadow-xs default" true
     (Astring.String.is_infix ~affix:"--drop-shadow-xs:" css)
 
-(* drop-shadow-<color> resolves the colour itself (oklch) for the srgb fallback
-   instead of requiring a scheme hex; it used to raise on the default theme
-   (which has no hex colours). *)
+(* drop-shadow-<color> resolves the palette colour itself for the fallback, so
+   the default theme (which declares no hex colours) still gets one. The
+   fallback is what a browser without color-mix reads, so it has to be a plain
+   hex rather than a mix of its own. *)
 let test_drop_shadow_color () =
   let css cls =
     match Tw.of_string cls with
@@ -40,7 +41,11 @@ let test_drop_shadow_color () =
        (css "drop-shadow-red-500"));
   Alcotest.(check bool)
     "drop-shadow-red-500/50 uses color-mix" true
-    (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"))
+    (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"));
+  Alcotest.(check bool)
+    "drop-shadow-blue-500/50 falls back to a plain hex" true
+    (Astring.String.is_infix ~affix:"--tw-drop-shadow-color: #3080ff80"
+       (css "drop-shadow-blue-500/50"))
 
 (* A fractional opacity modifier keeps its fraction: drop-shadow/12.5 -> alpha
    12.5%, not the truncated 12%. *)


### PR DESCRIPTION
Container variants all shared a single variant order key, so `@sm:`, `@md:` and `@max-sm:` fell through to an alphabetical comparison of the class prefix -- `@2xl:` came out before `@sm:`. They now project onto the equivalent media query and reuse the breakpoint ordering, so `@max-*` comes first widest-first and the rest ascend, with a named container interleaved at its own width.

Based on #242.