### PR TITLE
utility: sort a project's own @utility where the utility it applies sorts

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -659,6 +659,50 @@ let add_once buf seen items =
       end)
     items
 
+(* The [@apply] run starting at [i]: the classes it names, and the offset of the
+   [;] or [}] that ends it. [@apply] is not CSS, so it is found by scanning
+   rather than through the parser. *)
+let apply_run_at css i =
+  let len = String.length css in
+  let ident c =
+    (c >= 'a' && c <= 'z')
+    || (c >= 'A' && c <= 'Z')
+    || (c >= '0' && c <= '9')
+    || c = '-' || c = '_'
+  in
+  if
+    not
+      (i + 6 <= len
+      && String.sub css i 6 = "@apply"
+      && (i = 0 || not (ident css.[i - 1])))
+  then None
+  else begin
+    let stop = ref (i + 6) in
+    while !stop < len && css.[!stop] <> ';' && css.[!stop] <> '}' do
+      incr stop
+    done;
+    let names =
+      String.sub css (i + 6) (!stop - i - 6)
+      |> String.split_on_char ' '
+      |> List.concat_map (String.split_on_char '\n')
+      |> List.map String.trim
+      |> List.filter (fun n -> n <> "")
+    in
+    Some (names, !stop)
+  end
+
+(* Every class a body [@apply]s, at any depth. *)
+let applied_classes css =
+  let len = String.length css in
+  let rec go i acc =
+    if i >= len then List.rev acc
+    else
+      match apply_run_at css i with
+      | Some (names, stop) -> go stop (List.rev_append names acc)
+      | None -> go (i + 1) acc
+  in
+  go 0 []
+
 (* Tailwind's [@apply] pulls a utility's declarations into an author rule. It is
    not CSS, so the at-rule drops out and takes the whole rule with it once the
    rule is left empty. *)
@@ -667,88 +711,68 @@ let expand_apply ~theme ~defs ?(udefs = []) css =
   let buf = Buffer.create len in
   let hoisted = Buffer.create 0 in
   let seen = ref [] in
-  let ident c =
-    (c >= 'a' && c <= 'z')
-    || (c >= 'A' && c <= 'Z')
-    || (c >= '0' && c <= '9')
-    || c = '-' || c = '_'
-  in
   let rec go i =
-    if i >= len then ()
-    else if
-      i + 6 <= len
-      && String.sub css i 6 = "@apply"
-      && (i = 0 || not (ident css.[i - 1]))
-    then begin
-      let stop = ref (i + 6) in
-      while !stop < len && css.[!stop] <> ';' && css.[!stop] <> '}' do
-        incr stop
-      done;
-      let names =
-        String.sub css (i + 6) (!stop - i - 6)
-        |> String.split_on_char ' '
-        |> List.concat_map (String.split_on_char '\n')
-        |> List.map String.trim
-        |> List.filter (fun n -> n <> "")
-      in
-      let emit name =
-        let variants, bare = split_declared_variants defs name in
-        (* [@apply line-t] names a utility the project declared, whose body is
-           author CSS in its own right. *)
-        let body, top =
-          match List.assoc_opt bare udefs with
-          | Some decls -> (decls, [])
-          | None -> nested_utilities ~theme [ bare ]
-        in
-        add_once hoisted seen top;
-        if body = "" then ()
+    match apply_run_at css i with
+    | None ->
+        if i >= len then ()
         else begin
-          List.iter
-            (fun v ->
-              Buffer.add_string buf (String.concat "" [ "@variant "; v; "{" ]))
-            variants;
-          Buffer.add_string buf body;
-          List.iter (fun _ -> Buffer.add_char buf '}') variants
+          Buffer.add_char buf css.[i];
+          go (i + 1)
         end
