### PR TITLE
outline: sort the outline colours with the rest of the family

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -865,15 +865,15 @@ module Handler = struct
         1500
     | Border_transparent -> 1500
     | Border_current -> 1500
-    (* Outline utilities — hidden first, then width, then styles last *)
+    (* Outline utilities — hidden first, then width, then offset. The colors
+       (color.ml, 3000-28000) and the styles (Outline_style_handler,
+       30000-30004) close the family. *)
     | Outline_hidden -> 1990
     | Outline -> 1999
     | Outline_0 -> 2000
     | Outline_width n -> 2000 + n
     | Outline_width_bracket _ -> 2009
     | Outline_width_var _ -> 2010
-    (* Outline styles come after colors (which are in Color handler at
-       priority 23 > borders priority 19, so they naturally sort after) *)
     (* Outline offset — negatives before positives *)
     | Neg_outline_offset n -> 2200 + n
     | Neg_outline_offset_var _ -> 2209
@@ -1181,14 +1181,15 @@ module Outline_style_handler = struct
         let decl, _ = Var.binding Handler.outline_style_var Css.Solid in
         style [ decl; Css.outline_style Css.Solid ]
 
-  (* outline-style sorts after outline-width (borders handler, up to ~2009 at
-     priority 28); alphabetical: dashed, dotted, double, none, solid. *)
+  (* outline-style closes the outline family at priority 28, after the widths
+     and offsets here and after color.ml's outline colors (3000-28000);
+     alphabetical: dashed, dotted, double, none, solid. *)
   let suborder = function
