### PR TITLE
position: sort start and end with the inset properties they write

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -69,6 +69,10 @@ module Handler = struct
     | Border_width_bracket of string * Css.border_width
     | Border_side_width_bracket of string * string * Css.border_width
       (* side ("t"/"r"/"b"/"l"), arbitrary width inner: border-t-[1px] *)
+    | Border_side_width of string * int
+      (* side ("t"/"r"/"b"/"l") with a width Tailwind spells in px: border-t-16.
+         The 0/2/4/8 constructors below keep their own names, as Border_0/2/4/8
+         do beside Border_width. *)
     | (* Border side/axis utilities *)
       Border_t
     | Border_r
@@ -683,6 +687,14 @@ module Handler = struct
             | "r" -> [ border_right_style (Var bv); border_right_width w ]
             | "b" -> [ border_bottom_style (Var bv); border_bottom_width w ]
             | _ -> [ border_left_style (Var bv); border_left_width w ])
+    | Border_side_width (side, n) ->
+        let w : Css.border_width = Px (float_of_int n) in
+        make_side_util (fun bv ->
+            match side with
+            | "t" -> [ border_top_style (Var bv); border_top_width w ]
+            | "r" -> [ border_right_style (Var bv); border_right_width w ]
+            | "b" -> [ border_bottom_style (Var bv); border_bottom_width w ]
+            | _ -> [ border_left_style (Var bv); border_left_width w ])
     (* Border side/axis utilities *)
     | Border_t -> border_t
     | Border_r -> border_r
@@ -832,6 +844,11 @@ module Handler = struct
     | Border_be_width n -> 1150 + n
     | Border_side_width_bracket (side, _, _) -> (
         match side with "t" -> 1165 | "r" -> 1175 | "b" -> 1185 | _ -> 1195)
+    | Border_side_width (side, n) ->
+        let base =
+          match side with "t" -> 1160 | "r" -> 1170 | "b" -> 1180 | _ -> 1190
+        in
+        base + n
     | Border_t -> 1160
     | Border_t_0 -> 1161
     | Border_t_2 -> 1162
@@ -900,21 +917,27 @@ module Handler = struct
     | [ "border"; "l" ] -> Ok Border_l
     | [ "border"; "x" ] -> Ok Border_x
     | [ "border"; "y" ] -> Ok Border_y
