### PR TITLE
filters: order the drop-shadow sizes and colours by class name

### DIFF
--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1217,22 +1217,24 @@ module Handler = struct
     | Contrast n -> 2000 + n
     | Contrast_arbitrary _ -> 2500
     | Drop_shadow_opacity _ -> 2690
-    | Drop_shadow_keyword_color _ -> 2691
     | Drop_shadow_size_opacity _ -> 2692
     | Drop_shadow -> 2700
     | Drop_shadow_arbitrary _ -> 2701
     | Drop_shadow_multi -> 2702
-    | Drop_shadow_2xl -> 2703
-    | Drop_shadow_lg -> 2704
-    | Drop_shadow_md -> 2705
-    | Drop_shadow_sm -> 2706
-    | Drop_shadow_xs -> 2706
-    | Drop_shadow_xl -> 2707
+    (* The named sizes share one slot: Tailwind orders them by class name, and
+       the alphabetical tie-break puts xl before xs where a per-size number had
+       them the other way round. *)
+    | Drop_shadow_2xl | Drop_shadow_lg | Drop_shadow_md | Drop_shadow_sm
+    | Drop_shadow_xs | Drop_shadow_xl ->
+        2703
     | Drop_shadow_none -> 2708
-    | Drop_shadow_inherit -> 2709
     | Drop_shadow_named _ -> 2701
-    | Drop_shadow_color _ -> 2710
-    | Drop_shadow_color_opacity _ -> 2711
+    (* Every drop-shadow colour shares one slot, after the sizes: Tailwind
+       orders them among themselves by class name, which the alphabetical
+       tie-break already does. *)
+    | Drop_shadow_keyword_color _ | Drop_shadow_inherit | Drop_shadow_color _
+    | Drop_shadow_color_opacity _ ->
+        2710
     | Filter -> 9000
     | Filter_arbitrary _ -> 9001
     | Filter_none -> 9002

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -63,6 +63,48 @@ let test_backdrop () =
   check "backdrop-opacity-50";
   check "backdrop-invert"
 
+(* The drop-shadow sizes come before the colours, and each group is ordered by
+   class name. Sizes and colours both write --tw-drop-shadow, so the order
+   decides the value: with the colours ahead of the sizes, drop-shadow-current
+   beat drop-shadow-sm. *)
+let drop_shadow_slot_order () =
+  let classes =
+    [
+      "drop-shadow-2xl";
+      "drop-shadow-lg";
+      "drop-shadow-sm";
+      "drop-shadow-xl";
+      "drop-shadow-xs";
+      "drop-shadow-current";
+      "drop-shadow-indigo-500";
+      "drop-shadow-inherit";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css =
+    Cascade.Css.to_string ~minify:true (Tw.to_css ~base:false utilities)
+  in
+  let positions =
+    List.map
+      (fun c ->
+        let needle = "." ^ c ^ "{" in
+        let n = String.length needle and h = String.length css in
+        let rec go i =
+          if i + n > h then -1
+          else if String.sub css i n = needle then i
+          else go (i + 1)
+        in
+        go 0)
+      classes
+  in
+  Alcotest.check bool "every utility is emitted" true
+    (List.for_all (fun p -> p >= 0) positions);
+  Alcotest.check
+    (Alcotest.list Alcotest.int)
+    "sizes then colours, each group by class name"
+    (List.sort Int.compare positions)
+    positions
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -136,6 +178,7 @@ let tests =
     test_case "backdrop-blur token" `Quick test_backdrop_blur_token;
     test_case "filters suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "drop-shadow slot order" `Quick drop_shadow_slot_order;
   ]
 
 let suite = ("filters", tests)


### PR DESCRIPTION
`drop-shadow-current` sorted ahead of `drop-shadow-sm`, and `drop-shadow-xs` ahead of `drop-shadow-xl`. Both groups write `--tw-drop-shadow`, so the first of those changed the rendered shadow.

Each variant used to carry its own suborder number, which is what let a colour land among the sizes and two sizes tie. Tailwind orders each group by class name, so the sizes now share one slot and the colours a later one, and the existing alphabetical tie-break does the rest.