### PR TITLE
parse: read every arbitrary length with the shared CSS parser

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -36,6 +36,15 @@ module Handler = struct
     | Css_color of Css.color
     | None
 
+  (* One layer of an arbitrary shadow value, read from its bracket. *)
+  type arbitrary_shadow = {
+    h_offset : Css.length;
+    v_offset : Css.length;
+    blur : Css.length option;
+    spread : Css.length option;
+    color : arbitrary;
+  }
+
   type t =
     (* Shadows — shape utilities *)
     | Shadow_none
@@ -469,35 +478,9 @@ module Handler = struct
   let shadow_inner = shadow_shape_style Inner
 
   (* Parse arbitrary shadow value like "12px_12px_#0088cc" *)
-  let parse_arbitrary_shadow (s : string) :
-      (Css.length * Css.length * Css.length option * arbitrary) option =
+  let parse_arbitrary_shadow (s : string) : arbitrary_shadow option =
     let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
     let parts = String.split_on_char ' ' normalized in
-    let parse_length str : Css.length option =
-      let len = String.length str in
-      if len >= 1 then (
-        let num_end = ref 0 in
-        while
-          !num_end < len
-          && (str.[!num_end] = '-'
-             || str.[!num_end] = '.'
-             || (str.[!num_end] >= '0' && str.[!num_end] <= '9'))
-        do
-          incr num_end
-        done;
-        let num_str = String.sub str 0 !num_end in
-        let unit_str = String.sub str !num_end (len - !num_end) in
-        match float_of_string_opt num_str with
-        | Some n -> (
-            match unit_str with
-            | "px" -> Some (Px n)
-            | "rem" -> Some (Rem n)
-            | "em" -> Some (Em n)
-            | "" when n = 0.0 -> Some Zero
-            | _ -> None)
-        | None -> None)
-      else None
-    in
     let rec find_color_and_lengths acc (parts : string list) :
         string list * arbitrary =
       match parts with
@@ -515,12 +498,26 @@ module Handler = struct
       | x :: rest -> find_color_and_lengths (x :: acc) rest
     in
     let length_strs, color = find_color_and_lengths [] parts in
-    let lengths = List.filter_map parse_length length_strs in
-    match lengths with
-    | [ h; v ] -> Some (h, v, None, color)
-    | [ h; v; blur ] -> Some (h, v, Some blur, color)
-    | [ h; v; blur; _spread ] -> Some (h, v, Some blur, color)
-    | _ -> None
+    let lengths = List.filter_map Parse.arbitrary_length length_strs in
+    (* A token that is not a length makes the value not a shadow. Dropping it
+       instead would slide the surviving lengths into the wrong slots. *)
+    if List.compare_lengths lengths length_strs <> 0 then None
+    else
+      match lengths with
+      | [ h_offset; v_offset ] ->
+          Some { h_offset; v_offset; blur = None; spread = None; color }
+      | [ h_offset; v_offset; blur ] ->
+          Some { h_offset; v_offset; blur = Some blur; spread = None; color }
+      | [ h_offset; v_offset; blur; spread ] ->
+          Some
+            {
+              h_offset;
+              v_offset;
+              blur = Some blur;
+              spread = Some spread;
+              color;
+            }
+      | _ -> None
 
   (** Wrap a shadow's color with [var(--tw-shadow-color, <fallback>)]. Converts
       CSS color functions to hex for Tailwind parity. *)
@@ -557,20 +554,20 @@ module Handler = struct
 
   let shadow_arbitrary (arb : string) =
     let normalized = String.map (fun c -> if c = '_' then ' ' else c) arb in
-    (* The reading below takes one shadow and no spread, so anything with a
-       comma - a layer list, or a colour function carrying one - goes to the
-       value parser instead. *)
+    (* The reading below takes one shadow, so anything with a comma - a layer
+       list, or a colour function carrying one - goes to the value parser
+       instead. *)
     match
       if String.contains arb ',' then Option.None
       else parse_arbitrary_shadow arb
     with
-    | Some (h_offset, v_offset, blur, Var v) ->
+    | Some { h_offset; v_offset; blur; spread; color = Var v } ->
         (* A trailing var() is the colour, not the blur (Tailwind). *)
         let color_ref =
           Var.reference_with_fallback shadow_color_var (make_full_color_var v)
         in
         let shadow_value =
