### PR TITLE
test: compare the two sheets as a browser renders them

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -814,42 +814,44 @@ module Handler = struct
     | Border_width n -> 1001 + n
     | Border_width_bracket _ -> 1005
     (* Border sides are side-major (Tailwind groups each side's bare width, its
-       numeric widths and its arbitrary width together): t, r, b, l, then x, y.
+       numeric widths and its arbitrary width together), and the axes and
+       logical sides come first: x, y, s, e, bs, be, then t, r, b, l. The order
+       decides the width, since border-y and border-b both write the bottom one.
        Within a side: bare, 0, 2, 4, 8, arbitrary. *)
+    | Border_x -> 1100
+    | Border_x_width n -> 1100 + n
+    | Border_y -> 1110
+    | Border_y_width n -> 1110 + n
+    | Border_s -> 1120
+    | Border_s_width n -> 1120 + n
+    | Border_e -> 1130
+    | Border_e_width n -> 1130 + n
+    | Border_bs -> 1140
+    | Border_bs_width n -> 1140 + n
+    | Border_be -> 1150
+    | Border_be_width n -> 1150 + n
     | Border_side_width_bracket (side, _, _) -> (
-        match side with "t" -> 1105 | "r" -> 1115 | "b" -> 1125 | _ -> 1135)
-    | Border_t -> 1100
-    | Border_t_0 -> 1101
-    | Border_t_2 -> 1102
-    | Border_t_4 -> 1103
-    | Border_t_8 -> 1104
-    | Border_r -> 1110
-    | Border_r_0 -> 1111
-    | Border_r_2 -> 1112
-    | Border_r_4 -> 1113
-    | Border_r_8 -> 1114
-    | Border_b -> 1120
-    | Border_b_0 -> 1121
-    | Border_b_2 -> 1122
-    | Border_b_4 -> 1123
-    | Border_b_8 -> 1124
-    | Border_l -> 1130
-    | Border_l_0 -> 1131
-    | Border_l_2 -> 1132
-    | Border_l_4 -> 1133
-    | Border_l_8 -> 1134
-    | Border_x -> 1140
-    | Border_x_width n -> 1140 + n
-    | Border_y -> 1150
-    | Border_y_width n -> 1150 + n
-    | Border_s -> 1160
-    | Border_s_width n -> 1160 + n
-    | Border_e -> 1170
-    | Border_e_width n -> 1170 + n
-    | Border_bs -> 1180
-    | Border_bs_width n -> 1180 + n
-    | Border_be -> 1190
-    | Border_be_width n -> 1190 + n
+        match side with "t" -> 1165 | "r" -> 1175 | "b" -> 1185 | _ -> 1195)
+    | Border_t -> 1160
+    | Border_t_0 -> 1161
+    | Border_t_2 -> 1162
+    | Border_t_4 -> 1163
+    | Border_t_8 -> 1164
+    | Border_r -> 1170
+    | Border_r_0 -> 1171
+    | Border_r_2 -> 1172
+    | Border_r_4 -> 1173
+    | Border_r_8 -> 1174
+    | Border_b -> 1180
+    | Border_b_0 -> 1181
+    | Border_b_2 -> 1182
+    | Border_b_4 -> 1183
+    | Border_b_8 -> 1184
+    | Border_l -> 1190
+    | Border_l_0 -> 1191
+    | Border_l_2 -> 1192
+    | Border_l_4 -> 1193
+    | Border_l_8 -> 1194
     (* Border style utilities (1400-1499) - alphabetical *)
     | Border_dashed -> 1400
     | Border_dotted -> 1401

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@tailwindcss/cli": "4.3.3",
         "@tailwindcss/forms": "0.5.11",
         "@tailwindcss/typography": "0.5.20",
+        "playwright": "^1.62.1",
         "tailwindcss": "4.3.3"
       }
     },
@@ -738,6 +739,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1128,6 +1144,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss-selector-parser": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@tailwindcss/cli": "4.3.3",
     "@tailwindcss/forms": "0.5.11",
     "@tailwindcss/typography": "0.5.20",
+    "playwright": "^1.62.1",
     "tailwindcss": "4.3.3"
   }
 }

