### PR TITLE
flex: interleave the basis fractions with the numerics

### DIFF
--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -240,14 +240,16 @@ module Handler = struct
     | Flex_grow_0 -> 30001
     | Flex_grow_n n -> 30000 + n
     | Flex_grow_arbitrary _ -> 30002
-    (* Basis: fractions → arbitrary → keywords alphabetical → named *)
-    | Basis_fraction (n, m) -> 40000 + (n * 10) + m
+    (* Basis: Tailwind interleaves the fractions with the numerics by numerator
+       (basis-1, basis-1/2, basis-1/3, basis-2, basis-2/3, basis-3/4, basis-4),
+       then arbitrary, then the keywords and named sizes. *)
+    | Basis_0 -> 40000
+    | Basis_1 -> 40010
+    | Basis_spacing n -> 40000 + (n * 10)
+    | Basis_fraction (n, m) -> 40000 + (n * 10) + 1 + m
     | Basis_arbitrary _ -> 42000
-    | Basis_0 -> 43000
-    | Basis_1 -> 43001
-    | Basis_spacing _ -> 43001
-    | Basis_auto -> 43002
-    | Basis_full -> 43003
+    | Basis_auto -> 43000
+    | Basis_full -> 43001
     | Basis_named _ -> 44000
 
   let err_not_utility = Error (`Msg "Not a flex property utility")

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -97,12 +97,61 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"flex_props suborder matches Tailwind" shuffled
 
+(* Tailwind interleaves the basis fractions with the numerics by numerator, so
+   basis-1/2 lands between basis-1 and basis-2. tw sorted every fraction ahead
+   of every numeric, so basis-0 beat basis-1/2 on an element carrying both. The
+   canonical diff matches rules by key and passes either way, so assert on the
+   positions. *)
+let basis_value_order_matches_tailwind () =
+  let mk s =
+    match Tw.of_string s with
+    | Ok u -> u
+    | Error (`Msg m) -> failwith (s ^ ": " ^ m)
+  in
+  let classes =
+    [
+      "basis-0";
+      "basis-1";
+      "basis-1/2";
+      "basis-1/3";
+      "basis-2";
+      "basis-2/3";
+      "basis-3/4";
+      "basis-4";
+      "basis-[10rem]";
+      "basis-auto";
+      "basis-full";
+    ]
+  in
+  let css =
+    Tw.to_css ~base:false (List.map mk (Test_helpers.shuffle classes))
+  in
+  let emitted =
+    Test_helpers.extract_rule_selectors
+      (Test_helpers.extract_utilities_layer_rules css)
+  in
+  let escape c =
+    String.concat ""
+      (List.map
+         (fun ch ->
+           match ch with
+           | ('/' | '[' | ']' | '.' | '%') as ch -> "\\" ^ String.make 1 ch
+           | ch -> String.make 1 ch)
+         (List.init (String.length c) (String.get c)))
+  in
+  Alcotest.(check (list string))
+    "basis value order"
+    (List.map (fun c -> "." ^ escape c) classes)
+    emitted
+
 let tests =
   [
     test_case "flex_props of_string - valid values" `Quick of_string_valid;
     test_case "flex_props of_string - invalid values" `Quick of_string_invalid;
     test_case "flex_props suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "basis value order matches Tailwind" `Quick
+      basis_value_order_matches_tailwind;
   ]
 
 let suite = ("flex_props", tests)


### PR DESCRIPTION
Tailwind sorts `basis-1/2` between `basis-1` and `basis-2`, the same interleave the inset family already uses. tw sorted every fraction ahead of every numeric, so `basis-0` won over `basis-1/2` on an element carrying both.

Follow-up to #268.