### PR TITLE
utility: sort a project's own utility by the property it declares

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1307,6 +1307,33 @@ let is_custom_routed ~defs ~udefs cls =
    author CSS uses: the declarations land under the escaped class, wrapped in
    the declared variants, and cascade flattens the nesting into the project's
    selector. *)
+(* The class a routed rule belongs to: its selector's first class, which is the
+   declared utility itself for both [.line-y] and [.line-y:before]. *)
+let rec first_class_of_statement stmt =
+  match Css.as_rule stmt with
+  | Some (selector, _, _) -> Css.Selector.first_class selector
+  | None -> (
+      match Css.as_media stmt with
+      | Some (_, inner) -> List.find_map first_class_of_statement inner
+      | None -> (
+          match Css.as_supports stmt with
+          | Some (_, inner) -> List.find_map first_class_of_statement inner
+          | None -> None))
+
+(* Where a declared utility sorts: the slot of the property it writes first. *)
+let rec slot_of_statement stmt =
+  match Css.as_rule stmt with
+  | Some (_, d :: _, _) ->
+      Tw.Utility.order_of_property (Css.Declaration.property_key d)
+  | Some (_, [], _) -> None
+  | None -> (
+      match Css.as_media stmt with
+      | Some (_, inner) -> List.find_map slot_of_statement inner
+      | None -> (
+          match Css.as_supports stmt with
+          | Some (_, inner) -> List.find_map slot_of_statement inner
+          | None -> None))
+
 let custom_routed_utilities ~theme ~defs ~udefs candidates =
   let hoisted = Buffer.create 0 in
   let seen = ref [] in
@@ -1342,7 +1369,7 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
         if body = "" then None else Some (wrapped_block cls variants body)
   in
   match List.filter_map one candidates with
-  | [] -> (0, [])
+  | [] -> (0, [], [])
   | blocks -> (
       (* A [@variant] inside a declared utility's body names a built-in too. *)
       List.iter
@@ -1363,7 +1390,7 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
           (String.concat "" (blocks @ [ Buffer.contents hoisted ]))
       in
       match Css.of_string css with
-      | Error _ -> (0, [])
+      | Error _ -> (0, [], [])
       | Ok p ->
           let stmts = Css.statements (Css.flatten_nesting p.Css.stylesheet) in
           (* [@layer properties] and [@property] sit beside the utilities layer,
@@ -1386,8 +1413,49 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
                 end)
               hoisted_stmts
           in
-          ( List.length blocks,
-            Css.layer ~name:"utilities" rules :: hoisted_stmts ))
+          (* Tailwind sorts a declared utility at the slot of the property it
+             declares, so group the rules it produced under their own class and
+             read that slot off the first declaration. A property no handler
+             claims leaves the group without an order; those keep their old
+             place at the end of the layer rather than being dropped. *)
+          let group = Hashtbl.create 8 in
+          let order_of = Hashtbl.create 8 in
+          let classless = ref [] in
+          List.iter
+            (fun stmt ->
+              match first_class_of_statement stmt with
+              | None -> classless := stmt :: !classless
+              | Some cls -> (
+                  let prev =
+                    Stdlib.Option.value ~default:[] (Hashtbl.find_opt group cls)
+                  in
+                  Hashtbl.replace group cls (prev @ [ stmt ]);
+                  if not (Hashtbl.mem order_of cls) then
+                    match slot_of_statement stmt with
+                    | Some order -> Hashtbl.add order_of cls order
+                    | None -> ()))
+            rules;
+          (* Two declared utilities can land on the same slot, and their rules
+             would then interleave by selector, splitting each one's own rules
+             apart. Offset the suborder per class so each stays contiguous. *)
+          let nth = ref 0 in
+          let ordered, unordered =
+            Hashtbl.fold
+              (fun cls stmts (ordered, unordered) ->
+                match Hashtbl.find_opt order_of cls with
+                | Some (priority, suborder) ->
+                    incr nth;
+                    ( (cls, (priority, suborder + !nth), stmts) :: ordered,
+                      unordered )
+                | None -> (ordered, stmts @ unordered))
+              group
+              ([], List.rev !classless)
+          in
+          let unplaced =
+            if unordered = [] then []
+            else [ Css.layer ~name:"utilities" unordered ]
+          in
+          (List.length blocks, ordered, unplaced @ hoisted_stmts))
 
 let native_files paths flag ~(opts : gen_opts) =
   let include_base = eval_flag flag ~default:true in
@@ -1406,9 +1474,12 @@ let native_files paths flag ~(opts : gen_opts) =
       parse_known_candidates ~theme:opts.theme ?input_css:opts.input_css normal
     in
     let tw_styles = List.map snd known in
-    let stylesheet = Tw.to_css ~theme:opts.theme ~base:include_base tw_styles in
-    let routed_count, routed_stmts =
+    let routed_count, routed_extra, routed_stmts =
       custom_routed_utilities ~theme:opts.theme ~defs ~udefs routed
+    in
+    let stylesheet =
+      Tw.to_css ~theme:opts.theme ~base:include_base ~extra:routed_extra
+        tw_styles
     in
     let stylesheet =
       match routed_stmts with