--- a/test/helpers/browser/compare.js
+++ b/test/helpers/browser/compare.js
@@ -1,0 +1,85 @@
+// Differential rendering: the same elements under tw's sheet and Tailwind's,
+// compared on what the browser computes. A property that computes the same is
+// equivalent however the two sheets spell it; one that differs is observable.
+// Exit codes: 0 no differences, 1 differences on stdout, 2 no usable browser.
+const fs = require('fs');
+
+let chromium;
+try {
+  ({ chromium } = require('playwright'));
+} catch (e) {
+  console.error(e.message);
+  process.exit(2);
+}
+
+const [, , elementsFile, twCss, tailwindCss] = process.argv;
+const elements = fs.readFileSync(elementsFile, 'utf8').split('\n').filter((l) => l.trim());
+
+// Custom properties are absent from getComputedStyle's enumeration, so collect
+// the names the sheets declare and ask for each by hand.
+const customNames = (css) => new Set(css.match(/--[A-Za-z0-9_-]+/g) || []);
+
+const page = (css, classes) =>
+  `<!doctype html><meta charset="utf-8"><style>${css}</style>` +
+  `<body>${classes.map((c, i) => `<div id="e${i}" class="${c}"></div>`).join('')}</body>`;
+
+async function computed(browser, css, names) {
+  const p = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await p.setContent(page(css, elements));
+  const out = await p.evaluate((ns) => {
+    const res = {};
+    document.querySelectorAll('div[id^=e]').forEach((el) => {
+      const cs = getComputedStyle(el);
+      const o = {};
+      for (const prop of cs) o[prop] = cs.getPropertyValue(prop);
+      for (const n of ns) {
+        const v = cs.getPropertyValue(n);
+        if (v !== '') o[n] = v;
+      }
+      res[el.id] = o;
+    });
+    return res;
+  }, names);
+  await p.close();
+  return out;
+}
+
+(async () => {
+  const a = fs.readFileSync(twCss, 'utf8');
+  const b = fs.readFileSync(tailwindCss, 'utf8');
+  const names = [...new Set([...customNames(a), ...customNames(b)])];
+  let browser;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    console.error(e.message);
+    process.exit(2);
+  }
+  const ta = await computed(browser, a, names);
+  const tb = await computed(browser, b, names);
+  await browser.close();
+
+  // A custom property is a token stream: the browser hands back the author's
+  // own whitespace and quoting, so two sheets that minify differently differ on
+  // spelling alone. Compare them with both dropped - whatever reads the
+  // variable shows a real difference in its own property.
+  const norm = (k, v) =>
+    k.startsWith('--') && v !== undefined ? v.replace(/["'\s]+/g, '') : v;
+
+  const lines = [];
+  for (const [id, pa] of Object.entries(ta)) {
+    const pb = tb[id];
+    for (const k of new Set([...Object.keys(pa), ...Object.keys(pb)])) {
+      // A custom property one sheet declares and the other prunes renders the
+      // same unless something reads it, and whatever reads it differs instead.
+      if (k.startsWith('--') && (pa[k] === undefined || pb[k] === undefined)) continue;
+      if (norm(k, pa[k]) !== norm(k, pb[k]))
+        lines.push(`${elements[Number(id.slice(1))]}: ${k}: ${pa[k]} (tw) vs ${pb[k]} (tailwind)`);
+    }
+  }
+  if (lines.length) {
+    console.log(lines.join('\n'));
+    process.exit(1);
+  }
+  process.exit(0);
+})();

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -36,6 +36,57 @@ let tailwind_css ?(forms = false) classnames =
   if not (Tw_tools.Tailwind_gen.available ()) then Alcotest.skip ();
   Tw_tools.Tailwind_gen.generate ~minify:true ~optimize:true ~forms classnames
 
+(* Which CSS properties a class declares. Custom properties count: a drop-shadow
+   colour and a drop-shadow size conflict only on [--tw-drop-shadow]. *)
+let properties_of_class cls =
+  match Tw.of_string cls with
+  | Error _ -> []
+  | Ok u ->
+      Tw.to_css ~base:false [ u ]
+      |> Css.fold
+           (fun acc stmt ->
+             match Css.as_rule stmt with
+             | Some (sel, decls, _) when Css.Selector.to_string sel <> ":root"
+               ->
+                 List.map Css.Declaration.property_key decls @ acc
+             | _ -> acc)
+           []
+
+(* Classes that declare a property in common, paired up. An ordering difference
+   is only observable on an element carrying two such classes; one class on its
+   own can only show a difference in value. *)
+let same_property_pairs classes =
+  let by_prop = Hashtbl.create 256 in
+  List.iter
+    (fun cls ->
+      List.iter
+        (fun k ->
+          let prev = Option.value ~default:[] (Hashtbl.find_opt by_prop k) in
+          Hashtbl.replace by_prop k (cls :: prev))
+        (properties_of_class cls))
+    classes;
+  let seen = Hashtbl.create 1024 in
+  Hashtbl.fold
+    (fun _ cs acc ->
+      let cs = List.sort_uniq String.compare cs in
+      let rec pairs acc = function
+        | [] | [ _ ] -> acc
+        | a :: tl ->
+            let acc =
+              List.fold_left
+                (fun acc b ->
+                  let p = (a, b) in
+                  if Hashtbl.mem seen p then acc
+                  else (
+                    Hashtbl.add seen p ();
+                    p :: acc))
+                acc tl
+            in
+            pairs acc tl
+      in
+      pairs acc cs)
+    by_prop []
+
 let check_ordering_fails ?(forms = false) utilities =
   let classnames = List.map Tw.pp utilities in
   not
@@ -130,6 +181,109 @@ let minimize_failing_case check_fails initial =
       else minimal
     in
     Some final
+
+(* Differential rendering. Both sheets are loaded in headless Chromium and the
+   computed styles compared: a property that computes the same is equivalent
+   however the two sheets spell it, and one that differs is observable by
+   definition. It needs node, Playwright and its Chromium, none of which a plain
+   opam build has, so the check skips when they are missing rather than being
+   gated in dune. Set TW_BROWSER_TESTS=0 to opt out where they are present. *)
+let rec dir_containing name dir =
+  if Sys.file_exists (Filename.concat dir name) then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else dir_containing name parent
+
+(* Tests run from the build directory, which is itself inside the project, so
+   the walk up finds the root whether or not dune sandboxed us. node_modules is
+   what we are really after: node resolves playwright from there. *)
+let project_root = lazy (dir_containing "node_modules" (Sys.getcwd ()))
+let browser_script = "test/helpers/browser/compare.js"
+
+let browser_available root =
+  Sys.getenv_opt "TW_BROWSER_TESTS" <> Some "0"
+  && Sys.file_exists (Filename.concat root "node_modules/playwright")
+  && Sys.file_exists (Filename.concat root browser_script)
+  && Sys.command "node --version > /dev/null 2>&1" = 0
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let read_file path =
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic;
+  s
+
+(* One directory per test, kept after the run: the two sheets and the element
+   list are what you need to reproduce a failure by hand. *)
+let render_dir root test_name =
+  let safe =
+    String.map
+      (fun c ->
+        match c with 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> c | _ -> '_')
+      test_name
+  in
+  let mkdir dir =
+    (* Another runner may have created it between the two calls. *)
+    if not (Sys.file_exists dir) then
+      try Sys.mkdir dir 0o755 with Sys_error _ -> ()
+  in
+  List.fold_left
+    (fun dir part ->
+      let dir = Filename.concat dir part in
+      mkdir dir;
+      dir)
+    root [ "tmp"; "browser"; safe ]
+
+let dedup l =
+  List.rev
+    (fst
+       (List.fold_left
+          (fun (acc, seen) x ->
+            if List.mem x seen then (acc, seen) else (x :: acc, x :: seen))
+          ([], []) l))
+
+let check_rendering_matches ?(forms = false) ~test_name utilities =
+  let root =
+    match Lazy.force project_root with Some r -> r | None -> Alcotest.skip ()
+  in
+  if not (browser_available root) then Alcotest.skip ();
+  let classnames = List.map Tw.pp utilities in
+  (* A class on its own can only show a difference in value; an ordering
+     difference needs an element carrying two classes that write the same
+     property. *)
+  let pairs = same_property_pairs classnames in
+  let elements =
+    dedup (classnames @ List.map (fun (a, b) -> a ^ " " ^ b) pairs)
+  in
+  let tailwind = tailwind_css ~forms classnames in
+  let dir = render_dir root test_name in
+  let path name = Filename.concat dir name in
+  write_file (path "tw.css") (our_css utilities);
+  write_file (path "tailwind.css") tailwind;
+  write_file (path "elements.txt") (String.concat "\n" elements);
+  let out = path "diff.txt" and err = path "stderr.txt" in
+  let cmd =
+    Fmt.str "node %s %s %s %s > %s 2> %s"
+      (Filename.quote (Filename.concat root browser_script))
+      (Filename.quote (path "elements.txt"))
+      (Filename.quote (path "tw.css"))
+      (Filename.quote (path "tailwind.css"))
+      (Filename.quote out) (Filename.quote err)
+  in
+  match Sys.command cmd with
+  | 0 -> ()
+  | 1 -> Alcotest.failf "%s\n%s" test_name (read_file out)
+  | _ ->
+      (* No usable browser (Chromium not downloaded, sandbox refused to start).
+         Report it and skip: it is a missing tool, not a difference. *)
+      Fmt.epr "browser rendering unavailable: %s@."
+        (String.trim (read_file err));
+      Alcotest.skip ()
 
 let check_ordering_matches ?(forms = false) ~test_name utilities =
   let classnames = List.map Tw.pp utilities in

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -13,6 +13,23 @@ val extract_utilities_layer_rules : Css.t -> Css.statement list
 val extract_rule_selectors : Css.statement list -> string list
 (** [extract_rule_selectors stmts] extracts selector strings from CSS rules. *)
 
+val our_css : Tw.t list -> string
+(** [our_css utilities] is tw's stylesheet for [utilities], base layer included
+    and minified. *)
+
+val tailwind_css : ?forms:bool -> string list -> string
+(** [tailwind_css classnames] is the pinned Tailwind CLI's stylesheet for the
+    same classes. Skips the test when the CLI is unavailable. *)
+
+val properties_of_class : string -> Css.Declaration.prop_key list
+(** [properties_of_class cls] is every property [cls] declares, custom
+    properties included: two utilities can conflict on a [--tw-*] alone. *)
+
+val same_property_pairs : string list -> (string * string) list
+(** [same_property_pairs classes] pairs up the classes that declare a property
+    in common. An element carrying such a pair is where an ordering difference
+    becomes observable; a class on its own can only differ in value. *)
+
 val check_ordering_fails : ?forms:bool -> Tw.t list -> bool
 (** [check_ordering_fails ?forms utilities] checks if utilities produce
     different ordering than Tailwind CSS. *)
@@ -35,6 +52,14 @@ val check_ordering_matches :
 (** [check_ordering_matches ?forms ~test_name utilities] compares the ordering
     of utilities between our implementation and Tailwind CSS, failing the test
     if they differ. *)
+
+val check_rendering_matches :
+  ?forms:bool -> test_name:string -> Tw.t list -> unit
+(** [check_rendering_matches ?forms ~test_name utilities] renders both sheets in
+    headless Chromium and fails on any computed style that differs. Each class
+    gets an element of its own, plus one per {!same_property_pairs} pair, which
+    is where an ordering difference shows. Skips when node or Playwright is
+    absent; [TW_BROWSER_TESTS=0] opts out where they are present. *)
 
 (** {1 CSS Test Helpers} *)
 

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -173,6 +173,37 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"backgrounds suborder matches Tailwind" shuffled
 
+(* A gradient and a background colour both end up in background-image and
+   background-color, and the gradient stops share the --tw-gradient-* slots.
+   Palette colours are left out: tw declares the theme token as a hex where
+   Tailwind keeps oklch, which [tw --diff] already reports on its own. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "bg-current";
+      "bg-transparent";
+      "bg-black";
+      "bg-white";
+      "bg-linear-to-r";
+      "bg-linear-to-b";
+      "from-current";
+      "via-transparent";
+      "to-black";
+      "from-50%";
+      "bg-cover";
+      "bg-contain";
+      "bg-center";
+      "bg-top";
+      "bg-no-repeat";
+      "bg-repeat-x";
+      "bg-fixed";
+      "bg-local";
+    ]
+  in
+  Test_helpers.check_rendering_matches
+    ~test_name:"backgrounds render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 (* An arbitrary url() with its own quotes must not be double-wrapped: tw used to
    emit the broken url("'/img/x.png'"); it now canonicalises to a valid
    url(). *)
