### PR TITLE
build: emit one block for a run of starting-style utilities

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -454,6 +454,32 @@ let utilities_layer ~layers ~statements =
   if layers then Css.v [ Css.layer ~name:"utilities" statements ]
   else Css.v statements
 
+(* [@starting-style] carries no condition, so a run of [starting:] utilities is
+   one block in Tailwind's output. Each is wrapped on its own here, and the
+   optimizer's merging covers [@media] and [@supports] but not this, so collapse
+   a run before the statements are handed over. *)
+let statements_of_sorted_rules sorted_rules =
+  let is_starting (r : Sort.indexed_rule) = r.rule_type = `Starting in
+  let rec take_run taken = function
+    | (x : Sort.indexed_rule) :: tl when is_starting x ->
+        take_run (x :: taken) tl
+    | tl -> (List.rev taken, tl)
+  in
+  let rec go acc = function
+    | [] -> List.rev acc
+    | (r : Sort.indexed_rule) :: rest when is_starting r ->
+        let run, rest = take_run [ r ] rest in
+        let inner =
+          List.map
+            (fun (x : Sort.indexed_rule) ->
+              Css.rule ~selector:x.selector (filter_utility_properties x.props))
+            run
+        in
+        go (Css.starting_style inner :: acc) rest
+    | r :: rest -> go (indexed_rule_to_statement r :: acc) rest
+  in
+  go [] sorted_rules
+
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)
 let sorted_indexed_rules order_map all_rules =
@@ -1428,7 +1454,7 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) tw_classes =
      utilities-layer statements and the variable first-usage order, so compute
      it once and share it rather than recomputing inside [layers]. *)
   let sorted_rules = sorted_indexed_rules order_map selector_props in
-  let statements = List.map indexed_rule_to_statement sorted_rules in
+  let statements = statements_of_sorted_rules sorted_rules in
   let layer_results =
     layers ~theme ~layers:config.layers ~include_base:config.base
       ?forms:config.forms ~selector_props ~sorted_rules tw_classes statements

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -523,31 +523,40 @@ module Handler = struct
           filter composable_filter_chain;
         ])
 
-  let drop_shadow_default () =
+  (* The default [--drop-shadow] is a two-shadow stack. [size_fallback] is what
+     each layer falls back to when no [--tw-drop-shadow-color] is set: the
+     token's own alpha for the bare utility, and black at the modifier's alpha
+     for [drop-shadow/<n>]. *)
+  let drop_shadow_default_size size_fallback : Css.filter =
+    let fallback_a, fallback_b =
+      match size_fallback with
+      | Some c -> (c, c)
+      | None -> (Css.hex "#0000001a", Css.hex "#0000000f")
+    in
+    Css.List
+      [
+        drop_shadow_filter Zero (Px 1.) (Some (Px 2.)) fallback_a;
+        drop_shadow_filter Zero (Px 1.) (Some (Px 1.)) fallback_b;
+      ]
+
+  let drop_shadow_default_literal : Css.filter =
     let fallback_a = Css.hex "#0000001a" in
     let fallback_b = Css.hex "#0000000f" in
-    let size : Css.filter =
-      Css.List
-        [
-          drop_shadow_filter Zero (Px 1.) (Some (Px 2.)) fallback_a;
-          drop_shadow_filter Zero (Px 1.) (Some (Px 1.)) fallback_b;
-        ]
-    in
-    let literal : Css.filter =
-      Css.List
-        [
-          Css.Drop_shadow
-            (Css.shadow ~h_offset:Zero ~v_offset:(Px 1.) ~blur:(Px 2.)
-               ~color:fallback_a ());
-          Css.Drop_shadow
-            (Css.shadow ~h_offset:Zero ~v_offset:(Px 1.) ~blur:(Px 1.)
-               ~color:fallback_b ());
-        ]
-    in
+    Css.List
+      [
+        Css.Drop_shadow
+          (Css.shadow ~h_offset:Zero ~v_offset:(Px 1.) ~blur:(Px 2.)
+             ~color:fallback_a ());
+        Css.Drop_shadow
+          (Css.shadow ~h_offset:Zero ~v_offset:(Px 1.) ~blur:(Px 1.)
+             ~color:fallback_b ());
+      ]
+
+  let drop_shadow_default () =
     style ~property_rules:filter_property_rules
       [
-        bind_drop_shadow_size size;
-        bind_drop_shadow literal;
+        bind_drop_shadow_size (drop_shadow_default_size None);
+        bind_drop_shadow drop_shadow_default_literal;
         filter composable_filter_chain;
       ]
 
@@ -812,16 +821,31 @@ module Handler = struct
       match opacity with Color.Opacity_percent p -> p | _ -> 100.
     in
     let fallback = Color.hex_to_oklab_alpha "#000000" (percent /. 100.) in
+    (* The modifier recolours the shadow, so it applies to the size, which is
+       what [--tw-drop-shadow-color] overrides. [--tw-drop-shadow] keeps the
+       token's own value: a project that overrides [--drop-shadow] is referenced
+       there, and the default two-shadow stack is written out. *)
+    let size_and_shadow =
+      match Scheme.theme_value theme "drop-shadow" with
+      | Some _ ->
+          [
+            bind_drop_shadow_size
+              (drop_shadow_filter Zero (Px 1.) (Some (Px 1.)) fallback);
+            bind_drop_shadow (drop_shadow_theme_ref "drop-shadow");
+          ]
+      | None ->
+          [
+            bind_drop_shadow_size
+              (drop_shadow_default_size (Option.Some fallback));
+            bind_drop_shadow drop_shadow_default_literal;
+          ]
+    in
     style ~property_rules:filter_property_rules
       (theme_decl_if_set ?theme "drop-shadow"
-      @ [
-          Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
-            alpha_str;
-          bind_drop_shadow_size
-            (drop_shadow_filter Zero (Px 1.) (Some (Px 1.)) fallback);
-          bind_drop_shadow (drop_shadow_theme_ref "drop-shadow");
-          filter composable_filter_chain;
-        ])
+      @ Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
+          alpha_str
+        :: size_and_shadow
+      @ [ filter composable_filter_chain ])
 
   (* [drop-shadow-xl/25]: the named size with its default colour replaced by
      black at that alpha, which leaves the theme token out of it entirely. *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -851,8 +851,29 @@ let test_referenced_theme_token () =
     (Astring.String.is_infix ~affix:"--my-color:"
        (css "bg-[color:var(--my-color)]/50"))
 
+(* [@starting-style] takes no condition, so a run of starting: utilities is one
+   block in Tailwind's output. Each utility is wrapped on its own, and the
+   optimizer's merging covers @media and @supports but not this. *)
+let test_starting_style_merges () =
+  let classes = [ "starting:opacity-0"; "starting:scale-90" ] in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let count needle =
+    let n = String.length needle and h = String.length css in
+    let rec go i acc =
+      if i + n > h then acc
+      else if String.sub css i n = needle then go (i + 1) (acc + 1)
+      else go (i + 1) acc
+    in
+    go 0 0
+  in
+  check int "one @starting-style block" 1 (count "@starting-style");
+  check bool "both utilities are in it" true
+    (count ".starting\\:opacity-0" = 1 && count ".starting\\:scale-90" = 1)
+
 let tests =
   [
+    test_case "starting-style blocks merge" `Quick test_starting_style_merges;
     test_case "referenced theme token emitted" `Quick
       test_referenced_theme_token;
     test_case "spacing-0 prunes --spacing" `Quick check_spacing_zero_prune;

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -47,6 +47,22 @@ let test_drop_shadow_color () =
     (Astring.String.is_infix ~affix:"--tw-drop-shadow-color: #3080ff80"
        (css "drop-shadow-blue-500/50"))
 
