### PR TITLE
modifiers: read arbitrary selector content instead of string-matching

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -220,6 +220,21 @@ let open_pseudo () =
   let open Css.Selector in
   is_ [ attribute "open" Presence; Popover_open; Open ]
 
+let nest_selector ~parent template =
+  let open Css.Selector in
+  let sel = Css.Selector.read (Cascade.Cursor.of_string template) in
+  if Cascade.Nest.contains sel then Cascade.Nest.substitute ~parent sel
+  else
+    (* No anchor: the template compounds onto the parent. A type selector cannot
+       follow a class in a compound, so it goes in an [:is()]; anything else
+       ([.line], [[data-x]], [:hover]) attaches directly. *)
+    let inner =
+      match sel with
+      | Element _ | Compound (Element _ :: _) -> is_ [ sel ]
+      | _ -> sel
+    in
+    compound [ parent; inner ]
+
 (** Parse arbitrary bracket content into a selector tree. In bracket content:
     [_] = space, [&] = anchor (group/peer). E.g. "&_p" with group anchor ->
     ":where(.group) p" E.g. "&:hover" with group anchor ->
@@ -228,47 +243,7 @@ let parse_arbitrary_selector_content content anchor =
   let open Css.Selector in
   (* Replace _ with space for Tailwind convention *)
   let s = String.map (fun c -> if c = '_' then ' ' else c) content in
-  (* Split on & to find the anchor positions *)
-  let parts = String.split_on_char '&' s in
-  match parts with
-  | [ ""; rest ] ->
-      (* Content starts with & — most common case *)
-      let rest = String.trim rest in
-      if rest = "" then
-        (* Just "&" → :where(.group/peer) descendant *)
-        combine (where [ anchor ]) Descendant universal
-      else if rest.[0] = ':' then
-        (* "&:hover" → :where(.group):hover descendant. The reader keeps a
-           pseudo-class it does not know as one ([Unknown_pseudo_class]), so it
-           covers the whole grammar rather than a list of spelled-out names. *)
-        let pseudo_sel = Css.Selector.read (Cascade.Cursor.of_string rest) in
-        combine (compound [ where [ anchor ]; pseudo_sel ]) Descendant universal
-      else
-        (* "& p" → :where(.group) p * — content after & is a descendant
-           selector, and a compound one ([& p.foo]) is not an element name. *)
-        let descendant = Css.Selector.read (Cascade.Cursor.of_string rest) in
-        combine
-          (combine (where [ anchor ]) Descendant descendant)
-          Descendant universal
-  | [ before; "" ] when String.trim before <> "" ->
-      (* "<prefix> &" → <prefix> :where(.group) * — the [&] anchor is preceded
-         by an ancestor context (e.g. [:nth-of-type(3)_&]). *)
-      let prefix_sel =
-        Css.Selector.read (Cascade.Cursor.of_string (String.trim before))
-      in
-      combine
-        (combine prefix_sel Descendant (where [ anchor ]))
-        Descendant universal
-  | [ single ] when String.trim single <> "" ->
-      (* No [&]: a bare compound like [[.is-published]] attaches to the anchor,
-         giving [:where(.group).is-published *]. *)
-      let extra =
-        Css.Selector.read (Cascade.Cursor.of_string (String.trim single))
-      in
-      combine (compound [ where [ anchor ]; extra ]) Descendant universal
-  | _ ->
-      (* Fallback — just use the anchor as descendant *)
-      combine (where [ anchor ]) Descendant universal
+  combine (nest_selector ~parent:(where [ anchor ]) s) Descendant universal
 
 (** Build an anchor-based variant selector: :where(.anchor):pseudo combinator *)
 let anchor_pseudo_selector ~anchor ~combinator cls prefix pseudo =

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -238,29 +238,17 @@ let parse_arbitrary_selector_content content anchor =
         (* Just "&" → :where(.group/peer) descendant *)
         combine (where [ anchor ]) Descendant universal
       else if rest.[0] = ':' then
-        (* "&:hover" → :where(.group):hover descendant *)
-        let pseudo_str = String.sub rest 1 (String.length rest - 1) in
-        let pseudo_sel =
-          match pseudo_str with
-          | "hover" -> Hover
-          | "focus" -> Focus
-          | "active" -> Active
-          | "focus-within" -> Focus_within
-          | "focus-visible" -> Focus_visible
-          | "checked" -> Checked
-          | "disabled" -> Disabled
-          | "first-child" -> First_child
-          | "last-child" -> Last_child
-          | _ -> Class (":" ^ pseudo_str)
-        in
+        (* "&:hover" → :where(.group):hover descendant. The reader keeps a
+           pseudo-class it does not know as one ([Unknown_pseudo_class]), so it
+           covers the whole grammar rather than a list of spelled-out names. *)
+        let pseudo_sel = Css.Selector.read (Cascade.Cursor.of_string rest) in
         combine (compound [ where [ anchor ]; pseudo_sel ]) Descendant universal
       else
         (* "& p" → :where(.group) p * — content after & is a descendant
-           element *)
-        let trimmed = String.trim rest in
-        let element_sel = Element (None, trimmed) in
+           selector, and a compound one ([& p.foo]) is not an element name. *)
+        let descendant = Css.Selector.read (Cascade.Cursor.of_string rest) in
         combine
