### PR TITLE
filters: fall back to a hex for a drop-shadow colour with opacity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Fall back to a plain hex for `drop-shadow-<color>/<opacity>`. The fallback
+  was itself a `color-mix`, so a browser without `color-mix` had nothing to
+  read (#244)
+
 - Order container variants by width like breakpoints: `@max-*` first and widest
   first, then ascending. They were compared alphabetically by class prefix, so
   `@2xl:` landed before `@sm:` (#243)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -764,15 +764,17 @@ module Handler = struct
     let color_name = Color.scheme_color_name c shade in
     let scheme = match theme with Some t -> t | None -> Scheme.default in
     let percent = Color.opacity_to_percent opacity in
-    (* srgb fallback: a scheme hex gets a hex+alpha; without one (the default
-       scheme) mix the resolved colour in srgb, matching Tailwind. The old path
-       raised when the scheme had no hex. *)
+    (* The fallback is what a browser without color-mix reads, so it has to be a
+       plain hex. [Scheme.hex_color] only holds the hexes a project declared, so
+       resolve the palette colour when it has none. *)
     let fallback_color =
-      match Scheme.hex_color scheme color_name with
-      | Option.Some hex -> Css.hex (Color.hex_with_alpha hex percent)
-      | Option.None ->
-          Css.color_mix ~in_space:Srgb (Color.to_css c shade) Css.Transparent
-            ~percent1:percent
+      let hex =
+        match Scheme.hex_color scheme color_name with
+        | Option.Some hex -> hex
+        | Option.None ->
+            Color.rgb_to_hex (Color.oklch_to_rgb (Color.to_oklch c shade))
+      in
+      Css.hex (Color.hex_with_alpha hex percent)
     in
     let color_ref : Css.color Css.var = Var.bracket ("color-" ^ color_name) in
     let supports_decl =

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -25,9 +25,10 @@ let test_drop_shadow_xs () =
     "emits --drop-shadow-xs default" true
     (Astring.String.is_infix ~affix:"--drop-shadow-xs:" css)
 
-(* drop-shadow-<color> resolves the colour itself (oklch) for the srgb fallback
-   instead of requiring a scheme hex; it used to raise on the default theme
-   (which has no hex colours). *)
+(* drop-shadow-<color> resolves the palette colour itself for the fallback, so
+   the default theme (which declares no hex colours) still gets one. The
+   fallback is what a browser without color-mix reads, so it has to be a plain
+   hex rather than a mix of its own. *)
 let test_drop_shadow_color () =
   let css cls =
     match Tw.of_string cls with
@@ -40,7 +41,11 @@ let test_drop_shadow_color () =
        (css "drop-shadow-red-500"));
   Alcotest.(check bool)
     "drop-shadow-red-500/50 uses color-mix" true
-    (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"))
+    (Astring.String.is_infix ~affix:"color-mix" (css "drop-shadow-red-500/50"));
+  Alcotest.(check bool)
+    "drop-shadow-blue-500/50 falls back to a plain hex" true
+    (Astring.String.is_infix ~affix:"--tw-drop-shadow-color: #3080ff80"
+       (css "drop-shadow-blue-500/50"))
 
 (* A fractional opacity modifier keeps its fraction: drop-shadow/12.5 -> alpha
    12.5%, not the truncated 12%. *)


### PR DESCRIPTION
`drop-shadow-blue-500/50` wrote `color-mix(in srgb, ...)` as the fallback beside its `@supports` color-mix rule, so a browser without `color-mix` had nothing to read. The palette colour resolves to a hex the same way the other colour utilities do.

Based on #243.