+(* drop-shadow/<n> recolours the default shadow, which is a two-layer stack, so
+   both layers carry the modifier's alpha as their fallback. It used to emit one
+   layer and reference the theme token, losing the first shadow. *)
+let test_drop_shadow_opacity_keeps_both_layers () =
+  let css =
+    match Tw.of_string "drop-shadow/50" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "drop-shadow/50: %s" m
+  in
+  let has affix = Astring.String.is_infix ~affix css in
+  Alcotest.(check bool) "the first layer is emitted" true (has "0 1px 2px");
+  Alcotest.(check bool) "the second layer is emitted" true (has "0 1px 1px");
+  Alcotest.(check bool)
+    "--tw-drop-shadow is the default stack, not the theme reference" false
+    (has "drop-shadow(var(--drop-shadow))")
+
 (* A fractional opacity modifier keeps its fraction: drop-shadow/12.5 -> alpha
    12.5%, not the truncated 12%. *)
 let test_drop_shadow_fractional_alpha () =
@@ -172,6 +188,8 @@ let tests =
     test_case "invalid arbitrary amount" `Quick test_invalid_arbitrary_amount;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;
     test_case "drop-shadow color (default theme)" `Quick test_drop_shadow_color;
+    test_case "drop-shadow opacity keeps both layers" `Quick
+      test_drop_shadow_opacity_keeps_both_layers;
     test_case "drop-shadow fractional alpha" `Quick
       test_drop_shadow_fractional_alpha;
     test_case "backdrop" `Quick test_backdrop;


### PR DESCRIPTION
Each `starting:` utility was wrapped in its own `@starting-style`, so a page using several got one block each where Tailwind emits a single one. The optimizer folds consecutive `@media` and `@supports` blocks but not this one, since `@starting-style` carries no condition to match on.

This is what turned the `animations` example red once CI picked up the current cascade.