-      in
-      (* A utility with no declared variant and no body of its own decorates the
-         applying rule's [&] directly. A run of those renders in one call, so
-         their declarations land in a single rule the way Tailwind emits them,
-         rather than one rule of the author's selector per utility. *)
-      let plain name =
-        match split_declared_variants defs name with
-        | [], bare when not (List.mem_assoc bare udefs) -> Some bare
-        | _ -> None
-      in
-      let rec emit_all = function
-        | [] -> ()
-        | name :: tl as all -> (
-            match plain name with
-            | None ->
-                emit name;
-                emit_all tl
-            | Some _ ->
-                let run, rest =
-                  let rec span acc = function
-                    | n :: tl when plain n <> None -> span (n :: acc) tl
-                    | rest -> (List.rev acc, rest)
+    | Some (names, stop) ->
+        let emit name =
+          let variants, bare = split_declared_variants defs name in
+          (* [@apply line-t] names a utility the project declared, whose body is
+             author CSS in its own right. *)
+          let body, top =
+            match List.assoc_opt bare udefs with
+            | Some decls -> (decls, [])
+            | None -> nested_utilities ~theme [ bare ]
+          in
+          add_once hoisted seen top;
+          if body = "" then ()
+          else begin
+            List.iter
+              (fun v ->
+                Buffer.add_string buf (String.concat "" [ "@variant "; v; "{" ]))
+              variants;
+            Buffer.add_string buf body;
+            List.iter (fun _ -> Buffer.add_char buf '}') variants
+          end
+        in
+        (* A utility with no declared variant and no body of its own decorates
+           the applying rule's [&] directly. A run of those renders in one call,
+           so their declarations land in a single rule the way Tailwind emits
+           them, rather than one rule of the author's selector per utility. *)
+        let plain name =
+          match split_declared_variants defs name with
+          | [], bare when not (List.mem_assoc bare udefs) -> Some bare
+          | _ -> None
+        in
+        let rec emit_all = function
+          | [] -> ()
+          | name :: tl as all -> (
+              match plain name with
+              | None ->
+                  emit name;
+                  emit_all tl
+              | Some _ ->
+                  let run, rest =
+                    let rec span acc = function
+                      | n :: tl when plain n <> None -> span (n :: acc) tl
+                      | rest -> (List.rev acc, rest)
+                    in
+                    span [] all
                   in
-                  span [] all
-                in
-                let body, top =
-                  nested_utilities ~theme (List.filter_map plain run)
-                in
-                add_once hoisted seen top;
-                Buffer.add_string buf body;
-                emit_all rest)
-      in
-      emit_all names;
-      go (if !stop < len && css.[!stop] = ';' then !stop + 1 else !stop)
-    end
-    else begin
-      Buffer.add_char buf css.[i];
-      go (i + 1)
-    end
+                  let body, top =
+                    nested_utilities ~theme (List.filter_map plain run)
+                  in
+                  add_once hoisted seen top;
+                  Buffer.add_string buf body;
+                  emit_all rest)
+        in
+        emit_all names;
+        go (if stop < len && css.[stop] = ';' then stop + 1 else stop)
   in
   go 0;
   (* The hoisted blocks go last: their layer is ordered by the sheet's [@layer]
@@ -1307,32 +1331,62 @@ let is_custom_routed ~defs ~udefs cls =
    author CSS uses: the declarations land under the escaped class, wrapped in
    the declared variants, and cascade flattens the nesting into the project's
    selector. *)
+(* Every rule a routed statement holds, at whatever at-rule depth. One traversal
+   for both questions asked of it below: which class it belongs to, and which
+   properties it writes. *)
+let rec routed_rules stmt =
+  match Css.as_rule stmt with
+  | Some (selector, decls, nested) ->
+      (selector, decls) :: List.concat_map routed_rules nested
+  | None ->
+      let inner =
+        match Css.as_media stmt with
+        | Some (_, inner) -> inner
+        | None -> (
+            match Css.as_supports stmt with
+            | Some (_, inner) -> inner
+            | None -> (
+                match Css.as_container stmt with
+                | Some (_, _, inner) -> inner
+                | None -> []))
+      in
+      List.concat_map routed_rules inner
+
 (* The class a routed rule belongs to: its selector's first class, which is the
    declared utility itself for both [.line-y] and [.line-y:before]. *)
-let rec first_class_of_statement stmt =
-  match Css.as_rule stmt with
-  | Some (selector, _, _) -> Css.Selector.first_class selector
-  | None -> (
-      match Css.as_media stmt with
-      | Some (_, inner) -> List.find_map first_class_of_statement inner
-      | None -> (
-          match Css.as_supports stmt with
-          | Some (_, inner) -> List.find_map first_class_of_statement inner
-          | None -> None))
+let first_class_of_statement stmt =
+  List.find_map
+    (fun (selector, _) -> Css.Selector.first_class selector)
+    (routed_rules stmt)
 
-(* Where a declared utility sorts: the slot of the property it writes first. *)
-let rec slot_of_statement stmt =
-  match Css.as_rule stmt with
-  | Some (_, d :: _, _) ->
-      Tw.Declared.Slot.of_property (Css.Declaration.property_key d)
-  | Some (_, [], _) -> None
-  | None -> (
-      match Css.as_media stmt with
-      | Some (_, inner) -> List.find_map slot_of_statement inner
-      | None -> (
-          match Css.as_supports stmt with
-          | Some (_, inner) -> List.find_map slot_of_statement inner
-          | None -> None))
+(* The utility a class names, with any variant prefix dropped: [dark:line-t] is
+   still the declared [line-t]. *)
+let declared_utility_name cls =
+  match List.rev (variant_segments cls) with [] -> cls | name :: _ -> name
+
+(* Where a declared utility sorts. Tailwind expands the body and orders the
+   result by the properties it writes, so the utility takes the earliest slot
+   its body reaches: the utilities it [@apply]s sort at one, and the families
+   writing the properties it declares itself sort at another. Reading both keeps
+   the answer right when either alone is silent - [@apply] names a utility the
+   project declared, and a raw declaration names no utility at all. *)
+let slot_of_declared ~theme ~udefs cls stmts =
+  let applied =
+    match List.assoc_opt (declared_utility_name cls) udefs with
+    | Some body -> applied_classes body
+    | None -> []
+  in
+  let of_class name =
+    Tw.Declared.Slot.of_class ~theme (declared_utility_name name)
+  in
+  let of_property (_, decls) =
+    List.filter_map
+      (fun d -> Tw.Declared.Slot.of_property (Css.Declaration.property_key d))
+      decls
+  in
+  Tw.Declared.Slot.earliest
+    (List.filter_map of_class applied
+    @ List.concat_map of_property (List.concat_map routed_rules stmts))
 
 let custom_routed_utilities ~theme ~defs ~udefs candidates =
   let hoisted = Buffer.create 0 in
@@ -1413,43 +1467,37 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
                 end)
               hoisted_stmts
           in
-          (* Tailwind sorts a declared utility at the slot of the property it
-             declares, so group the rules it produced under their own class and
-             read that slot off the first declaration. A property no handler
-             claims leaves the group without an order; those keep their old
-             place at the end of the layer rather than being dropped. *)
-          let group = Hashtbl.create 8 in
-          let order_of = Hashtbl.create 8 in
-          let classless = ref [] in
+          (* Group the rules a declared utility produced under its own class, in
+             the order they were emitted, then give each group its slot. A body
+             reaching no slot at all - every property it writes is one no
+             handler claims - keeps its old place at the end of the layer rather
+             than being dropped. *)
+          let groups = ref [] and classless = ref [] in
           List.iter
             (fun stmt ->
               match first_class_of_statement stmt with
               | None -> classless := stmt :: !classless
               | Some cls -> (
-                  let prev =
-                    Stdlib.Option.value ~default:[] (Hashtbl.find_opt group cls)
-                  in
-                  Hashtbl.replace group cls (prev @ [ stmt ]);
-                  if not (Hashtbl.mem order_of cls) then
-                    match slot_of_statement stmt with
-                    | Some order -> Hashtbl.add order_of cls order
-                    | None -> ()))
+                  match List.assoc_opt cls !groups with
+                  | Some stmts -> stmts := stmt :: !stmts
+                  | None -> groups := !groups @ [ (cls, ref [ stmt ]) ]))
             rules;
           let declared, unordered =