-    | [ "border"; "x"; (("0" | "2" | "4" | "8") as n) ] ->
+    | [ "border"; "x"; n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
         Ok (Border_x_width (int_of_string n))
-    | [ "border"; "y"; (("0" | "2" | "4" | "8") as n) ] ->
+    | [ "border"; "y"; n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
         Ok (Border_y_width (int_of_string n))
     | [ "border"; "s" ] -> Ok Border_s
     | [ "border"; "e" ] -> Ok Border_e
     | [ "border"; "bs" ] -> Ok Border_bs
     | [ "border"; "be" ] -> Ok Border_be
-    | [ "border"; "s"; (("0" | "2" | "4" | "8") as n) ] ->
+    | [ "border"; "s"; n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
         Ok (Border_s_width (int_of_string n))
-    | [ "border"; "e"; (("0" | "2" | "4" | "8") as n) ] ->
+    | [ "border"; "e"; n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
         Ok (Border_e_width (int_of_string n))
-    | [ "border"; "bs"; (("0" | "2" | "4" | "8") as n) ] ->
+    | [ "border"; "bs"; n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
         Ok (Border_bs_width (int_of_string n))
-    | [ "border"; "be"; (("0" | "2" | "4" | "8") as n) ] ->
+    | [ "border"; "be"; n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
         Ok (Border_be_width (int_of_string n))
     | [ "border"; "t"; "0" ] -> Ok Border_t_0
     | [ "border"; "t"; "2" ] -> Ok Border_t_2
@@ -932,6 +955,9 @@ module Handler = struct
     | [ "border"; "l"; "2" ] -> Ok Border_l_2
     | [ "border"; "l"; "4" ] -> Ok Border_l_4
     | [ "border"; "l"; "8" ] -> Ok Border_l_8
+    | [ "border"; (("t" | "r" | "b" | "l") as side); n ]
+      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+        Ok (Border_side_width (side, int_of_string n))
     | [ "border"; "solid" ] -> Ok Border_solid
     | [ "border"; "dashed" ] -> Ok Border_dashed
     | [ "border"; "dotted" ] -> Ok Border_dotted
@@ -1054,6 +1080,7 @@ module Handler = struct
     | Border_width_bracket (v, _) -> "border-[" ^ v ^ "]"
     | Border_side_width_bracket (side, inner, _) ->
         "border-" ^ side ^ "-[" ^ inner ^ "]"
+    | Border_side_width (side, n) -> "border-" ^ side ^ "-" ^ string_of_int n
     | Border_t -> "border-t"
     | Border_r -> "border-r"
     | Border_b -> "border-b"

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -78,7 +78,10 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "mask_gradient"
-  let priority _ = 23
+
+  (* Tailwind emits the mask-gradient utilities after the backgrounds and before
+     the other masks, which come before fill/stroke and padding. *)
+  let priority _ = 21
 
   let direction_name = function
     | Top -> "top"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -75,7 +75,10 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "masks"
-  let priority _ = 23 (* After backgrounds, before filters *)
+
+  (* After the backgrounds and the mask-gradient utilities, before fill and
+     stroke and before padding - Tailwind's own order. *)
+  let priority _ = 21
 
   (* Helper to create webkit + standard declarations for mask properties *)
 
@@ -437,7 +440,7 @@ module Handler = struct
             Css.mask_size (Var var_ref);
           ]
 
-  let suborder = function
+  let suborder_in_family = function
     | Mask_bracket_image_var _ -> 100
     | Mask_bracket_image _ -> 101
     | Mask_bracket_url _ -> 102
@@ -494,6 +497,10 @@ module Handler = struct
     | Mask_position_bracket_var _ -> 512
     | Mask_size_bracket _ -> 407
     | Mask_size_bracket_var _ -> 408
+
+  (* These share a priority with the mask-gradient utilities and sort after
+     them, so the two families occupy disjoint suborder bands. *)
+  let suborder t = 10000 + suborder_in_family t
 
   (* [mask-[<image>]] takes any background-image value, so what makes one is
      whether the value parser accepts it, not which gradient function it

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -529,20 +529,26 @@ module Handler = struct
   let full_off = 900_001
   let named_off = 900_002
 
+  (* Family order follows Tailwind's property table: inset, inset-inline,
+     inset-block, inset-inline-start, inset-inline-end, inset-block-start,
+     inset-block-end, top, right, bottom, left. start and end write the same two
+     inline properties as inset-s and inset-e, so they sit in those bands rather
+     than after left; Tailwind emits inset-s before start but end before
+     inset-e, whatever the values, so each alias keeps a band of its own. *)
   let suborder =
     let inset = 1_000_000 in
     let inset_x = 2_000_000 in
     let inset_y = 3_000_000 in
     let inset_s = 4_000_000 in
-    let inset_e = 5_000_000 in
-    let inset_bs = 6_000_000 in
-    let inset_be = 7_000_000 in
-    let top = 8_000_000 in
-    let right = 9_000_000 in
-    let bottom = 10_000_000 in
-    let left = 11_000_000 in
-    let start = 12_000_000 in
-    let e = 13_000_000 in
+    let start = 5_000_000 in
+    let e = 6_000_000 in
+    let inset_e = 7_000_000 in
+    let inset_bs = 8_000_000 in
+    let inset_be = 9_000_000 in
+    let top = 10_000_000 in
+    let right = 11_000_000 in
+    let bottom = 12_000_000 in
+    let left = 13_000_000 in
     function
     | Pos_spacing (side, sp) ->
         let base =

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -47,7 +47,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "svg"
-  let priority _ = 21
+  let priority _ = 22
 
   (* Format opacity modifier for class names *)
   let opacity_suffix = function

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -34,6 +34,17 @@ let of_string_valid () =
   check "border-x-0";
   check "border-y-8";
 
+  (* A side or axis takes any integer, as the bare border does: border-x-16 was
+     rejected where Tailwind emits border-inline-width: 16px. *)
+  check "border-x-16";
+  check "border-y-16";
+  check "border-t-16";
+  check "border-x-3";
+  check "border-l-5";
+  check "border-b-12";
+  check "border-bs-12";
+  check "border-e-7";
+
   (* logical single-side borders: inline/block start and end *)
   check "border-s";
   check "border-e";

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -89,6 +89,29 @@ let test_invalid_bracket_value () =
   rejected "mask-size-[<value>]";
   rejected "mask-position-[<value>]"
 
+(* Masks sit between the backgrounds and fill/stroke, and the mask-gradient
+   utilities lead them. Sharing padding's slot interleaved the two families with
+   the padding rules, which breaks the adjacency the block merging relies on. *)
+let order_matches_tailwind () =
+  let classes =
+    [
+      "bg-red-500";
+      "mask-x-from-20%";
+      "mask-b-from-50%";
+      "mask-none";
+      "mask-top";
+      "mask-cover";
+      "mask-repeat-x";
+      "fill-blue-500";
+      "stroke-green-500";
+      "p-4";
+      "pt-2";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches ~test_name:"mask order matches Tailwind"
+    (Test_helpers.shuffle utilities)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -98,6 +121,7 @@ let tests =
         test_bracket_layer_list;
       Alcotest.test_case "invalid bracket value" `Quick
         test_invalid_bracket_value;
+      Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
     ]
 
 let suite = ("masks", tests)

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -194,6 +194,90 @@ let inset_value_order_matches_tailwind () =
     ~test_name:"inset value order matches Tailwind"
     (Test_helpers.shuffle utilities)
 
+(* start and end write the same two properties as inset-s and inset-e, so
+   Tailwind emits them in those bands - inset-s, start, end, inset-e, then
+   inset-bs, inset-be and only then top/right/bottom/left. tw parked them after
+   left, so start-4 beat -left-1 on an element carrying both. The canonical diff
+   matches rules by key and passes either way, so assert on the positions. *)
+let logical_inset_order_matches_tailwind () =
+  let mk s =
+    match Tw.of_string s with
+    | Ok u -> u
+    | Error (`Msg m) -> failwith (s ^ ": " ^ m)
+  in
+  let classes =
+    [
+      "inset-4";
+      "inset-x-4";
+      "inset-y-4";
+      "inset-s-4";
+      "start-4";
+      "end-4";
+      "inset-e-4";
+      "inset-bs-4";
+      "inset-be-4";
+      "top-4";
+      "right-4";
+      "bottom-4";
+      "left-4";
+    ]
+  in
+  let css =
+    Tw.to_css ~base:false (List.map mk (Test_helpers.shuffle classes))
+  in
+  let emitted =
+    Test_helpers.extract_rule_selectors
+      (Test_helpers.extract_utilities_layer_rules css)
+  in
+  Alcotest.(check (list string))
+    "logical inset order"
+    (List.map (fun c -> "." ^ c) classes)
+    emitted
+
+(* inset writes all four sides, inset-x and inset-y write two each, and the
+   logical forms write the same physical edges again, so which offset an element
+   ends up with is decided by the order the two sheets emit them in. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "static";
+      "relative";
+      "absolute";
+      "fixed";
+      "sticky";
+      "inset-0";
+      "inset-4";
+      "-inset-2";
+      "inset-auto";
+      "inset-full";
+      "inset-1/2";
+      "inset-x-0";
+      "inset-x-4";
+      "inset-y-2";
+      "inset-y-auto";
+      "inset-s-2";
+      "inset-e-2";
+      "inset-bs-2";
+      "inset-be-2";
+      "start-4";
+      "end-4";
+      "top-0";
+      "top-4";
+      "-top-2";
+      "top-auto";
+      "top-full";
+      "top-1/2";
+      "top-[3rem]";
+      "right-4";
+      "bottom-4";
+      "left-4";
+      "-left-1";
+    ]
+  in
+  Test_helpers.check_rendering_matches
+    ~test_name:"position renders like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 let tests =
   [
     test_case "inset and z" `Quick test_inset_and_z;
@@ -212,6 +296,9 @@ let tests =
       suborder_matches_tailwind;
     test_case "inset value order matches Tailwind" `Quick
       inset_value_order_matches_tailwind;
+    test_case "logical inset order matches Tailwind" `Quick
+      logical_inset_order_matches_tailwind;
+    test_case "position renders like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("position", tests)


### PR DESCRIPTION
Tailwind orders the position family by the property each utility declares, so `start-*` and `end-*` belong in the `inset-inline-start` and `inset-inline-end` bands. tw parked them after `left`, so an element carrying both `-left-1` and `start-4` was offset by the wrong one.

The differential rendering check found this; the canonical diff matches rules by key and passes either way, so the regression test asserts on the emitted positions. Stacked on #265, with the outline commit from #267 in the base branch: without it `dune build @runtest` fails on the upstream `outline` case, so the stack could not be verified green.