### PR TITLE
test: remove the ordering suite's blind spots

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -544,6 +544,15 @@ let rule_sets tw_classes =
   let all_rules = List.concat_map (Rule.outputs ~order_tbl) tw_classes in
   rule_sets_from_selector_props order_tbl all_rules
 
+let indexed_rules tw_classes =
+  let order_tbl = Hashtbl.create 256 in
+  List.concat_map (Rule.outputs ~order_tbl) tw_classes
+  |> List.filter_map (rule_to_triple order_tbl)
+  |> deduplicate_typed_triples |> add_index
+
+let compare_rules = Sort.compare_indexed_rules
+let rule_selector (r : Sort.indexed_rule) = r.selector_str
+
 (* ======================================================================== *)
 (* Layer Generation - CSS @layer directives and theme variable resolution *)
 (* ======================================================================== *)

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -19,8 +19,11 @@
     ([theme_layer_of], [rule_sets], [utilities_layer]) are exposed for testing
     and for the [tw] CLI. *)
 
-open Cascade
+(* [open Cascade] below shadows this library's own [Sort] with cascade's; bind
+   it first so the signature can still name the rule type. *)
+module Rule_sort := Sort
 
+open Cascade
 (** {1 CSS generation} *)
 
 type config = {
@@ -91,6 +94,19 @@ val conflict_order : string -> int * int
 (** [conflict_order selector] returns the [(priority, suborder)] pair that
     determines cascade position for the utility named by [selector]. Lower
     priority numbers win over higher ones when classes conflict. *)
+
+val indexed_rules : Utility.t list -> Rule_sort.indexed_rule list
+(** [indexed_rules utilities] is the unsorted rule list that {!compare_rules} is
+    applied to, exposed so the comparator can be checked on the values it
+    actually sees rather than on hand-built records. *)
+
+val compare_rules : Rule_sort.indexed_rule -> Rule_sort.indexed_rule -> int
+(** [compare_rules] is the comparator {!val-rule_sets} sorts with. Sorting is
+    only defined for a total order, so this is the function whose antisymmetry
+    and transitivity the sort suite checks. *)
+
+val rule_selector : Rule_sort.indexed_rule -> string
+(** [rule_selector r] is [r]'s selector, for naming a rule in a failure. *)
 
 val selector_props_pairs :
   Output.t list -> (Css.Selector.t * Css.declaration list * (int * int)) list

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -87,12 +87,23 @@ let same_property_pairs classes =
       pairs acc cs)
     by_prop []
 
-let check_ordering_fails ?(forms = false) utilities =
+(* The single ordering predicate. The fuzzer minimises with it and every suite
+   asserts on it, so a minimal case it reports is a case the assertion also
+   rejects; two predicates that disagree let the fuzzer print a failing case and
+   pass anyway. Pruning dead custom properties makes it blind to utilities whose
+   only output is an unreferenced binding - check_rendering_matches covers that
+   class now, and agreeing on one predicate is worth more than the extra
+   sensitivity here. *)
+let ordering_diff ?(forms = false) utilities =
   let classnames = List.map Tw.pp utilities in
-  not
-    (Css_compare.equal ~mode:`Canonical
-       (tailwind_css ~forms classnames)
-       (our_css utilities))
+  Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+    (tailwind_css ~forms classnames)
+    (our_css utilities)
+
+let check_ordering_fails ?forms utilities =
+  match (ordering_diff ?forms utilities).Css_compare.result with
+  | Css_compare.No_diff _ -> false
+  | _ -> true
 
 (** Delta Debugging (ddmin algorithm by Zeller) Minimizes a failing test case by
     binary search *)
@@ -285,13 +296,8 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
         (String.trim (read_file err));
       Alcotest.skip ()
 
-let check_ordering_matches ?(forms = false) ~test_name utilities =
-  let classnames = List.map Tw.pp utilities in
-  let diff =
-    Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
-      (tailwind_css ~forms classnames)
-      (our_css utilities)
-  in
+let check_ordering_matches ?forms ~test_name utilities =
+  let diff = ordering_diff ?forms utilities in
   match diff.Css_compare.result with
   | Css_compare.No_diff _ -> ()
   | _ ->

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -297,22 +297,7 @@ let check_ordering_matches ?(forms = false) ~test_name utilities =
   | _ ->
       let buf = Buffer.create 1024 in
       Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
-      let rendered = Buffer.contents buf in
-      let contains needle haystack =
-        let needle_len = String.length needle in
-        let haystack_len = String.length haystack in
-        let rec scan i =
-          i + needle_len <= haystack_len
-          && (String.sub haystack i needle_len = needle || scan (i + 1))
-        in
-        needle_len = 0 || scan 0
-      in
-      if
-        contains "--radius-sm" rendered
-        && contains ".25rem" rendered
-        && contains ".125rem" rendered
-      then ()
-      else Alcotest.failf "%s\n%s" test_name rendered
+      Alcotest.failf "%s\n%s" test_name (Buffer.contents buf)
 
 (** CSS Test Helpers *)
 

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -30,9 +30,18 @@ val same_property_pairs : string list -> (string * string) list
     in common. An element carrying such a pair is where an ordering difference
     becomes observable; a class on its own can only differ in value. *)
 
+val ordering_diff : ?forms:bool -> Tw.t list -> Cascade_diff.Css_compare.t
+(** [ordering_diff ?forms utilities] compares tw's sheet for [utilities] against
+    the pinned Tailwind CLI's, canonically and with dead custom properties
+    pruned. Both {!check_ordering_fails} and {!check_ordering_matches} go
+    through it: the fuzzer minimises with the same predicate the suites assert
+    on, so a case it reports as minimal is one the assertion also rejects.
+    Pruning is what makes it blind to a utility whose only output is an
+    unreferenced binding; {!check_rendering_matches} covers that class. *)
+
 val check_ordering_fails : ?forms:bool -> Tw.t list -> bool
-(** [check_ordering_fails ?forms utilities] checks if utilities produce
-    different ordering than Tailwind CSS. *)
+(** [check_ordering_fails ?forms utilities] is [true] when {!ordering_diff}
+    finds a difference. The minimisation predicate. *)
 
 val delta_debug : ('a list -> bool) -> 'a list -> 'a list
 (** [delta_debug check_fails lst] uses delta debugging (ddmin algorithm) to

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1195,6 +1195,199 @@ let test_regular_before_media () =
   Test_helpers.check_ordering_matches ~test_name:"regular always before media"
     utilities
 
+(* Comparator laws.
+
+   [List.sort] is defined only for a total order. When the comparator is not
+   antisymmetric or not transitive, the same set of rules can sort into
+   different sequences depending on the order it happens to arrive in, which is
+   how every ordering bug recorded in this file has presented: a diff that
+   appears and disappears as utilities are added around it.
+
+   Checked over the rules real utilities produce rather than hand-built records,
+   so a field or a branch is covered as soon as some class reaches it. The
+   corpus deliberately spans the branches the comparator dispatches on: plain
+   rules, media and container variants, stacked variants, bracket values holding
+   a colon, not-/has-/group-/peer- variants, @supports and @starting-style, and
+   the outline and prose special cases.
+
+   [compare_by_order_regular_first] returns -1 on a tie on purpose; the
+   Media/Regular arm negates it, so it is the composed comparator - what
+   [List.sort] actually calls - that has to obey the laws, and that is what is
+   tested here. *)
+let comparator_corpus =
+  [
+    "p-4";
+    "px-2";
+    "m-4";
+    "-m-2";
+    "mt-8";
+    "gap-4";
+    "gap-x-2";
+    "block";
+    "flex";
+    "grid";
+    "hidden";
+    "w-4";
+    "h-8";
+    "max-w-4xl";
+    "z-10";
+    "top-0";
+    "absolute";
+    "relative";
+    "border";
+    "border-2";
+    "border-b";
+    "border-gray-200";
+    "border-solid";
+    "divide-x-2";
+    "divide-gray-200";
+    "rounded-sm";
+    "rounded-t-lg";
+    "bg-white";
+    "bg-blue-600";
+    "text-lg";
+    "text-gray-900";
+    "font-bold";
+    "leading-relaxed";
+    "shadow-md";
+    "opacity-50";
+    "outline-none";
+    "outline-2";
+    "grid-cols-2";
+    "flex-col";
+    "items-center";
+    "justify-between";
+    "transition-all";
+    "duration-150";
+    "animate-spin";
+    "blur-sm";
+    "translate-x-4";
+    "rotate-90";
+    "scale-50";
+    "cursor-pointer";
+    "select-none";
+    "sr-only";
+    "container";
+    "prose";
+    "prose-sm";
+    (* Bracket values: the ones holding a colon are what a bracket-blind variant
+       split mis-reads. *)
+    "bg-[color:var(--brand)]";
+    "hover:bg-[color:var(--brand)]";
+    "w-[calc(100%-1rem)]";
+    "text-[14px]";
+    "rotate-[10deg]";
+    (* Single variants. *)
+    "hover:bg-blue-500";
+    "focus:outline-none";
+    "active:bg-blue-700";
+    "disabled:opacity-50";
+    "first:pt-0";
+    "last:pb-0";
+    "odd:bg-gray-50";
+    "before:block";
+    "after:block";
+    "marker:text-gray-500";
+    "placeholder:text-gray-400";
+    "dark:bg-gray-900";
+    "sm:p-2";
+    "md:grid-cols-2";
+    "lg:flex";
+    "xl:hidden";
+    "max-md:block";
+    "min-lg:flex";
+    "motion-safe:animate-pulse";
+    "motion-reduce:transition-none";
+    "contrast-more:border-4";
+    "group-hover:text-white";
+    "peer-checked:bg-blue-500";
+    "peer-focus:ring-2";
+    "aria-checked:bg-blue-500";
+    "data-[state=open]:block";
+    "not-hover:opacity-50";
+    "has-[:focus]:border-2";
+    "supports-grid:flex";
+    "starting:opacity-0";
+    "@container";
+    "@sm:flex";
+    (* Stacked variants: the compound-order path. *)
+    "dark:hover:bg-gray-800";
+    "dark:focus:outline-none";
+    "md:hover:bg-blue-500";
+    "sm:dark:p-4";
+    "lg:group-hover:text-white";
+  ]
+
+let utility_of_corpus_class cls =
+  let modifiers, base_class = Tw.Modifiers.of_string cls in
+  match Tw.Utility.base_of_class Tw.Scheme.default base_class with
+  | Error (`Msg m) -> Alcotest.failf "corpus class %S does not parse: %s" cls m
+  | Ok b -> (
+      match Tw.Modifiers.apply modifiers (Tw.Utility.base b) with
+      | Some u -> u
+      | None -> Alcotest.failf "corpus class %S: unknown modifier" cls)
+
+(* Shuffled so a run does not always present the rules in corpus order: the
+   index tiebreaker is part of the comparator, and a law that only holds for one
+   arrival order is exactly the bug being looked for. *)
+let corpus_rules () =
+  comparator_corpus |> Test_helpers.shuffle
+  |> List.map utility_of_corpus_class
+  |> Tw.Build.indexed_rules
+
+let describe r = Tw.Build.rule_selector r
+
+let test_comparator_antisymmetry () =
+  let rules = Array.of_list (corpus_rules ()) in
+  let n = Array.length rules in
+  Alcotest.check Alcotest.bool "corpus produced rules" true (n > 50);
+  for i = 0 to n - 1 do
+    let c = Tw.Build.compare_rules rules.(i) rules.(i) in
+    if c <> 0 then
+      Alcotest.failf "compare is not reflexive on %s: %d" (describe rules.(i)) c;
+    for j = i + 1 to n - 1 do
+      let ab = Tw.Build.compare_rules rules.(i) rules.(j) in
+      let ba = Tw.Build.compare_rules rules.(j) rules.(i) in
+      if Int.compare ab 0 <> -Int.compare ba 0 then
+        Alcotest.failf
+          "compare is not antisymmetric:\n\
+          \  a = %s\n\
+          \  b = %s\n\
+          \  a vs b = %d, b vs a = %d"
+          (describe rules.(i))
+          (describe rules.(j))
+          ab ba
+    done
+  done
+
+let test_comparator_transitivity () =
+  let rules = Array.of_list (corpus_rules ()) in
+  let n = Array.length rules in
+  let sign x = Int.compare x 0 in
+  let pick () = rules.(Random.State.int Test_helpers.test_rng n) in
+  (* Sampled: the corpus has too many triples to enumerate on every run, and a
+     violation is dense enough in the pairs that reach it for sampling to find
+     it. The seed is printed, so a failure replays. *)
+  for _ = 1 to 200_000 do
+    let a = pick () and b = pick () and c = pick () in
+    let ab = sign (Tw.Build.compare_rules a b) in
+    let bc = sign (Tw.Build.compare_rules b c) in
+    let ac = sign (Tw.Build.compare_rules a c) in
+    let violates =
+      (ab < 0 && bc < 0 && ac >= 0)
+      || (ab > 0 && bc > 0 && ac <= 0)
+      || (ab = 0 && bc = 0 && ac <> 0)
+    in
+    if violates then
+      Alcotest.failf
+        "compare is not transitive:\n\
+        \  a = %s\n\
+        \  b = %s\n\
+        \  c = %s\n\
+        \  a vs b = %d, b vs c = %d, a vs c = %d"
+        (describe a) (describe b) (describe c) ab bc ac
+  done
+
 let prose_p_selector prose_class =
   Css.Selector.combine prose_class Css.Selector.Descendant
     (Css.Selector.where
@@ -1311,6 +1504,8 @@ let tests =
     test_case "suborder within group" `Slow test_suborder_within_group;
     test_case "random utilities with minimization" `Slow
       test_random_utilities_with_minimization;
+    test_case "comparator is antisymmetric" `Quick test_comparator_antisymmetry;
+    test_case "comparator is transitive" `Quick test_comparator_transitivity;
   ]
 
 let suite = ("sort", tests)


### PR DESCRIPTION
The ordering check exempted any diff mentioning the border-radius values, and the sort fuzzer minimised a failing case with one predicate and asserted with another, so it could shrink a case until it no longer reproduced. This PR drops the stale exemption, puts both fuzzer steps through `ordering_diff`, and adds a test that the rule comparator is antisymmetric and transitive.