--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -40,6 +40,8 @@ module Handler = struct
     | [ "forced"; "color"; "adjust"; "auto" ] -> Ok Forced_color_adjust_auto
     | [ "forced"; "color"; "adjust"; "none" ] -> Ok Forced_color_adjust_none
     | _ -> Error (`Msg "Not an accessibility utility")
+
+  let examples = [ Forced_color_adjust_auto ]
 end
 
 open Handler

--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -358,6 +358,19 @@ module Handler = struct
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not an alignment utility")
+
+  let examples =
+    [
+      Justify_start;
+      Justify_items_start;
+      Justify_self_start;
+      Items_start;
+      Content_start;
+      Self_start;
+      Place_content_center;
+      Place_items_start;
+      Place_self_auto;
+    ]
 end
 
 open Handler

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -342,6 +342,8 @@ module Handler = struct
     | Animate_bounce -> "animate-bounce"
     | Animate_bracket v -> "animate-[" ^ v ^ "]"
     | Animate_named name -> "animate-" ^ name
+
+  let examples = [ Animate_none ]
 end
 
 open Handler

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -416,6 +416,8 @@ module Handler = struct
                 with
                 | Some _ -> Ok (Parsed_decl { property; value })
                 | None -> err_not_utility))
+
+  let examples = []
 end
 
 let () = Utility.register (module Handler)

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1935,6 +1935,17 @@ module Handler = struct
     | "via" :: rest -> parse_gradient_color ~theme Gradient_via rest
     | "to" :: rest -> parse_gradient_color ~theme Gradient_to rest
     | _ -> Error (`Msg "Unknown background class")
+
+  let examples =
+    [
+      Bg_none;
+      Bg_auto;
+      Bg_no_repeat;
+      Bg_fixed;
+      Bg_clip_border;
+      Bg_origin_border;
+      Bg_current;
+    ]
 end
 
 open Handler

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1106,6 +1106,8 @@ module Handler = struct
     | Outline_offset_arbitrary v -> "outline-offset-[" ^ v ^ "]"
     | Neg_outline_offset n -> "-outline-offset-" ^ string_of_int n
     | Neg_outline_offset_var v -> "-outline-offset-[" ^ v ^ "]"
+
+  let examples = [ Border_0; Border_x; Border_y; Border_solid; Border_current ]
 end
 
 open Handler
@@ -1170,6 +1172,8 @@ module Outline_style_handler = struct
     | Double -> "outline-double"
     | None_ -> "outline-none"
     | Solid -> "outline-solid"
+
+  let examples = [ Solid ]
 end
 
 let () = Utility.register (module Outline_style_handler)

