### PR TITLE
sort: drop the inner variant order nothing reads

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -416,7 +416,7 @@ let add_index triples =
          merge_key;
          not_order;
          variant_order;
-         variant_key = Sort.variant_sort_key base_class nested;
+         variant_prefix = Sort.variant_prefix base_class;
          variant_orders = Sort.variant_order_list base_class variant_order;
          base_class_key = Option.value ~default:"" base_class;
          media_key;

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2253,26 +2253,3 @@ let variant_order_of_prefix prefix =
       else if String.length prefix > 0 && prefix.[0] = '[' then 100000
       else if String.length prefix > 0 && prefix.[0] = '@' then 110000
       else 0
-
-(* [variant_order_of_media_cond cond] returns the same sort key as
-   [variant_order_of_prefix] for the corresponding CSS media condition. Used to
-   determine the cascade position of rules with nested media queries (e.g.,
-   dark:group-hover has a nested @media(hover:hover), so its effective inner
-   order is 20000, matching standalone hover). *)
-let variant_order_of_media_cond (cond : Css.Media.t) =
-  let open Css.Media in
-  match cond with
-  | Cond (Feature (Plain (Hover, Ident Hover))) -> 20000
-  | Cond (Feature (Plain (Prefers_reduced_motion, Ident No_preference))) ->
-      50000
-  | Cond (Feature (Plain (Prefers_reduced_motion, Ident Reduce))) -> 50100
-  | Cond (Feature (Plain (Prefers_contrast, Ident More))) -> 50200
-  | Cond (Feature (Plain (Prefers_contrast, Ident Less))) -> 50300
-  | Cond (Feature (Plain (Orientation, Ident Portrait))) -> 70000
-  | Cond (Feature (Plain (Orientation, Ident Landscape))) -> 70100
-  | Cond (Feature (Plain (Prefers_color_scheme, Ident Dark))) -> 90000
-  | Cond (Feature (Plain (Prefers_color_scheme, Ident Light))) -> 90000
-  | Type { prefix = None; type_ = Print; trailing = None } -> 91000
-  | Cond (Feature (Plain (Forced_colors, Ident Active))) -> 92000
-  | Cond (Feature (Plain (Inverted_colors, Ident Inverted))) -> 93100
-  | _ -> 0

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -716,9 +716,3 @@ val variant_order_of_prefix : string -> int
     string in the Tailwind v4 variant cascade. The prefix is the part before the
     last ":" in a base class name (e.g. ["hover"], ["dark:group-hover"]).
     Returns 0 for unknown prefixes. *)
