### PR TITLE
test: compare the remaining suites as a browser renders them

### DIFF
--- a/test/test_animations.ml
+++ b/test/test_animations.ml
@@ -103,6 +103,32 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"animations suborder matches Tailwind" shuffled
 
+(* Every animate-* writes the animation shorthand and every transition-* the
+   transition one, so which one an element ends up running is decided by the
+   order the two sheets emit them in. duration and delay reach the shorthand
+   through --tw-duration, which only a rendered element resolves. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "animate-none";
+      "animate-spin";
+      "animate-ping";
+      "animate-pulse";
+      "animate-bounce";
+      "transition-all";
+      "transition-colors";
+      "transition-none";
+      "duration-150";
+      "delay-200";
+      "ease-in";
+      "ease-out";
+      "ease-linear";
+    ]
+  in
+  Test_helpers.check_rendering_matches
+    ~test_name:"animations render like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 let tests =
   [
     test_case "transitions" `Quick test_transitions;
@@ -112,6 +138,7 @@ let tests =
     test_case "transition CSS output" `Quick test_transition_css;
     test_case "animations suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "animations render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("animations", tests)

--- a/test/test_flex.ml
+++ b/test/test_flex.ml
@@ -75,11 +75,50 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"flex suborder matches Tailwind" shuffled
 
+(* flex-1, flex-auto, flex-initial and flex-none all write the flex shorthand
+   and grow/shrink/basis write the longhands it expands to, so what an element
+   ends up flexing by is decided by the order the two sheets emit them in. The
+   set is Tw.Flex's own surface, re-exports included. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "flex";
+      "inline-flex";
+      "flex-row";
+      "flex-row-reverse";
+      "flex-col";
+      "flex-wrap";
+      "flex-nowrap";
+      "flex-1";
+      "flex-auto";
+      "flex-initial";
+      "flex-none";
+      "grow";
+      "grow-0";
+      "shrink";
+      "shrink-0";
+      "basis-0";
+      "basis-1";
+      "basis-1/2";
+      "basis-3/4";
+      "basis-[10rem]";
+      "basis-full";
+      "basis-auto";
+      "order-1";
+      "order-first";
+      "order-last";
+      "order-none";
+    ]
+  in
+  Test_helpers.check_rendering_matches ~test_name:"flex renders like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 let tests =
   [
     test_case "flex of_string - valid values" `Quick of_string_valid;
     test_case "flex of_string - invalid values" `Quick of_string_invalid;
     test_case "flex suborder matches Tailwind" `Quick suborder_matches_tailwind;
+    test_case "flex renders like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("flex", tests)

--- a/test/test_forms.ml
+++ b/test/test_forms.ml
@@ -46,11 +46,22 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches ~forms:true
     ~test_name:"forms suborder matches Tailwind" shuffled
 
+(* The five form utilities write the same appearance, border and background
+   properties, so which one an element ends up styled by is decided by the order
+   the two sheets emit them in. The plugin only exposes them as classes under
+   its class strategy, hence [~forms]. *)
+let rendering_matches_tailwind () =
+  let open Tw in
+  Test_helpers.check_rendering_matches ~forms:true
+    ~test_name:"forms render like Tailwind"
+    [ form_input; form_checkbox; form_radio; form_select; form_textarea ]
+
 let tests =
   [
     test_case "inputs" `Quick test_inputs;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "forms suborder matches Tailwind" `Quick suborder_matches_tailwind;
+    test_case "forms render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("forms", tests)

--- a/test/test_grid.ml
+++ b/test/test_grid.ml
@@ -29,11 +29,34 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"grid suborder matches Tailwind" shuffled
 
+(* grid and inline-grid share one priority with every other display utility and
+   are told apart by suborder alone, so which display an element ends up with is
+   decided by the order the two sheets emit the band in. The band is the set the
+   suborder table in Grid.Handler enumerates. *)
+let rendering_matches_tailwind () =
+  let classes =
+    [
+      "grid";
+      "inline-grid";
+      "block";
+      "inline-block";
+      "inline";
+      "flex";
+      "inline-flex";
+      "hidden";
+      "contents";
+      "flow-root";
+    ]
+  in
+  Test_helpers.check_rendering_matches ~test_name:"grid renders like Tailwind"
+    (List.map (fun c -> Result.get_ok (Tw.of_string c)) classes)
+
 let tests =
   [
     test_case "grid of_string - valid values" `Quick of_string_valid;
     test_case "grid of_string - invalid values" `Quick of_string_invalid;
     test_case "grid suborder matches Tailwind" `Quick suborder_matches_tailwind;
+    test_case "grid renders like Tailwind" `Slow rendering_matches_tailwind;
   ]
 
 let suite = ("grid", tests)

--- a/test/test_prose.ml
+++ b/test/test_prose.ml
@@ -98,6 +98,28 @@ let test_color_theme_parity () =
       prose_orange;
     ]
 
+(* Every size writes font-size and line-height on the root and every colour
+   theme writes the same --tw-prose-* slots, so which one an element ends up
+   reading is decided by the order the two sheets emit them in. The elements are
+   bare divs, so this covers the root declarations and the palette variables the
+   descendant rules read, not the descendant rules themselves. *)
+let rendering_matches_tailwind () =
+  Test_helpers.check_rendering_matches ~test_name:"prose renders like Tailwind"
+    [
+      prose;
+      prose_sm;
+      prose_lg;
+      prose_xl;
+      prose_2xl;
+      prose_gray;
+      prose_slate;
+      prose_zinc;
+      prose_neutral;
+      prose_stone;
+      prose_invert;
+      prose_orange;
+    ]
+
 let suite =
   ( "prose",
     [
@@ -109,4 +131,6 @@ let suite =
       Alcotest.test_case "size parity with Tailwind" `Quick test_size_parity;
       Alcotest.test_case "colour theme parity with Tailwind" `Quick
         test_color_theme_parity;
+      Alcotest.test_case "prose renders like Tailwind" `Slow
+        rendering_matches_tailwind;
     ] )


### PR DESCRIPTION
Wires grid, flex, animations, prose and forms into the differential rendering check, completing the coverage started in #258. It is the only one of the three comparisons that sees an ordering difference between two utilities writing the same property, and it found the two fixes this PR is stacked on.

The prose elements are bare divs, so that suite covers the root declarations and the palette variables the descendant rules read, not the descendant rules themselves.

Follow-up to #269.