@@ -294,6 +325,8 @@ let tests =
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "backgrounds suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "backgrounds render like Tailwind" `Slow
+      rendering_matches_tailwind;
   ]
 
 let suite = ("backgrounds", tests)

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -122,6 +122,38 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"borders suborder matches Tailwind" shuffled
 
+(* A width, a side width and a style all write border-*-width or -style, so what
+   an element is actually bordered with is a rendering question. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "border";
+      "border-2";
+      "border-4";
+      "border-x-2";
+      "border-y-4";
+      "border-t-4";
+      "border-b-2";
+      "border-solid";
+      "border-dashed";
+      "border-dotted";
+      "border-none";
+      "border-current";
+      "rounded";
+      "rounded-md";
+      "rounded-lg";
+      "rounded-full";
+      "rounded-t-lg";
+      "rounded-br-xl";
+      "outline";
+      "outline-2";
+      "outline-dashed";
+      "outline-offset-2";
+    ]
+  in
+  Test_helpers.check_rendering_matches ~test_name:"borders render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 (* rounded-sm's default radius is .25rem in v4.3.1, not the old .125rem. *)
 let test_rounded_sm_default () =
   let css = Tw.to_css ~base:false [ Tw.rounded_sm ] |> Tw.Css.to_string in
@@ -349,6 +381,7 @@ let tests =
     test_case "borders of_string - invalid values" `Quick of_string_invalid;
     test_case "borders suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "borders render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("borders", tests)

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -140,6 +140,34 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"effects suborder matches Tailwind" shuffled
 
+(* A shadow size and a shadow colour meet in --tw-shadow, so which one an
+   element ends up painting is only settled once the sheet is rendered. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "shadow-2xs";
+      "shadow-xs";
+      "shadow-sm";
+      "shadow";
+      "shadow-md";
+      "shadow-lg";
+      "shadow-none";
+      (* A palette colour would only re-report the known theme-token gap
+         (--color-indigo-500 as a hex where Tailwind keeps oklch), which [tw
+         --diff] already reports; the keyword colours conflict with the sizes
+         just as well. *)
+      "shadow-current";
+      "shadow-transparent";
+      "inset-shadow-sm";
+      "opacity-0";
+      "opacity-50";
+      "opacity-100";
+      "mix-blend-multiply";
+    ]
+  in
+  Test_helpers.check_rendering_matches ~test_name:"effects render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 (* shadow-2xl's default shadow alpha is .25 (#00000040) in v4, not the .10
    (#0000001a) the smaller shadows use. *)
 let test_shadow_2xl_alpha () =
@@ -313,6 +341,7 @@ let tests =
     test_case "filters css generation" `Quick test_filters_css_generation;
     test_case "effects suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "effects render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("effects", tests)

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -180,10 +180,36 @@ let test_invalid_arbitrary_amount () =
   check "saturate-[150%]";
   check "brightness-[var(--x)]"
 