-            Hashtbl.fold
-              (fun cls stmts (declared, unordered) ->
-                match Hashtbl.find_opt order_of cls with
+            List.fold_left
+              (fun (declared, unordered) (cls, stmts) ->
+                let stmts = List.rev !stmts in
+                match slot_of_declared ~theme ~udefs cls stmts with
                 | Some slot ->
                     (Tw.Declared.v ~cls ~slot stmts :: declared, unordered)
-                | None -> (declared, stmts @ unordered))
-              group
+                | None -> (declared, unordered @ stmts))
               ([], List.rev !classless)
+              !groups
           in
           let unplaced =
             if unordered = [] then []
             else [ Css.layer ~name:"utilities" unordered ]
           in
-          (List.length blocks, declared, unplaced @ hoisted_stmts))
+          (List.length blocks, List.rev declared, unplaced @ hoisted_stmts))
 
 let native_files paths flag ~(opts : gen_opts) =
   let include_base = eval_flag flag ~default:true in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1324,7 +1324,7 @@ let rec first_class_of_statement stmt =
 let rec slot_of_statement stmt =
   match Css.as_rule stmt with
   | Some (_, d :: _, _) ->
-      Tw.Utility.order_of_property (Css.Declaration.property_key d)
+      Tw.Declared.Slot.of_property (Css.Declaration.property_key d)
   | Some (_, [], _) -> None
   | None -> (
       match Css.as_media stmt with
@@ -1435,19 +1435,13 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
                     | Some order -> Hashtbl.add order_of cls order
                     | None -> ()))
             rules;