-    | Dashed -> 2050
-    | Dotted -> 2051
-    | Double -> 2052
-    | None_ -> 2053
-    | Solid -> 2054
+    | Dashed -> 30000
+    | Dotted -> 30001
+    | Double -> 30002
+    | None_ -> 30003
+    | Solid -> 30004
 
   let err_not_utility = Error (`Msg "Not an outline style utility")
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1934,10 +1934,12 @@ module Handler = struct
   (* Color families sort at their property's canonical rank, not together:
      border-color (rank ~65) joins border-width/style at priority 19; text-color
      (the `color` property, rank ~86) interleaves inside the late-typography
-     block, after text-transform and before font-style, at priority 26. The rest
-     (accent, caret, ...) stay at 25. [_opacity] variants lead each group so the
-     type resolves to the color [t] rather than the shadowed [Css.Border] /
-     [Css.user_select] [Text] constructors. *)
+     block, after text-transform and before font-style, at priority 26;
+     outline-color (rank ~92) joins the outline width, offset and style
+     utilities at priority 28. The rest (accent, caret, ...) stay at 25.
+     [_opacity] variants lead each group so the type resolves to the color [t]
+     rather than the shadowed [Css.Border] / [Css.user_select] [Text]
+     constructors. *)
   let priority = function
     | Border_opacity _ | Border _ | Border_transparent | Border_current
     | Border_current_opacity _ | Border_bracket_color _ | Border_side_color _
@@ -1949,6 +1951,12 @@ module Handler = struct
     | Text_bracket_var_opacity _ | Text_bracket_typed_var _
     | Text_bracket_typed_var_opacity _ ->
         26
+    | Outline_opacity _ | Outline _ | Outline_current
+    | Outline_current_opacity _ | Outline_inherit | Outline_transparent
+    | Outline_bracket_color _ | Outline_bracket_color_opacity _
+    | Outline_bracket_var _ | Outline_bracket_var_opacity _
+    | Outline_bracket_typed_var _ | Outline_bracket_typed_var_opacity _ ->
+        28
     | _ -> 25
 
   (* Helper to check if a string contains an opacity modifier *)
@@ -3137,7 +3145,10 @@ module Handler = struct
     | Caret_bracket_color _ -> 60000
     | Caret_bracket_color_opacity _ -> 60000
     (* t -> after all colors (max=24) *)
-    (* Outline comes after caret. Use 70000 base. *)
+    (* Outline colors run at priority 28 with the rest of the outline family
+       (see [priority]): the 3000 base puts them after borders.ml's outline
+       width (1999-2010) and offset (2200-2299) and before its outline
+       styles (30000-30004). *)
     | Outline (color, shade) ->
         let base =
           if is_base_color color then
@@ -3146,7 +3157,7 @@ module Handler = struct
             suborder_with_shade
               (color_to_string color ^ "-" ^ string_of_int shade)
         in
-        70000 + base
+        3000 + base
     | Outline_opacity (color, shade, _) ->
         let base =
           if is_base_color color then
@@ -3155,20 +3166,20 @@ module Handler = struct
             suborder_with_shade
               (color_to_string color ^ "-" ^ string_of_int shade)
         in
-        70000 + base
+        3000 + base
     | Outline_current ->
-        70000 + (4 * 1000) (* c -> between cyan(4) and emerald(5) *)
-    | Outline_current_opacity _ -> 70000 + (4 * 1000)
-    | Outline_inherit -> 70000 + (9 * 1000)
+        3000 + (4 * 1000) (* c -> between cyan(4) and emerald(5) *)
+    | Outline_current_opacity _ -> 3000 + (4 * 1000)
+    | Outline_inherit -> 3000 + (9 * 1000)
     (* i -> between indigo(9) and lime(10) *)
-    | Outline_transparent -> 70000 + (22 * 1000)
+    | Outline_transparent -> 3000 + (22 * 1000)
     (* t -> between teal and violet *)
-    | Outline_bracket_color _ -> 70000
-    | Outline_bracket_color_opacity _ -> 70000
-    | Outline_bracket_var _ -> 70000
-    | Outline_bracket_var_opacity _ -> 70000
-    | Outline_bracket_typed_var _ -> 70000
-    | Outline_bracket_typed_var_opacity _ -> 70000
+    | Outline_bracket_color _ -> 3000
+    | Outline_bracket_color_opacity _ -> 3000
+    | Outline_bracket_var _ -> 3000
+    | Outline_bracket_var_opacity _ -> 3000
+    | Outline_bracket_typed_var _ -> 3000
+    | Outline_bracket_typed_var_opacity _ -> 3000
     (* Placeholder colors: 80000 base *)
     | Placeholder _ -> 80000
     | Placeholder_opacity _ -> 80000

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -219,6 +219,37 @@ let test_outline_hidden_modifier_forced_colors () =
     "forced-colors block is not the bare .outline-hidden" false
     (Astring.String.is_infix ~affix:" .outline-hidden " out)
 
+(* The outline family sorts as one block: outline-hidden, the widths, the
+   offsets, the colors, then the styles. Order matters beyond byte parity here:
+   outline-hidden's forced-colors reset writes the outline shorthand, so a color
+   rule ahead of it loses its outline-color. *)
+let test_outline_ordering () =
+  let parse cls =
+    match Tw.of_string cls with
+    | Ok u -> u
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let utilities =
+    List.map parse
+      [
+        "outline";
+        "outline-2";
+        "outline-[3px]";
+        "outline-hidden";
+        "outline-offset-2";
+        "-outline-offset-4";
+        "outline-red-500";
+        "outline-blue-500";
+        "outline-current";
+        "outline-transparent";
+        "outline-dashed";
+        "outline-solid";
+        "outline-none";
+      ]
+  in
+  Test_helpers.check_ordering_matches ~test_name:"outline family order"
+    (Test_helpers.shuffle utilities)
+
 (* Arbitrary per-side border widths (border-t-[1px], ...) emit the side width
    plus the side border-style var; they used to be unknown classes. *)
 let test_border_side_arbitrary_width () =
@@ -309,6 +340,8 @@ let tests =
       test_outline_offset_arbitrary;
     test_case "outline-hidden modifier forced-colors" `Quick
       test_outline_hidden_modifier_forced_colors;
+    test_case "outline family order matches Tailwind" `Quick
+      test_outline_ordering;
     test_case "border side arbitrary widths" `Quick
       test_border_side_arbitrary_width;
     test_case "logical single-side borders" `Quick test_logical_side_borders;


### PR DESCRIPTION
`outline-color` sorted at the colour priority, which put every outline colour rule ahead of `outline-hidden`, whose `@media (forced-colors: active)` reset writes the `outline` shorthand and so wiped their `outline-color`. The colours now sort at the outline priority, between the offsets and the styles, matching Tailwind.

This turns the upstream parity test `utilities 589 outline` green; cascade's differ started reporting it once it learned that a typed shorthand overlaps the longhands it resets.