-
-val variant_order_of_media_cond : Css.Media.t -> int
-(** [variant_order_of_media_cond cond] returns the same sort key as
-    {!val-variant_order_of_prefix} for the corresponding CSS media condition.
-    Used to derive the cascade position of rules whose ordering comes from a
-    nested media query rather than from the class-name prefix alone. *)

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -51,9 +51,9 @@ type indexed_rule = {
   merge_key : string option;
   not_order : int;
   variant_order : int;
-  variant_key : string * int;
-      (* Precomputed (variant prefix, effective inner order) - see
-         [variant_sort_key]. Read by [compare_variant_ordered]. *)
+  variant_prefix : string;
+      (* Precomputed variant prefix - see [variant_prefix]. Read by
+         [compare_variant_ordered]. *)
   variant_orders : (int * int) list;
       (* The rule's variant order keys sorted descending - see
          [variant_order_list]. Compared lexicographically by
@@ -853,95 +853,6 @@ let strip_group_peer_vo p =
     Modifiers.variant_order_of_prefix (String.sub p 5 (String.length p - 5))
   else Modifiers.variant_order_of_prefix p
 
-(* Find the first ':' in a string that is not inside brackets. Returns None if
-   all colons are inside bracket pairs. *)
-let index_colon_outside_brackets s =
-  let len = String.length s in
-  let rec loop i depth =
-    if i >= len then None
-    else
-      match s.[i] with
-      | '[' -> loop (i + 1) (depth + 1)
-      | ']' -> loop (i + 1) (max 0 (depth - 1))
-      | ':' when depth = 0 -> Some i
-      | _ -> loop (i + 1) depth
-  in
-  loop 0 0
-
-(* Split a string on ':' but respecting bracket nesting, so colons inside [...]
-   are not treated as separators. *)
-let split_on_colon_outside_brackets s =
-  let len = String.length s in
-  let buf = Buffer.create 16 in
-  let acc = ref [] in
-  let rec loop i depth =
-    if i >= len then (
-      let last = Buffer.contents buf in
-      if last <> "" then acc := last :: !acc;
-      List.rev !acc)
-    else
-      match s.[i] with
-      | '[' ->
-          Buffer.add_char buf '[';
-          loop (i + 1) (depth + 1)
-      | ']' ->
-          Buffer.add_char buf ']';
-          loop (i + 1) (max 0 (depth - 1))
-      | ':' when depth = 0 ->
-          acc := Buffer.contents buf :: !acc;
-          Buffer.clear buf;
-          loop (i + 1) depth
-      | c ->
-          Buffer.add_char buf c;
-          loop (i + 1) depth
-  in
-  loop 0 0
-
-(* Compute the inner variant order for a compound prefix like "hover:focus" *)
-let inner_vo prefix =
-  match index_colon_outside_brackets prefix with
-  | Some j ->
-      let outer = String.sub prefix 0 j in
-      if
-        Parse.has_prefix ~prefix:"group-" outer
-        || Parse.has_prefix ~prefix:"peer-" outer
-      then
-        let parts = split_on_colon_outside_brackets prefix in
-        List.fold_left (fun acc p -> max acc (strip_group_peer_vo p)) 0 parts
-        + 1
-      else
-        let inner = String.sub prefix (j + 1) (String.length prefix - j - 1) in
-        Modifiers.variant_order_of_prefix inner
-  | None ->
-      if Parse.has_prefix ~prefix:"group-" prefix then
-        Modifiers.variant_order_of_prefix
-          (String.sub prefix 6 (String.length prefix - 6))
-      else if Parse.has_prefix ~prefix:"peer-" prefix then
-        Modifiers.variant_order_of_prefix
-          (String.sub prefix 5 (String.length prefix - 5))
-      else 0
-
-(* Effective inner variant order: prefer prefix-derived, fall back to nested
-   media *)
-let effective_ivo_of nested prefix =
-  let ivo = inner_vo prefix in
-  if ivo > 0 then ivo
-  else
-    match nested with
-    | [ n ] -> (
-        match Css.as_media n with
-        | Some (cond, _) -> Modifiers.variant_order_of_media_cond cond
-        | None -> 0)
-    | _ -> 0
-
-(* The variant prefix and effective inner order are pure functions of a rule's
-   base class and nested statements, but [compare_variant_ordered] needs them on
-   every comparison. Precompute them once per rule (see [add_index]) so the hot
-   sort comparator only reads the result. *)
-let variant_sort_key base_class nested =
-  let prefix = variant_prefix base_class in
-  (prefix, effective_ivo_of nested prefix)
-
 (* One modifier token's sort key: its variant order, paired with the inner
    pseudo order for group-/peer- wrappers so group-focus and group-has (both
    order 500) keep their focus-before-has order. Non-wrapper tokens use 0. *)
@@ -1074,8 +985,8 @@ let compare_variant_ordered r1 r2 =
       in
       if list_cmp <> 0 then list_cmp
       else
-        let p1_prefix, _ = r1.variant_key in
-        let p2_prefix, _ = r2.variant_key in
+        let p1_prefix = r1.variant_prefix in
+        let p2_prefix = r2.variant_prefix in
         (* The descending variant-order lists tie (same variant multiset). The
            remaining keys order within that group: a nested breakpoint or hover,
            the media condition itself (sm before md), then the prefix and the

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -1,8 +1,8 @@
 (** CSS rule cascade sort order.
 
-    Provides the [indexed_rule] type and [compare_indexed_rules], the comparison
-    function that produces Tailwind v4 cascade order when used with [List.sort].
-*)
+    Provides the [indexed_rule] type and {!val-compare_indexed_rules}, the
+    comparison function that produces Tailwind v4 cascade order when used with
+    [List.sort]. *)
 
 open Cascade
 
@@ -43,18 +43,17 @@ type indexed_rule = {
   not_order : int;
   variant_order : int;
       (** Non-zero for modifier-prefixed rules; they sort after base rules. *)
-  variant_key : string * int;
-      (** Precomputed [(variant prefix, effective inner order)], built with
-          {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
-          per comparison. *)
+  variant_prefix : string;
+      (** Precomputed variant prefix, built with {!val-variant_prefix}, so
+          {!val-compare_indexed_rules} does not recompute it per comparison. *)
   variant_orders : (int * int) list;
       (** The rule's variant order keys sorted descending, built with
           {!variant_order_list}. Compared lexicographically by
-          [compare_indexed_rules] so a stacked variant sorts into the group of
-          its highest-order component. *)
+          {!val-compare_indexed_rules} so a stacked variant sorts into the group
+          of its highest-order component. *)
   base_class_key : string;
       (** The rule's base class ([""] when it has none), used by
-          [compare_indexed_rules] as the lexicographic sort key. *)
+          {!val-compare_indexed_rules} as the lexicographic sort key. *)
   media_key : Css.Media.key option;
       (** Precomputed sort key of the rule's own breakpoint condition: the
           [`Media] case of {!field-rule_type}, or the [`Container] case
@@ -68,10 +67,10 @@ type indexed_rule = {
 val classify_selector : Css.Selector.t -> selector_kind
 (** [classify_selector sel] classifies a selector for ordering purposes. *)
 
-val variant_sort_key : string option -> Css.statement list -> string * int
-(** [variant_sort_key base_class nested] is the
-    [(variant prefix, effective inner variant order)] pair stored in
-    {!field-variant_key}. *)
+val variant_prefix : string option -> string
+(** [variant_prefix base_class] is the variant prefix stored in
+    {!field-variant_prefix}: [base_class]'s modifier segments rejoined with
+    [":"], and [""] when it has none. *)
 
 val variant_order_list : string option -> int -> (int * int) list
 (** [variant_order_list base_class variant_order] is the descending list of


### PR DESCRIPTION
`Sort.indexed_rule` carried `variant_key : string * int`, but both readers in `compare_variant_ordered` destructure the pair and discard the int. The four functions that computed it, and the `Modifiers.variant_order_of_media_cond` table they called, therefore ran once per rule and fed nothing.

The field becomes the prefix it is actually used as. Generated sheets are byte-identical before and after on a variant-heavy class set, which is what makes the reachability claim checkable. Stacked on #271.