### PR TITLE
reject class spellings that compile to a dead selector

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1034,6 +1034,13 @@ let is_plain_ident str =
          || c = '-' || c = '_')
        str
 
+(* An aria- or data- variant names an attribute: [aria-[modal]] matches
+   [[aria-modal]]. An argument that leaves the name empty gives [[aria-]], a
+   selector browsers parse and keep although nothing ever matches it, so it is
+   not a variant. An underscore stands for a space, so it is empty as well. *)
+let names_attribute expr =
+  String.trim (String.map (fun c -> if c = '_' then ' ' else c) expr) <> ""
+
 (* [group-data-dragging] is [group-data-[dragging]] with a different spelling,
    so it keeps its own class name. *)
 let try_bare_data s prefix make =
@@ -1041,7 +1048,8 @@ let try_bare_data s prefix make =
   if String.length s <= plen || String.sub s 0 plen <> prefix then None
   else
     let base, name = split_name (String.sub s plen (String.length s - plen)) in
-    if is_plain_ident base then Some (make base name) else None
+    if is_plain_ident base && names_attribute base then Some (make base name)
+    else None
 
 let extract_bracket_content_with_name ~prefix s =
   if String.starts_with ~prefix s then
@@ -1216,13 +1224,15 @@ let is_valid_nth_expr expr =
 (* Build the list of bracket pattern matchers for a given input string *)
 let bracket_named_patterns s =
   let ( let* ) = Option.bind in
-  let try_pattern prefix make =
-    let* content = extract_bracket_content ~prefix s in
-    Some (make content)
+  (* Every aria- and data- bracket here takes an attribute expression, so the
+     argument has to name an attribute. *)
+  let try_attr prefix make =
+    let* expr = extract_bracket_content ~prefix s in
+    if names_attribute expr then Some (make expr) else None
   in
   let try_named prefix make =
     let* expr, name = extract_bracket_content_with_name ~prefix s in
-    Some (make expr name)
+    if names_attribute expr then Some (make expr name) else None
   in
   let try_named_has prefix make =
     let* sel, name = extract_bracket_content_with_name ~prefix s in
