### PR TITLE
colors: read every bracketed # value with the total hex parser

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1599,6 +1599,14 @@ module Handler = struct
     && float_of_string_opt (String.sub inner 0 (n - 1)) <> None
     || Css.parse_length inner <> None
 
+  (* A [#] stop only names a colour when what follows is a hex spelling. The
+     stop keeps the text after the [#] and hands it to the raising [Css.hex]
+     when the sheet is rendered, so the parser has to decide here. *)
+  let is_bracket_hex inner =
+    String.length inner > 0
+    && inner.[0] = '#'
+    && Option.is_some (Css.hex_opt inner)
+
   let parse_gradient_color ?theme target rest =
     let gc src = Ok (Gradient_color (target, src)) in
     let gp src = Ok (Gradient_stop_position (target, src)) in
@@ -1628,7 +1636,7 @@ module Handler = struct
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
               gc (Gc_bracket_color_var var_str)
-            else if String.length inner > 0 && inner.[0] = '#' then
+            else if is_bracket_hex inner then
               gc (Gc_bracket_hex (String.sub inner 1 (String.length inner - 1)))
             else if Parse.is_var inner then gc (Gc_bracket_var inner)
             else if is_gradient_position inner then gp (Gp_bracket inner)
@@ -1640,7 +1648,7 @@ module Handler = struct
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
               gc (Gc_bracket_color_var_opacity (var_str, opacity))
-            else if String.length inner > 0 && inner.[0] = '#' then
+            else if is_bracket_hex inner then
               gc
                 (Gc_bracket_hex_opacity
                    (String.sub inner 1 (String.length inner - 1), opacity))
@@ -1661,7 +1669,7 @@ module Handler = struct
         if String.length inner > 6 && String.sub inner 0 6 = "color:" then
           let var_str = String.sub inner 6 (String.length inner - 6) in
           gc (Gc_bracket_color_var var_str)
-        else if String.length inner > 0 && inner.[0] = '#' then
+        else if is_bracket_hex inner then
           gc (Gc_bracket_hex (String.sub inner 1 (String.length inner - 1)))
         else if Parse.is_var inner then gc (Gc_bracket_var inner)
         else if Color.parse_bracket_color inner <> None then

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -950,21 +950,16 @@ let of_string = function
   | "rose" -> Ok Rose
   | s ->
       let len = String.length s in
-      if len >= 4 && s.[0] = '[' && s.[1] = '#' && s.[len - 1] = ']' then (
+      if len >= 4 && s.[0] = '[' && s.[1] = '#' && s.[len - 1] = ']' then
         (* Arbitrary bracket hex value like [#0088cc]. Store original hex
            (unshortened) so class names preserve it. Shortening happens later in
-           to_css for CSS output. Validate hex chars to avoid matching
-           [#0088cc]/[0.5] where the ] belongs to a different bracket. *)
+           to_css for CSS output, through the raising [Css.hex], so only a
+           spelling that constructor reads is a colour: a digit count it does
+           not know ([#12345]) is as much a miss as [#0088cc]/[0.5], where the ]
+           belongs to a different bracket. *)
         let hex = String.sub s 2 (len - 3) in
-        let is_hex c =
-          (c >= '0' && c <= '9')
-          || (c >= 'a' && c <= 'f')
-          || (c >= 'A' && c <= 'F')
-        in
-        let valid = ref true in
-        String.iter (fun c -> if not (is_hex c) then valid := false) hex;
-        if !valid && String.length hex >= 3 then Ok (Hex hex)
-        else Error (`Msg ("Unknown color: " ^ s)))
+        if Option.is_some (Css.hex_opt hex) then Ok (Hex hex)
+        else Error (`Msg ("Unknown color: " ^ s))
       else if len >= 3 && s.[0] = '[' && s.[len - 1] = ']' then
         let inner = String.sub s 1 (len - 2) in
         let normalized =
@@ -2017,8 +2012,11 @@ module Handler = struct
                 (Css.color_mix ~in_space:Oklab ~percent1:pct c Css.Transparent)
           | _ -> None)
       | None -> (
-          if String.length inner > 0 && inner.[0] = '#' then
-            Some (Css.hex inner)
+          (* A [#] prefix only names a colour when what follows is a hex
+             spelling; [Css.hex] raises on anything else, and this runs inside
+             [of_class]. *)
+          let starts_with_hash = String.length inner > 0 && inner.[0] = '#' in
+          if starts_with_hash then Css.hex_opt inner
           else
             let normalized =
               String.map (fun c -> if c = '_' then ' ' else c) inner

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -515,8 +515,10 @@ module Handler = struct
           || Parse.is_css_color_fn normalized
         then
           let css_color =
-            if String.length inner > 0 && inner.[0] = '#' then
-              Some (Css.hex inner)
+            (* A [#] prefix only names a colour when what follows is a hex
+               spelling; [Css.hex] raises on anything else, and this runs inside
+               [of_class]. *)
+            if String.length inner > 0 && inner.[0] = '#' then Css.hex_opt inner
             else Css.parse_color normalized
           in
           match css_color with

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -500,24 +500,29 @@ module Handler = struct
     let length_strs, color = find_color_and_lengths [] parts in
     let lengths = List.filter_map Parse.arbitrary_length length_strs in
     (* A token that is not a length makes the value not a shadow. Dropping it
-       instead would slide the surviving lengths into the wrong slots. *)
+       instead would slide the surviving lengths into the wrong slots. A [#]
+       token is only the shadow's colour when it is a hex spelling. *)
     if List.compare_lengths lengths length_strs <> 0 then None
     else
-      match lengths with
-      | [ h_offset; v_offset ] ->
-          Some { h_offset; v_offset; blur = None; spread = None; color }
-      | [ h_offset; v_offset; blur ] ->
-          Some { h_offset; v_offset; blur = Some blur; spread = None; color }
-      | [ h_offset; v_offset; blur; spread ] ->
-          Some
-            {
-              h_offset;
-              v_offset;
-              blur = Some blur;
-              spread = Some spread;
-              color;
-            }
-      | _ -> None
+      match color with
+      | Hex h when Option.is_none (Css.hex_opt h) -> None
+      | _ -> (
+          match lengths with
+          | [ h_offset; v_offset ] ->
+              Some { h_offset; v_offset; blur = None; spread = None; color }
+          | [ h_offset; v_offset; blur ] ->
+              Some
+                { h_offset; v_offset; blur = Some blur; spread = None; color }
+          | [ h_offset; v_offset; blur; spread ] ->
+              Some
+                {
+                  h_offset;
+                  v_offset;
+                  blur = Some blur;
+                  spread = Some spread;
+                  color;
+                }
+          | _ -> None)
 
   (** Wrap a shadow's color with [var(--tw-shadow-color, <fallback>)]. Converts
       CSS color functions to hex for Tailwind parity. *)
@@ -2358,9 +2363,9 @@ module Handler = struct
       String.length s >= String.length prefix
       && String.sub s 0 (String.length prefix) = prefix
     in
-    if starts "#" inner then
-      let c = Color.hex inner in
-      Some (Color.to_css c 500)
+    (* A [#] prefix only names a colour when what follows is a hex spelling;
+       [Css.hex] raises on anything else, and this runs inside [of_class]. *)
+    if starts "#" inner then Css.hex_opt inner
     else
       let normalized = String.map (fun c -> if c = '_' then ' ' else c) inner in
       if Parse.is_css_color_fn normalized then

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -57,6 +57,11 @@ module Handler = struct
 
   let shorten_hex = Color.shorten_hex_str
 
+  (* A [#] value only names a colour when what follows is a hex spelling;
+     [Css.hex] raises on anything else, here once the sheet is rendered. *)
+  let is_hex_value s =
+    String.length s > 0 && s.[0] = '#' && Stdlib.Option.is_some (Css.hex_opt s)
+
   let alpha_decl percent =
     Css.custom_property ~layer:"utilities" "--tw-text-shadow-alpha"
       (pp_float percent ^ "%")
@@ -102,10 +107,13 @@ module Handler = struct
        text-shadow has no spread, so a fourth length is not one either. *)
     if List.compare_lengths lengths length_strs <> 0 then Stdlib.Option.None
     else
-      match lengths with
-      | [ h; v ] -> Some (h, v, Stdlib.Option.None, color)
-      | [ h; v; blur ] -> Some (h, v, Some blur, color)
-      | _ -> Stdlib.Option.None
+      match color with
+      | Arb_hex h when not (is_hex_value h) -> Stdlib.Option.None
+      | _ -> (
+          match lengths with
+          | [ h; v ] -> Some (h, v, Stdlib.Option.None, color)
+          | [ h; v; blur ] -> Some (h, v, Some blur, color)
+          | _ -> Stdlib.Option.None)
 
   (* ============ Shape definitions ============ *)
 
@@ -678,7 +686,7 @@ module Handler = struct
               Ok (Text_shadow_bracket_shadow var_part)
             else if Parse.is_var inner && not (is_shadow_value inner) then
               Ok (Text_shadow_bracket_var inner)
-            else if String.length inner > 0 && inner.[0] = '#' then
+            else if is_hex_value inner then
               let hex = String.sub inner 1 (String.length inner - 1) in
               match opacity with
               | Color.No_opacity -> Ok (Text_shadow_bracket_hex hex)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1652,7 +1652,10 @@ module Typography_late = struct
                   String.map (fun c -> if c = '_' then ' ' else c) inner
                 in
                 let css_color =
-                  if inner.[0] = '#' then Some (Css.hex inner)
+                  (* A [#] prefix only names a colour when what follows is a hex
+                     spelling; [Css.hex] raises on anything else, and this runs
+                     inside [of_class]. *)
+                  if inner.[0] = '#' then Css.hex_opt inner
                   else Css.parse_color normalized
                 in
                 match css_color with

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -320,8 +320,38 @@ let test_invalid_gradient_stop () =
   accepted "from-[var(--x)]";
   accepted "from-[#0088cc]"
 
+(* A [#] gradient stop is only a colour when what follows is a hex spelling. The
+   stop reader kept the text after the [#] as-is and the raising constructor saw
+   it when the sheet was rendered, so a malformed hex escaped as an exception
+   instead of failing the parse. *)
+let test_invalid_bracket_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  List.iter
+    (fun prefix ->
+      rejected (prefix ^ "-[#zz]");
+      rejected (prefix ^ "-[#]");
+      rejected (prefix ^ "-[#12345]");
+      rejected (prefix ^ "-[#zz]/50"))
+    [ "from"; "via"; "to" ];
+  emits "from-[#fff]" "--tw-gradient-from:#fff";
+  emits "via-[#abc]" "--tw-gradient-via:#abc";
+  emits "to-[#123456]" "--tw-gradient-to:#123456"
+
 let tests =
   [
+    test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     test_case "bg colors" `Quick test_bg_colors;
     test_case "invalid gradient stop" `Quick test_invalid_gradient_stop;
     test_case "bg var color with opacity" `Quick test_bg_var_opacity;

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -454,8 +454,54 @@ let test_shorthand_hex_alpha () =
     "a six-digit hex is unchanged" "#0307121a"
     (Tw.Color.hex_with_alpha "#030712" 10.)
 
+(* A [#] bracket only names a colour when what follows is a hex spelling. The
+   colour handler handed everything after the [#] to the raising constructor
+   from inside [of_class], so a malformed hex escaped the parser as an exception
+   instead of failing the match. *)
+let test_invalid_bracket_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  List.iter
+    (fun prefix ->
+      rejected (prefix ^ "-[#zz]");
+      rejected (prefix ^ "-[#]");
+      rejected (prefix ^ "-[#12345]");
+      rejected (prefix ^ "-[#zz]/50"))
+    [
+      "text";
+      "bg";
+      "border";
+      "fill";
+      "stroke";
+      "accent";
+      "caret";
+      "outline";
+      "placeholder";
+    ];
+  emits "text-[#abc]" "color:#abc";
+  emits "bg-[#00ff0080]" "background-color:#00ff0080";
+  emits "border-[#123456]" "border-color:#123456";
+  emits "fill-[#abc]" "fill:#abc";
+  emits "stroke-[#abc]" "stroke:#abc";
+  emits "accent-[#abc]" "accent-color:#abc";
+  emits "caret-[#abc]" "caret-color:#abc";
+  emits "outline-[#abc]" "outline-color:#abc";
+  emits "placeholder-[#abc]" "color:#abc"
+
 let tests =
   [
+    ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
     ("Achromatic colour keeps a none hue", `Quick, test_achromatic_none_hue);
     ("Per-side border colors", `Quick, test_border_side_color);
     ("Border color var", `Quick, test_border_color_var);

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -69,6 +69,29 @@ let rendering_matches_tailwind () =
   Test_helpers.check_rendering_matches ~test_name:"divide renders like Tailwind"
     (divide_utilities ())
 
+(* A [#] bracket is only a divide colour when what follows is a hex spelling.
+   The divide reader handed everything after the [#] to the raising constructor
+   from inside [of_class], so a malformed hex escaped the parser as an exception
+   instead of failing the match. *)
+let test_invalid_bracket_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "divide-[#zz]";
+  rejected "divide-[#]";
+  rejected "divide-[#12345]";
+  rejected "divide-[#zz]/50";
+  Alcotest.(check bool)
+    "divide-[#ff0000] still emits the colour" true
+    (Astring.String.is_infix ~affix:"border-color:#f00" (css "divide-[#ff0000]"))
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -76,6 +99,7 @@ let tests =
       Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
       Alcotest.test_case "renders like Tailwind" `Slow
         rendering_matches_tailwind;
+      Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     ]
 
 let suite = ("divide", tests)

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -349,8 +349,49 @@ let test_invalid_arbitrary_shadow () =
   accepted "shadow-[0_1px_2px_#000]";
   accepted "inset-shadow-[0_1px_2px_#000]"
 
+(* A [#] bracket only names a shadow or ring colour when what follows is a hex
+   spelling. The bracket-colour reader handed everything after the [#] to the
+   raising constructor from inside [of_class], so a malformed hex escaped the
+   parser as an exception instead of failing the match. *)
+let test_invalid_bracket_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  List.iter
+    (fun prefix ->
+      rejected (prefix ^ "-[#zz]");
+      rejected (prefix ^ "-[#]");
+      rejected (prefix ^ "-[#12345]");
+      rejected (prefix ^ "-[#zz]/50"))
+    [ "shadow"; "ring"; "inset-shadow"; "inset-ring"; "ring-offset" ];
+  (* The colour of an arbitrary shadow is read the same way. *)
+  rejected "shadow-[0_1px_2px_#zz]";
+  rejected "shadow-[0_1px_2px_#12345]";
+  rejected "shadow-[0_1px_2px_#zz]/50";
+  rejected "inset-shadow-[0_1px_2px_#zz]";
+  emits "shadow-[#abc]" "--tw-shadow-color:#abc";
+  emits "ring-[#123456]" "--tw-ring-color:#123456";
+  emits "inset-shadow-[#abc]" "--tw-inset-shadow-color:#abc";
+  emits "inset-ring-[#abc]" "--tw-inset-ring-color:#abc";
+  emits "ring-offset-[#abc]" "--tw-ring-offset-color:#abc";
+  emits "shadow-[0_1px_2px_#000]"
+    "--tw-shadow:0 1px 2px var(--tw-shadow-color,#000)";
+  emits "inset-shadow-[0_1px_2px_#000]"
+    "--tw-inset-shadow:inset 0 1px 2px var(--tw-inset-shadow-color,#000)"
+
 let tests =
   [
+    test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -65,6 +65,34 @@ let test_arbitrary_lengths () =
   | Ok _ -> Alcotest.fail "expected text-shadow-[0_bogus_2px] to be rejected"
   | Error _ -> ()
 
+(* A [#] value is only a colour when what follows is a hex spelling, both as the
+   whole bracket and as the colour of an arbitrary shadow. The reader kept the
+   text after the [#] as-is and the raising constructor saw it when the sheet
+   was rendered, so a malformed hex escaped as an exception instead of failing
+   the parse. *)
+let test_invalid_bracket_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  rejected "text-shadow-[#zz]";
+  rejected "text-shadow-[#]";
+  rejected "text-shadow-[#12345]";
+  rejected "text-shadow-[#zz]/50";
+  rejected "text-shadow-[0_1px_2px_#zz]";
+  emits "text-shadow-[#abc]" "--tw-text-shadow-color:#abc";
+  emits "text-shadow-[0_1px_2px_#ff0000]"
+    "text-shadow:0 1px 2px var(--tw-text-shadow-color,#f00)"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -72,6 +100,7 @@ let tests =
       Alcotest.test_case "default scale (v4.3.1)" `Quick test_default_scale;
       Alcotest.test_case "@theme override threads through" `Quick
         test_theme_override;
+      Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     ]
 
 let suite = ("text_shadow", tests)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -571,8 +571,34 @@ let test_decoration_bracket_thickness () =
   rejected "decoration-[.]";
   rejected "decoration-[1e]"
 
+(* A [#] bracket is only a decoration colour when what follows is a hex
+   spelling. The decoration reader handed everything after the [#] to the
+   raising constructor from inside [of_class], so a malformed hex escaped the
+   parser as an exception instead of failing the match. *)
+let test_invalid_decoration_bracket_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "decoration-[#zz]";
+  rejected "decoration-[#]";
+  rejected "decoration-[#12345]";
+  rejected "decoration-[#zz]/50";
+  Alcotest.(check bool)
+    "decoration-[#ff0000] still emits the colour" true
+    (Astring.String.is_infix ~affix:"text-decoration-color:#f00"
+       (css "decoration-[#ff0000]"))
+
 let tests =
   [
+    test_case "invalid decoration bracket hex" `Quick
+      test_invalid_decoration_bracket_hex;
     test_case "decoration bracket thickness" `Quick
       test_decoration_bracket_thickness;
     test_case "bracket list-style" `Quick test_bracket_list_style;


### PR DESCRIPTION
PR #257 fixed [color:#zz] raising out of of_class; the same raising Css.hex survived at seven more reader sites, so decoration-[#zz], bg-[#zz], shadow-[#zz] and twenty other prefixes crashed the scanner. All bracketed # values now go through Css.hex_opt with a clean Unknown-class error. Two hidden bugs fell out: shadow-[0_1px_2px_#zz] silently emitted #0000 instead of failing, and bg-[#12345] accepted a 5-digit hex CSS rejects. Valid spellings are byte-identical (48 checked).