+(* Filters are the case the text-level comparison cannot judge: a drop-shadow
+   colour and a drop-shadow size meet in --tw-drop-shadow-size, so what an
+   element ends up filtering by is only visible once rendered. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "blur-sm";
+      "blur";
+      "brightness-125";
+      "contrast-75";
+      "grayscale";
+      "invert";
+      "saturate-150";
+      "sepia";
+      "drop-shadow-sm";
+      "drop-shadow-xl";
+      "drop-shadow-current";
+      "drop-shadow-indigo-500";
+      "backdrop-blur";
+      "backdrop-opacity-50";
+    ]
+  in
+  Test_helpers.check_rendering_matches ~test_name:"filters render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 let tests =
   [
     test_case "drop-shadow keyword color and alpha" `Quick
       test_drop_shadow_keyword_and_alpha;
+    test_case "filters render like Tailwind" `Slow rendering_matches_tailwind;
     test_case "blur" `Quick test_blur;
     test_case "invalid arbitrary amount" `Quick test_invalid_arbitrary_amount;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;

--- a/test/test_margin.ml
+++ b/test/test_margin.ml
@@ -104,6 +104,31 @@ let negative_suborder_matches_tailwind () =
     ~test_name:"negative margin suborder matches Tailwind"
     (Test_helpers.shuffle utilities)
 
+(* m, mx and ml all write margin-left, so which one an element ends up with is
+   decided by the order the two sheets emit them in. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "m-0";
+      "m-2";
+      "-m-1";
+      "mx-2";
+      "mx-auto";
+      "my-4";
+      "-mx-1";
+      "mt-2";
+      "-mt-1";
+      "mr-2";
+      "mb-4";
+      "ml-2";
+      "-ml-1";
+      "ms-2";
+      "me-4";
+    ]
+  in
+  Test_helpers.check_rendering_matches ~test_name:"margins render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 (** Test that CSS values use the correct spacing multiplier. m-64 should
     generate calc(var(--spacing)*64), not calc(var(--spacing)*16) *)
 let test_css_values () =
