### PR TITLE
sort: split a class's variant prefix with the modifier parser

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -187,17 +187,14 @@ let selector_modifier_depth sel =
       String.fold_left (fun acc c -> if c = ':' then acc + 1 else acc) 0 cls
   | None -> 0
 
+(* Shares [any_outside_not]'s traversal: the hand-rolled one missed [Has] and
+   [Relative], so :hover inside a :has() did not count. Both want the same
+   thing, a :hover that is not under a :not(). *)
+
 (** Check if a selector contains :hover pseudo-class at any depth (used to
     detect compound variants like group-hocus that combine hover+focus). *)
-let rec selector_has_hover = function
-  | Css.Selector.Hover -> true
-  | Css.Selector.Compound sels -> List.exists selector_has_hover sels
-  | Css.Selector.Combined (l, _, r) ->
-      selector_has_hover l || selector_has_hover r
-  | Css.Selector.Is sels | Css.Selector.Where sels ->
-      List.exists selector_has_hover sels
-  | Css.Selector.List sels -> List.exists selector_has_hover sels
-  | _ -> false
+let selector_has_hover sel =
+  any_outside_not (function Css.Selector.Hover -> true | _ -> false) sel
 
 (* Determine sort group for rule types. Regular and Media are grouped together
    to preserve utility grouping - media queries appear immediately after their
@@ -283,7 +280,8 @@ let compare_simple_selectors sel_str1 sel_str2 s1 s2 i1 i2 =
 let compare_complex_selectors sel_str1 sel_str2 kind1 kind2 s1 s2 i1 i2 =
   let k1 = complex_selector_order kind1 and k2 = complex_selector_order kind2 in
   if k1 <> k2 then Int.compare k1 k2
-  else if k1 = 60 then
+  else if match kind1 with Complex { has_aria = true; _ } -> true | _ -> false
+  then
     (* Both are aria selectors - compare by selector string (aria attribute)
        before suborder (property shade) to match Tailwind v4 behavior *)
     let sel_cmp = String.compare sel_str1 sel_str2 in
@@ -330,10 +328,19 @@ let compare_by_priority_suborder_alpha kind1 kind2 sel_str1 sel_str2 (p1, s1)
 (* Media Query Comparison *)
 (* ======================================================================== *)
 
+(* The two groups below are compared on something other than their key, so they
+   need naming. Taken from [Css.Media.group_order] rather than written out, so
+   they follow it if it moves. *)
+let responsive_group =
+  fst (Css.Media.group_order (Css.Media.Responsive (0, 0.)))
+
+let accessibility_preference_group =
+  fst (Css.Media.group_order Css.Media.Preference_accessibility)
+
 (** Compare two media conditions within the same group *)
 let compare_media_conditions group1 sub1 sub2 cond1 cond2 key1 key2 =
-  if group1 = 2000 then Float.compare sub1 sub2
-  else if group1 = 1000 then
+  if group1 = responsive_group then Float.compare sub1 sub2
+  else if group1 = accessibility_preference_group then
     match (cond1, cond2) with
     | Some c1, Some c2 ->
         Int.compare

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -824,12 +824,12 @@ let compare_nested_media r1 r2 =
       | _ -> 0)
   | _ -> 0
 