--- a/lib/box_sizing.ml
+++ b/lib/box_sizing.ml
@@ -27,6 +27,8 @@ module Handler = struct
     | [ "box"; "border" ] -> Ok Border
     | [ "box"; "content" ] -> Ok Content
     | _ -> Error (`Msg "Not a box-sizing utility")
+
+  let examples = [ Border ]
 end
 
 open Handler

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -248,10 +248,23 @@ let merge_key_of_base_class base_class =
       in
       Some key
 
-(* Convert indexed rule to CSS statement *)
-let indexed_rule_to_statement (r : Sort.indexed_rule) =
-  let filtered_props = filter_utility_properties r.props in
-  let filtered_nested = filter_theme_from_statements r.nested in
+(* Convert indexed rule to CSS statement. [verbatim] names the base classes
+   whose rules arrived as finished CSS - a project's own [@utility] - so their
+   declarations are emitted as written. The theme filter exists to split a
+   utility's theme variables out of the utilities layer, and it recognises them
+   by the layer metadata [Var.binding] attaches; a declaration parsed from
+   author CSS carries none, so filtering it drops every [--tw-*] it sets. *)
+let indexed_rule_to_statement ?(verbatim = fun _ -> false)
+    (r : Sort.indexed_rule) =
+  let keep_as_written =
+    match r.base_class with Some c -> verbatim c | None -> false
+  in
+  let filtered_props =
+    if keep_as_written then r.props else filter_utility_properties r.props
+  in
+  let filtered_nested =
+    if keep_as_written then r.nested else filter_theme_from_statements r.nested
+  in
   let merge_key =
     match r.merge_key with
     | Some _ as mk -> mk
@@ -458,7 +471,7 @@ let utilities_layer ~layers ~statements =
    one block in Tailwind's output. Each is wrapped on its own here, and the
    optimizer's merging covers [@media] and [@supports] but not this, so collapse
    a run before the statements are handed over. *)
-let statements_of_sorted_rules sorted_rules =
+let statements_of_sorted_rules ?verbatim sorted_rules =
   let is_starting (r : Sort.indexed_rule) = r.rule_type = `Starting in
   let rec take_run taken = function
     | (x : Sort.indexed_rule) :: tl when is_starting x ->
@@ -476,7 +489,7 @@ let statements_of_sorted_rules sorted_rules =
             run
         in
         go (Css.starting_style inner :: acc) rest
-    | r :: rest -> go (indexed_rule_to_statement r :: acc) rest
+    | r :: rest -> go (indexed_rule_to_statement ?verbatim r :: acc) rest
   in
   go [] sorted_rules
 
@@ -1442,7 +1455,75 @@ type config = { base : bool; forms : bool option; layers : bool }
 
 let default_config = { base = true; forms = None; layers = true }
 
-let to_css ?(theme = Scheme.default) ?(config = default_config) tw_classes =
+(* A statement a project's own [@utility] produced, in the shape a built-in
+   utility yields, so the utilities layer sorts it by its order rather than
+   receiving it after everything else. *)
+let rec first_selector stmt =
+  match Css.as_rule stmt with
+  | Some (selector, _, _) -> Some selector
+  | None ->
+      let inner =
+        match Css.as_media stmt with
+        | Some (_, inner) -> inner
+        | None -> (
+            match Css.as_supports stmt with
+            | Some (_, inner) -> inner
+            | None -> (
+                match Css.as_container stmt with
+                | Some (_, _, inner) -> inner
+                | None -> []))
+      in
+      List.find_map first_selector inner
+
+let outputs_of_statement ~base_class stmt =
+  (* An at-rule nested in another - what a project's own [dark] variant builds
+     around a colour utility's [@supports] - keeps the inner one verbatim in
+     [nested], the same shape a compound modifier already uses. Decomposing it
+     instead would emit the inner rule without the outer condition. *)
+  let of_inner wrap inner =
+    if List.for_all (fun st -> Css.as_rule st <> None) inner then
+      List.concat_map
+        (fun st ->
+          match Css.as_rule st with
+          | Some (selector, props, _) -> [ wrap ~selector ~props ~nested:[] ]
+          | None -> [])
+        inner
+    else
+      match List.find_map first_selector inner with
+      | Some selector -> [ wrap ~selector ~props:[] ~nested:inner ]
+      | None -> []
+  in
+  match Css.as_rule stmt with
+  | Some (selector, props, nested) ->
+      [ Output.regular ~selector ~props ~base_class ~nested () ]
+  | None -> (
+      match Css.as_media stmt with
+      | Some (condition, inner) ->
+          of_inner
+            (fun ~selector ~props ~nested ->
+              Output.media_query ~condition ~selector ~props ~base_class ~nested
+                ())
+            inner
+      | None -> (
+          match Css.as_supports stmt with
+          | Some (condition, inner) ->
+              of_inner
+                (fun ~selector ~props ~nested:_ ->
+                  Output.supports_query ~condition ~selector ~props ~base_class
+                    ())
+                inner
+          | None -> (
+              match Css.as_container stmt with
+              | Some (_, Some condition, inner) ->
+                  of_inner
+                    (fun ~selector ~props ~nested ->
+                      Output.container_query ~condition ~selector ~props
+                        ~base_class ~nested ())
+                    inner
+              | _ -> [])))
+
+let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
+    tw_classes =
   (* [Rule.outputs ~order_tbl] records each base utility's order under the class
      name it already builds, so [order_of_base] looks it up instead of
      re-parsing the class string while building/sorting rules. *)
@@ -1450,11 +1531,28 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) tw_classes =
   let selector_props =
     List.concat_map (Rule.outputs ~theme ~order_tbl:order_map) tw_classes
   in
+  (* A declared utility means nothing to the handlers, so its order arrives with
+     it and is seeded under the same key [order_of_base] looks up. *)
+  let selector_props =
+    selector_props
+    @ List.concat_map
+        (fun (class_name, order, statements) ->
+          Hashtbl.replace order_map (extract_base_utility class_name) order;
+          List.concat_map
+            (outputs_of_statement ~base_class:class_name)
+            statements)
+        extra
+  in
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute
      it once and share it rather than recomputing inside [layers]. *)
   let sorted_rules = sorted_indexed_rules order_map selector_props in