@@ -161,6 +186,7 @@ let tests =
       negative_suborder_matches_tailwind;
     test_case "margin CSS values" `Quick test_css_values;
     test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
+    test_case "margins render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("margin", tests)

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -128,6 +128,32 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"transforms suborder matches Tailwind" shuffled
 
+(* Every transform utility writes into the same --tw-* slots and the shared
+   transform property, so the composed matrix is what has to agree. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "translate-x-4";
+      "translate-y-2";
+      "-translate-x-2";
+      "translate-4";
+      "rotate-45";
+      "-rotate-90";
+      "scale-50";
+      "scale-x-75";
+      "scale-y-125";
+      "skew-x-3";
+      "skew-y-6";
+      "origin-center";
+      "origin-top-right";
+      "transform-gpu";
+      "transform-none";
+    ]
+  in
+  Test_helpers.check_rendering_matches
+    ~test_name:"transforms render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 (* skew_x/skew_y (int) and the transform-origin constructors are newly exposed
    in tw.mli; check they agree with the parser on class names. *)
 let test_typed () =
@@ -205,6 +231,7 @@ let tests =
     test_case "typed constructors" `Quick test_typed;
     test_case "transforms suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "transforms render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("transforms", tests)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -358,6 +358,41 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"typography suborder matches Tailwind" shuffled
 