-          (* Two declared utilities can land on the same slot, and their rules
-             would then interleave by selector, splitting each one's own rules
-             apart. Offset the suborder per class so each stays contiguous. *)
-          let nth = ref 0 in
-          let ordered, unordered =
+          let declared, unordered =
             Hashtbl.fold
-              (fun cls stmts (ordered, unordered) ->
+              (fun cls stmts (declared, unordered) ->
                 match Hashtbl.find_opt order_of cls with
-                | Some (priority, suborder) ->
-                    incr nth;
-                    ( (cls, (priority, suborder + !nth), stmts) :: ordered,
-                      unordered )
-                | None -> (ordered, stmts @ unordered))
+                | Some slot ->
+                    (Tw.Declared.v ~cls ~slot stmts :: declared, unordered)
+                | None -> (declared, stmts @ unordered))
               group
               ([], List.rev !classless)
           in
@@ -1455,7 +1449,7 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
             if unordered = [] then []
             else [ Css.layer ~name:"utilities" unordered ]
           in
-          (List.length blocks, ordered, unplaced @ hoisted_stmts))
+          (List.length blocks, declared, unplaced @ hoisted_stmts))
 
 let native_files paths flag ~(opts : gen_opts) =
   let include_base = eval_flag flag ~default:true in
@@ -1474,11 +1468,11 @@ let native_files paths flag ~(opts : gen_opts) =
       parse_known_candidates ~theme:opts.theme ?input_css:opts.input_css normal
     in
     let tw_styles = List.map snd known in
-    let routed_count, routed_extra, routed_stmts =
+    let routed_count, routed_declared, routed_stmts =
       custom_routed_utilities ~theme:opts.theme ~defs ~udefs routed
     in
     let stylesheet =
-      Tw.to_css ~theme:opts.theme ~base:include_base ~extra:routed_extra
+      Tw.to_css ~theme:opts.theme ~base:include_base ~declared:routed_declared
         tw_styles
     in
     let stylesheet =

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1945,6 +1945,7 @@ module Handler = struct
       Bg_clip_border;
       Bg_origin_border;
       Bg_current;
+      Bg_position Pos_center;
     ]
 end
 

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1172,7 +1172,16 @@ module Handler = struct
     | Neg_outline_offset n -> "-outline-offset-" ^ string_of_int n
     | Neg_outline_offset_var v -> "-outline-offset-[" ^ v ^ "]"
 
-  let examples = [ Border_0; Border_x; Border_y; Border_solid; Border_current ]
+  let examples =
+    [
+      Border_0;
+      Border_x;
+      Border_y;
+      Border_solid;
+      Border_current;
+      Rounded (Rp_all, Rsz_default);
+      Outline_0;
+    ]
 end
 
 open Handler

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1531,7 +1531,32 @@ let outputs_of_statement ~base_class stmt =
                     inner
               | _ -> [])))
 