-  let statements = statements_of_sorted_rules sorted_rules in
+  let verbatim =
+    let names = Hashtbl.create 8 in
+    List.iter (fun (cls, _, _) -> Hashtbl.replace names cls ()) extra;
+    fun cls -> Hashtbl.mem names cls
+  in
+  let statements = statements_of_sorted_rules ~verbatim sorted_rules in
   let layer_results =
     layers ~theme ~layers:config.layers ~include_base:config.base
       ?forms:config.forms ~selector_props ~sorted_rules tw_classes statements

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -40,12 +40,24 @@ type config = {
 val default_config : config
 (** The default configuration. Base layer enabled. *)
 
-val to_css : ?theme:Scheme.t -> ?config:config -> Utility.t list -> Css.t
+val to_css :
+  ?theme:Scheme.t ->
+  ?config:config ->
+  ?extra:(string * (int * int) * Css.statement list) list ->
+  Utility.t list ->
+  Css.t
 (** [to_css ?theme ?config utilities] generates a full CSS stylesheet for
     [utilities]. This is the main entry point for the library. [theme] (default
     {!Scheme.default}) supplies the theme values utilities read while generating
     CSS. Rendering concerns such as inlining and optimization are handled by
-    {!Css.to_string}. *)
+    {!Css.to_string}.
+
+    [extra] carries rules a project's own [@utility] produced, each as
+    [(class name, order, statements)]. The handlers know nothing about a
+    declared utility, so its order comes in with it - see
+    {!Utility.order_of_property} for where that order is read from - and the
+    statements sort into the utilities layer at that order instead of landing
+    after it. *)
 
 val to_inline_style : ?theme:Scheme.t -> Utility.t list -> string
 (** [to_inline_style ?theme utilities] returns a CSS [style] attribute string

--- a/lib/clipping.ml
+++ b/lib/clipping.ml
@@ -55,6 +55,7 @@ module Handler = struct
   let to_style _theme = function Clip_polygon points -> clip_polygon' points
   let suborder = function Clip_polygon _ -> 0
   let of_class _theme _class_name = Error (`Msg "Not a clipping utility")
+  let examples = [ Clip_polygon [] ]
 end
 
 open Handler

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -3349,6 +3349,17 @@ module Handler = struct
     | Placeholder_bracket_color (v, _) -> "placeholder-[" ^ v ^ "]"
     | Placeholder_bracket_color_opacity (v, _, opacity) ->
         "placeholder-[" ^ v ^ "]" ^ opacity_suffix opacity
+
+  let examples =
+    [
+      Bg_transparent;
+      Text_transparent;
+      Border_transparent;
+      Outline_transparent;
+      Accent_transparent;
+      Caret_transparent;
+      Placeholder_transparent;
+    ]
 end
 
 open Handler

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -198,6 +198,8 @@ module Handler = struct
     | Columns_arbitrary n -> "columns-[" ^ string_of_int n ^ "]"
     | Columns_arbitrary_len s -> "columns-[" ^ s ^ "]"
     | Columns_bracket_var s -> "columns-[" ^ s ^ "]"
+
+  let examples = [ Columns_auto ]
 end
 
 open Handler

--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -152,6 +152,7 @@ module Handler = struct
         else Error (`Msg "Not a contain utility")
 
   let utility t = Utility.base (Self t)
+  let examples = [ Strict ]
 end
 
 let () = Utility.register (module Handler)

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -92,6 +92,8 @@ module Handler = struct
         let name = String.sub n 11 (String.length n - 11) in
         Ok (Container_named name)
     | _ -> Error (`Msg "Not a container utility")
+
+  let examples = [ Container ]
 end
 
 open Handler

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -169,6 +169,8 @@ module Handler = struct
         match List.assoc_opt cls of_class_map with
         | Some t -> Ok t
         | None -> Error (`Msg "Not a cursor utility"))
+
+  let examples = [ Cursor_auto ]
 end
 
 open Handler

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -549,6 +549,8 @@ module Handler = struct
             then Ok (Divide_color (Theme_named name, 500))
             else Error (`Msg ("Invalid divide color: " ^ name)))
     | _ -> Error (`Msg "Not a divide utility")
+
+  let examples = []
 end
 
 open Handler

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -3117,6 +3117,17 @@ module Handler = struct
     | Ring_offset_bracket_color_var _ | Ring_offset_bracket_cvar_opacity _
     | Ring_offset_bracket_var _ | Ring_offset_bracket_var_opacity _ ->
         100000
+
+  let examples =
+    [
+      Shadow_none;
+      Opacity 50;
+      Mix_blend_normal;
+      Bg_blend_normal;
+      Ring_none;
+      Inset_ring_default;
+      Ring_offset_width 0;
+    ]
 end
 
 open Handler