+(* text-<size> also sets the line height, so a size and a leading on the same
+   element decide between them what the text is laid out with. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "text-xs";
+      "text-base";
+      "text-lg";
+      "text-3xl";
+      "font-thin";
+      "font-normal";
+      "font-bold";
+      "leading-none";
+      "leading-relaxed";
+      "leading-6";
+      "tracking-tight";
+      "tracking-wide";
+      "text-left";
+      "text-center";
+      "text-right";
+      "underline";
+      "line-through";
+      "no-underline";
+      "italic";
+      "not-italic";
+      "uppercase";
+      "truncate";
+      "indent-4";
+      "align-middle";
+    ]
+  in
+  Test_helpers.check_rendering_matches
+    ~test_name:"typography renders like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 (* tracking-normal's token must keep the em unit (0em), not collapse to 0. *)
 let test_tracking_normal_unit () =
   let css = Tw.to_css [ Tw.tracking_normal ] |> Tw.Css.pp ~minify:true in
@@ -559,6 +594,8 @@ let tests =
       suborder_matches_tailwind;
     test_case "line-clamp sorts with box-sizing" `Quick
       line_clamp_sorts_with_box_sizing;
+    test_case "typography renders like Tailwind" `Slow
+      rendering_matches_tailwind;
   ]
 
 let suite = ("typography", tests)


### PR DESCRIPTION
Every parity check we have compares CSS text or its AST, which cannot say whether a difference is observable. This PR adds `check_rendering_matches`, which loads both sheets in headless Chromium and diffs `getComputedStyle`, and it carries the border axis-order fix that the new check found, which the canonical diff reports only as a benign reordering.