@@ -1231,7 +1241,7 @@ let bracket_named_patterns s =
   [
     (fun () -> try_named "group-aria-[" (fun e n -> Group_aria (e, n)));
     (fun () -> try_named "peer-aria-[" (fun e n -> Peer_aria (e, n)));
-    (fun () -> try_pattern "aria-[" (fun expr -> Aria_bracket expr));
+    (fun () -> try_attr "aria-[" (fun expr -> Aria_bracket expr));
     (fun () ->
       try_named "group-data-[" (fun e n -> Group_data ("[" ^ e ^ "]", n)));
     (fun () ->
@@ -1240,9 +1250,7 @@ let bracket_named_patterns s =
        different spelling, so it keeps its own class name. *)
     (fun () -> try_bare_data s "group-data-" (fun e n -> Group_data (e, n)));
     (fun () -> try_bare_data s "peer-data-" (fun e n -> Peer_data (e, n)));
-    (fun () ->
-      let* expr = extract_bracket_content ~prefix:"data-[" s in
-      if expr = "" then None else Some (Data_bracket expr));
+    (fun () -> try_attr "data-[" (fun expr -> Data_bracket expr));
     (fun () -> try_named_has "group-has-[" (fun s n -> Group_has (s, n)));
     (fun () -> try_named_has "peer-has-[" (fun s n -> Peer_has (s, n)));
     (fun () ->
@@ -1767,7 +1775,9 @@ let try_bare_data_aria s =
     String.length s > 5
     && String.sub s 0 5 = "aria-"
     && not (String.contains s '[')
-  then Some (Aria_bracket (String.sub s 5 (String.length s - 5)))
+  then
+    let expr = String.sub s 5 (String.length s - 5) in
+    if names_attribute expr then Some (Aria_bracket expr) else None
   else None
 
 (* Ordering of prose element variants (matches Tailwind v4 typography plugin) *)

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -8,13 +8,40 @@ let has_prefix ~prefix s =
   let lp = String.length prefix in
   lp <= String.length s && prefix_loop prefix s 0 lp
 
+let is_digits s =
+  s <> "" && String.for_all (function '0' .. '9' -> true | _ -> false) s
+
+let without_sign s =
+  if s <> "" && s.[0] = '-' then String.sub s 1 (String.length s - 1) else s
+
+(* A class suffix is written in plain decimal, but OCaml's literal grammar also
+   admits [0x]/[0o]/[0b] bases, [_] digit separators, hex-float exponents and a
+   leading [+]. Handing a suffix straight to [int_of_string_opt] therefore reads
+   [p-0x4] as 4 and emits [.p-4] — a rule nobody wrote, and not a class Tailwind
+   accepts. Both readers below check the spelling first. *)
+let decimal_int s =
+  if is_digits (without_sign s) then int_of_string_opt s else None
+
+(* Plain decimal: digits, then at most one fractional part with digits of its
+   own. [.5], [1.] and [1e2] are not spellings of a class suffix. *)
+let decimal_float s =
+  let digits = without_sign s in
+  let plain =
+    match String.index_opt digits '.' with
+    | None -> is_digits digits
+    | Some i ->
+        is_digits (String.sub digits 0 i)
+        && is_digits (String.sub digits (i + 1) (String.length digits - i - 1))
+  in
+  if plain then float_of_string_opt s else None
+
 let int_any s =
-  match int_of_string_opt s with
+  match decimal_int s with
   | Some n -> Ok n
   | None -> Error (`Msg ("Invalid number: " ^ s))
 
 let nonnegative_int ~name s =
-  match int_of_string_opt s with
+  match decimal_int s with
   | Some n when n >= 0 -> Some (Ok n)
   | Some _ -> Some (Error (`Msg (name ^ " must be non-negative: " ^ s)))
   | None -> None
@@ -27,14 +54,12 @@ let int_pos ~name s =
 (* Parse decimal values like "0.5", "1.5" for spacing utilities. Valid decimals
    must be multiples of 0.25 (i.e., value * 4 is integer). *)
 let decimal_pos ~name s =
-  try
-    let f = Float.of_string s in
-    if f < 0.0 then Error (`Msg (name ^ " must be non-negative: " ^ s))
-    else
-      let scaled = f *. 4.0 in
-      if Float.is_integer scaled then Ok f
+  match decimal_float s with
+  | None -> Error (`Msg ("Invalid " ^ name ^ " value: " ^ s))
+  | Some f ->
+      if f < 0.0 then Error (`Msg (name ^ " must be non-negative: " ^ s))
+      else if Float.is_integer (f *. 4.0) then Ok f
       else Error (`Msg ("Invalid " ^ name ^ " value: " ^ s))
-  with Failure _ -> Error (`Msg ("Invalid " ^ name ^ " value: " ^ s))
 
 (* Parse spacing values - handles both integers and decimals *)
 let spacing_value ~name s =
@@ -44,7 +69,7 @@ let spacing_value ~name s =
   | None -> decimal_pos ~name s
 
 let int_bounded ~name ~min ~max s =
-  match int_of_string_opt s with
+  match decimal_int s with
   | Some n when n >= min && n <= max -> Ok n
   | Some _ ->
       Error

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -785,6 +785,47 @@ let test_invalid_bracket_modifiers () =
   rejected "nth-last-of-type-[]:flex";
   rejected "supports-[]:flex"
 
+(* An aria- or data- variant names an attribute, so an empty argument would
+   compile to [[aria-]] or [[data-]]: a selector browsers parse and keep, and
+   nothing ever matches. An underscore stands for a space, so it is empty
+   too. *)
+let test_empty_attribute_brackets () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  rejected "aria-[]:flex";
+  rejected "aria-[_]:flex";
+  rejected "aria-_:flex";
+  rejected "group-aria-[]:flex";
+  rejected "peer-aria-[]:flex";
+  rejected "data-[]:flex";
+  rejected "data-[_]:flex";
+  rejected "group-data-[]:flex";
+  rejected "peer-data-[]:flex";
+  rejected "group-data-_:flex";
+  rejected "peer-data-_:flex"
+
+(* The attribute spellings that do name something keep working, including the
+   empty-name-with-value form Tailwind also accepts. *)
+let test_attribute_brackets_still_parse () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "[aria-modal]" "aria-[modal]:flex";
+  emits "[aria-sort=ascending]" "aria-[sort=ascending]:flex";
+  emits "[aria-=true]" "aria-[=true]:flex";
+  emits "[data-state=open]" "data-[state=open]:flex";
+  emits "[data-dragging]" "group-data-[dragging]:flex";
+  emits "[data-dragging]" "peer-data-[dragging]:flex";
+  emits "[data-modified]" "group-data-modified:flex"
+
 (* The valid spellings the validation must keep accepting. *)
 let test_valid_bracket_modifiers () =
   let css cls =
@@ -808,6 +849,9 @@ let tests =
       test_case "invalid bracket modifiers" `Quick
         test_invalid_bracket_modifiers;
       test_case "valid bracket modifiers" `Quick test_valid_bracket_modifiers;
+      test_case "empty attribute brackets" `Quick test_empty_attribute_brackets;
+      test_case "attribute brackets still parse" `Quick
+        test_attribute_brackets_still_parse;
       test_case "not-[selector] arbitrary negation" `Quick
         test_not_bracket_arbitrary_selector;
       test_case "group arbitrary prefix anchor" `Quick

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -35,17 +35,14 @@ let test_int_rejects_non_decimal_spellings () =
       "duration-0x4";
       "delay-1_0";
       "rotate-0x4";
-      "z-0x10";
-      "order-1_0";
       "line-clamp-0x2";
-      "border-0x2";
       "opacity-0x10";
     ]
 
 (* The sign is stripped before the suffix is read, so a negative utility takes
    the same grammar. *)
 let test_negative_int_rejects_non_decimal_spellings () =
-  List.iter unknown [ "-m-1_0"; "-rotate-0x4"; "-translate-x-0x4"; "-z-0x10" ]
+  List.iter unknown [ "-m-1_0"; "-rotate-0x4"; "-translate-x-0x4" ]
 
 (* [Float.of_string] reads the same non-decimal spellings plus hex-float
    exponents, which would make [p-0x1p4] mean [.p-16]. A fractional suffix needs

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -8,11 +8,90 @@ let test_escape_in_selector () =
       Alcotest.failf "Failed to parse escaped selector: %s"
         (Cascade.Error.to_string e)
 
+let unknown cls =
+  match Tw.of_string cls with
+  | Ok u -> Alcotest.failf "expected %s to be unknown, got %s" cls (Tw.pp u)
+  | Error (`Msg _) -> ()
+
+let round_trips cls =
+  match Tw.of_string cls with
+  | Ok u -> Alcotest.(check string) "round-trips" cls (Tw.pp u)
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+(* A class suffix is written in plain decimal. OCaml's literal grammar also
+   admits [0x]/[0o]/[0b] bases, [_] digit separators and a leading [+]; reading
+   a suffix as an OCaml literal would accept [p-0x4] and emit [.p-4], a rule
+   nobody wrote. One class per integer reader: spacing_value, int_pos, int_any,
+   int_bounded. *)
+let test_int_rejects_non_decimal_spellings () =
+  List.iter unknown
+    [
+      "p-0x4";
+      "p-0X4";
+      "p-0o17";
+      "p-0b101";
+      "p-1_0";
+      "gap-1_0";
+      "duration-0x4";
+      "delay-1_0";
+      "rotate-0x4";
+      "z-0x10";
+      "order-1_0";
+      "line-clamp-0x2";
+      "border-0x2";
+      "opacity-0x10";
+    ]
+
+(* The sign is stripped before the suffix is read, so a negative utility takes
+   the same grammar. *)
+let test_negative_int_rejects_non_decimal_spellings () =
+  List.iter unknown [ "-m-1_0"; "-rotate-0x4"; "-translate-x-0x4"; "-z-0x10" ]
+
+(* [Float.of_string] reads the same non-decimal spellings plus hex-float
+   exponents, which would make [p-0x1p4] mean [.p-16]. A fractional suffix needs
+   digits on both sides of the point. *)
+let test_decimal_rejects_non_decimal_spellings () =
+  List.iter unknown
+    [
+      "p-0x1p4"; "p-1_5"; "p-1.2_5"; "p-1e2"; "p-+1.5"; "p-.5"; "p-1."; "m-1e1";
+    ]
+
+let test_decimal_class_suffixes_round_trip () =
+  List.iter round_trips
+    [
+      "p-4";
+      "p-0";
+      "p-96";
+      "p-0.5";
+      "p-1.5";
+      "p-2.5";
+      "m-3.5";
+      "gap-10";
+      "opacity-25";
+      "border-2";
+      "z-10";
+      "order-10";
+      "line-clamp-2";
+      "duration-150";
+      "delay-100";
+      "rotate-45";
+      "-m-10";
+      "-rotate-45";
+    ]
+
 let tests =
   Alcotest.
     [
       test_case "parse backslash escape in selector" `Quick
         test_escape_in_selector;
+      test_case "int suffixes reject non-decimal spellings" `Quick
+        test_int_rejects_non_decimal_spellings;
+      test_case "negative int suffixes reject non-decimal spellings" `Quick
+        test_negative_int_rejects_non_decimal_spellings;
+      test_case "decimal suffixes reject non-decimal spellings" `Quick
+        test_decimal_rejects_non_decimal_spellings;
+      test_case "decimal class suffixes round-trip" `Quick
+        test_decimal_class_suffixes_round_trip;
     ]
 
 let suite = ("parse", tests)


### PR DESCRIPTION
A number suffix was read with OCaml's literal grammar, so `p-0x4`, `p-1_0` and `p-0x1p4` compiled to `.p-4`, `.p-10` and `.p-16`; an aria- or data- variant with no attribute name compiled to `[aria-]` or `[data-]`, which parses and never matches. Both are now unknown classes, as in Tailwind.