### PR TITLE
spacing: declare the theme token a named spacing references

### DIFF
--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -40,38 +40,17 @@ module Handler = struct
 
   (** {2 Typed Gap Utilities} *)
 
-  (** Convert spacing to (declaration, length) using Theme.spacing_calc_float.
-  *)
-  let spacing_to_decl_len ?theme (s : spacing) : Css.declaration option * length
-      =
-    match s with
-    | `Px ->
-        let len : length = Px 1. in
-        let decl, _ = Var.binding Spacing.var (Rem 0.25) in
-        (Some decl, len)
-    | `Full ->
-        let len : length = Pct 100. in
-        let decl, _ = Var.binding Spacing.var (Rem 0.25) in
-        (Some decl, len)
-    | `Named name ->
-        let len = Spacing.named_spacing_ref name in
-        (None, len)
-    | `Rem f ->
-        let n = f /. 0.25 in
-        let decl, len = Theme.spacing_calc_float ?theme n in
-        (Some decl, len)
-
   let gap_standard ?theme (s : spacing) =
-    let decl, len = spacing_to_decl_len ?theme s in
+    let decl, len = Spacing.to_decl_len ?theme s in
     let gap_value = Lengths { row_gap = Some len; column_gap = Some len } in
     style (Option.to_list decl @ [ gap gap_value ])
 
   let gap_x_standard ?theme (s : spacing) =
-    let decl, len = spacing_to_decl_len ?theme s in
+    let decl, len = Spacing.to_decl_len ?theme s in
     style (Option.to_list decl @ [ column_gap len ])
 
   let gap_y_standard ?theme (s : spacing) =
-    let decl, len = spacing_to_decl_len ?theme s in
+    let decl, len = Spacing.to_decl_len ?theme s in
     style (Option.to_list decl @ [ row_gap len ])
 
   let gap_arb len =
@@ -417,17 +396,18 @@ module Handler = struct
         | None -> None
     else None
 
-  let parse_gap_value value =
+  (* Shared with padding and margin, so a named spacing reaches gap too:
+     [gap-form] is a class Tailwind emits whenever the theme defines
+     [--spacing-form]. *)
+  let parse_gap_value ?theme value =
     if String.length value > 0 && value.[0] = '[' then parse_gap_arbitrary value
     else
