### PR TITLE
typography: sort line-clamp with box-sizing

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1599,14 +1599,17 @@ module Typography_late = struct
   (* Most late-typography families (decoration, tracking, whitespace,
      word-break) sort at priority 26. Three occupy earlier canonical slots:
      list-style (rank 48, by cursor/resize at priority 11),
-     text-overflow/truncate (rank 62, just before overflow at priority 18), and
+     text-overflow/truncate (rank 62, just before overflow at priority 18),
      vertical-align (rank 80, right after text-align in the early handler at
-     priority 24). *)
+     priority 24), and line-clamp (rank 26, with box-sizing at priority 3). *)
   let priority = function
     | List_none | List_disc | List_decimal | List_inside | List_outside
     | List_image_none | List_image_url _ | List_bracket_var _
     | List_image_bracket_var _ | List_bracket _ | List_image_bracket _ ->
         11
+    (* line-clamp (rank 26) sits between box-sizing and the display family, so
+       it shares box-sizing's priority and sorts after it on suborder. *)
+    | Line_clamp _ | Line_clamp_arbitrary _ | Line_clamp_none -> 3
     | Truncate -> 17
     | Align_baseline | Align_top | Align_middle | Align_bottom | Align_sub
     | Align_super | Align_text_top | Align_text_bottom | Align_arbitrary_var _

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -319,6 +319,15 @@ let of_string_invalid () =
   fail_maybe [ "unknown" ]
 (* Unknown typography type *)
 
+(* line-clamp sits between box-sizing and the display family in Tailwind's
+   order, not among the typography utilities its class name suggests. *)
+let line_clamp_sorts_with_box_sizing () =
+  let classes =
+    [ "indent-4"; "line-clamp-2"; "block"; "box-border"; "ml-auto" ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches ~test_name:"line-clamp order" utilities
+
 let suborder_matches_tailwind () =
   let open Tw in
   let utilities =
@@ -521,6 +530,8 @@ let tests =
     test_case "typography of_string - invalid values" `Quick of_string_invalid;
     test_case "typography suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "line-clamp sorts with box-sizing" `Quick
+      line_clamp_sorts_with_box_sizing;
   ]
 
 let suite = ("typography", tests)


### PR DESCRIPTION
`line-clamp-*` sorted among the typography utilities, after `indent-*`, but Tailwind's utility order puts it between `box-sizing` and the display family.

Reopened against main as #246 never reached it. Based on #249.