### PR TITLE
layout: give isolation, float and clear their own order slots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Sort `isolation-*` between `inset-*` and `z-*`, and `float-*`/`clear-*`
+  between the grid-column group and `.container`, where Tailwind's utility
+  order puts them; they sorted with the display family (#247)
+
 - Sort `line-clamp-*` between `box-sizing` and the display family, where
   Tailwind's utility order puts it, rather than among the typography utilities
   (#246)

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -221,6 +221,14 @@ module Handler = struct
     | Neg_z _ | Z_0 | Z _ | Z_10 | Z_20 | Z_30 | Z_40 | Z_50 | Neg_z_arbitrary _
     | Z_arbitrary _ | Z_auto ->
         0
+    (* isolation (rank 11) sits between inset and z-index. *)
+    | Isolate | Isolation_auto -> 0
+    (* float and clear (ranks 21-22) sit between the grid-column/grid-row group
+       and .container, both at priority 1. *)
+    | Float_end | Float_left | Float_none | Float_right | Float_start
+    | Clear_both | Clear_end | Clear_left | Clear_none | Clear_right
+    | Clear_start ->
+        1
     (* object-fit / object-position (rank ~72): after svg fill/stroke (21),
        before padding (23). *)
     | Object_contain | Object_cover | Object_fill | Object_none
@@ -262,9 +270,10 @@ module Handler = struct
     | Collapse -> -20
     | Invisible -> -19
     | Visible -> -18
-    (* Isolation - order: isolate, isolation-auto *)
-    | Isolate -> 200
-    | Isolation_auto -> 201
+    (* Isolation (priority 0) - after inset (up to ~13M in position.ml), before
+       z-index (20M). Order: isolate, isolation-auto *)
+    | Isolate -> 15_000_000
+    | Isolation_auto -> 15_000_001
     (* Z-index (priority 0) - after inset (up to ~13M in position.ml), before
        container (priority 1). Order: negative, positive, arbitrary, auto. *)
     | Neg_z n -> 20_000_000 + 500 + n (* -z-50, -z-10 *)
@@ -299,19 +308,22 @@ module Handler = struct
     | Object_top_left -> 711
     | Object_top_right -> 712
     | Object_arbitrary _ -> 650
-    (* Float - alphabetical order: end, left, none, right, start *)
-    | Float_end -> 800
-    | Float_left -> 801
-    | Float_none -> 802
-    | Float_right -> 803
-    | Float_start -> 804
-    (* Clear - alphabetical order: both, end, left, none, right, start *)
-    | Clear_both -> 900
-    | Clear_end -> 901
-    | Clear_left -> 902
-    | Clear_none -> 903
-    | Clear_right -> 904
-    | Clear_start -> 905
+    (* Float (priority 1) - after the grid-column/grid-row group (up to ~2.6K in
+       grid_item.ml), before .container (9M). Alphabetical: end, left, none,
+       right, start *)
+    | Float_end -> 3_000_000
+    | Float_left -> 3_000_001
+    | Float_none -> 3_000_002
+    | Float_right -> 3_000_003
+    | Float_start -> 3_000_004
+    (* Clear (priority 1) - right after float. Alphabetical: both, end, left,
+       none, right, start *)
+    | Clear_both -> 3_000_100
+    | Clear_end -> 3_000_101
+    | Clear_left -> 3_000_102
+    | Clear_none -> 3_000_103
+    | Clear_right -> 3_000_104
+    | Clear_start -> 3_000_105
     (* Box decoration break - alphabetical: clone, slice *)
     | Box_decoration_clone -> 1000
     | Box_decoration_slice -> 1001

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -160,6 +160,50 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"layout suborder matches Tailwind" shuffled
 
+(* isolation sits between inset and z-index in Tailwind's order, and float and
+   clear between the grid-column/grid-row group and .container -- not with the
+   display family their module groups them into. *)
+let isolation_and_float_slots () =
+  let classes =
+    [
+      "inset-0";
+      "isolate";
+      "isolation-auto";
+      "z-10";
+      "col-span-2";
+      "row-span-2";
+      "float-left";
+      "clear-both";
+      "ml-auto";
+      "box-border";
+      "block";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css =
+    Cascade.Css.to_string ~minify:true (Tw.to_css ~base:false utilities)
+  in
+  let positions =
+    List.map
+      (fun c ->
+        let needle = "." ^ c ^ "{" in
+        let n = String.length needle and h = String.length css in
+        let rec go i =
+          if i + n > h then -1
+          else if String.sub css i n = needle then i
+          else go (i + 1)
+        in
+        go 0)
+      classes
+  in
+  Alcotest.check bool "every utility is emitted" true
+    (List.for_all (fun p -> p >= 0) positions);
+  Alcotest.check
+    (Alcotest.list Alcotest.int)
+    "the utilities come out in Tailwind's order"
+    (List.sort Int.compare positions)
+    positions
+
 (* Visibility, float and break-* typed constructors are newly exposed in tw.mli;
    check they agree with the parser on class names. *)
 let test_typed () =
@@ -212,6 +256,7 @@ let tests =
     test_case "layout container matches Tailwind" `Quick
       test_layout_container_matches_tailwind;
     test_case "layout of_string - invalid values" `Quick of_string_invalid;
+    test_case "isolation and float slots" `Quick isolation_and_float_slots;
     test_case "layout suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
   ]


### PR DESCRIPTION
`isolation-*`, `float-*` and `clear-*` sorted with the display family. Tailwind's utility order puts isolation between `inset-*` and `z-*`, and float and clear between the grid-column/grid-row group and `.container`.

Based on #246.