### PR TITLE
colors: fold bracket angles and hues through cascade

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -427,9 +427,6 @@ module Handler = struct
     | Bottom_left -> "to bottom left"
 
   open Style
-
-  let pp_float_n = Pp.float_n
-
   open Css
 
   let name = "backgrounds"
@@ -769,7 +766,7 @@ module Handler = struct
       | Some rad ->
           let deg = rad *. 180.0 /. Float.pi in
           (* Round to 4 decimal places to match Lightning CSS *)
-          pp_float_n 4 deg ^ "deg"
+          Cascade.Pp.string_of_float ~max_decimals:4 deg ^ "deg"
       | None -> String.map (fun c -> if c = '_' then ' ' else c) inner
     else String.map (fun c -> if c = '_' then ' ' else c) inner
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2501,34 +2501,20 @@ module Handler = struct
             let full_hex = hex ^ to_hex_byte a_int in
             Some (Css.hex ("#" ^ shorten_hex_str full_hex))
         | None -> Some (Css.hex ("#" ^ shorten_hex_str hex)))
-    | Hsl { h; s; l; a } ->
-        let h_deg =
-          match h with Unitless f -> f | Angle (Deg f) -> f | _ -> 0.
-        in
-        let s_pct = match s with Pct f -> f /. 100. | _ -> 0. in
-        let l_pct = match l with Pct f -> f /. 100. | _ -> 0. in
-        let c = (1. -. abs_float ((2. *. l_pct) -. 1.)) *. s_pct in
-        let h' = h_deg /. 60. in
-        let x = c *. (1. -. abs_float (Float.rem h' 2. -. 1.)) in
-        let r1, g1, b1 =
-          if h' < 1. then (c, x, 0.)
-          else if h' < 2. then (x, c, 0.)
-          else if h' < 3. then (0., c, x)
-          else if h' < 4. then (0., x, c)
-          else if h' < 5. then (x, 0., c)
-          else (c, 0., x)
-        in
-        let m = l_pct -. (c /. 2.) in
-        let r = Float.to_int (Float.round ((r1 +. m) *. 255.)) in
-        let g = Float.to_int (Float.round ((g1 +. m) *. 255.)) in
-        let b = Float.to_int (Float.round ((b1 +. m) *. 255.)) in
-        let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in
-        let hex =
-          match alpha_to_int a with
-          | Some a_int -> hex ^ to_hex_byte a_int
-          | None -> hex
-        in
-        Some (Css.hex ("#" ^ shorten_hex_str hex))
+    | Hsl _ -> (
+        (* Fold through cascade's own colour path: it knows every hue unit and
+           reads a bare number for saturation and lightness as the percentage of
+           the same value. It leaves a colour whose channels are not all static
+           alone, and that one has no hex form. *)
+        match
+          Cascade.Values.nonkeyword_color
+            (Cascade.Values.normalize_color ~in_feature_query:false c)
+        with
+        | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
+            let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in
+            let hex = if a = 255 then hex else hex ^ to_hex_byte a in
+            Some (Css.hex ("#" ^ shorten_hex_str hex))
+        | _ -> None)
     | _ -> None
 
   (** Resolve a typed [Css.color] to its emission form. Hex colors are

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -67,33 +67,3 @@ let float f =
   let s = string_of_float f in
   if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
   else s
-
-(** Format float with n decimal places *)
-let float_n decimals f =
-  let multiplier = Float.pow 10.0 (float_of_int decimals) in
-  let rounded = Float.round (f *. multiplier) /. multiplier in
-  (* Check if it's a whole number *)
-  if Float.is_integer rounded then int (int_of_float rounded)
-  else
-    (* Format without Printf *)
-    let whole = int_of_float (Float.floor rounded) in
-    let frac_value = (rounded -. Float.floor rounded) *. multiplier in
-    let frac_int = int_of_float (Float.round frac_value) in
-    if frac_int = 0 then int whole
-    else
-      (* Convert fraction to string with proper padding *)
-      let frac_str = string_of_int frac_int in
-      (* Pad with leading zeros if needed *)
-      let padded_frac =
-        let len = String.length frac_str in
-        if len < decimals then String.make (decimals - len) '0' ^ frac_str
-        else frac_str
-      in
-      let rec remove_trailing_zeros s =
-        let len = String.length s in
-        if len > 0 && s.[len - 1] = '0' then
-          remove_trailing_zeros (String.sub s 0 (len - 1))
-        else s
-      in
-      let trimmed_frac = remove_trailing_zeros padded_frac in
-      str [ int whole; "."; trimmed_frac ]

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -65,7 +65,3 @@ val hex_byte : int -> string
 
 val float : float -> string
 (** [float f] formats a float without trailing dots. *)
-
-val float_n : int -> float -> string
-(** [float_n decimals f] formats a float with n decimal places. Whole numbers
-    are formatted without decimal point. Trailing zeros are removed. *)

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -159,6 +159,21 @@ let test_bracket_image_literal () =
     (Astring.String.is_infix ~affix:"background-image: var(--x)"
        (css "bg-[image:var(--x)]"))
 
+(* An arbitrary gradient angle in radians is converted to degrees. A negative
+   angle used to come out as its floor plus a positive fraction, so
+   bg-linear-[-0.5rad] rendered -29.3521deg instead of -28.6479deg. *)
+let test_bracket_gradient_radians () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css_of cls))
+  in
+  has "bg-linear-[-0.5rad]" "--tw-gradient-position: -28.6479deg";
+  has "bg-linear-[1.3rad]" "--tw-gradient-position: 74.4845deg"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let colors = [ red; blue; green; yellow; purple; pink ] in
@@ -284,6 +299,8 @@ let tests =
     test_case "gradient stop-position @property family" `Quick
       test_gradient_stop_position_properties;
     test_case "gradient direction" `Quick test_gradient_direction;
+    test_case "bracket gradient angle in radians" `Quick
+      test_bracket_gradient_radians;
     test_case "bracket image literal" `Quick test_bracket_image_literal;
     test_case "bracket length keywords" `Quick test_bracket_length_keywords;
     test_case "bg-position bracket keyword+length" `Quick

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -327,6 +327,46 @@ let test_bracket_css_colors () =
   (* a CSS keyword still beats the palette entry of the same name *)
   has "bg-[red]" "background-color:red"
 
+(* An hsl() hue takes any angle unit. Folding one to a hex colour used to keep
+   only bare numbers and [deg] and read every other unit as 0, so a half turn
+   painted red instead of cyan. *)
+let test_hsl_hue_units () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "bg-[hsl(180deg_100%_50%)]" "background-color: #00ffff";
+  has "bg-[hsl(0.5turn_100%_50%)]" "background-color: #00ffff";
+  has "bg-[hsl(200grad_100%_50%)]" "background-color: #00ffff";
+  has "bg-[hsl(3.14159rad_100%_50%)]" "background-color: #00ffff"
+
+(* hsl() saturation and lightness also accept a bare number, which is the same
+   value as the percentage; both used to be read as 0, which painted the colour
+   black. A channel that is not static cannot fold at all. *)
+let test_hsl_non_percentage_channels () =
+  let fold (c : Css.color) =
+    match Tw.Color.css_color_to_hex c with
+    | Some folded -> Cascade.Pp.to_string Css.pp_color folded
+    | None -> "unfolded"
+  in
+  Alcotest.(check string)
+    "a number saturation and lightness are percentages" "#00ffff"
+    (fold (Hsl { h = Unitless 180.; s = Num 1.0; l = Num 0.5; a = None }));
+  Alcotest.(check string)
+    "a var() saturation does not fold" "unfolded"
+    (fold
+       (Hsl
+          {
+            h = Unitless 180.;
+            s = Var (Cascade.Values.var_ref "x");
+            l = Pct 50.;
+            a = None;
+          }))
+
 let test_invalid_shade () =
   Alcotest.check_raises "bg ~shade:250 gray raises at construction"
     (Invalid_argument
@@ -421,6 +461,8 @@ let tests =
     ("Border color var", `Quick, test_border_color_var);
     ("Border side color opacity", `Quick, test_border_side_color_opacity);
     ("Bracket CSS colors", `Quick, test_bracket_css_colors);
+    ("hsl hue units", `Quick, test_hsl_hue_units);
+    ("hsl non-percentage channels", `Quick, test_hsl_non_percentage_channels);
     ("Alpha from a var", `Quick, test_alpha_from_a_var);
     ("Invalid shades", `Quick, test_invalid_shade);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);


### PR DESCRIPTION
Two hand-rolled folds diverged from cascade's correct ones: Pp.float_n rendered a negative decimal as floor+fraction, so bg-linear-[-0.5rad] emitted -29.3521deg for -28.6479deg, and css_color_to_hex dropped every hue unit but deg, so bg-[hsl(0.5turn_100%_50%)] folded to red instead of cyan. Both now route through cascade (Pp.string_of_float, Values.normalize_color + nonkeyword_color); tw's float_n is deleted. A Var saturation used to fold to black and now refuses to fold.