--- a/lib/field_sizing.ml
+++ b/lib/field_sizing.ml
@@ -27,6 +27,8 @@ module Handler = struct
     | [ "field"; "sizing"; "content" ] -> Ok Content
     | [ "field"; "sizing"; "fixed" ] -> Ok Fixed
     | _ -> Error (`Msg "Not a field-sizing utility")
+
+  let examples = [ Content ]
 end
 
 open Handler

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1614,6 +1614,8 @@ module Handler = struct
         "backdrop-hue-rotate-[" ^ pp_angle_bracket angle ^ "]"
     | Neg_backdrop_hue_rotate_arbitrary angle ->
         "-backdrop-hue-rotate-[" ^ pp_angle_bracket angle ^ "]"
+
+  let examples = [ Filter_none; Backdrop_filter_none ]
 end
 
 open Handler

--- a/lib/flex.ml
+++ b/lib/flex.ml
@@ -38,6 +38,7 @@ module Handler = struct
     | _ -> err_not_utility
 
   let to_class = function Flex -> "flex" | Inline_flex -> "inline-flex"
+  let examples = [ Flex ]
 end
 
 open Handler

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -57,6 +57,8 @@ module Handler = struct
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not a flex layout utility")
+
+  let examples = [ Flex_row; Flex_wrap ]
 end
 
 open Handler

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -437,6 +437,8 @@ module Handler = struct
     | Order_first -> "order-first"
     | Order_last -> "order-last"
     | Order_none -> "order-none"
+
+  let examples = [ Flex_1; Flex_grow; Flex_shrink; Basis_0 ]
 end
 
 open Handler

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -362,6 +362,8 @@ module Handler = struct
     | Form_input -> "form-input"
     | Form_checkbox -> "form-checkbox"
     | Form_radio -> "form-radio"
+
+  let examples = []
 end
 
 (* Handler for select/textarea - priority 7 *)
@@ -490,6 +492,8 @@ module Select = struct
   let to_class = function
     | Form_select -> "form-select"
     | Form_textarea -> "form-textarea"
+
+  let examples = []
 end
 
 (* Register both handlers *)

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -504,6 +504,15 @@ module Handler = struct
       | _ -> err_not_utility
     in
     parse_class parts
+
+  let examples =
+    [
+      Gap { axis = `All; value = Standard (`Rem 1.) };
+      Gap { axis = `X; value = Standard (`Rem 1.) };
+      Gap { axis = `Y; value = Standard (`Rem 1.) };
+      Space { negative = false; axis = `X; value = `Rem 1. };
+      Space { negative = false; axis = `Y; value = `Rem 1. };
+    ]
 end
 
 open Handler

--- a/lib/grid.ml
+++ b/lib/grid.ml
@@ -38,6 +38,7 @@ module Handler = struct
     | _ -> err_not_utility
 
   let to_class = function Grid -> "grid" | Inline_grid -> "inline-grid"
+  let examples = [ Grid ]
 end
 
 open Handler

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -467,6 +467,16 @@ module Handler = struct
     | Row_end_arbitrary s -> "row-end-" ^ to_class_arbitrary s
     | Row_end_auto -> "row-end-auto"
     | Row_end_named s -> "row-end-" ^ s
+
+  let examples =
+    [
+      Col_auto;
+      Col_start_auto;
+      Col_end_auto;
+      Row_auto;
+      Row_start_auto;
+      Row_end_auto;
+    ]
 end
 
 open Handler

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -512,6 +512,15 @@ module Handler = struct
     | Auto_rows_fr -> "auto-rows-fr"
     | Auto_rows_spacing n -> "auto-rows-" ^ pp_float n
     | Auto_rows_arbitrary s -> "auto-rows-[" ^ s ^ "]"
+
+  let examples =
+    [
+      Grid_cols_none;
+      Grid_rows_none;
+      Grid_flow_row;
+      Auto_cols_auto;
+      Auto_rows_auto;
+    ]
 end
 
 open Handler

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -362,6 +362,20 @@ module Handler = struct
     | Scheme_normal -> "scheme-normal"
     | Scheme_only_dark -> "scheme-only-dark"
     | Scheme_only_light -> "scheme-only-light"
+
+  let examples =
+    [
+      Select_none;
+      Scroll_auto;
+      Snap_x;
+      Snap_start;
+      Snap_mandatory;
+      Resize_none;
+      Pointer_events_none;
+      Appearance_none;
+      Will_change_auto;
+      Scheme_dark;
+    ]
 end
 
 open Handler

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -65,6 +65,8 @@ module Screen_reader_handler = struct
     | [ "sr"; "only" ] -> Ok Sr_only
     | [ "not"; "sr"; "only" ] -> Ok Not_sr_only
     | _ -> Error (`Msg "Not a screen reader utility")
+
+  let examples = []
 end
 
 (* Theme variable for z-index-auto. When the threaded theme overrides this token
@@ -722,6 +724,18 @@ module Handler = struct
     | [ "break"; "inside"; "avoid"; "column" ] -> Ok Break_inside_avoid_column
     | [ "break"; "inside"; "avoid"; "page" ] -> Ok Break_inside_avoid_page
     | _ -> Error (`Msg "Not a layout utility")
+
+  let examples =
+    [
+      Block;
+      Visible;
+      Z_auto;
+      Isolate;
+      Float_left;
+      Clear_both;
+      Object_contain;
+      Object_center;
+    ]
 end
 
 open Handler

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -408,6 +408,21 @@ module Handler = struct
                       else Ok { negative = false; axis; value = Standard `Auto }
                   ))
         | None -> Error (`Msg "Not a margin utility"))
+
+  let examples =
+    [
+      { negative = false; axis = `All; value = Standard `Auto };
+      { negative = false; axis = `X; value = Standard `Auto };
+      { negative = false; axis = `Y; value = Standard `Auto };
+      { negative = false; axis = `T; value = Standard `Auto };
+      { negative = false; axis = `R; value = Standard `Auto };
+      { negative = false; axis = `B; value = Standard `Auto };
+      { negative = false; axis = `L; value = Standard `Auto };
+      { negative = false; axis = `S; value = Standard `Auto };
+      { negative = false; axis = `E; value = Standard `Auto };
+      { negative = false; axis = `Bs; value = Standard `Auto };
+      { negative = false; axis = `Be; value = Standard `Auto };
+    ]
 end
 
 open Handler

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -1132,6 +1132,8 @@ module Handler = struct
     | Mask_radial_size (Arbitrary_size s) ->
         let escaped = String.map (fun c -> if c = ' ' then '_' else c) s in
         "mask-radial-[" ^ escaped ^ "]"
+
+  let examples = [ Mask_linear_angle (Angle_int 0) ]
 end
 
 open Handler

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -662,6 +662,17 @@ module Handler = struct
     | Mask_position_bracket_var v -> "mask-position-[" ^ v ^ "]"
     | Mask_size_bracket v -> "mask-size-[" ^ v ^ "]"
     | Mask_size_bracket_var v -> "mask-size-[" ^ v ^ "]"
+
+  let examples =
+    [
+      Mask_none;
+      Mask_clip_border;
+      Mask_origin_border;
+      Mask_repeat;
+      Mask_type_alpha;
+      Mask_add;
+      Mask_alpha;
+    ]
 end
 
 open Handler

--- a/lib/overflow.ml
+++ b/lib/overflow.ml
@@ -73,6 +73,8 @@ module Handler = struct
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not an overflow utility")
+
+  let examples = [ Auto; X_auto; Y_auto ]
 end
 
 open Handler

--- a/lib/overflow_wrap.ml
+++ b/lib/overflow_wrap.ml
@@ -37,6 +37,8 @@ module Handler = struct
     | [ "wrap"; "break"; "word" ] -> Ok Break_word
     | [ "wrap"; "anywhere" ] -> Ok Anywhere
     | _ -> Error (`Msg "Not an overflow-wrap utility")
+
+  let examples = [ Normal ]
 end
 
 open Handler

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -76,6 +76,8 @@ module Handler = struct
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not an overscroll utility")
+
+  let examples = [ Auto; X_auto; Y_auto ]
 end
 
 open Handler

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -190,6 +190,21 @@ module Handler = struct
                       Ok { axis; value = Standard spacing_val }
                   | Some `Auto -> Error (`Msg "Not a padding utility")))
         | None -> Error (`Msg "Not a padding utility"))
+
+  let examples =
+    [
+      { axis = `All; value = Standard (`Rem 1.) };
+      { axis = `X; value = Standard (`Rem 1.) };
+      { axis = `Y; value = Standard (`Rem 1.) };
+      { axis = `T; value = Standard (`Rem 1.) };
+      { axis = `R; value = Standard (`Rem 1.) };
+      { axis = `B; value = Standard (`Rem 1.) };
+      { axis = `L; value = Standard (`Rem 1.) };
+      { axis = `S; value = Standard (`Rem 1.) };
+      { axis = `E; value = Standard (`Rem 1.) };
+      { axis = `Bs; value = Standard (`Rem 1.) };
+      { axis = `Be; value = Standard (`Rem 1.) };
+    ]
 end
 
 open Handler

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -1112,6 +1112,20 @@ module Handler = struct
     | End n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "end-" ^ string_of_int (abs n)
+
+  let examples =
+    [
+      Position_static;
+      Inset_0;
+      Inset_x_0;
+      Inset_y_0;
+      Top_auto;
+      Right_auto;
+      Bottom_auto;
+      Left_auto;
+      Start_auto;
+      End_auto;
+    ]
 end
 
 open Handler

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2084,6 +2084,8 @@ module Handler = struct
     | Prose_xl -> 4650004
     | Lead -> 4650005
     | Not_prose -> 4650006
+
+  let examples = []
 end
 
 (* Handler for prose color variants - priority 21 *)
@@ -2149,6 +2151,8 @@ module Color_Handler = struct
     | Prose_zinc -> 30004
     | Prose_invert -> 30005
     | Prose_orange -> 30006
+
+  let examples = []
 end
 
 (** Register both handlers with Utility system *)

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -286,6 +286,32 @@ module Handler = struct
                 | None -> Error (`Msg "Not a scroll utility")))
         | _ -> Error (`Msg "Not a scroll utility"))
     | _ -> Error (`Msg "Not a scroll utility")
+
+  let examples =
+    [
+      { kind = Margin; negative = false; axis = All; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = X; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = Y; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = T; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = R; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = B; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = L; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = S; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = E; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = Bs; value = Spacing 1. };
+      { kind = Margin; negative = false; axis = Be; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = All; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = X; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = Y; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = T; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = R; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = B; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = L; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = S; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = E; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = Bs; value = Spacing 1. };
+      { kind = Padding; negative = false; axis = Be; value = Spacing 1. };
+    ]
 end
 
 open Handler

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -258,6 +258,8 @@ module Handler = struct
     | "scrollbar" :: "track" :: rest ->
         parse_color ~theme (fun s -> Track s) rest
     | _ -> Error (`Msg "Not a scrollbar utility")
+
+  let examples = [ Width_auto; Gutter_auto; Thumb Current; Track Current ]
 end
 
 let () = Utility.register (module Handler)

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -1922,6 +1922,23 @@ module Handler = struct
         in
         "aspect-[" ^ num w ^ "/" ^ num h ^ "]"
     | Aspect_bracket_num s -> "aspect-[" ^ s ^ "]"
+
+  let examples =
+    [
+      H_auto;
+      Max_h_none;
+      Min_h_auto;
+      W_auto;
+      Max_w_none;
+      Min_w_auto;
+      Aspect_auto;
+      Block_auto;
+      Max_block_none;
+      Min_block_auto;
+      Inline_auto;
+      Max_inline_none;
+      Min_inline_auto;
+    ]
 end
 
 open Handler

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -464,6 +464,8 @@ module Handler = struct
         | Ok (color, shade) -> Ok (Stroke_color (color, shade))
         | Error e -> Error e)
     | _ -> err_not_utility
+
+  let examples = [ Fill_none; Stroke_none; Stroke_0 ]
 end
 
 let () = Utility.register (module Handler)

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -46,6 +46,8 @@ module Handler = struct
             | Some v -> Ok (Tab_arbitrary (n, v))
             | None -> Error (`Msg "Not a tab utility")))
     | _ -> Error (`Msg "Not a tab utility")
+
+  let examples = [ Tab 4 ]
 end
 
 open Handler

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -289,6 +289,16 @@ module Handler = struct
     | Table_fixed -> "table-fixed"
     | Caption_top -> "caption-top"
     | Caption_bottom -> "caption-bottom"
+
+  let examples =
+    [
+      Border_collapse;
+      Border_spacing 1.;
+      Border_spacing_x 1.;
+      Border_spacing_y 1.;
+      Table_auto;
+      Caption_top;
+    ]
 end
 
 open Handler

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -788,6 +788,8 @@ module Handler = struct
         | Stdlib.Option.None -> 0)
     | Text_shadow_shape_opacity _ -> -1 (* no @supports *)
     | _ -> 0
+
+  let examples = [ Text_shadow_shape S_sm; Text_shadow_current ]
 end
 
 open Handler

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -101,6 +101,8 @@ module Handler = struct
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not a touch-action utility")
+
+  let examples = [ Touch_auto ]
 end
 
 open Handler

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1996,6 +1996,9 @@ module Handler = struct
         (* Convert spaces back to underscores for class name *)
         let s = String.map (fun c -> if c = ' ' then '_' else c) s in
         "origin-[" ^ s ^ "]"
+
+  let examples =
+    [ Origin_top; Perspective_none; Perspective_origin_top; Backface_hidden ]
 end
 
 open Handler

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -652,6 +652,8 @@ module Handler = struct
     | Ease_in_out -> "ease-in-out"
     | Ease_initial -> "ease-initial"
     | Ease_arbitrary s -> "ease-[" ^ s ^ "]"
+
+  let examples = [ Transition; Duration 150; Delay 150; Ease_linear ]
 end
 
 open Handler

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -65,8 +65,8 @@ include Scroll
 include Arbitrary
 
 let to_css ?theme ?(base = Build.default_config.base) ?forms
-    ?(layers = Build.default_config.layers) utilities =
-  Build.to_css ?theme ~config:{ base; forms; layers } utilities
+    ?(layers = Build.default_config.layers) ?extra utilities =
+  Build.to_css ?theme ~config:{ base; forms; layers } ?extra utilities
 
 let to_inline_style ?theme utilities = Build.to_inline_style ?theme utilities
 let preflight = Preflight.stylesheet

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3786,6 +3786,7 @@ val to_css :
   ?base:bool ->
   ?forms:bool ->
   ?layers:bool ->
+  ?extra:(string * (int * int) * Css.statement list) list ->
   t list ->
   Css.t
 (** [to_css ?theme ?base ?forms ?layers styles] generates a CSS stylesheet for

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1405,6 +1405,8 @@ module Typography_early = struct
         let fs_decls = bracket_font_size_decls raw in
         let lh_extra, lh_value = lh_modifier_to_css lh_mod in
         style (fs_decls @ lh_extra @ [ line_height lh_value ])
+
+  let examples = [ Text_base; Font_normal ]
 end
 
 (** Late typography handler - comes after color utilities (priority 24) *)
@@ -3101,6 +3103,34 @@ module Typography_late = struct
     | Content_raw (_, c) -> content_raw c
     | Content_squote s -> content_squote s
     | Content_named name -> content_named name
+
+  let examples =
+    [
+      Align_baseline;
+      Antialiased;
+      Break_normal;
+      Capitalize;
+      Content_none;
+      Decoration_transparent;
+      Decoration_solid;
+      Decoration_auto;
+      Font_stretch_normal;
+      Hyphens_none;
+      Indent_px;
+      Line_clamp_none;
+      Line_through;
+      List_none;
+      List_image_none;
+      List_inside;
+      Normal_nums;
+      Overflow_wrap_normal;
+      Text_balance;
+      Text_ellipsis;
+      Text_nowrap;
+      Tracking_normal;
+      Underline_offset_auto;
+      Whitespace_normal;
+    ]
 end
 
 (* Register both handlers *)

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -27,15 +27,81 @@ module type Handler = sig
   val suborder : t -> int
   val of_class : Scheme.t -> string -> (t, [ `Msg of string ]) result
   val to_class : t -> string
+  val examples : t list
 end
 
 type handler = H : (module Handler with type t = 'a) -> handler
 
 let handlers : handler list ref = ref []
 
+(* A project's [@utility] sorts at the slot of the property it declares, so that
+   slot has to be readable from a property. Each handler offers a few of its own
+   utilities as {!Handler.examples}; running them through [to_style] says which
+   properties they set, and the lowest order among the ones setting a property
+   is that property's slot. The ordering itself stays declared once, on the
+   utilities - nothing here restates it. *)
+let property_slots :
+    (Cascade.Css.Declaration.prop_key, int * int) Hashtbl.t option ref =
+  ref None
+
 let register (type a) (module M : Handler with type t = a) =
   let internal_h = H (module M : Handler with type t = a) in
+  property_slots := None;
   handlers := internal_h :: !handlers
+
+(* The declarations a style writes, its own and those of the rules it
+   carries. *)
+let rec style_declarations (s : Style.t) =
+  match s with
+  | Style.Style { props; rules; _ } ->
+      props
+      @ List.concat_map
+          (fun rule ->
+            match Cascade.Css.as_rule rule with
+            | Some (_, decls, _) -> decls
+            | None -> [])
+          (Stdlib.Option.value ~default:[] rules)
+  | Style.Modified (_, inner) -> style_declarations inner
+  | Style.Group inner -> List.concat_map style_declarations inner
+
+let build_property_slots () =
+  let tbl = Hashtbl.create 512 in
+  let record key order =
+    match Hashtbl.find_opt tbl key with
+    | Some existing when existing <= order -> ()
+    | _ -> Hashtbl.replace tbl key order
+  in
+  List.iter
+    (fun (H (module M)) ->
+      List.iter
+        (fun example ->
+          let order = (M.priority example, M.suborder example) in
+          (* The property a utility claims is the one it writes first: the one
+             it is named for. A later declaration is incidental - line-clamp
+             ends with [display: -webkit-box] but the display slot belongs to
+             the display utilities, which sort elsewhere. *)
+          match style_declarations (M.to_style Scheme.default example) with
+          | [] -> ()
+          | d :: _ -> (
+              match Cascade.Css.Declaration.property_key d with
+              (* An author's own variable is not a slot: only the properties
+                 Tailwind orders utilities by are. *)
+              | Key (Custom_property _) | Key (Unknown_property _) -> ()
+              | key -> record key order))
+        M.examples)
+    !handlers;
+  tbl
+
+let order_of_property key =
+  let tbl =
+    match !property_slots with
+    | Some tbl -> tbl
+    | None ->
+        let tbl = build_property_slots () in
+        property_slots := Some tbl;
+        tbl
+  in
+  Hashtbl.find_opt tbl key
 
 let name_of_base u =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -29,6 +29,10 @@
           | _ -> Error (`Msg "Not an example utility")
 
         let to_class = function Block -> "example-block"
+
+        (* One utility per property this handler sets, so a project's own
+           [@utility] declaring [display] can find its slot. *)
+        let examples = [ Block ]
       end
 
       let () = Utility.register (module Handler)
@@ -113,10 +117,23 @@ module type Handler = sig
 
   val to_class : t -> string
   (** [to_class u] is the CSS class name for utility [u]. *)
+
+  val examples : t list
+  (** A few of this handler's utilities, one per property it can set.
+      {!order_of_property} runs them through {!to_style} to learn which
+      properties belong to which slot, so nothing has to restate the order or
+      pair a property with a variant by hand. Covering a property here is what
+      lets a project's [@utility] declaring it sort in the right place. *)
 end
 
 val register : (module Handler with type t = 'a) -> unit
 (** [register h] registers a utility handler module. *)
+
+val order_of_property : Cascade.Css.Declaration.prop_key -> (int * int) option
+(** [order_of_property k] is the [(priority, suborder)] of the utility family
+    that sets property [k], or [None] when no registered handler claims it. This
+    is where a declared [@utility] gets its place: Tailwind sorts one by the
+    property it declares, not by its name. *)
 
 val base_of_class : Scheme.t -> string -> (base, [ `Msg of string ]) result
 (** [base_of_class theme class_name] parses a class name into a base utility

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -50,6 +50,8 @@ module Handler = struct
             | Some v -> Ok (Zoom_arbitrary (n, v))
             | None -> Error (`Msg "Not a zoom utility")))
     | _ -> Error (`Msg "Not a zoom utility")
+
+  let examples = [ Zoom_pct 100. ]
 end
 
 let () = Utility.register (module Handler)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -754,6 +754,7 @@ let test_style_rules_props () =
     let to_style _theme _t = style
     let suborder _t = 0
     let of_class _ _ = Error (`Msg "test utility")
+    let examples = []
   end in
   let () = Tw.Utility.register (module TestHandler) in
   let test_utility = Tw.Utility.base (TestHandler.Self TestHandler.Test) in

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -120,6 +120,33 @@ let test_order_consistency () =
   check (pair int int) "first equals second" o1 o2;
   check (pair int int) "second equals third" o2 o3
 
+(* A project's [@utility] sorts at the slot of the property it declares, so a
+   property has to resolve to the order of the utilities that set it. The slots
+   are derived from each handler's examples, not from a table restating the
+   order. *)
+let test_order_of_property () =
+  let open Tw.Utility in
+  let order_of cls =
+    match base_of_class Tw.Scheme.default cls with
+    | Ok b -> order b
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check
+    (option (pair int int))
+    "display resolves to the display utilities"
+    (Some (order_of "block"))
+    (order_of_property (Key Display));
+  check
+    (option (pair int int))
+    "box-sizing resolves to the box-sizing utilities"
+    (Some (order_of "box-border"))
+    (order_of_property (Key Box_sizing));
+  check
+    (option (pair int int))
+    "isolation keeps its own slot, not the display family's"
+    (Some (order_of "isolate"))
+    (order_of_property (Key Isolation))
+
 let tests =
   [
     test_case "base_of_class valid input" `Quick test_base_of_class_valid;
@@ -128,6 +155,7 @@ let tests =
     test_case "deduplicate handles empty list" `Quick test_deduplicate_empty;
     (* test_case "css_of_string valid input" `Quick test_css_of_string_valid; *)
     (* test_case "css_of_string invalid input" `Quick test_css_of_string_invalid; *)
+    test_case "order_of_property" `Quick test_order_of_property;
     test_case "order returns correct priorities" `Quick test_order_priorities;
     test_case "order returns correct suborders" `Quick test_order_suborders;
     test_case "order is consistent" `Quick test_order_consistency;


### PR DESCRIPTION
A project's `@utility` landed at the end of the utilities layer instead of at the slot of the property it declares, so on tailwindcss.com `.line-y` sat at 88% of the sheet where Tailwind puts it at 5%. Since it sets `position: relative`, it beat `.absolute` on any element carrying both.

Each handler now offers a few of its own utilities as `examples`, and `Utility.order_of_property` reads the slots off what those emit, so nothing restates an order that the utilities already declare.