-let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
+module Declared = struct
+  module Slot = struct
+    type t = int * int
+
+    let of_class ?(theme = Scheme.default) cls =
+      match Utility.base_of_class theme cls with
+      | Ok base -> Some (Utility.order base)
+      | Error _ -> None
+
+    let of_property key = Utility.order_of_property key
+
+    let earliest = function
+      | [] -> None
+      | slot :: rest -> Some (List.fold_left Stdlib.min slot rest)
+  end
+
+  type t = {
+    cls : string;
+    slot : Slot.t;
+    statements : Cascade.Css.statement list;
+  }
+
+  let v ~cls ~slot statements = { cls; slot; statements }
+end
+
+let to_css ?(theme = Scheme.default) ?(config = default_config) ?(declared = [])
     tw_classes =
   (* [Rule.outputs ~order_tbl] records each base utility's order under the class
      name it already builds, so [order_of_base] looks it up instead of
@@ -1540,17 +1565,15 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
   let selector_props =
     List.concat_map (Rule.outputs ~theme ~order_tbl:order_map) tw_classes
   in
-  (* A declared utility means nothing to the handlers, so its order arrives with
+  (* A declared utility means nothing to the handlers, so its slot arrives with
      it and is seeded under the same key [order_of_base] looks up. *)
   let selector_props =
     selector_props
     @ List.concat_map
-        (fun (class_name, order, statements) ->
-          Hashtbl.replace order_map (extract_base_utility class_name) order;
-          List.concat_map
-            (outputs_of_statement ~base_class:class_name)
-            statements)
-        extra
+        (fun { Declared.cls; slot; statements } ->
+          Hashtbl.replace order_map (extract_base_utility cls) slot;
+          List.concat_map (outputs_of_statement ~base_class:cls) statements)
+        declared
   in
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute
@@ -1558,7 +1581,7 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
   let sorted_rules = sorted_indexed_rules order_map selector_props in
   let verbatim =
     let names = Hashtbl.create 8 in
-    List.iter (fun (cls, _, _) -> Hashtbl.replace names cls ()) extra;
+    List.iter (fun d -> Hashtbl.replace names d.Declared.cls ()) declared;
     fun cls -> Hashtbl.mem names cls
   in
   let statements = statements_of_sorted_rules ~verbatim sorted_rules in

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -43,23 +43,55 @@ type config = {
 val default_config : config
 (** The default configuration. Base layer enabled. *)
 
+(** A utility a project declared with Tailwind's [@utility], as the CSS its body
+    expanded to plus the position it takes among the built-in utilities. *)
+module Declared : sig
+  (** Where a rule sorts in the utilities layer.
+
+      Tailwind orders that layer by the property each utility writes, and a
+      project's own [@utility] takes its place in it like any other. A body
+      reaches a slot two ways: by applying a utility that sorts there, or by
+      declaring one of the properties that sort there. *)
+  module Slot : sig
+    type t
+
+    val of_class : ?theme:Scheme.t -> string -> t option
+    (** [of_class cls] is the slot the utility named [cls] sorts at, and [None]
+        when [cls] names no utility. A body that [@apply]s [cls] reaches it. *)
+
+    val of_property : Css.Declaration.prop_key -> t option
+    (** [of_property k] is the slot of the utility family that writes [k], and
+        [None] when no family writes it. A body that declares [k] reaches it. *)
+
+    val earliest : t list -> t option
+    (** [earliest slots] is the first of [slots] in the layer, and [None] for
+        the empty list. A utility sorts at the earliest slot it reaches:
+        Tailwind sorts [@utility x { @apply bg-red-500 relative }] with
+        [relative], not with [bg-red-500]. *)
+  end
+
+  type t
+
+  val v : cls:string -> slot:Slot.t -> Css.statement list -> t
+  (** [v ~cls ~slot stmts] is the utility [cls], whose body expanded to [stmts],
+      sorting into the utilities layer at [slot]. *)
+end
+
 val to_css :
   ?theme:Scheme.t ->
   ?config:config ->
-  ?extra:(string * (int * int) * Css.statement list) list ->
+  ?declared:Declared.t list ->
   Utility.t list ->
   Css.t
-(** [to_css ?theme ?config utilities] generates a full CSS stylesheet for
-    [utilities]. This is the main entry point for the library. [theme] (default
-    {!Scheme.default}) supplies the theme values utilities read while generating
-    CSS. Rendering concerns such as inlining and optimization are handled by
-    {!Css.to_string}.
+(** [to_css ?theme ?config ?declared utilities] generates a full CSS stylesheet
+    for [utilities]. This is the main entry point for the library. [theme]
+    (default {!Scheme.default}) supplies the theme values utilities read while
+    generating CSS. Rendering concerns such as inlining and optimization are
+    handled by {!Css.to_string}.
 
-    [extra] carries rules a project's own [@utility] produced, each as
-    [(class name, order, statements)]. The handlers know nothing about a
-    declared utility, so its order comes in with it - see
-    {!Utility.order_of_property} for where that order is read from - and the
-    statements sort into the utilities layer at that order instead of landing
+    [declared] carries the project's own [@utility] rules. The handlers know
+    nothing about a declared utility, so its slot comes in with it, and its
+    statements sort into the utilities layer at that slot instead of landing
     after it. *)
 
 val to_inline_style : ?theme:Scheme.t -> Utility.t list -> string

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -440,7 +440,7 @@ module Handler = struct
     | Order_last -> "order-last"
     | Order_none -> "order-none"
 
-  let examples = [ Flex_1; Flex_grow; Flex_shrink; Basis_0 ]
+  let examples = [ Flex_1; Flex_grow; Flex_shrink; Basis_0; Order_none ]
 end
 
 open Handler

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -735,6 +735,8 @@ module Handler = struct
       Clear_both;
       Object_contain;
       Object_center;
+      Break_after_auto;
+      Box_decoration_slice;
     ]
 end
 

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1998,7 +1998,13 @@ module Handler = struct
         "origin-[" ^ s ^ "]"
 
   let examples =
-    [ Origin_top; Perspective_none; Perspective_origin_top; Backface_hidden ]
+    [
+      Origin_top;
+      Perspective_none;
+      Perspective_origin_top;
+      Backface_hidden;
+      Transform_none;
+    ]
 end
 
 open Handler

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -63,10 +63,11 @@ include Columns
 include Contain
 include Scroll
 include Arbitrary
+module Declared = Build.Declared
 
 let to_css ?theme ?(base = Build.default_config.base) ?forms
-    ?(layers = Build.default_config.layers) ?extra utilities =
-  Build.to_css ?theme ~config:{ base; forms; layers } ?extra utilities
+    ?(layers = Build.default_config.layers) ?declared utilities =
+  Build.to_css ?theme ~config:{ base; forms; layers } ?declared utilities
 
 let to_inline_style ?theme utilities = Build.to_inline_style ?theme utilities
 let preflight = Preflight.stylesheet

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3781,17 +3781,25 @@ module Var = Var
 
 (* Version module is now in the css library *)
 
+module Declared = Build.Declared
+(** Utilities a project declared with Tailwind's [@utility]. Each carries the
+    CSS its body expanded to and the {!Declared.Slot} it sorts at, so
+    {!val-to_css} places it among the built-in utilities rather than after them.
+*)
+
 val to_css :
   ?theme:Scheme.t ->
   ?base:bool ->
   ?forms:bool ->
   ?layers:bool ->
-  ?extra:(string * (int * int) * Css.statement list) list ->
+  ?declared:Declared.t list ->
   t list ->
   Css.t
-(** [to_css ?theme ?base ?forms ?layers styles] generates a CSS stylesheet for
-    the given styles. [theme] (default {!Scheme.default}) supplies the theme
-    values utilities read while generating CSS.
+(** [to_css ?theme ?base ?forms ?layers ?declared styles] generates a CSS
+    stylesheet for the given styles. [theme] (default {!Scheme.default})
+    supplies the theme values utilities read while generating CSS. [declared]
+    carries the project's own [@utility] rules, each sorting into the utilities
+    layer at its own slot.
 
     The generated CSS follows Tailwind's layering and ordering conventions:
 

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1406,7 +1406,7 @@ module Typography_early = struct
         let lh_extra, lh_value = lh_modifier_to_css lh_mod in
         style (fs_decls @ lh_extra @ [ line_height lh_value ])
 
-  let examples = [ Text_base; Font_normal ]
+  let examples = [ Text_base; Font_normal; Font_serif; Italic; Text_center ]
 end
 
 (** Late typography handler - comes after color utilities (priority 24) *)

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -49,10 +49,13 @@ let register (type a) (module M : Handler with type t = a) =
   property_slots := None;
   handlers := internal_h :: !handlers
 
-(* The declarations a style writes, its own and those of the rules it
-   carries. *)
+(* The declarations a style writes, its own and those of the rules it carries. A
+   style with a pseudo-element suffix is skipped: [placeholder-transparent]
+   writes [color], but the colour slot belongs to [text-*], which writes it on
+   the element itself. *)
 let rec style_declarations (s : Style.t) =
   match s with
+  | Style.Style { pseudo_suffix = Some _; _ } -> []
   | Style.Style { props; rules; _ } ->
       props
       @ List.concat_map
@@ -64,32 +67,78 @@ let rec style_declarations (s : Style.t) =
   | Style.Modified (_, inner) -> style_declarations inner
   | Style.Group inner -> List.concat_map style_declarations inner
 
+(* The property key a declaration can be a slot for. An author's own variable is
+   not one: only the properties Tailwind orders utilities by are. *)
+let plain_key d =
+  match Cascade.Css.Declaration.property_key d with
+  | Cascade.Css.Declaration.Key (Custom_property _)
+  | Cascade.Css.Declaration.Key (Unknown_property _) ->
+      None
+  | key -> Some key
+
+(* A vendor-prefixed name without its prefix: [-webkit-mask-image] is
+   [mask-image]. [None] when the name carries no prefix. *)
+let unprefixed name =
+  if String.length name = 0 || name.[0] <> '-' then None
+  else
+    match String.index_from_opt name 1 '-' with
+    | Some i -> Some (String.sub name (i + 1) (String.length name - i - 1))
+    | None -> None
+
+(* The properties an example claims: the one it is named for, and the ones it
+   writes alongside.
+
+   A vendor prefix names the same slot as the plain property, so it is passed
+   over when the style writes both - [mask-none] writes [-webkit-mask-image]
+   ahead of [mask-image], and the slot is [mask-image]'s. When only the prefixed
+   form is there the family is named for a property with no plain spelling, and
+   it claims nothing rather than the next declaration along: [line-clamp-none]
+   leads with [-webkit-line-clamp] and would otherwise claim [display], which
+   belongs to the display utilities. *)
+let claimed_keys decls =
+  let names = List.map Cascade.Css.Declaration.property_name decls in
+  let rec go named alongside = function
+    | [] -> (named, List.rev alongside)
+    | d :: rest -> (
+        match plain_key d with
+        | None -> go named alongside rest
+        | Some key -> (
+            match unprefixed (Cascade.Css.Declaration.property_name d) with
+            | Some plain when List.mem plain names -> go named alongside rest
+            | Some _ -> (named, List.rev alongside)
+            | None ->
+                if named = None then go (Some key) alongside rest
+                else go named (key :: alongside) rest))
+  in
+  go None [] decls
+
 let build_property_slots () =
   let tbl = Hashtbl.create 512 in
-  let record key order =
+  let alongside = Hashtbl.create 512 in
+  let record tbl key order =
     match Hashtbl.find_opt tbl key with
     | Some existing when existing <= order -> ()
     | _ -> Hashtbl.replace tbl key order
   in
+  (* A family claims the property it is named for before any property it merely
+     writes alongside, so the two are collected apart and the named ones win.
+     [border-2] writes [border-style: var(--tw-border-style)] ahead of
+     [border-width], and border-width is still claimed, from the second pass. *)
   List.iter
     (fun (H (module M)) ->
       List.iter
         (fun example ->
           let order = (M.priority example, M.suborder example) in
-          (* The property a utility claims is the one it writes first: the one
-             it is named for. A later declaration is incidental - line-clamp
-             ends with [display: -webkit-box] but the display slot belongs to
-             the display utilities, which sort elsewhere. *)
-          match style_declarations (M.to_style Scheme.default example) with
-          | [] -> ()
-          | d :: _ -> (
-              match Cascade.Css.Declaration.property_key d with
-              (* An author's own variable is not a slot: only the properties
-                 Tailwind orders utilities by are. *)
-              | Key (Custom_property _) | Key (Unknown_property _) -> ()
-              | key -> record key order))
+          let style = M.to_style Scheme.default example in
+          let named, rest = claimed_keys (style_declarations style) in
+          Stdlib.Option.iter (fun key -> record tbl key order) named;
+          List.iter (fun key -> record alongside key order) rest)
         M.examples)
     !handlers;
+  Hashtbl.iter
+    (fun key order ->
+      if not (Hashtbl.mem tbl key) then Hashtbl.add tbl key order)
+    alongside;
   tbl
 
 let order_of_property key =

--- a/test/cli/utility.t
+++ b/test/cli/utility.t
@@ -81,3 +81,47 @@ that only [Tw.of_string] knows.
   1
   $ tw --minify --input-css line.css line.html | grep -cF '.hover\:line-t:hover:before{'
   1
+
+A declared utility takes its place among the built-in ones rather than landing
+after them, at the slot of whatever its body [@apply]s: [bar] applies a
+position, so it sorts ahead of every other class here, and [foo] applies a
+background colour, which puts it between [block] and [underline]. Tailwind
+v4.3.3 emits exactly this order for the same input.
+
+  $ cat > sort.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @utility foo { @apply bg-red-500; }
+  > @utility bar { @apply relative; }
+  > EOF
+  $ cat > sort.html <<EOF
+  > <div class="bar z-10 ml-auto box-border block foo underline"></div>
+  > EOF
+  $ tw --minify --input-css sort.css sort.html | grep -oE '\.(bar|foo|z-10|ml-auto|box-border|block|underline)\{'
+  .bar{
+  .z-10{
+  .ml-auto{
+  .box-border{
+  .block{
+  .foo{
+  .underline{
+
+A body that only declares CSS is placed the same way, by the family that writes
+the property: [pad-thing] sorts with [p-8] and [col-thing] with [text-black].
+It lands at the head of that family, where Tailwind orders it against the
+family's own members by class name.
+
+  $ cat > decl.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @utility pad-thing { padding: 1rem; }
+  > @utility col-thing { color: red; }
+  > EOF
+  $ cat > decl.html <<EOF
+  > <div class="underline pad-thing p-8 block col-thing text-black"></div>
+  > EOF
+  $ tw --minify --input-css decl.css decl.html | grep -oE '\.(pad-thing|col-thing|p-8|block|text-black|underline)\{'
+  .block{
+  .pad-thing{
+  .p-8{
+  .col-thing{
+  .text-black{
+  .underline{

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -147,6 +147,68 @@ let test_order_of_property () =
     (Some (order_of "isolate"))
     (order_of_property (Key Isolation))
 
+(* The families whose first emitted declaration is a variable rather than the
+   property they are named for. Each registered nothing at all while the slot
+   was read off that first declaration, so a project's [@utility] declaring one
+   of these sorted after the whole sheet. *)
+let test_order_of_property_behind_a_variable () =
+  let open Tw.Utility in
+  let order_of cls =
+    match base_of_class Tw.Scheme.default cls with
+    | Ok b -> order b
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let slot name key expected =
+    check
+      (option (pair int int))
+      name
+      (Some (order_of expected))
+      (order_of_property key)
+  in
+  (* Some families spread over several handlers, or write the property as a
+     companion to the one they are named for, so the slot lands on a sibling
+     rather than on the utility named here. The family is what the property has
+     to resolve to; which member of it holds the slot is not load-bearing. *)
+  let family name key expected =
+    check (option int) name
+      (Some (fst (order_of expected)))
+      (Stdlib.Option.map fst (order_of_property key))
+  in
+  (* [--spacing] is declared ahead of the property itself. *)
+  slot "padding is the padding utilities' slot" (Key Padding) "p-4";
+  slot "gap is the gap utilities' slot" (Key Gap) "gap-4";
+  (* [--tw-shadow] and friends come first. *)
+  slot "box-shadow is the shadow utilities' slot" (Key Box_shadow) "shadow-none";
+  (* [border-style: var(--tw-border-style)] is written ahead of the width. *)
+  slot "border-width is the border width utilities' slot" (Key Border_width)
+    "border-0";
+  (* [outline-style] follows a custom property in every outline utility. *)
+  family "outline-style is the outline utilities' slot" (Key Outline_style)
+    "outline-solid";
+  (* [-webkit-mask-image] is written ahead of the plain property. *)
+  family "mask-image is the mask utilities' slot, not the -webkit- alias'"
+    (Key Mask_image) "mask-none"
+
+(* [placeholder-*] writes [color] too, at a lower order than [text-*], so it
+   took the colour slot and a declared [color] sorted with ::placeholder. A
+   pseudo-element style names no slot: the property belongs to the family that
+   writes it on the element itself. *)
+let test_order_of_property_skips_pseudo_elements () =
+  let open Tw.Utility in
+  let order_of cls =
+    match base_of_class Tw.Scheme.default cls with
+    | Ok b -> order b
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check
+    (option (pair int int))
+    "colour is the text utilities' slot"
+    (Some (order_of "text-transparent"))
+    (order_of_property (Key Color));
+  Alcotest.(check bool)
+    "colour is not the ::placeholder slot" false
+    (order_of_property (Key Color) = Some (order_of "placeholder-transparent"))
+
 let tests =
   [
     test_case "base_of_class valid input" `Quick test_base_of_class_valid;
@@ -156,6 +218,10 @@ let tests =
     (* test_case "css_of_string valid input" `Quick test_css_of_string_valid; *)
     (* test_case "css_of_string invalid input" `Quick test_css_of_string_invalid; *)
     test_case "order_of_property" `Quick test_order_of_property;
+    test_case "order_of_property behind a variable" `Quick
+      test_order_of_property_behind_a_variable;
+    test_case "order_of_property skips pseudo-elements" `Quick
+      test_order_of_property_skips_pseudo_elements;
     test_case "order returns correct priorities" `Quick test_order_priorities;
     test_case "order returns correct suborders" `Quick test_order_suborders;
     test_case "order is consistent" `Quick test_order_consistency;


### PR DESCRIPTION
A declared `@utility` took its sort position from the first declaration of the first rule its body expanded to. That declaration is a `--tw-*` or `--spacing` binding for most families, so padding, gap, box-shadow, border-width, outline-style and the mask utilities registered no slot at all and anything declaring them landed after the whole sheet; `color` resolved to the `::placeholder` slot. The slot now comes from the earliest position the body reaches, over both the utilities it `@apply`s and every property the expansion declares, which is what Tailwind itself orders by.

`to_css` used to take these as an untyped `(class, (priority, suborder), statements)` triple; commit ee2678b2 replaces it with `Tw.Declared`, whose `Slot` is abstract and is asked for by the utility or the property that sorts there. Measured against tailwindcss v4.3.3 over 95 declared properties, 92 now sort adjacent to their own family against 56 before; of the three left, `transform` and `outline-style` are pre-existing gaps in how tw orders those families rather than slot derivation, and a declared `border-style` lands on the border-width member of its family.