-      match Parse.spacing_value ~name:"gap" value with
-      | Ok f -> Some (Standard (`Rem (f *. 0.25)))
-      | Error _ ->
-          if value = "px" then Some (Standard `Px)
-          else if value = "full" then Some (Standard `Full)
-          else None
+      match Spacing.parse_value_string ?theme ~allow_auto:false value with
+      | Some (#Style.spacing as s) -> Some (Standard s)
+      | Some `Auto | None -> None
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
+    let parse_gap_value value = parse_gap_value ~theme value in
     let parts = Parse.split_class class_name in
     let err_not_utility = Error (`Msg "Not a gap utility") in
     let parse_class = function

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -27,60 +27,18 @@ module Handler = struct
 
   (** {2 Typed Margin Utilities} *)
 
-  (** Convert spacing to (declaration option, length) using
-      Theme.spacing_calc_float. For rem values, checks scheme for explicit
-      spacing variables. *)
-  let spacing_to_decl_len ?theme ~negative (s : Style.spacing) :
-      Css.declaration option * length =
-    match s with
-    | `Px ->
-        let len : length = if negative then Px (-1.) else Px 1. in
-        let decl, _ = Var.binding Spacing.var (Rem 0.25) in
-        (Some decl, len)
-    | `Full ->
-        let len : length = if negative then Pct (-100.) else Pct 100. in
-        let decl, _ = Var.binding Spacing.var (Rem 0.25) in
-        (Some decl, len)
-    | `Named name -> (
-        let prop_name = "spacing-" ^ name in
-        match Scheme.theme_value theme prop_name with
-        | Some value_str ->
-            let decl =
-              Css.custom_property ~layer:"theme" ("--" ^ prop_name) value_str
-            in
-            let ref : Css.length Css.var =
-              Var.theme_ref prop_name
-                ~default:(Css.Zero : Css.length)
-                ~default_css:"0px"
-            in
-            let len : Css.length = Var ref in
-            if negative then
-              ( Some decl,
-                Calc (Calc.mul (Calc.var prop_name) (Calc.float (-1.))) )
-            else (Some decl, len)
-        | None ->
-            let len = Spacing.named_spacing_ref name in
-            if negative then
-              (None, Calc (Calc.mul (Calc.length len) (Calc.float (-1.))))
-            else (None, len))
-    | `Rem f ->
-        let n = f /. 0.25 in
-        let n = if negative then -.n else n in
-        let decl, len = Theme.spacing_calc_float ?theme n in
-        (Some decl, len)
-
   let v ?theme (prop : length -> declaration) (m : margin) =
     match m with
     | `Auto -> style [ prop Auto ]
     | #Style.spacing as s ->
-        let decl, len = spacing_to_decl_len ?theme ~negative:false s in
+        let decl, len = Spacing.to_decl_len ?theme ~negative:false s in
         style (Option.to_list decl @ [ prop len ])
 
   let vs ?theme (prop : length list -> declaration) (m : margin) =
     match m with
     | `Auto -> style [ prop [ Auto ] ]
     | #Style.spacing as s ->
-        let decl, len = spacing_to_decl_len ?theme ~negative:false s in
+        let decl, len = Spacing.to_decl_len ?theme ~negative:false s in
         style (Option.to_list decl @ [ prop [ len ] ])
 
   let named_margin_value ?theme name : Css.declaration option * Css.length =
@@ -104,12 +62,12 @@ module Handler = struct
 
   let margin_util_neg ?theme (prop : length -> declaration) (s : Style.spacing)
       =
-    let decl, len = spacing_to_decl_len ?theme ~negative:true s in
+    let decl, len = Spacing.to_decl_len ?theme ~negative:true s in
     style (Option.to_list decl @ [ prop len ])
 
   let margin_list_util_neg ?theme (prop : length list -> declaration)
       (s : Style.spacing) =
-    let decl, len = spacing_to_decl_len ?theme ~negative:true s in
+    let decl, len = Spacing.to_decl_len ?theme ~negative:true s in
     style (Option.to_list decl @ [ prop [ len ] ])
 
   (* Spacing keywords sort by their suffix's first character, matching

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -44,32 +44,13 @@ module Handler = struct
     in
     prefix ^ value_suffix
 
-  (** Convert spacing to (declaration option, length) using
-      Theme.spacing_calc_float. *)
-  let spacing_to_decl_len ?theme (s : Style.spacing) :
-      Css.declaration option * length =
-    match s with
-    | `Px ->
-        let len : length = Px 1. in
-        let decl, _ = Var.binding Spacing.var (Rem 0.25) in
-        (Some decl, len)
-    | `Full ->
-        let len : length = Pct 100. in
-        let decl, _ = Var.binding Spacing.var (Rem 0.25) in
-        (Some decl, len)
-    | `Named name -> Spacing.named_spacing_binding name
-    | `Rem f ->
-        let n = f /. 0.25 in
-        let decl, len = Theme.spacing_calc_float ?theme n in
-        (Some decl, len)
-
   let v_spacing ?theme (prop : length -> declaration) (s : Style.spacing) =
-    let decl, len = spacing_to_decl_len ?theme s in
+    let decl, len = Spacing.to_decl_len ?theme s in
     style (Option.to_list decl @ [ prop len ])
 
   let vs_spacing ?theme (prop : length list -> declaration) (s : Style.spacing)
       =
-    let decl, len = spacing_to_decl_len ?theme s in
+    let decl, len = Spacing.to_decl_len ?theme s in
     style (Option.to_list decl @ [ prop [ len ] ])
 
   let spacing_value_order = function

--- a/lib/spacing.ml
+++ b/lib/spacing.ml
@@ -57,6 +57,39 @@ let named_spacing_binding ?theme name : Css.declaration option * Css.length =
       let ref = named_spacing_ref name in
       (None, ref)
 
+(* The declaration a spacing value needs alongside the length that reads it.
+   Padding, margin and gap all emit [var(--spacing-<name>)] for a named value,
+   and the binding that declares it has to come with it: a reference to a
+   variable nothing declares renders as nothing. *)
+let to_decl_len ?theme ?(negative = false) (s : spacing) :
+    Css.declaration option * Css.length =
+  match s with
+  | `Px ->
+      let len : Css.length = if negative then Px (-1.) else Px 1. in
+      let decl, _ = Var.binding var (Css.Rem 0.25) in
+      (Some decl, len)
+  | `Full ->
+      let len : Css.length = if negative then Pct (-100.) else Pct 100. in
+      let decl, _ = Var.binding var (Css.Rem 0.25) in
+      (Some decl, len)
+  | `Named name -> (
+      match named_spacing_binding ?theme name with
+      | (Some _ as decl), len ->
+          if negative then
+            ( decl,
+              Css.Calc
+                (Calc.mul (Calc.var ("spacing-" ^ name)) (Calc.float (-1.))) )
+          else (decl, len)
+      | None, len ->
+          if negative then
+            (None, Css.Calc (Calc.mul (Calc.length len) (Calc.float (-1.))))
+          else (None, len))
+  | `Rem f ->
+      let n = f /. 0.25 in
+      let n = if negative then -.n else n in
+      let decl, len = Theme.spacing_calc_float ?theme n in
+      (Some decl, len)
+
 let length_with ~px ~full ~rem_factor spacing_ref : spacing -> length = function
   | `Px -> Px px
   | `Full -> Pct full

--- a/lib/spacing.mli
+++ b/lib/spacing.mli
@@ -84,6 +84,17 @@ val named_spacing_binding :
     named spacing value, returning both the theme declaration (if theme value is
     set) and a var reference. *)
 
+val to_decl_len :
+  ?theme:Scheme.t ->
+  ?negative:bool ->
+  Style.spacing ->
+  Css.declaration option * Css.length
+(** [to_decl_len ?theme ?negative s] is the declaration [s] needs and the length
+    that reads it. Padding, margin and gap share it: each emits
+    [var(--spacing-<name>)] for a named value, and the theme binding that
+    declares the variable has to travel with the reference. [negative] flips the
+    sign, for the margin utilities that allow it. *)
+
 val is_named_spacing : string -> bool
 (** [is_named_spacing value] checks if a string is a valid named spacing
     identifier. *)

--- a/test/test_spacing.ml
+++ b/test/test_spacing.ml
@@ -43,11 +43,33 @@ let test_int_constructor () =
     end)
     "int spacing" (`Rem 1.0) (int 4)
 
+(* A named spacing renders as [var(--spacing-<name>)], so the utility has to
+   declare the token as well as reference it: padding and gap used to emit the
+   reference alone, which renders as nothing. Tailwind emits the binding for
+   every one of these classes given the same @theme. *)
+let test_named_spacing_declares_token () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("spacing-form", "1rem") ]
+  in
+  List.iter
+    (fun cls ->
+      match Tw.of_string ~theme cls with
+      | Error (`Msg m) -> Alcotest.failf "%s rejected: %s" cls m
+      | Ok u ->
+          let css = Tw.to_css ~theme ~base:false [ u ] in
+          if not (Test_helpers.has_var_in_layer "--spacing-form" "theme" css)
+          then
+            Alcotest.failf "%s references --spacing-form without declaring it"
+              cls)
+    [ "m-form"; "-m-form"; "p-form"; "px-form"; "gap-form"; "gap-x-form" ]
+
 let tests =
   [
     test_case "pp_spacing_suffix" `Quick test_pp_spacing_suffix;
     test_case "pp_margin_suffix" `Quick test_pp_margin_suffix;
     test_case "int constructor" `Quick test_int_constructor;
+    test_case "named spacing declares its token" `Quick
+      test_named_spacing_declares_token;
   ]
 
 let suite = ("spacing", tests)


### PR DESCRIPTION
Padding and gap emitted `var(--spacing-<name>)` without the binding that declares it, so the property resolved to nothing, and gap rejected a named spacing outright. All three utilities now share margin's conversion, checked against Tailwind given the same `@theme`.