-          (combine (where [ anchor ]) Descendant element_sel)
+          (combine (where [ anchor ]) Descendant descendant)
           Descendant universal
   | [ before; "" ] when String.trim before <> "" ->
       (* "<prefix> &" → <prefix> :where(.group) * — the [&] anchor is preceded

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -11,6 +11,14 @@ val compact_length : Css.length -> string
 (** [compact_length l] renders a CSS length without spaces (for use in class
     names). *)
 
+val nest_selector : parent:Css.Selector.t -> string -> Css.Selector.t
+(** [nest_selector ~parent template] reads [template] as a selector and replaces
+    each [&] in it with [parent], as CSS nesting does. A template with no [&] at
+    all compounds onto [parent] instead, with a type selector wrapped in [:is()]
+    since it cannot follow a class. Substituting over the parsed selector rather
+    than over the source text leaves an [&] inside a quoted attribute value
+    alone. *)
+
 val to_selector : modifier -> string -> Css.Selector.t
 (** [to_selector modifier base_class] generates the CSS selector for a modifier
     applied to a base class. *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1671,35 +1671,10 @@ let arbitrary_selector_rule content base_class selector props =
     Rules_selector.transform_selector_with_modifier modified base_class
       modified_class selector
   in
-  let anchored =
-    if String.contains s '&' then (
-      (* Replace each [&] anchor with the utility's own class and parse the
-         whole selector, so combinators ([&>div], [&+p], [&~p]), compounds
-         ([&:hover]) and trailing anchors ([input&]) all flatten correctly. A
-         naive split-on-[&] + Descendant combine mis-parses any remainder that
-         starts with a combinator. *)
-      let anchor = Class modified_class in
-      let anchor_str = Css.Selector.to_string anchor in
-      let buf = Buffer.create (String.length s + String.length anchor_str) in
-      String.iter
-        (fun c ->
-          if c = '&' then Buffer.add_string buf anchor_str
-          else Buffer.add_char buf c)
-        s;
-      Css.Selector.read (Cascade.Cursor.of_string (Buffer.contents buf)))
-    else
-      (* No anchor: the selector compounds onto the utility's own class. A type
-         selector cannot follow a class in a compound, so it goes in an [:is()];
-         anything else ([.line], [[data-x]], [:hover]) attaches directly. *)
-      let is_type_selector =
-        match s.[0] with
-        | 'a' .. 'z' | 'A' .. 'Z' -> true
-        | _ | (exception _) -> false
-      in
-      let inner = Css.Selector.read (Cascade.Cursor.of_string s) in
-      let inner = if is_type_selector then is_ [ inner ] else inner in
-      compound [ Class modified_class; inner ]
-  in
+  (* Each [&] anchor stands for the utility's own class, so combinators
+     ([&>div], [&+p], [&~p]), compounds ([&:hover]) and trailing anchors
+     ([input&]) all flatten correctly. *)
+  let anchored = Modifiers.nest_selector ~parent:(Class modified_class) s in
   let sel =
     match decoration with
     | Some [] -> anchored
@@ -1732,14 +1707,8 @@ let at_rule_variant content ~selector base_class props =
    The canonical optimizer then reduces the single-argument [:is()]. *)
 let custom_variant_rule token template base_class props =
   let modified_class = token ^ ":" ^ base_class in
-  let class_str = Css.Selector.to_string (Css.Selector.Class modified_class) in
-  let buf = Buffer.create (String.length template + String.length class_str) in
-  String.iter
-    (fun c ->
-      if c = '&' then Buffer.add_string buf class_str else Buffer.add_char buf c)
-    template;
   let sel =
-    Css.Selector.read (Cascade.Cursor.of_string (Buffer.contents buf))
+    Modifiers.nest_selector ~parent:(Css.Selector.Class modified_class) template
   in
   regular ~selector:sel ~props ~base_class:modified_class ()
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -606,6 +606,33 @@ let test_anchor_bracket_without_ampersand () =
   (* the spelled anchor still works *)
   has "group-[&:hover]:block" ":is(:where(.group):hover *)"
 
+(* What follows the [&] anchor in a group or peer bracket is a selector, so it
+   is read as one. A pseudo-class outside a short hand-written list came out as
+   a class literally named [:defined], and a compound remainder was taken whole
+   as an element name, so [&_p.foo] named an element [p.foo]. *)
+let test_anchor_bracket_reads_remainder () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "group-[&:defined]:flex"
+    {|.group-\[\&\:defined\]\:flex:is(:where(.group):defined *)|};
+  has "group-[&:nth-child(2)]:flex"
+    {|.group-\[\&\:nth-child\(2\)\]\:flex:is(:where(.group):nth-child(2) *)|};
+  has "group-[&_p.foo]:flex"
+    {|.group-\[\&_p\.foo\]\:flex:is(:where(.group) p.foo *)|};
+  (* the spellings that already worked stay byte-identical *)
+  has "group-[&:hover]:flex"
+    {|.group-\[\&\:hover\]\:flex:is(:where(.group):hover *)|};
+  has "group-[&_p]:flex" {|.group-\[\&_p\]\:flex:is(:where(.group) p *)|};
+  has "group-[:nth-of-type(3)_&]:flex" {|:is(:nth-of-type(3) :where(.group) *)|};
+  has "peer-[&:hover]:flex"
+    {|.peer-\[\&\:hover\]\:flex:is(:where(.peer):hover~*)|}
+
 (* Test ARIA and data modifiers class names *)
 let test_aria_and_data_modifiers () =
   check string "aria-checked:p-4" "aria-checked:p-4"
@@ -799,6 +826,8 @@ let tests =
       test_case "has bracket arguments" `Quick test_has_bracket_arguments;
       test_case "anchor bracket without ampersand" `Quick
         test_anchor_bracket_without_ampersand;
+      test_case "anchor bracket reads its remainder" `Quick
+        test_anchor_bracket_reads_remainder;
       test_case "ARIA and data modifiers" `Quick test_aria_and_data_modifiers;
       test_case "modifier class round-trips" `Quick
         test_modifier_class_roundtrip;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -125,6 +125,29 @@ let test_arbitrary_selector_combinator () =
   check bool "[&_p] still flattens to a descendant" true
     (Astring.String.is_infix ~affix:"]\\:underline p" (css "[&_p]:underline"))
 
+(* [&] is the CSS nesting anchor and stands for the utility's own class, so it
+   is substituted over the parsed selector. Rewriting the [&] bytes of the
+   source text and re-parsing the result also rewrote an [&] that was part of a
+   quoted attribute value. *)
+let test_arbitrary_anchor_in_quoted_value () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|[&[data-x="a&b"]]:flex|}
+    {|.\[\&\[data-x\=\"a\&b\"\]\]\:flex[data-x="a&b"]|};
+  (* the spellings that already worked stay byte-identical *)
+  has "[&>*]:flex" {|.\[\&\>\*\]\:flex>*|};
+  has "[&_p]:flex" {|.\[\&_p\]\:flex p|};
+  has "[&:hover]:flex" {|.\[\&\:hover\]\:flex:hover|};
+  has "[input&]:flex" {|input.\[input\&\]\:flex|};
+  has "[p.foo]:flex" {|.\[p\.foo\]\:flex:is(p.foo)|};
+  has "[.line]:block" {|.\[\.line\]\:block.line|}
+
 (* Regression: an opacity color emits a progressive-enhancement @supports block.
    Under a variant, that block must stay scoped to the variant instead of
    leaking a bare base-class rule. dark:text-white/80 previously emitted a
@@ -434,6 +457,8 @@ let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
+    test_case "arbitrary anchor inside a quoted value" `Quick
+      test_arbitrary_anchor_in_quoted_value;
     test_case "arbitrary selector stacks with other variants" `Quick
       test_arbitrary_selector_stacking;
     test_case "pseudo-element content once" `Quick


### PR DESCRIPTION
Two string-munging bugs in arbitrary variants: an unknown pseudo-class fell through to Class(":"^s), so group-[&:defined]:flex emitted a class literally named :defined, and the nesting & was substituted bytewise over the printed selector, so [&[data-x="a&b"]]:flex spliced the whole class name inside the quoted attribute value. Both now go through cascade's typed API (Selector.read + Nest.substitute, previously unused); the nine-name pseudo-class table was byte-for-byte redundant and is deleted.