-          Css.shadow ~h_offset ~v_offset ?blur ~color:(Var color_ref) ()
+          Css.shadow ~h_offset ~v_offset ?blur ?spread ~color:(Var color_ref) ()
         in
         let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
         style ~property_rules:shadow_property_rules
@@ -588,7 +585,7 @@ module Handler = struct
 
   let shadow_arbitrary_opacity (arb : string) opacity =
     match parse_arbitrary_shadow arb with
-    | Some (h_offset, v_offset, blur, color) -> (
+    | Some { h_offset; v_offset; blur; spread; color } -> (
         let percent = Color.opacity_to_percent opacity in
         let alpha = percent /. 100.0 in
         let alpha_d = shadow_alpha_decl percent in
@@ -604,7 +601,8 @@ module Handler = struct
           Var.reference_with_fallback shadow_color_var base_fallback
         in
         let base_shadow =
-          Css.shadow ~h_offset ~v_offset ?blur ~color:(Var base_color_ref) ()
+          Css.shadow ~h_offset ~v_offset ?blur ?spread
+            ~color:(Var base_color_ref) ()
         in
         let d_shadow, v_shadow = Var.binding shadow_var base_shadow in
         let supports_rules =
@@ -617,7 +615,7 @@ module Handler = struct
                     Var.reference_with_fallback shadow_color_var relative_color
                   in
                   let enhanced_shadow =
-                    Css.shadow ~h_offset ~v_offset ?blur
+                    Css.shadow ~h_offset ~v_offset ?blur ?spread
                       ~color:(Var enhanced_ref) ()
                   in
                   let d_enhanced, _ = Var.binding shadow_var enhanced_shadow in
@@ -639,8 +637,8 @@ module Handler = struct
                 Var.reference_with_fallback shadow_color_var color_mix_fallback
               in
               let enhanced_shadow =
-                Css.shadow ~h_offset ~v_offset ?blur ~color:(Var enhanced_ref)
-                  ()
+                Css.shadow ~h_offset ~v_offset ?blur ?spread
+                  ~color:(Var enhanced_ref) ()
               in
               let d_enhanced, _ = Var.binding shadow_var enhanced_shadow in
               let supports_block = color_mix_supports [ d_enhanced ] in
@@ -1055,7 +1053,7 @@ module Handler = struct
     | Stdlib.Option.Some parsed_parts ->
         let shadow_values =
           List.map
-            (fun (h_offset, v_offset, blur, color) ->
+            (fun { h_offset; v_offset; blur; spread; color } ->
               let fallback_color : Css.color =
                 match color with
                 | Hex c -> Css.hex (shorten_hex c)
@@ -1070,7 +1068,7 @@ module Handler = struct
                 Var.reference_with_fallback inset_shadow_color_var
                   fallback_color
               in
-              Css.shadow ~inset:true ~h_offset ~v_offset ?blur
+              Css.shadow ~inset:true ~h_offset ~v_offset ?blur ?spread
                 ~color:(Var color_ref) ())
             parsed_parts
         in
@@ -1121,7 +1119,7 @@ module Handler = struct
            fallbacks *)
         let needs_supports =
           List.exists
-            (fun (_, _, _, color) ->
+            (fun { color; _ } ->
               match color with Var _ | None -> true | _ -> false)
             parsed_parts
         in
@@ -1129,7 +1127,7 @@ module Handler = struct
            fallbacks (shortened hex); otherwise use oklab *)
         let base_shadow_values =
           List.map
-            (fun (h_offset, v_offset, blur, color) ->
+            (fun { h_offset; v_offset; blur; spread; color } ->
               let base_fallback : Css.color =
                 match color with
                 | Hex c ->
@@ -1145,7 +1143,7 @@ module Handler = struct
               let color_ref =
                 Var.reference_with_fallback inset_shadow_color_var base_fallback
               in
-              Css.shadow ~inset:true ~h_offset ~v_offset ?blur
+              Css.shadow ~inset:true ~h_offset ~v_offset ?blur ?spread
                 ~color:(Var color_ref) ())
             parsed_parts
         in
@@ -1163,7 +1161,7 @@ module Handler = struct
             (* Build enhanced shadow values with oklab *)
             let enhanced_shadow_values =
               List.map
-                (fun (h_offset, v_offset, blur, color) ->
+                (fun { h_offset; v_offset; blur; spread; color } ->
                   let enhanced_ref =
                     match color with
                     | Hex c ->
@@ -1192,7 +1190,7 @@ module Handler = struct
                         Var.reference_with_fallback inset_shadow_color_var
                           color_mix_fallback
                   in
-                  Css.shadow ~inset:true ~h_offset ~v_offset ?blur
+                  Css.shadow ~inset:true ~h_offset ~v_offset ?blur ?spread
                     ~color:(Css.Var enhanced_ref) ())
                 parsed_parts
             in
@@ -1206,7 +1204,7 @@ module Handler = struct
             in
             let has_real_var =
               List.exists
-                (fun (_, _, _, color) ->
+                (fun { color; _ } ->
                   match color with Var _ -> true | _ -> false)
                 parsed_parts
             in

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -217,6 +217,8 @@ let expand_spacing_fn s =
 let decode_arbitrary_value s =
   s |> decode_underscores |> expand_spacing_fn |> normalize_css_math_operators
 
+let arbitrary_length s = Cascade.Css.parse_length (decode_arbitrary_value s)
+
 (* A CSS identifier, which is what a custom-ident or a property name written in
    an arbitrary value has to be. The docs pages carry [<value>] placeholders
    that are not CSS, and passing one through emits an invalid declaration. *)

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -68,6 +68,12 @@ val normalize_css_math_operators : string -> string
     (calc/min/max/...) require around binary [+] and [-], e.g.
     [calc(var(--a)-var(--b))] becomes [calc(var(--a) - var(--b))]. *)
 
+val arbitrary_length : string -> Cascade.Css.length option
+(** [arbitrary_length s] reads the inside of an arbitrary value as a CSS length.
+    [s] goes through {!decode_arbitrary_value} first, so underscores, [calc()]
+    and [--spacing()] all read; the whole CSS length grammar is accepted, not a
+    hand-picked subset of units. Returns [None] when [s] is not a length. *)
+
 val is_ident : string -> bool
 (** [is_ident s] is [true] when [s] is a CSS identifier, as a custom-ident or a
     property name written in an arbitrary value has to be. *)

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -24,7 +24,8 @@ module Handler = struct
 
   type scroll_value =
     | Spacing of float (* scroll-m-4, scroll-m-0.5 *)
-    | Arbitrary of Css.length (* scroll-m-[4px] *)
+    | Arbitrary of string * Css.length
+      (* scroll-m-[4px], raw kept for round-trip *)
     | Arbitrary_var of string (* scroll-m-[var(--value)] *)
 
   type t = {
@@ -49,37 +50,18 @@ module Handler = struct
       let mult = if negative then -.n else n in
       Theme.spacing_calc_float ?theme mult
 
-  let try_parse_length inner =
-    let unit_table : (string * int * (float -> Css.length)) list =
-      [
-        ("rem", 3, fun f -> Css.Rem f);
-        ("px", 2, fun f -> Css.Px f);
-        ("em", 2, fun f -> Css.Em f);
-        ("%", 1, fun f -> Css.Pct f);
-      ]
-    in
-    let rec try_units = function
-      | [] -> None
-      | (suffix, suffix_len, mk) :: rest ->
-          if String.ends_with ~suffix inner then
-            let n = String.sub inner 0 (String.length inner - suffix_len) in
-            match float_of_string_opt n with
-            | Some f -> Some (`Length (mk f : Css.length))
-            | None -> None
-          else try_units rest
-    in
-    try_units unit_table
-
-  let parse_arbitrary s : [ `Length of Css.length | `Var of string ] option =
-    (* Parse [4px] or [1rem] or [var(--value)] etc. *)
+  let parse_arbitrary s : scroll_value option =
+    (* Parse [4px] or [1rem] or [var(--value)] etc. Only a var() reference is a
+       variable name: anything else that is not a length is not a utility, and
+       reading it as one emitted [scroll-margin: var(--2vh)]. *)
     let len = String.length s in
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
-      if Parse.is_var inner then Some (`Var inner)
+      if Parse.is_var inner then Some (Arbitrary_var inner)
       else
-        match try_parse_length inner with
-        | Some _ as result -> result
-        | None -> Some (`Var inner)
+        Option.map
+          (fun l -> Arbitrary (inner, l))
+          (Parse.arbitrary_length inner)
     else None
 
   let scroll_prop kind axis len =
@@ -115,7 +97,7 @@ module Handler = struct
     | Spacing n ->
         let decl, len = spacing_to_decl_len ~negative n in
         style [ decl; scroll_prop kind axis len ]
-    | Arbitrary len ->
+    | Arbitrary (_, len) ->
         let len : Css.length =
           if negative then
             Css.Calc (Css.Calc.mul (Css.Calc.length len) (Css.Calc.float (-1.)))
@@ -159,20 +141,6 @@ module Handler = struct
     in
     kind_offset + neg_offset + axis_offset + value_order
 
-  let pp_float n =
-    (* Format float without trailing dot: 4. -> 4, 4.5 -> 4.5 *)
-    let s = string_of_float n in
-    if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
-    else s
-
-  let pp_length_suffix (len : Css.length) =
-    match len with
-    | Css.Px n -> "[" ^ pp_float n ^ "px]"
-    | Css.Rem n -> "[" ^ pp_float n ^ "rem]"
-    | Css.Em n -> "[" ^ pp_float n ^ "em]"
-    | Css.Pct n -> "[" ^ pp_float n ^ "%]"
-    | _ -> "[<length>]"
-
   let axis_suffix = function
     | All -> ""
     | X -> "x"
@@ -195,7 +163,7 @@ module Handler = struct
     let value_suffix =
       match value with
       | Spacing n -> Spacing.pp_spacing_suffix (`Rem (Float.abs n *. 0.25))
-      | Arbitrary len -> pp_length_suffix len
+      | Arbitrary (raw, _) -> "[" ^ raw ^ "]"
       | Arbitrary_var s -> "[" ^ s ^ "]"
     in
     neg_prefix ^ kind_prefix ^ axis_str ^ "-" ^ value_suffix
@@ -244,10 +212,7 @@ module Handler = struct
             | Error _ -> (
                 (* Try as arbitrary value *)
                 match parse_arbitrary value with
-                | Some (`Length len) ->
-                    Ok { kind; negative; axis; value = Arbitrary len }
-                | Some (`Var var_str) ->
-                    Ok { kind; negative; axis; value = Arbitrary_var var_str }
+                | Some value -> Ok { kind; negative; axis; value }
                 | None -> Error (`Msg "Not a scroll utility")))
         | _ -> Error (`Msg "Not a scroll utility"))
     (* Handle block-start/end with longer axis names: scroll-mbs-4 *)
@@ -279,10 +244,7 @@ module Handler = struct
             | Ok n -> Ok { kind; negative; axis; value = Spacing n }
             | Error _ -> (
                 match parse_arbitrary value3 with
-                | Some (`Length len) ->
-                    Ok { kind; negative; axis; value = Arbitrary len }
-                | Some (`Var var_str) ->
-                    Ok { kind; negative; axis; value = Arbitrary_var var_str }
+                | Some value -> Ok { kind; negative; axis; value }
                 | None -> Error (`Msg "Not a scroll utility")))
         | _ -> Error (`Msg "Not a scroll utility"))
     | _ -> Error (`Msg "Not a scroll utility")

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -85,31 +85,6 @@ module Handler = struct
       (length * length * length option * arb_color) option =
     let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
     let parts = String.split_on_char ' ' normalized in
-    let parse_length str : length option =
-      let len = String.length str in
-      if len >= 1 then (
-        let num_end = ref 0 in
-        while
-          !num_end < len
-          && (str.[!num_end] = '-'
-             || str.[!num_end] = '.'
-             || (str.[!num_end] >= '0' && str.[!num_end] <= '9'))
-        do
-          incr num_end
-        done;
-        let num_str = String.sub str 0 !num_end in
-        let unit_str = String.sub str !num_end (len - !num_end) in
-        match float_of_string_opt num_str with
-        | Some n -> (
-            match unit_str with
-            | "px" -> Some (Px n)
-            | "rem" -> Some (Rem n)
-            | "em" -> Some (Em n)
-            | "" when n = 0.0 -> Some Zero
-            | _ -> Stdlib.Option.None)
-        | Stdlib.Option.None -> Stdlib.Option.None)
-      else Stdlib.Option.None
-    in
     let rec find_color_and_lengths acc (parts : string list) :
         string list * arb_color =
       match parts with
@@ -121,11 +96,16 @@ module Handler = struct
       | x :: rest -> find_color_and_lengths (x :: acc) rest
     in
     let length_strs, color = find_color_and_lengths [] parts in
-    let lengths = List.filter_map parse_length length_strs in
-    match lengths with
-    | [ h; v ] -> Some (h, v, Stdlib.Option.None, color)
-    | [ h; v; blur ] -> Some (h, v, Some blur, color)
-    | _ -> Stdlib.Option.None
+    let lengths = List.filter_map Parse.arbitrary_length length_strs in
+    (* A token that is not a length makes the value not a shadow. Dropping it
+       instead would slide the surviving lengths into the wrong slots. CSS
+       text-shadow has no spread, so a fourth length is not one either. *)
+    if List.compare_lengths lengths length_strs <> 0 then Stdlib.Option.None
+    else
+      match lengths with
+      | [ h; v ] -> Some (h, v, Stdlib.Option.None, color)
+      | [ h; v; blur ] -> Some (h, v, Some blur, color)
+      | _ -> Stdlib.Option.None
 
   (* ============ Shape definitions ============ *)
 

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -443,27 +443,12 @@ module Typography_early = struct
     | "xxx-large" -> Stdlib.Option.Some Css.Xxx_large
     | _ -> Stdlib.Option.None
 
-  (** Try to parse a string as a CSS length value. *)
+  (** A bracket font-size is any CSS length, but it has to carry a unit:
+      Tailwind reads the unitless zero of [text-[0]] as a colour, not a size. *)
   let try_parse_length_value s =
-    let unit_table : (string * int * (float -> Css.length)) list =
-      [
-        ("rem", 3, fun f -> Css.Rem f);
-        ("px", 2, fun f -> Css.Px f);
-        ("em", 2, fun f -> Css.Em f);
-        ("%", 1, fun f -> Css.Pct f);
-      ]
-    in
-    let rec try_units = function
-      | [] -> Stdlib.Option.None
-      | (suffix, suffix_len, mk) :: rest ->
-          if String.ends_with ~suffix s then
-            let n = String.sub s 0 (String.length s - suffix_len) in
-            match float_of_string_opt n with
-            | Stdlib.Option.Some f -> Stdlib.Option.Some (mk f)
-            | Stdlib.Option.None -> try_units rest
-          else try_units rest
-    in
-    try_units unit_table
+    match Parse.arbitrary_length s with
+    | Stdlib.Option.Some Css.Zero -> Stdlib.Option.None
+    | len -> len
 
   (** Split a type prefix like "absolute-size:var(--my-size)" into (prefix,
       value). Finds first ':' outside parens/brackets. *)
@@ -487,11 +472,11 @@ module Typography_early = struct
 
   (** Does [inner] look like something we can emit as a font-size? Accepts typed
       prefix (length/percentage/absolute-size/relative-size), font-size keyword
-      (medium, xxx-large, larger, ...), length with unit (16px, 1rem, 1.5em,
-      100%), clamp(...), or var(...). Rejects bare identifiers that aren't
-      recognised keywords -- e.g. a bare "1A202C" is not a valid font-size: a
-      length must carry a unit and a hex color must start with "#" (CSS Color
-      §5.4.6). *)
+      (medium, xxx-large, larger, ...), any CSS length carrying a unit (16px,
+      1rem, 1.5em, 3ch, 100%, clamp(...), calc(...)), or var(...). Rejects bare
+      identifiers that aren't recognised keywords -- e.g. a bare "1A202C" is not
+      a valid font-size: a length must carry a unit and a hex color must start
+      with "#" (CSS Color §5.4.6). *)
   let parse_spacing_call s =
     let prefix = "--spacing(" in
     let pl = String.length prefix and n = String.length s in
@@ -508,16 +493,10 @@ module Typography_early = struct
     | _ -> (
         match font_size_keyword inner with
         | Some _ -> true
-        | Stdlib.Option.None -> (
-            match try_parse_length_value inner with
-            | Some _ -> true
-            | Stdlib.Option.None ->
-                let len = String.length inner in
-                len > 6
-                && String.sub inner 0 6 = "clamp("
-                && inner.[len - 1] = ')'
-                || Parse.is_var inner
-                || parse_spacing_call inner <> Stdlib.Option.None))
+        | Stdlib.Option.None ->
+            try_parse_length_value inner <> Stdlib.Option.None
+            || Parse.is_var inner
+            || parse_spacing_call inner <> Stdlib.Option.None)
 
   (** Check if bracket content looks like a color (should go to color handler).
   *)
@@ -1222,17 +1201,14 @@ module Typography_early = struct
             | Stdlib.Option.None -> (
                 match try_parse_length_value inner with
                 | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
-                | Stdlib.Option.None -> (
-                    match Css.parse_length inner with
-                    | Stdlib.Option.Some fs_len -> [ font_size fs_len ]
-                    | Stdlib.Option.None ->
-                        if Parse.is_var inner then
-                          let bare = Parse.extract_var_name inner in
-                          [ font_size (Css.Var (Var.bracket bare)) ]
-                        else
-                          invalid_arg
-                            ("bracket_font_size_decls: not a valid font-size \
-                              value: " ^ inner)))))
+                | Stdlib.Option.None ->
+                    if Parse.is_var inner then
+                      let bare = Parse.extract_var_name inner in
+                      [ font_size (Css.Var (Var.bracket bare)) ]
+                    else
+                      invalid_arg
+                        ("bracket_font_size_decls: not a valid font-size \
+                          value: " ^ inner))))
 
   (** Generate font-size-only style for bracket value. *)
   let bracket_font_size_style raw = style (bracket_font_size_decls raw)
@@ -1413,32 +1389,6 @@ end
 module Typography_late = struct
   open Style
   open Css
-
-  let parse_length_value str : Css.length option =
-    let len = String.length str in
-    if len = 0 then None
-    else
-      let num_end = ref 0 in
-      while
-        !num_end < len
-        &&
-        let c = str.[!num_end] in
-        (c >= '0' && c <= '9') || c = '.' || c = '-'
-      do
-        incr num_end
-      done;
-      let num_str = String.sub str 0 !num_end in
-      let unit_str = String.sub str !num_end (len - !num_end) in
-      match float_of_string_opt num_str with
-      | Some n -> (
-          match unit_str with
-          | "px" -> Some (Px n)
-          | "rem" -> Some (Rem n)
-          | "em" -> Some (Em n)
-          | "%" -> Some (Pct n)
-          | "" when n = 0.0 -> Some Zero
-          | _ -> None)
-      | None -> None
 
   (* A bare number is not a CSS length, but Tailwind admits [decoration-[2]] and
      emits it as a thickness, so it reads as px. *)
@@ -1897,11 +1847,11 @@ module Typography_late = struct
     | [ ""; "indent"; "px" ] -> Ok Indent_neg_px
     | [ "indent"; n ] when Parse.is_bracket_value n ->
         let inner = Parse.bracket_inner n in
-        if parse_length_value inner = None then err_not_utility
+        if Parse.arbitrary_length inner = None then err_not_utility
         else Ok (Indent_arbitrary inner)
     | [ ""; "indent"; n ] when Parse.is_bracket_value n ->
         let inner = Parse.bracket_inner n in
-        if parse_length_value inner = None then err_not_utility
+        if Parse.arbitrary_length inner = None then err_not_utility
         else Ok (Indent_neg_arbitrary inner)
     | [ "indent"; n ] -> (
         match Parse.spacing_value ~name:"indent" n with
@@ -2639,17 +2589,14 @@ module Typography_late = struct
     style [ spacing_decl; text_indent_length length ]
 
   let indent_arbitrary s =
-    match parse_length_value s with
+    match Parse.arbitrary_length s with
     | Some len -> style [ text_indent_length (Length len) ]
     | None -> style [ text_indent_length (Length (Px 0.)) ]
 
   let indent_neg_arbitrary s =
-    match parse_length_value s with
-    | Some (Px n) -> style [ text_indent_length (Length (Px (-.n))) ]
-    | Some (Rem n) -> style [ text_indent_length (Length (Rem (-.n))) ]
-    | Some (Em n) -> style [ text_indent_length (Length (Em (-.n))) ]
-    | Some (Pct n) -> style [ text_indent_length (Length (Pct (-.n))) ]
-    | _ -> style [ text_indent_length (Length (Px 0.)) ]
+    match Parse.arbitrary_length s with
+    | Some len -> style [ text_indent_length (Length (negate_length len)) ]
+    | None -> style [ text_indent_length (Length (Px 0.)) ]
 
   let line_clamp n =
     style

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -292,10 +292,12 @@ let test_arbitrary_shadow_lengths () =
     "shadow-[0_1ch_2px_3vmin_#000]/50";
   (* inset-shadow reads its arbitrary value through the same parser, with no
      [Css.parse_shadow] fallback to hide the dropped tokens. *)
-  emits "--tw-inset-shadow: inset 0 1ch 2px var(--tw-inset-shadow-color, #000)"
+  emits
+    "--tw-inset-shadow: inset 0 1ch 2px var(--tw-inset-shadow-color, #000000)"
     "inset-shadow-[0_1ch_2px_#000]";
   emits
-    "--tw-inset-shadow: inset 0 1px 2px 3px var(--tw-inset-shadow-color, #000)"
+    "--tw-inset-shadow: inset 0 1px 2px 3px var(--tw-inset-shadow-color, \
+     #000000)"
     "inset-shadow-[0_1px_2px_3px_#000]";
   match Tw.of_string "shadow-[0_bogus_2px]" with
   | Ok _ -> Alcotest.fail "expected shadow-[0_bogus_2px] to be rejected"

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -271,6 +271,36 @@ let test_arbitrary_shadow_list () =
        (css
           "shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)]"))
 
+(* A single arbitrary shadow reads every CSS length, not the px/rem/em subset,
+   and keeps its spread. A token that is not a length makes the whole value not
+   a shadow rather than dropping out and shifting its neighbours along. *)
+let test_arbitrary_shadow_lengths () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "--tw-shadow: 0 1ch 2px var(--tw-shadow-color, oklab(0% 0 0 / .5))"
+    "shadow-[0_1ch_2px_#000]/50";
+  emits "--tw-shadow: 0 1px 2px 3px var(--tw-shadow-color, oklab(0% 0 0 / .5))"
+    "shadow-[0_1px_2px_3px_#000]/50";
+  emits
+    "--tw-shadow: 0 1ch 2px 3vmin var(--tw-shadow-color, oklab(0% 0 0 / .5))"
+    "shadow-[0_1ch_2px_3vmin_#000]/50";
+  (* inset-shadow reads its arbitrary value through the same parser, with no
+     [Css.parse_shadow] fallback to hide the dropped tokens. *)
+  emits "--tw-inset-shadow: inset 0 1ch 2px var(--tw-inset-shadow-color, #000)"
+    "inset-shadow-[0_1ch_2px_#000]";
+  emits
+    "--tw-inset-shadow: inset 0 1px 2px 3px var(--tw-inset-shadow-color, #000)"
+    "inset-shadow-[0_1px_2px_3px_#000]";
+  match Tw.of_string "shadow-[0_bogus_2px]" with
+  | Ok _ -> Alcotest.fail "expected shadow-[0_bogus_2px] to be rejected"
+  | Error _ -> ()
+
 (* An arbitrary shadow that is not a shadow is not a utility: it used to fall
    back to the zero shadow. *)
 let test_invalid_arbitrary_shadow () =
@@ -294,6 +324,7 @@ let tests =
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;
+    test_case "arbitrary shadow lengths" `Quick test_arbitrary_shadow_lengths;
     test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;

--- a/test/test_scroll.ml
+++ b/test/test_scroll.ml
@@ -34,8 +34,30 @@ let test_typed () =
   Test_helpers.check_typed_class "scroll-pt-8" (Tw.scroll_pt 8.);
   Test_helpers.check_typed_class "scroll-ps-6" (Tw.scroll_ps 6.)
 
+(* An arbitrary scroll offset is any CSS length. A value the parser cannot read
+   is not a utility: it used to be reinterpreted as a variable name, so
+   [scroll-m-[2vh]] emitted [scroll-margin: var(--2vh)]. *)
+let test_arbitrary_length () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "scroll-margin: 2vh" "scroll-m-[2vh]";
+  emits "scroll-padding-top: 3ch" "scroll-pt-[3ch]";
+  emits "scroll-margin: var(--gap)" "scroll-m-[var(--gap)]";
+  match Tw.of_string "scroll-m-[bogus]" with
+  | Ok _ -> Alcotest.fail "expected scroll-m-[bogus] to be rejected"
+  | Error _ -> ()
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
-  @ [ Alcotest.test_case "typed constructors" `Quick test_typed ]
+  @ [
+      Alcotest.test_case "typed constructors" `Quick test_typed;
+      Alcotest.test_case "arbitrary length" `Quick test_arbitrary_length;
+    ]
 
 let suite = ("scroll", tests)

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -45,9 +45,30 @@ let test_theme_override () =
     "text-shadow-2xs @theme override flows to #0000001a" true
     (Astring.String.is_infix ~affix:"#0000001a" css)
 
+(* An arbitrary text-shadow reads every CSS length, not the px/rem/em subset. A
+   token that is not a length used to drop out of the list and shift its
+   neighbours along, so [0 1ch 2px] became a two-length [0 2px]. *)
+let test_arbitrary_lengths () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "text-shadow: 0 1ch 2px var(--tw-text-shadow-color, #000000)"
+    "text-shadow-[0_1ch_2px_#000]";
+  emits "text-shadow: 0 1ch 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .5))"
+    "text-shadow-[0_1ch_2px_#000]/50";
+  match Tw.of_string "text-shadow-[0_bogus_2px]" with
+  | Ok _ -> Alcotest.fail "expected text-shadow-[0_bogus_2px] to be rejected"
+  | Error _ -> ()
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
+      Alcotest.test_case "arbitrary lengths" `Quick test_arbitrary_lengths;
       Alcotest.test_case "default scale (v4.3.1)" `Quick test_default_scale;
       Alcotest.test_case "@theme override threads through" `Quick
         test_theme_override;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -282,7 +282,27 @@ let test_text_bracket_size_invalid () =
   (* Hex-looking, missing '#' *)
   bad "text-[FF0000]";
   bad "text-[totallyNotAColor]";
-  bad "text-[16]" (* Missing unit *)
+  (* Missing unit *)
+  bad "text-[16]";
+  (* The unitless zero reads as a colour in v4, not a size *)
+  bad "text-[0]"
+
+(* A bracket font-size is any CSS length, not the px/rem/em/% subset the
+   hand-rolled suffix parser knew. Same for an arbitrary text-indent. *)
+let test_bracket_length_units () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "font-size: 3ch" "text-[3ch]";
+  emits "font-size: 2vh" "text-[2vh]";
+  emits "font-size: calc(1rem + 2px)" "text-[calc(1rem+2px)]";
+  emits "text-indent: 3ch" "indent-[3ch]";
+  emits "text-indent: -3ch" "-indent-[3ch]"
 
 let of_string_invalid () =
   (* Invalid typography values *)
@@ -551,6 +571,7 @@ let tests =
       test_text_bracket_size_valid;
     test_case "text-[<font-size>] invalid values" `Quick
       test_text_bracket_size_invalid;
+    test_case "bracket length units" `Quick test_bracket_length_units;
     test_case "text-[--spacing()/--alpha()] functions" `Quick
       test_text_bracket_functions;
     test_case "named font family from the theme" `Quick test_named_font_family;


### PR DESCRIPTION
Five hand-rolled px/rem/em/% parsers silently corrupted output: an unrecognised unit was filter_map-ed away so the surviving shadow lengths shifted position (shadow-[0_1ch_2px_#000]/50 emitted 0 2px), spread was bound to _spread and dropped, text-[3ch] was rejected, and a failed scroll-* parse became a bogus var(--2vh) reference. One Parse.arbitrary_length helper over Css.parse_length replaces all five; shadow parsers reject instead of truncating, spread is carried through, and the scroll var branch is reserved for real var() input. All newly supported spellings are --diff clean.