-(* Extract the modifier prefix from a base_class, e.g. "hover:p-4" -> "hover" *)
+(* Extract the modifier prefix from a base_class, e.g. "hover:p-4" -> "hover".
+   Split with the modifier parser, not on the last ':': an arbitrary value can
+   hold one, and [hover:bg-[color:var(--x)]] split naively yields the prefix
+   [hover:bg-[color]. *)
 let variant_prefix = function
-  | Some s -> (
-      match String.rindex_opt s ':' with
-      | Some i -> String.sub s 0 i
-      | None -> "")
+  | Some s -> String.concat ":" (fst (Modifiers.of_string s))
   | None -> ""
 
 (* Compute variant order for a modifier prefix, stripping group-/peer-

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -560,13 +560,18 @@ let compare_by_priority_index r1 r2 =
         if idx_cmp <> 0 then idx_cmp
         else String.compare r1.selector_str r2.selector_str
 
+(* The outline utilities sort after the other focus modifiers. Read the base
+   class with the modifier parser: taking the first colon meant a stacked
+   variant never matched, so dark:focus:outline-none was never recognised. The
+   rule is inert on the current corpus - removing it altogether leaves the suite
+   and the Tailwind diffs green - so this makes the predicate say what it means
+   rather than changing an order that is already right. *)
 let is_outline_utility bc =
   match bc with
-  | Some s ->
-      String.contains s ':' && String.contains s 'o'
-      &&
-      let idx = String.index s ':' in
-      idx + 8 <= String.length s && String.sub s idx 8 = ":outline"
+  | Some s -> (
+      match Modifiers.of_string s with
+      | [], _ -> false
+      | _ :: _, base -> String.starts_with ~prefix:"outline" base)
   | None -> false
 
 (* Natural sort comparison: treats consecutive digit sequences as integers.

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1006,6 +1006,25 @@ let test_bracket_value_holding_a_colon () =
   Test_helpers.check_ordering_matches ~test_name:"bracket value holding a colon"
     utilities
 
+let test_stacked_variant_outline_order () =
+  (* The outline-sorts-last rule reads the base class, so it sees a stacked
+     variant: dark:focus:outline-none is an outline utility as much as
+     focus:outline-none is. Matching from the first colon saw neither. *)
+  let classes =
+    [
+      "dark:focus:outline-none";
+      "dark:focus:bg-blue-500";
+      "dark:focus:ring-2";
+      "first:focus:outline-2";
+      "first:focus:border-2";
+      "focus:outline-none";
+      "focus:bg-red-500";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches ~test_name:"stacked variant outline order"
+    utilities
+
 let test_rounded_position_order () =
   (* Border-radius position groups sort by the CSS corners they write, matching
      Tailwind: the physical ones grouped by first corner clockwise -- top, then
@@ -1504,6 +1523,8 @@ let tests =
       test_arbitrary_named_by_suffix;
     test_case "bracket value holding a colon" `Slow
       test_bracket_value_holding_a_colon;
+    test_case "stacked variant outline order" `Slow
+      test_stacked_variant_outline_order;
     test_case "rounded position order" `Slow test_rounded_position_order;
     test_case "color-mix @supports companion order" `Slow
       test_color_mix_supports_companion_order;

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -988,6 +988,24 @@ let test_arbitrary_named_by_suffix () =
   Test_helpers.check_ordering_matches
     ~test_name:"arbitrary value sorts by suffix within family" utilities
 
+let test_bracket_value_holding_a_colon () =
+  (* An arbitrary value can hold a colon, so the variant prefix has to be taken
+     with the modifier parser: splitting on the last ':' reads the prefix of
+     hover:bg-[color:var(--x)] as "hover:bg-[color", which sorts it away from
+     the other hover: rules. *)
+  let classes =
+    [
+      "hover:bg-[color:var(--x)]";
+      "hover:bg-red-500";
+      "bg-blue-500";
+      "focus:bg-[color:var(--y)]";
+      "hover:m-2";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches ~test_name:"bracket value holding a colon"
+    utilities
+
 let test_rounded_position_order () =
   (* Border-radius position groups sort by the CSS corners they write, matching
      Tailwind: the physical ones grouped by first corner clockwise -- top, then
@@ -1484,6 +1502,8 @@ let tests =
       test_arbitrary_vs_named_order;
     test_case "arbitrary value sorts by suffix within family" `Slow
       test_arbitrary_named_by_suffix;
+    test_case "bracket value holding a colon" `Slow
+      test_bracket_value_holding_a_colon;
     test_case "rounded position order" `Slow test_rounded_position_order;
     test_case "color-mix @supports companion order" `Slow
       test_color_mix_supports_companion_order;


### PR DESCRIPTION
An arbitrary value can hold a colon, so splitting the variant prefix on the last one read `hover:bg-[color:var(--x)]` as the prefix `hover:bg-[color` and sorted it away from the other hover rules. The same split made `is_outline_utility` miss a stacked variant, fixed here too, and the comparator constants are given names.