### PR TITLE
typography: accept an opacity on a shadeless decoration colour

### DIFF
--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -123,7 +123,7 @@ module Handler = struct
       else
         (* Full length grammar (percent, container units, calc), raw kept for
            round-trip. *)
-        match Css.parse_length (Parse.decode_arbitrary_value inner) with
+        match Parse.arbitrary_length inner with
         | Some l -> Some (Arbitrary (inner, l))
         | None -> None
     else None

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1400,7 +1400,7 @@ module Typography_late = struct
 
   (* An arbitrary decoration thickness is any CSS length. *)
   let parse_decoration_thickness inner : Css.length option =
-    match Css.parse_length inner with
+    match Parse.arbitrary_length inner with
     | Some _ as len -> len
     | None -> (
         match parse_bare_number inner with
@@ -1409,7 +1409,7 @@ module Typography_late = struct
 
   (* Tailwind converts a percentage thickness to em: 50% -> .5em. *)
   let parse_decoration_pct inner : Css.length option =
-    match Css.parse_length inner with
+    match Parse.arbitrary_length inner with
     | Some (Pct pct) -> Some (Em (pct /. 100.))
     | _ -> None
 
@@ -1687,11 +1687,15 @@ module Typography_late = struct
               | Ok i when opacity = Color.No_opacity ->
                   Ok (Decoration_thickness i)
               | _ -> (
-                  (* Try parsing as color *)
-                  match Color.of_string base_str with
-                  | Ok c when opacity = Color.No_opacity ->
+                  (* A shadeless colour (white, black, a theme name) carries its
+                     opacity on the single segment, so read the segment as a
+                     colour and an opacity together. *)
+                  match Color.shade_and_opacity_of_strings ~theme [ n ] with
+                  | Ok (c, _, Color.No_opacity) ->
                       Ok (Decoration_color (c, None))
-                  | _ -> err_not_utility)))
+                  | Ok (c, shade, opacity) ->
+                      Ok (Decoration_color_opacity (c, shade, opacity))
+                  | Error _ -> err_not_utility)))
     | [ "decoration"; color; shade ] -> (
         (* Check for opacity modifier in shade (e.g., "500/50" or
            "500/[0.5]") *)
@@ -1919,8 +1923,11 @@ module Typography_late = struct
     | Decoration_color (color, Some shade) ->
         "decoration-" ^ Color.pp color ^ "-" ^ string_of_int shade
     | Decoration_color_opacity (color, shade, opacity) ->
-        "decoration-" ^ Color.pp color ^ "-" ^ string_of_int shade ^ "/"
-        ^ Color.pp_opacity opacity
+        let base =
+          if Color.is_shadeless color then "decoration-" ^ Color.pp color
+          else "decoration-" ^ Color.pp color ^ "-" ^ string_of_int shade
+        in
+        base ^ "/" ^ Color.pp_opacity opacity
     | Decoration_transparent -> "decoration-transparent"
     | Decoration_current -> "decoration-current"
     | Decoration_current_opacity opacity ->

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -563,6 +563,12 @@ let test_decoration_bracket_thickness () =
   emits "text-decoration-thickness: 2px" "decoration-[2px]";
   emits "text-decoration-thickness: 2ch" "decoration-[2ch]";
   emits "text-decoration-thickness: .5em" "decoration-[50%]";
+  (* The bracket goes through the arbitrary-value decoder, so an escaped space
+     and a [--spacing()] call both read as lengths. *)
+  emits "text-decoration-thickness: calc(1rem + 2px)"
+    "decoration-[calc(1rem_+_2px)]";
+  emits "text-decoration-thickness: calc(var(--spacing) * 2)"
+    "decoration-[--spacing(2)]";
   let rejected cls =
     match Tw.of_string cls with
     | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
@@ -570,6 +576,33 @@ let test_decoration_bracket_thickness () =
   in
   rejected "decoration-[.]";
   rejected "decoration-[1e]"
+
+(* A shadeless decoration colour takes an opacity modifier the same way every
+   other colour family does, and keeps its shadeless class name. *)
+let test_decoration_shadeless_opacity () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  check_late "decoration-white/50";
+  check_late "decoration-black/50";
+  check_late "decoration-white/[0.5]";
+  emits "color-mix(in oklab,var(--color-white) 50%,transparent)"
+    "decoration-white/50";
+  emits "color-mix(in oklab,var(--color-black) 50%,transparent)"
+    "decoration-black/50";
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "decoration-2/50";
+  rejected "decoration-nosuchcolor/50";
+  rejected "decoration-white/"
 
 (* A [#] bracket is only a decoration colour when what follows is a hex
    spelling. The decoration reader handed everything after the [#] to the
@@ -601,6 +634,8 @@ let tests =
       test_invalid_decoration_bracket_hex;
     test_case "decoration bracket thickness" `Quick
       test_decoration_bracket_thickness;
+    test_case "decoration shadeless opacity" `Quick
+      test_decoration_shadeless_opacity;
     test_case "bracket list-style" `Quick test_bracket_list_style;
     test_case "invalid font family" `Quick test_invalid_font_family;
     test_case "font-features value" `Quick test_font_features_value;


### PR DESCRIPTION
`decoration-white/50` and `decoration-black/50` were rejected while every other colour family accepted them; the single-segment branch now reads colour and opacity together like backgrounds and divide do.

Arbitrary decoration and padding lengths also go through `Parse.arbitrary_length`, which makes `decoration-[calc(1rem_+_2px)]` and `decoration-[--spacing(2)]` read.