### PR TITLE
masks: give the mask utilities their own slot

### DIFF
--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -78,7 +78,10 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "mask_gradient"
-  let priority _ = 23
+
+  (* Tailwind emits the mask-gradient utilities after the backgrounds and before
+     the other masks, which come before fill/stroke and padding. *)
+  let priority _ = 21
 
   let direction_name = function
     | Top -> "top"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -75,7 +75,10 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "masks"
-  let priority _ = 23 (* After backgrounds, before filters *)
+
+  (* After the backgrounds and the mask-gradient utilities, before fill and
+     stroke and before padding - Tailwind's own order. *)
+  let priority _ = 21
 
   (* Helper to create webkit + standard declarations for mask properties *)
 
@@ -437,7 +440,7 @@ module Handler = struct
             Css.mask_size (Var var_ref);
           ]
 
-  let suborder = function
+  let suborder_in_family = function
     | Mask_bracket_image_var _ -> 100
     | Mask_bracket_image _ -> 101
     | Mask_bracket_url _ -> 102
@@ -494,6 +497,10 @@ module Handler = struct
     | Mask_position_bracket_var _ -> 512
     | Mask_size_bracket _ -> 407
     | Mask_size_bracket_var _ -> 408
+
+  (* These share a priority with the mask-gradient utilities and sort after
+     them, so the two families occupy disjoint suborder bands. *)
+  let suborder t = 10000 + suborder_in_family t
 
   (* [mask-[<image>]] takes any background-image value, so what makes one is
      whether the value parser accepts it, not which gradient function it

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -47,7 +47,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "svg"
-  let priority _ = 21
+  let priority _ = 22
 
   (* Format opacity modifier for class names *)
   let opacity_suffix = function

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -89,6 +89,29 @@ let test_invalid_bracket_value () =
   rejected "mask-size-[<value>]";
   rejected "mask-position-[<value>]"
 
+(* Masks sit between the backgrounds and fill/stroke, and the mask-gradient
+   utilities lead them. Sharing padding's slot interleaved the two families with
+   the padding rules, which breaks the adjacency the block merging relies on. *)
+let order_matches_tailwind () =
+  let classes =
+    [
+      "bg-red-500";
+      "mask-x-from-20%";
+      "mask-b-from-50%";
+      "mask-none";
+      "mask-top";
+      "mask-cover";
+      "mask-repeat-x";
+      "fill-blue-500";
+      "stroke-green-500";
+      "p-4";
+      "pt-2";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches ~test_name:"mask order matches Tailwind"
+    (Test_helpers.shuffle utilities)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -98,6 +121,7 @@ let tests =
         test_bracket_layer_list;
       Alcotest.test_case "invalid bracket value" `Quick
         test_invalid_bracket_value;
+      Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
     ]
 
 let suite = ("masks", tests)


### PR DESCRIPTION
The mask utilities shared padding's priority, so mask and padding rules interleaved and the two mask families landed in each other's runs, which defeats block merging. Tailwind emits them between the backgrounds and fill/stroke, which is what the slot now says.