### PR TITLE
docs: repoint the contributor docs at the code that exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## 1) Purpose
 
-This repo provides a type-safe Tailwind v4 implementation in OCaml. Utilities are compiled to CSS through a strongly-typed variable system and layered rules that mirror Tailwind's pipeline. The goal: **no raw `"var(--...)"` strings; no `Css.custom`; spec-faithful output.**
+This repo provides a type-safe Tailwind v4 implementation in OCaml. Utilities are compiled to CSS through a strongly-typed variable system and layered rules that mirror Tailwind's pipeline. The goal: **no raw `"var(--...)"` strings; no assembled CSS token strings; spec-faithful output.**
 
 ### Scope
 
@@ -14,24 +14,32 @@ All core Tailwind v4 utilities and all official plugins are in scope, including:
 
 ## 2) Core principles
 
-1. **Type safety over strings.** Never write `"var(--name)"` or `Css.custom`; represent variables and properties via `Var` and typed constructors. **NEVER add `Raw of string` or similar escape hatches to CSS types** — if a pattern cannot be expressed with existing types, extend the type system properly.
+1. **Type safety over strings.** Never write `"var(--name)"` and never hand `Css.custom_property` an assembled token string; represent variables and properties via `Var` and typed constructors. **NEVER add `Raw of string` or similar escape hatches to CSS types** — if a pattern cannot be expressed with existing types, extend the type system properly.
 2. **Spec-driven tests.** CSS behaviour is tested against MDN/W3C where applicable; utilities against Tailwind v4 output.
 3. **Variables follow four patterns.** See patterns below and `docs/adding-a-new-utility.md`.
-4. **Respect layers.** `theme → properties → base → components → utilities`. Utilities must not leak into theme or properties.
+4. **Respect layers.** `properties → theme → base → components → utilities`. Utilities must not leak into theme or properties.
 
 ---
 
 ## 3) Project structure
 
 ```
-lib/           core (utilities, CSS generation)
-  css/         CSS AST + emission
+lib/           core (utilities, class parsing, layer assembly)
   var.ml       variable system (critical)
-  rules.ml     layer assembly
-test/          Alcotest suites (CSS + Tailwind parity)
+  utility.ml   utility registry and the module shape every family follows
+  rule.ml      selector routing for variants
+  sort.ml      cascade order inside @layer utilities
+  build.ml     layer assembly
+  tools/       source scanning and the tailwindcss shell-out
+test/          Alcotest suites, one test_<module>.ml per lib/<module>.ml
+  upstream/    replay of Tailwind's own fixture corpus
+cascade/       sibling repo, symlinked in: CSS AST, printer, optimizer, differ
 docs/          adding-a-new-utility.md (start here for new utils)
                parity.md (how Tailwind parity is measured and read)
 ```
+
+The CSS type system lives in cascade, not here. `Cascade.Css` is aliased as
+`Css` at the top of each `lib/` module.
 
 Keep examples small and targeted; each test file should focus on one concept.
 
@@ -51,7 +59,7 @@ dune exec -- tw -s "p-4" --variables
 dune exec -- tw -s "p-4" --variables --base
 
 # For classes starting with -, use --single="..." to avoid CLI flag parsing
-dune exec -- tw --single="-content-around" --variables
+dune exec -- tw --single="-mt-4" --variables
 
 # Compare with real Tailwind CSS
 ## Method 1: Direct comparison using --diff (recommended)
@@ -72,19 +80,27 @@ The `tw` binary supports three backend modes:
 **Important**: `--diff` mode always uses:
 - Variables mode (ignores `--inline` flag)
 - Base layer included (ignores `--no-base` flag)
-- Minified and optimized output (forces `--minify --optimize`)
-- This ensures 1:1 equivalence comparison with Tailwind's optimized+minified output
+- Minified output (forces `--minify`; `--optimize` is passed through as given)
+- Canonical comparison with unused custom properties pruned, so the two sheets
+  are compared for equivalence rather than byte-for-byte. `--diff-mode` selects
+  a stricter mode (`tree` reports regrouping, `string` reports text).
 
 Example diff output:
 ```bash
-$ dune exec -- tw -s "prose-sm" --diff
-Differences found for 'prose-sm':
+$ dune exec -- tw --single="supports-[backdrop-filter]:bg-black/50" --diff
+Differences found between Tailwind and tw for 'supports-[backdrop-filter]:bg-black/50':
 
 --- Tailwind
 +++ tw
-- .prose-sm:
-    - modify: line-height 1.7142857 -> 1.71429
+└─ @layer utilities (1 removed)
+   ├─ .supports-\[backdrop-filter\]\:bg-black\/50
+   │     - background-color color-mix(in oklab, var(--color-black) 50%, #0000)
+   └─ @supports (backdrop-filter: var(--tw)) (added)
+      └─ .supports-\[backdrop-filter\]\:bg-black\/50 (added)
 ```
+
+That one is a known minifier difference, not a tw bug; `docs/parity.md` lists
+the residual the site comparison tolerates.
 
 > Note: Use `tmp/` (repo-local) for debug artefacts; do **not** use `/tmp`. Update any older scripts accordingly.
 
@@ -104,25 +120,31 @@ See `lib/var.mli` for detailed documentation and examples.
 
 ## 6) Layers and rule ordering
 
-Layer architecture is documented in **`lib/rules.mli`**. Key points:
+Layer architecture is documented in **`lib/build.mli`**, the sort order in
+**`lib/sort.mli`**. Key points:
 
 - **Layer order**: `properties → theme → base → components → utilities`
-- **Utilities layer**: Sorted by (priority, suborder) for conflict resolution
+- **Utilities layer**: Sorted by (priority, suborder) for conflict resolution; each
+  utility module supplies the pair through `Utility.S` (`priority`, `suborder`)
 - **Media queries**: Modifier-based media comes after regular rules; built-in media stays grouped with its utility
 
-See `lib/rules.mli` for the complete layer model documentation.
+See `lib/build.mli` for the layer model and `lib/sort.mli` for the comparator
+and the fields it keys on.
 
 ---
 
 ## 7) Adding a new utility — minimal workflow
 
 1. **Read** `docs/adding-a-new-utility.md`. Identify the variable pattern.
-2. **Implement** the utility in `lib/<area>.ml` using typed `Var` and the chosen pattern.
-3. **Place** declarations in the correct layer via `rules.ml`.
+2. **Implement** the utility in `lib/<area>.ml` using typed `Var` and the chosen
+   pattern, following the module shape in `lib/utility.mli`.
+3. **Check** the layer it lands in; `lib/build.ml` assembles them from the
+   utility's `(priority, suborder)` and its declarations.
 4. **Test**:
 
-   * CSS spec behaviour (if relevant) under `test/css/`.
-   * Tailwind parity under `test/`. Use a *single* concept per file.
+   * CSS spec behaviour (if relevant) belongs in cascade, under `cascade/test/`.
+   * Tailwind parity under `test/`, in the `test_<module>.ml` matching the
+     `lib/<module>.ml` you touched. Use a *single* concept per file.
 5. **Compare** against Tailwind:
 
    ```bash
@@ -130,11 +152,8 @@ See `lib/rules.mli` for the complete layer model documentation.
    dune exec -- tw -s "border-2 border-solid" --diff
 
    # Or for test files
-   ALCOTEST_VERBOSE=1 dune exec test/test.exe test tw 10
-   diff -u tmp/css_debug/test_10_tw.css tmp/css_debug/test_10_tailwind.css
+   ALCOTEST_VERBOSE=1 dune exec test/test.exe -- test borders 10
    ```
-
-   (Paths under `tmp/css_debug/` are created by tests.)
 
 ---
 
@@ -174,38 +193,44 @@ See `lib/rules.mli` for the complete layer model documentation.
   does NOT emit `@property --tw-leading` because it only references the variable with a fallback.
   However, `leading-relaxed` sets `--tw-leading: var(--leading-relaxed)` and DOES emit `@property`.
 
-  The logic is in `collect_all_property_rules` in `rules.ml` which filters by `set_var_names`
+  The logic is in `collect_all_property_rules` in `lib/build.ml` which filters by `set_var_names`
   extracted from Custom_declarations.
 
 * **Wrong property order in `@layer properties`?**
 
-  Check `property_order` in `rules.ml`. Properties are sorted by category:
-  - Transform (0-9): `tw-scale-x`, `tw-scale-y`, etc.
-  - Gradients (10-19): `tw-gradient-*`
-  - Borders (25): `tw-border-style`
-  - Typography (28-32): `tw-leading`, `tw-font-weight`, `tw-tracking`
-  - Animation (40-41): `tw-duration`, `tw-ease`
-  - Default (100): everything else
+  A variable's slot comes from the `~property_order` argument it was declared
+  with (`Var.property_default` or `Var.channel`), read back through
+  `Var.property_order`. `sort_properties_by_order` in `lib/build.ml` combines it
+  with `canonical_property_rank`, which ranks a `--tw-*` variable by the CSS
+  property it feeds: transform 16, background-image 28, line-height 39,
+  font-weight 40, letter-spacing 41, box-shadow 51, filter 53, transition 56,
+  text-shadow 59 (last), and 1000 for a variable with no family. Transform,
+  gradient, duration and typography families order by first usage instead;
+  `order_by_first_usage` decides which rule applies to a given pair.
 
-* **Order mismatch?**
+* **Order mismatch in `@layer theme`?**
 
   ```bash
   grep "~order:" lib/typography.ml
   ```
 
-  Match canonical order constants in `var.ml`.
+  Theme order is a `(group, index)` pair: the group buckets the family in
+  Tailwind's `@theme` order, the index places the token inside it. Match the
+  neighbours of the token you are adding; `Var.order` reads the pair back and
+  `lib/var.ml` refuses a second registration for an already-taken slot.
 
 * **Targeted test run:**
 
   ```bash
-  ALCOTEST_VERBOSE=1 dune exec test/test.exe test tw <N>
+  ALCOTEST_VERBOSE=1 dune exec test/test.exe -- test <suite> <N>
   ```
 
-  For tools tests (css diff, tree diff, etc.):
+  Suite names match the `lib/` module (`borders`, `sort`, `build`, …); run
+  `dune exec test/test.exe -- list` for the full set. Differ tests live in
+  cascade:
 
   ```bash
-  # Note the required -- before args
-  ALCOTEST_VERBOSE=1 dune exec test/tools/test.exe -- test css_compare 12
+  ALCOTEST_VERBOSE=1 dune exec cascade/test/test.exe -- test css_compare 12
   ```
 
 * **Example test failures (e.g., `dune runtest` in `examples/prose/`):**
@@ -221,7 +246,9 @@ See `lib/rules.mli` for the complete layer model documentation.
      dune exec -- tw -s 'md:grid-cols-2 max-w-4xl' --diff
      ```
 
-  2. **Add a unit test**: Create a test in `test/test_rules.ml` that codifies the expected behavior
+  2. **Add a unit test**: Codify the expected behaviour in the `test_<module>.ml`
+     of the utility family involved, or in `test/test_sort.ml` when the bug is in
+     the comparator itself
      ```ocaml
      let test_your_case () =
        let utilities = Tw.[ md [ grid_cols 2 ]; max_w_4xl ] in
@@ -229,14 +256,14 @@ See `lib/rules.mli` for the complete layer model documentation.
          ~test_name:"regular before media" utilities
      ```
 
-  3. **Fix the issue**: Modify the relevant code (usually in `lib/rules.ml`)
+  3. **Fix the issue**: Modify the relevant code (usually in `lib/sort.ml`)
      - Pay attention to comparison functions and ordering logic
      - Ensure symmetric comparisons negate results when arguments are swapped
      - Regular rules should come before media queries at the same priority
 
   4. **Verify**: Run both the unit test and the original example test
      ```bash
-     ALCOTEST_VERBOSE=1 dune exec test/test.exe test rules <N>
+     ALCOTEST_VERBOSE=1 dune exec test/test.exe -- test sort <N>
      dune runtest
      ```
 
@@ -251,8 +278,11 @@ See `lib/rules.mli` for the complete layer model documentation.
        - Block at position 26: .contrast-more\:text-black
        + Block at position 27: .contrast-more\:border-4, .contrast-more\:text-black
      ```
-     **Fix**: Check `lib/css/optimize.ml` for media query merging. Consecutive `@media` blocks
-     with the same condition should be merged. The `merge_consecutive_media` function handles this.
+     **Fix**: Media query merging is cascade's. Consecutive `@media` blocks with the same
+     condition should be merged; `merge_consecutive_media` in `cascade/lib/block.ml`
+     (re-exported from `cascade/lib/optimize.ml`) handles this. On the tw side,
+     `Build.utilities_layer` runs the same merge over the sorted utilities layer, so a
+     rule sorting between two blocks is the usual cause.
 
   2. **"blocks at different positions"** - Media query appears at wrong location:
      ```
@@ -260,7 +290,7 @@ See `lib/rules.mli` for the complete layer model documentation.
        - Block at position 8: .motion-safe\:animate-pulse
        + Block at position 25: .motion-safe\:animate-pulse
      ```
-     **Fix**: Check `lib/rules.ml` comparison functions. The issue is usually in:
+     **Fix**: Check `lib/sort.ml` comparison functions. The issue is usually in:
      - `compare_regular_vs_media`: Regular rules vs Media rules ordering
      - `compare_media_rules`: Media rules vs Media rules ordering
      - `extract_media_sort_key`: How media queries are sorted (responsive vs preference)
@@ -271,7 +301,8 @@ See `lib/rules.mli` for the complete layer model documentation.
         └─ .flex-col ↔  @media (min-width:48rem)
      ```
      **Fix**: This is a Regular vs Media ordering issue. Check `compare_regular_vs_media` in
-     `lib/rules.ml`. Uses `is_modifier_selector` to detect `\:` in CSS selector - modifier media
+     `lib/sort.ml`. It reads the rule's `has_modifier_colon` field, set from
+     `Css.Selector.contains_modifier_colon` when `lib/build.ml` indexes the rule - modifier media
      (like `.md\:grid-cols-2`) comes after Regular rules, but built-in media (like container's
      breakpoints) stays grouped with its base utility via priority comparison.
 
@@ -289,21 +320,23 @@ See `lib/rules.mli` for the complete layer model documentation.
        + --tw-ring-color
        + --tw-ring-shadow
      ```
-     **Fix**: Check `lib/rules.ml` `build_properties_layer` and ensure the utility
+     **Fix**: Check `properties_layer` in `lib/build.ml` and ensure the utility
      properly declares its variables using `Var.property_rule`.
 
 ---
 
 ## 9) Common pitfalls (and fixes)
 
-1. Writing raw `"var(--name)"` or `Css.custom` → model it in `Var`, extend types if missing.
+1. Writing raw `"var(--name)"` or building a `Css.custom_property` value by
+   concatenation → model it in `Var`, extend types if missing.
 2. Setting variables in the wrong utility → only **style** utilities set style vars.
 3. Forgetting `~property_rules` on referrers → `@property` never emitted.
 4. Spreading tests across multiple concerns → one concept per file.
 5. Silencing warnings with `OCAMLPARAM=_,w=-32` → address them; do not suppress.
-6. Using non-existent `Css.kind` constructors → check `lib/css/declaration_intf.ml` for valid kinds.
-   If the kind genuinely needs its own type, add it to `declaration_intf.ml`. Otherwise, use an
-   existing kind (e.g., `Length` for letter-spacing since it takes length values).
+6. Using non-existent `Css.kind` constructors → check `type _ kind` in
+   `cascade/lib/properties_intf.ml` for valid kinds. If the kind genuinely needs its own
+   type, add it there. Otherwise, use an existing kind (e.g., `Length` for letter-spacing
+   since it takes length values).
 7. Adding `Raw of string` or similar escape hatches to bypass type safety → **NEVER**. Always add
    the properly typed properties/variants you need. Extend the type system rather than escape it.
 
@@ -311,9 +344,12 @@ See `lib/rules.mli` for the complete layer model documentation.
 
 ## 10) Tests — organisation & rules
 
-* `test/css/`: MDN/W3C conformance where feasible.
-* `test/`: Tailwind v4 parity by utility.
-* Output artefacts live under `tmp/css_debug/`.
+* `cascade/test/`: CSS parsing, printing and optimizing, MDN/W3C conformance
+  where feasible.
+* `test/`: Tailwind v4 parity by utility, one `test_<module>.ml` per
+  `lib/<module>.ml`.
+* `test/upstream/`: replay of Tailwind's own fixture corpus. Generated; never
+  hand-edit.
 * **Rules:**
 
   1. Define named test functions (`let test_foo () = ...`).
@@ -332,7 +368,7 @@ See `lib/rules.mli` for the complete layer model documentation.
 
 ## 12) CSS comparison tool bugs — MUST FIX IMMEDIATELY
 
-⚠️ **CRITICAL**: If `--diff` or cssdiff reports **"No structural differences"** but there ARE actual differences in the CSS output, this is **NOT** a known limitation to work around. It is a **bug in the cssdiff tool that MUST be fixed before doing any other work**.
+⚠️ **CRITICAL**: If `--diff` or cssdiff reports **"No differences found"** but there ARE actual differences in the CSS output, this is **NOT** a known limitation to work around. It is a **bug in the cssdiff tool that MUST be fixed before doing any other work**.
 
 **Do NOT:**
 - Mark tests as "effectively passing" when cssdiff fails to detect real differences
@@ -341,16 +377,28 @@ See `lib/rules.mli` for the complete layer model documentation.
 
 **Instead:**
 1. **STOP** all other work immediately
-2. **FIX** the cssdiff tool in `lib/tools/css_compare.ml`
+2. **FIX** the differ in `cascade/lib/diff/css_compare.ml` (with `tree_diff.ml` and
+   `string_diff.ml` alongside it), add a case to `cascade/test/test_css_compare.ml`,
+   and land it in cascade. CI here pins cascade to its `main`, so the fix arrives
+   with the next run; bump the version bound in `dune-project` and `tw.opam` if it
+   needs a release
 3. **VERIFY** it correctly detects the differences it was missing
 4. **THEN** resume your original task
 
-**Known cssdiff bugs that need fixing** (not "limitations" — actual bugs):
-- Reports string diffs instead of structural diffs when selectors are fundamentally different (e.g., missing pseudo-elements like `::marker`)
-- Shows "no structural differences" when property values differ (e.g., `clip-path: inset(50%)` syntax)
-- Does not detect when entire selector chains are missing (e.g., `.hover\:prose:hover :where(ol>li)::marker` vs `.hover\:prose:hover`)
+The differ is cascade's, and tw only consumes it. Never work around a differ bug
+on the tw side: a comparison hack here hides the bug from every other cascade
+consumer and leaves the differ reporting the same false negative.
 
-The cssdiff tool is the foundation of our Tailwind parity testing. If it cannot reliably detect differences, we cannot trust any of our tests. Fixing it is always the highest priority.
+The one thing to check before calling it a bug is that you are comparing what you
+think you are. `--diff` defaults to canonical mode, which is deliberately blind to
+selector regrouping, cascade-neutral reordering and a few equivalent spellings; a
+difference it drops on purpose is not a false negative. Pass `--diff-mode=tree` or
+`--diff-mode=string` to see the layer below, and compare the raw sheets when
+duplication or placement is what you are chasing.
+
+The differ is the foundation of our Tailwind parity testing. If it cannot reliably
+detect differences, we cannot trust any of our tests. Fixing it is always the
+highest priority.
 
 ---
 
@@ -358,9 +406,9 @@ The cssdiff tool is the foundation of our Tailwind parity testing. If it cannot 
 
 * [ ] Variable pattern chosen and used consistently (link line numbers).
 * [ ] Correct layer(s) touched; no cross-layer leakage.
-* [ ] No raw `"var(--...)"` or `Css.custom`.
+* [ ] No raw `"var(--...)"` or assembled `Css.custom_property` values.
 * [ ] `@property` emitted when required (`~property_rules` present).
 * [ ] Tests: one concept/file; includes invalid input.
-* [ ] Tailwind parity diff checked under `tmp/css_debug/`.
+* [ ] Tailwind parity checked with `tw --diff`.
 * [ ] Warnings addressed; no suppression flags.
 * [ ] Commands in docs/scripts write to `tmp/` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Keep examples small and targeted; each test file should focus on one concept.
 
 ## 4) Quick start (build, run, compare)
 
+<!-- $MDX skip -->
 ```bash
 # Build
 dune build
@@ -69,6 +70,24 @@ dune exec -- tw -s "p-4" --diff
 dune exec -- tw -s "p-4" --tailwind
 ```
 
+The negative-class form, run against a `tw` already on `PATH`:
+
+```sh
+$ tw --single="-mt-4" --variables
+@layer theme, components, utilities;
+@layer theme {
+  :root, :host {
+    --spacing: .25rem;
+  }
+}
+@layer components;
+@layer utilities {
+  .-mt-4 {
+    margin-top: calc(var(--spacing) * -4);
+  }
+}
+```
+
 ### Backend modes (mutually exclusive)
 
 The `tw` binary supports three backend modes:
@@ -86,6 +105,7 @@ The `tw` binary supports three backend modes:
   a stricter mode (`tree` reports regrouping, `string` reports text).
 
 Example diff output:
+<!-- $MDX skip -->
 ```bash
 $ dune exec -- tw --single="supports-[backdrop-filter]:bg-black/50" --diff
 Differences found between Tailwind and tw for 'supports-[backdrop-filter]:bg-black/50':

--- a/docs/adding-a-new-utility.md
+++ b/docs/adding-a-new-utility.md
@@ -10,13 +10,13 @@ Every CSS variable in our system follows one of these patterns (4 variable types
 **Purpose**: Design tokens set once in theme layer, referenced by utilities
 **Examples**: `--text-xl: 1.25rem`, `--font-weight-bold: 700`, `--color-blue-500: #3b82f6`
 **Layer**: `@layer theme` in `:root,:host`
-**Usage**: `Var.theme kind name ~order:N` and set via `Var.binding` once
+**Usage**: `Var.theme kind name ~order:(group, index)` and set via `Var.binding` once
 
 ### Pattern 2: Property_default Variables
 **Purpose**: Variables with @property defaults that utilities can either SET or REFERENCE
 **Examples**: `--tw-border-style` (default: solid), `--tw-border-opacity` (default: 1)
 **Layer**: `@layer properties` for defaults, `@property` rules at top level
-**Usage**: Use `Var.property_default kind ~initial ~inherits? ~universal? name` (initial is mandatory). Referencing utilities call `Var.reference` and include `~property_rules:(Var.property_rule var)`
+**Usage**: Use `Var.property_default kind ~initial ~inherits? ~universal? name` (initial is mandatory). Referencing utilities call `Var.reference` and include `~property_rules:(Var.property_rules var)`
 
 ### Pattern 3: Channel Variables
 **Purpose**: Composition variables where multiple utilities contribute to a single CSS property
@@ -66,28 +66,35 @@ Use this decision tree:
   - Use for `channel` variables when you need a fallback value
   - Signature: `Var.reference_with_fallback var fallback_value`
 
-- `Var.property_rule`: generates @property rule (Pattern 2 only)
+- `Var.property_rule`: generates @property rule (Patterns 2 and 3)
   - Returns `Some rule` if variable has property metadata
-  - Pass to `style ~property_rules` to generate @property
+  - Pass to `Style.style ~property_rules` to generate @property
+  - `Var.property_rules` is the same thing for a `property_default`, already
+    defaulted to `Css.empty`
 
 ## Pattern Examples
+
+`Style.style` takes declarations only. The class name lives in the module's
+`Handler`, which maps a variant to its class through `to_class` and back through
+`of_class`; `lib/utility.mli` shows the whole shape.
 
 ### Pattern 1: Theme Variables (Typography)
 ```ocaml
 (* Define theme variables with explicit ordering *)
-let text_xl_size_var = Var.theme Css.Length "text-xl" ~order:110
-let text_xl_lh_var = Var.theme Css.Length "text-xl--line-height" ~order:111
+let text_xl_size_var = Var.theme Css.Length "text-xl" ~order:(6, 8)
+let text_xl_lh_var = Var.theme Css.Line_height "text-xl--line-height" ~order:(6, 9)
 
 (* Set theme values once *)
 let size_def, size_var = Var.binding text_xl_size_var (Rem 1.25)
 let lh_def, lh_var = Var.binding text_xl_lh_var (Rem 1.75)
 
 (* Utility references theme variables *)
-style "text-xl" [
-  size_def; lh_def;
-  font_size (Var size_var);
-  line_height (Var lh_var)
-]
+let text_xl =
+  Style.style [
+    size_def; lh_def;
+    font_size (Var size_var);
+    line_height (Var lh_var)
+  ]
 ```
 
 ### Pattern 2: Property_default Variables (Borders)
@@ -99,14 +106,12 @@ let border_style_var =
 (* Setting utility - changes the variable *)
 let border_solid =
   let decl, var_ref = Var.binding border_style_var Solid in
-  style "border-solid" [ decl; border_style (Var var_ref) ]
+  Style.style [ decl; border_style (Var var_ref) ]
 
 (* Referencing utility - uses @property default *)
 let border =
   let var_ref = Var.reference border_style_var in
-  let property_rule = match Var.property_rule border_style_var with
-    | Some rule -> rule | None -> Css.empty in
-  style "border" ~property_rules:property_rule [
+  Style.style ~property_rules:(Var.property_rules border_style_var) [
     border_style (Var var_ref);
     border_width (Px 1.)
   ]
@@ -123,18 +128,18 @@ let scale_var = Var.property_default Css.Number_percentage ~initial:(Num 1.0) "t
 (* Contributing utilities set their channels *)
 let translate_x_4 =
   let decl, _ = Var.binding translate_x_var (Rem 1.) in
-  style "translate-x-4" [ decl ]
+  Style.style [ decl ]
 
 let rotate_45 =
   let decl, _ = Var.binding rotate_var (Deg 45.) in
-  style "rotate-45" [ decl ]
+  Style.style [ decl ]
 
 (* Aggregator utility combines all channels - use reference_with_fallback for channels *)
 let transform =
   let tx_ref = Var.reference_with_fallback translate_x_var Zero in
   let rot_ref = Var.reference_with_fallback rotate_var (Deg 0.) in
   let scale_ref = Var.reference scale_var in  (* property_default has built-in default *)
-  style "transform" [
+  Style.style [
     transform (Transform [
       TranslateX (Var tx_ref);
       Rotate (Var rot_ref);
@@ -151,14 +156,14 @@ let shadow_color_var = Var.channel Css.Color "tw-shadow-color"
 (* Shadow utilities reference with fallback using reference_with_fallback *)
 let shadow_sm =
   let color_ref = Var.reference_with_fallback shadow_color_var (Css.hex "#0000001a") in
-  style "shadow-sm" [
+  Style.style [
     box_shadow (Shadow [0; 1; 3; 0; Var color_ref])
   ]
 
 (* Color utilities set the variable (in different module) *)
 let shadow_red_500 =
   let decl, _ = Var.binding shadow_color_var (Css.hex "#ef4444") in
-  style "shadow-red-500" [ decl ]
+  Style.style [ decl ]
 ```
 
 ### Pattern 5: Always-set Variables (Font Weight)
@@ -168,54 +173,62 @@ let font_weight_var = Var.channel Css.Font_weight "tw-font-weight"
 
 (* Every utility sets and uses it *)
 let font_bold =
-  let decl, var_ref = Var.binding font_weight_var (Int 700) in
-  style "font-bold" [
+  let decl, var_ref = Var.binding font_weight_var (Weight 700) in
+  Style.style [
     decl;
     font_weight (Var var_ref)
   ]
 
 let font_thin =
-  let decl, var_ref = Var.binding font_weight_var (Int 100) in
-  style "font-thin" [
+  let decl, var_ref = Var.binding font_weight_var (Weight 100) in
+  Style.style [
     decl;
     font_weight (Var var_ref)
   ]
 ```
 
-How Rules turns this into layers
+How Build turns this into layers
 
-- `compute_theme_layer` scans used styles, extracts custom declarations (from `Var.theme`), adds a small set of default vars (font families), and emits them under `@layer theme` in `:root,:host` with a stable order.
-  
-  **Variable Ordering**: The `order` function in `var.ml` determines the canonical ordering of variables in the theme layer. Each variable type has a numeric order value that ensures consistent output matching Tailwind v4. For example:
-  - Font families: 0-10
-  - Font sizes and line heights: 100-199  
-  - Font weights: 200-209
-  - Border radius: 300-307
-  - Default font families: 400-405
-  
-- `build_properties_layer` collects all `property_rules` attached to used utilities (from `Var.property_rule ...`) and emits an `@layer properties` that contains a single `@supports(...) { ... }` block with default custom-property values targeting `*, :before, :after, ::backdrop` (not the `@property` rules themselves).
-- `build_base_layer` wraps Preflight rules under `@layer base` and applies the placeholder support shim.
+- `theme_layer_of` scans used styles, extracts custom declarations (from `Var.theme`), adds a small set of default vars (font families), and emits them under `@layer theme` in `:root,:host` with a stable order.
+
+  **Variable Ordering**: `Var.order` reads back the `~order:(group, index)` pair a
+  theme variable was declared with. The group buckets the family in the order
+  Tailwind emits its `@theme` block (1 font families, 3 spacing, 5 container
+  widths, 6 font sizes, 7 animations, 8 blurs, 9 defaults) and the index places
+  the token inside its group. `lib/var.ml` keeps a registry of taken slots and
+  ignores a second registration for one, so two tokens cannot share a slot. Read
+  the neighbours of the token you are adding rather than guessing a group.
+
+- `properties_layer` collects all `property_rules` attached to used utilities (from `Var.property_rule ...`) and emits an `@layer properties` that contains a single `@supports(...) { ... }` block with default custom-property values targeting `*, :before, :after, ::backdrop` (not the `@property` rules themselves).
+- `base_layer` wraps Preflight rules under `@layer base` and applies the placeholder support shim.
 - Components is left empty by default; utilities render to `@layer utilities`.
 - When minifying, consecutive empty layers are merged into a single declaration, e.g., `@layer components,utilities;` to match Tailwind output.
 
-**Rule Ordering and Conflict Groups**:
-The Rules module uses a sophisticated conflict group system to ensure proper CSS cascade behavior:
+All four live in `lib/build.ml`; `lib/build.mli` documents the assembled result.
 
-- **Conflict Groups**: Utilities are grouped by their conflict relationships (e.g., all padding utilities conflict with each other)
-- **Stable Sort**: Within each conflict group, `List.stable_sort` preserves the original order while applying the group's sorting function
-- **Suborder Functions**: Fine-grained control within groups using the `suborder` field in conflict definitions
-- **Example**: For prose utilities, the suborder ensures `.prose` comes before `.prose :where(...)` child selectors:
+**Rule Ordering and Conflict Groups**:
+Cascade position comes from a `(priority, suborder)` pair, so utilities that
+conflict resolve in Tailwind's order:
+
+- **Priority**: `Utility.S.priority` groups a whole family (all padding utilities
+  share one). `lib/utility.mli` lists the bands.
+- **Suborder**: `Utility.S.suborder` orders variants inside the family. It is a
+  plain function on the module's variant type:
   ```ocaml
-  suborder = (fun core -> 
-    if core = "prose" then 0                        (* .prose first *)
-    else if String.starts_with ~prefix:"prose " then 1  (* .prose :where(...) second *)
-    else 2);                                         (* others last *)
+  let suborder = function Border -> 0 | Content -> 1
   ```
+- **Lookup**: `Build.conflict_order` resolves the pair for a selector, and
+  `Sort.compare_indexed_rules` sorts on it with the source index as a stable
+  tiebreaker.
+- **Pseudo-elements**: `adjust_pseudo` in `lib/build.ml` adds 5000 to the suborder
+  of a `before:`/`after:` rule, so it trails the base utility rather than
+  interleaving with it.
 
 **CSS Minification Considerations**:
-- The minifier must preserve spaces in descendant combinators (`.prose :where()` not `.prose:where()`)
-- Special handling for pseudo-classes: spaces before `:where()`, `:not()`, etc. are significant
-- Test with `--minify` flag to ensure selector specificity isn't altered
+- Minification is cascade's; `Css.Selector.to_string ~minify:true` is what tw calls
+- Descendant combinators must survive it (`.prose :where()`, not `.prose:where()`),
+  because the space before `:where()`, `:not()` and friends is significant
+- Test with `--minify` to ensure selector specificity isn't altered
 
 ## Applying the Patterns to New Utilities
 
@@ -231,7 +244,7 @@ Ask yourself these questions in order:
 ### Step 2: Implement According to Pattern
 
 **Pattern 1 (Theme)**:
-- Use `Var.theme kind name ~order:N`
+- Use `Var.theme kind name ~order:(group, index)`
 - Set value once with `Var.binding`
 - Reference in utilities with `Var` constructor
 
@@ -254,9 +267,9 @@ Ask yourself these questions in order:
 - Use `Var.channel kind name`
 - Always use `Var.binding` to set and reference
 
-### Step 3: Let Rules Handle Layers
+### Step 3: Let Build Handle Layers
 
-The Rules engine automatically:
+`lib/build.ml` automatically:
 - Collects Pattern 1 variables into `@layer theme`
 - Generates `@layer properties` for Pattern 2 defaults
 - Emits `@property` rules when needed
@@ -268,7 +281,8 @@ Good references
 - Typography font weight: `lib/typography.ml` (@property registration pattern)
 - Borders pattern: `lib/borders.ml` (setting vs referencing utilities)
 - Shadow utilities: `lib/effects.ml` (using `Var.reference` with fallback)
-- Layer assembly: `lib/rules.ml` (`compute_theme_layer`, `build_properties_layer`)
+- Layer assembly: `lib/build.ml` (`theme_layer_of`, `properties_layer`)
+- Module shape for a utility family: `lib/utility.mli`
 
 Debugging utilities
 
@@ -312,14 +326,14 @@ When output is shorter than expected:
 ```ocaml
 (* Define theme token with explicit order *)
 let my_size_var =
-  Var.theme Css.Length "my-size" ~order:150
+  Var.theme Css.Length "my-size" ~order:(4, 900)
 
 (* Set value once in theme *)
 let size_def, size_var = Var.binding my_size_var (Rem 2.5)
 
 (* Reference in utility *)
 let my_utility =
-  style "my-class" [
+  Style.style [
     size_def;  (* Include definition *)
     width (Var size_var);
     height (Var size_var)
@@ -335,14 +349,12 @@ let my_style_var =
 (* Setting utility *)
 let my_setter value =
   let decl, var_ref = Var.binding my_style_var value in
-  style "my-setter" [ decl; my_property (Var var_ref) ]
+  Style.style [ decl; my_property (Var var_ref) ]
 
 (* Referencing utility with @property *)
 let my_referencer =
   let var_ref = Var.reference my_style_var in
-  let property_rule = match Var.property_rule my_style_var with
-    | Some rule -> rule | None -> Css.empty in
-  style "my-ref" ~property_rules:property_rule [
+  Style.style ~property_rules:(Var.property_rules my_style_var) [
     my_property (Var var_ref)
   ]
 ```
@@ -356,13 +368,13 @@ let channel_b_var = Var.channel Css.Angle "tw-channel-b"
 (* Contributing utilities *)
 let set_channel_a value =
   let decl, _ = Var.binding channel_a_var value in
-  style "channel-a" [ decl ]
+  Style.style [ decl ]
 
 (* Aggregator utility - use reference_with_fallback for channels *)
 let aggregate =
   let a_ref = Var.reference_with_fallback channel_a_var Zero in
   let b_ref = Var.reference_with_fallback channel_b_var (Deg 0.) in
-  style "aggregate" [
+  Style.style [
     my_composite_property [Var a_ref; Var b_ref]
   ]
 ```
@@ -375,14 +387,14 @@ let color_override_var = Var.channel Css.Color "tw-my-color"
 (* Reference with fallback using reference_with_fallback *)
 let my_colored_thing =
   let color_ref = Var.reference_with_fallback color_override_var default_color in
-  style "my-thing" [
+  Style.style [
     background_color (Var color_ref)
   ]
 
 (* Set elsewhere (different module) *)
 let my_thing_red =
   let decl, _ = Var.binding color_override_var (Css.hex "#ff0000") in
-  style "my-thing-red" [ decl ]
+  Style.style [ decl ]
 ```
 
 ### Pattern 5: Always-set Template
@@ -394,38 +406,35 @@ let my_value_var =
 (* Every utility sets and uses *)
 let my_small =
   let decl, var_ref = Var.binding my_value_var (Px 10.) in
-  style "my-small" [ decl; padding (Var var_ref) ]
+  Style.style [ decl; padding (Var var_ref) ]
 
 let my_large =
   let decl, var_ref = Var.binding my_value_var (Px 40.) in
-  style "my-large" [ decl; padding (Var var_ref) ]
+  Style.style [ decl; padding (Var var_ref) ]
 ```
 
 Common pitfalls and solutions
 
 **Rule Ordering Issues**
 - **Problem**: Child selectors appearing before parent selectors (e.g., `.prose :where(p)` before `.prose`)
-- **Solution**: Adjust the conflict group's suborder function to explicitly order selectors
-- **Debugging**: Add print statements in `rules.ml` to see the order before and after sorting
+- **Solution**: Adjust the family's `suborder` function to order the variants explicitly
+- **Debugging**: `Build.indexed_rules` and `Build.compare_rules` are exposed so the comparator can be exercised on the values it really sees; `test/test_sort.ml` does this
 - **Key insight**: The order matters for CSS cascade - parent rules should come first
 
 **CSS Minification Breaking Selectors**
 - **Problem**: Minifier removing spaces in descendant combinators, changing selector meaning
-- **Solution**: Update `minify_selector` in `css.ml` to preserve spaces before pseudo-classes
+- **Solution**: Fix it in cascade, in `Selector.to_string ~minify:true`, not by rewriting the selector here
 - **Example**: `.prose :where(p)` (descendant) vs `.prose:where(p)` (direct) have different meanings
 - **Testing**: Always test with `--minify` flag to catch these issues early
 
-**CRITICAL: Never use var(...) in string literals or Css.custom**
-- **Never do this**: `Css.custom "box-shadow" "var(--tw-shadow)"` 
+**CRITICAL: Never use var(...) in string literals or assembled token strings**
+- **Never do this**: `Css.custom_property "--tw-shadow" "var(--tw-shadow-color)"`
 - **Never do this**: `box_shadow (Raw "var(--tw-shadow)")`
-- **Why**: 
-  - String literals containing `var(...)` break the Rules engine's ability to track dependencies, resolve variables, and generate correct layers
-  - `Css.custom` is a code smell - it bypasses the type system and makes the code fragile
+- **Why**:
+  - String literals containing `var(...)` break the ability to track dependencies, resolve variables, and generate correct layers
+  - Assembling a value as a string bypasses the type system and makes the code fragile
 - **Instead**: Always use typed `Var` references from `Var.theme`, `Var.channel`, or `Var.property_default`
-- **Exception**: When a CSS variable's actual value contains `var(...)` references (like Tailwind v4's `--tw-gradient-stops`), the string is the proper CSS value, not a reference. In these cases:
-  - The variable type should be `string t` in var.ml
-  - Use `Css.Computed_stops` or similar typed constructors when available
-  - Document clearly that this is the CSS value, not a variable reference
+- **Exception**: A variable whose value legitimately holds a stop list or a token stream (Tailwind v4's `--tw-gradient-stops`) still gets a typed kind. `backgrounds.ml` declares it `Var.property_default Gradient_stop ~universal:true`, which registers `syntax: "*"` while keeping the OCaml value typed
 - **If you need new functionality**: Extend the type system properly:
   - Add new constructors to existing types following the standard pattern:
     ```ocaml
@@ -451,17 +460,17 @@ Common pitfalls and solutions
 
 3. **@property syntax for enumerated values**
    - **Problem**: Using enumerated syntax like `"solid" | "dashed" | "dotted"` for `@property` registration
-   - **Solution**: Use `syntax:"*"` for generic/untyped properties that can accept any value
-   - **Example**: `Var.property Var.Border_style ~syntax:"*" ~inherits:false ~initial:"solid"`
+   - **Solution**: Pass `~universal:true` to `Var.property_default`, which registers `syntax: "*"` while the OCaml value stays typed
+   - **Example**: `Var.property_default Css.Border_style ~initial:Solid ~universal:true "tw-border-style"`
 
 4. **Variable ordering in theme layer**
    - **Problem**: Variables appearing in wrong order in `@layer theme`, causing test failures
-   - **Solution**: Ensure the `order` function in `var.ml` assigns correct numeric values to match Tailwind v4's output
-   - **Note**: The `canonical_theme_order` list is often redundant if the `order` function provides complete ordering
+   - **Solution**: Fix the `~order:(group, index)` pair the variable was declared with; `Var.order` is what the theme layer reads
+   - **Note**: `lib/var.ml` drops a registration whose slot is already taken, so a duplicated pair shows up as a missing variable rather than a reordering
 
 5. **Font-variant-numeric empty fallback handling**
-   - **Problem**: Font-variant-numeric variables need trailing commas in CSS but normal fallback generates wrong syntax
-   - **Solution**: Use `~fallback:Css.Empty` and add an `Empty` constructor to handle this special case
+   - **Problem**: Font-variant-numeric variables need trailing commas in CSS but a normal fallback generates the wrong syntax
+   - **Solution**: Pass `~fallback:Css.Empty` to `Var.binding` (or use `Var.reference_with_empty_fallback` where there is nothing to bind)
    - **Result**: Generates `var(--tw-ordinal,)` with trailing comma as required by Tailwind v4
 
 6. **Helper functions to reduce duplication**

--- a/docs/adding-a-new-utility.md
+++ b/docs/adding-a-new-utility.md
@@ -135,15 +135,15 @@ let rotate_45 =
   Style.style [ decl ]
 
 (* Aggregator utility combines all channels - use reference_with_fallback for channels *)
-let transform =
+let transform_all =
   let tx_ref = Var.reference_with_fallback translate_x_var Zero in
   let rot_ref = Var.reference_with_fallback rotate_var (Deg 0.) in
   let scale_ref = Var.reference scale_var in  (* property_default has built-in default *)
   Style.style [
-    transform (Transform [
-      TranslateX (Var tx_ref);
+    transform (List [
+      Translate_x (Var tx_ref);
       Rotate (Var rot_ref);
-      Scale (Var scale_ref)
+      Scale_x (Var scale_ref)
     ])
   ]
 ```
@@ -157,7 +157,11 @@ let shadow_color_var = Var.channel Css.Color "tw-shadow-color"
 let shadow_sm =
   let color_ref = Var.reference_with_fallback shadow_color_var (Css.hex "#0000001a") in
   Style.style [
-    box_shadow (Shadow [0; 1; 3; 0; Var color_ref])
+    box_shadow (Shadow {
+      h_offset = Px 0.; v_offset = Px 1.;
+      blur = Some (Px 3.); spread = Some (Px 0.);
+      color = Some (Var color_ref)
+    })
   ]
 
 (* Color utilities set the variable (in different module) *)
@@ -213,10 +217,8 @@ conflict resolve in Tailwind's order:
 - **Priority**: `Utility.S.priority` groups a whole family (all padding utilities
   share one). `lib/utility.mli` lists the bands.
 - **Suborder**: `Utility.S.suborder` orders variants inside the family. It is a
-  plain function on the module's variant type:
-  ```ocaml
-  let suborder = function Border -> 0 | Content -> 1
-  ```
+  plain function on the module's variant type, as in `box_sizing.ml`'s
+  `let suborder = function Border -> 0 | Content -> 1`.
 - **Lookup**: `Build.conflict_order` resolves the pair for a selector, and
   `Sort.compare_indexed_rules` sorts on it with the source index as a stable
   tiebreaker.
@@ -286,22 +288,43 @@ Good references
 
 Debugging utilities
 
-To debug CSS generation issues, use the tw CLI tool:
+To debug CSS generation issues, use the tw CLI tool. The commands below call `tw`
+directly; from a checkout without it on `PATH`, prefix them with `dune exec --`.
 
-```bash
+<!-- $MDX skip -->
+```sh
 # Generate CSS for a class without the base layer (useful for test comparisons)
-dune exec -- tw -s <class> --variables
+tw -s <class> --variables
 
 # Include the base layer
-dune exec -- tw -s <class> --variables --base
+tw -s <class> --variables --base
 
 # Test with minification (critical for finding selector issues)
-dune exec -- tw -s <class> --variables --minify
+tw -s <class> --variables --minify
+```
 
-# Examples:
-dune exec -- tw -s shadow-sm --variables  # See shadow-sm without base layer
-dune exec -- tw -s border-none --variables # Debug border utilities
-dune exec -- tw -s "prose prose-lg" --variables --minify # Test complex selectors
+A style utility sets its variable and reads it back in the same rule:
+
+```sh
+$ tw -s border-none --variables
+@layer theme, components, utilities;
+@layer theme {
+
+}
+@layer components;
+@layer utilities {
+  .border-none {
+    --tw-border-style: none;
+    border-style: none;
+  }
+}
+```
+
+Minified, which is where a selector bug shows up:
+
+```sh
+$ tw -s border-none --variables --minify
+@layer theme,components,utilities;@layer theme;@layer components;@layer utilities{.border-none{--tw-border-style:none;border-style:none}}
 ```
 
 This helps you:
@@ -343,39 +366,39 @@ let my_utility =
 ### Pattern 2: Property_default Template
 ```ocaml
 (* Variable with @property default *)
-let my_style_var =
-  Var.property_default Css.My_type ~initial:default_value "tw-my-style"
+let my_content_var =
+  Var.property_default Css.Content ~initial:(String "") "tw-my-content"
 
 (* Setting utility *)
 let my_setter value =
-  let decl, var_ref = Var.binding my_style_var value in
-  Style.style [ decl; my_property (Var var_ref) ]
+  let decl, var_ref = Var.binding my_content_var value in
+  Style.style [ decl; content (Var var_ref) ]
 
 (* Referencing utility with @property *)
 let my_referencer =
-  let var_ref = Var.reference my_style_var in
-  Style.style ~property_rules:(Var.property_rules my_style_var) [
-    my_property (Var var_ref)
+  let var_ref = Var.reference my_content_var in
+  Style.style ~property_rules:(Var.property_rules my_content_var) [
+    content (Var var_ref)
   ]
 ```
 
 ### Pattern 3: Channel Template
 ```ocaml
 (* Channel variables for composition *)
-let channel_a_var = Var.channel Css.Length "tw-channel-a"
-let channel_b_var = Var.channel Css.Angle "tw-channel-b"
+let channel_blur_var = Var.channel Css.Length "tw-channel-blur"
+let channel_hue_var = Var.channel Css.Angle "tw-channel-hue"
 
 (* Contributing utilities *)
-let set_channel_a value =
-  let decl, _ = Var.binding channel_a_var value in
+let set_channel_blur value =
+  let decl, _ = Var.binding channel_blur_var value in
   Style.style [ decl ]
 
 (* Aggregator utility - use reference_with_fallback for channels *)
 let aggregate =
-  let a_ref = Var.reference_with_fallback channel_a_var Zero in
-  let b_ref = Var.reference_with_fallback channel_b_var (Deg 0.) in
+  let blur_ref = Var.reference_with_fallback channel_blur_var Zero in
+  let hue_ref = Var.reference_with_fallback channel_hue_var (Deg 0.) in
   Style.style [
-    my_composite_property [Var a_ref; Var b_ref]
+    filter (List [ Blur (Var blur_ref); Hue_rotate (Var hue_ref) ])
   ]
 ```
 
@@ -386,7 +409,9 @@ let color_override_var = Var.channel Css.Color "tw-my-color"
 
 (* Reference with fallback using reference_with_fallback *)
 let my_colored_thing =
-  let color_ref = Var.reference_with_fallback color_override_var default_color in
+  let color_ref =
+    Var.reference_with_fallback color_override_var (Css.hex "#0000001a")
+  in
   Style.style [
     background_color (Var color_ref)
   ]
@@ -406,11 +431,11 @@ let my_value_var =
 (* Every utility sets and uses *)
 let my_small =
   let decl, var_ref = Var.binding my_value_var (Px 10.) in
-  Style.style [ decl; padding (Var var_ref) ]
+  Style.style [ decl; padding [ Var var_ref ] ]
 
 let my_large =
   let decl, var_ref = Var.binding my_value_var (Px 40.) in
-  Style.style [ decl; padding (Var var_ref) ]
+  Style.style [ decl; padding [ Var var_ref ] ]
 ```
 
 Common pitfalls and solutions
@@ -435,18 +460,24 @@ Common pitfalls and solutions
   - Assembling a value as a string bypasses the type system and makes the code fragile
 - **Instead**: Always use typed `Var` references from `Var.theme`, `Var.channel`, or `Var.property_default`
 - **Exception**: A variable whose value legitimately holds a stop list or a token stream (Tailwind v4's `--tw-gradient-stops`) still gets a typed kind. `backgrounds.ml` declares it `Var.property_default Gradient_stop ~universal:true`, which registers `syntax: "*"` while keeping the OCaml value typed
-- **If you need new functionality**: Extend the type system properly:
-  - Add new constructors to existing types following the standard pattern:
-    ```ocaml
-    type box_shadow =
-      | Shadow of shadow
-      | Shadows of shadow list  
-      | None
-      | Var of box_shadow var  (* Standard pattern: Var (no suffix) with typed variable *)
-    ```
-  - The naming convention is always `Var` (not `Var_list`, `Var_composition`, etc.)
-  - The `Var` constructor holds a typed variable reference created by `Var.channel`, `Var.property_default`, or `Var.theme`
-  - Never work around the type system with strings
+- **If you need new functionality**: Extend the type system properly. Add new
+  constructors to existing types following the standard pattern, which every
+  cascade value type follows:
+
+```ocaml
+type my_shadow =
+  | Shadow of shadow
+  | Shadows of shadow list
+  | None
+  | Var of my_shadow var  (* Standard pattern: Var (no suffix), typed variable *)
+
+let _ : my_shadow = Shadows []
+```
+
+The naming convention is always `Var`, never `Var_list` or `Var_composition`,
+and the constructor holds a typed variable reference created by `Var.channel`,
+`Var.property_default` or `Var.theme`. Never work around the type system with
+strings.
 
 1. **Border utilities setting variables incorrectly**
    - **Problem**: Border width utilities (border, border-2, etc.) were incorrectly setting the `--tw-border-style` variable instead of just using it

--- a/docs/dune
+++ b/docs/dune
@@ -1,0 +1,5 @@
+(mdx
+ (files adding-a-new-utility.md parity.md)
+ (preludes mdx/prelude.ml)
+ (libraries tw cascade)
+ (deps %{bin:tw}))

--- a/docs/mdx/prelude.ml
+++ b/docs/mdx/prelude.ml
@@ -1,0 +1,4 @@
+module Css = Cascade.Css
+module Var = Tw.Var
+module Style = Tw.Style
+open Cascade.Css

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -106,6 +106,38 @@ canonicalised sheets and diff the multisets instead.
 
 ## Why the number is not zero
 
+### The current residual
+
+Every entry the whole-site comparison still reports is tolerated: a class tw
+rejects on purpose, a disagreement between the two minifiers, or a spelling that
+selects the same elements. None of them changes what a browser renders. Treat a
+new entry, or the disappearance of one of these, as something to investigate.
+
+In the utilities layer:
+
+- The docs pages' literal `[<value>]` placeholder classes, which Tailwind
+  splices verbatim into CSS no browser accepts and tw rejects. See below.
+- `after:content-['_↗']`. Tailwind leaves the arrow unescaped in the class
+  selector. U+2197 is not one of the non-ASCII ident code points CSS Syntax 3
+  admits, so an ident cannot carry it literally; tw writes `\2197 `. The two
+  selectors match the same element.
+- `supports-[backdrop-filter]:*`. cascade keeps the `@supports` guard,
+  lightningcss elides it under Tailwind's browserslist.
+- `hue-rotate-0` and `backdrop-hue-rotate-0`. `hue-rotate()` is the spec-legal
+  minification of `hue-rotate(0deg)`; lightningcss does not perform it.
+- `@container` block splits, from container variants written as function calls.
+  Given `@min-[theme(--breakpoint-lg)]`, tw resolves the token and sorts the
+  block by the width it denotes; Tailwind sorts by the bracket text. The blocks
+  land in different places, so different neighbours merge with them.
+
+In the components layer:
+
+- `calc(28 / 18)`, which cascade will not fold.
+- `-webkit-text-decoration-color`, which lightningcss emits twice.
+
+The four minifier entries are in the table under *Two minifiers*, the
+placeholders under *Placeholder classes*.
+
 ### Placeholder classes
 
 The docs pages contain literal `<value>` placeholders, so the site's class list
@@ -132,14 +164,21 @@ implementations:
 | `hue-rotate(0deg)` | `hue-rotate()` | keeps it |
 | `@supports (backdrop-filter: ...)` | keeps the guard | elides it |
 | `@media not (X)` | Level 4 form | `not all and (X)` |
-| `grid-auto-flow: row dense` | keeps `row` | `dense` |
 | `text-decoration-color` | no prefix | adds `-webkit-` |
+| `-webkit-text-decoration-color` | one declaration | two |
 | `calc(28 / 18)` | keeps it | folds to `1.55556` |
 
 The guard and the downlevelling are threshold differences: cascade's bar is
 Baseline "widely available", lightningcss's is Tailwind's browserslist. The
 `calc` refusal is a precision commitment - the quotient does not survive
 cascade's serialisation rounding.
+
+The two decoration rows are one difference seen from either side. Tailwind's
+unminified output carries no prefix; lightningcss adds one while minifying and
+emits it twice, so `decoration-sky-500` arrives as
+`-webkit-text-decoration-color; -webkit-text-decoration-color;
+text-decoration-color`. tw writes the prefixed declaration itself, once, and
+cascade neither adds nor removes it.
 
 There is also one real bug in the Tailwind minification path. The site's search
 CSS contains:

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -15,7 +15,8 @@ and the CSS Tailwind emits for it. `test/upstream/test.exe` replays every case
 (782 of them) and fails when tw parses a class Tailwind accepts, or emits
 different CSS for it.
 
-```
+<!-- $MDX skip -->
+```sh
 dune exec test/upstream/test.exe
 ```
 
@@ -26,7 +27,8 @@ These files are generated. Never hand-edit them; regenerate from upstream.
 Each of the nine examples builds its CSS twice, once through tw and once through
 `npx tailwindcss`, then diffs the two:
 
-```
+<!-- $MDX skip -->
+```sh
 cascade diff --diff=canonical --prune-unused-custom-props landing.css tailwind.css
 ```
 
@@ -36,7 +38,8 @@ freshly built cascade, not whatever is on `PATH`.
 
 ### One class at a time
 
-```
+<!-- $MDX skip -->
+```sh
 dune exec -- tw --single="hover:bg-blue-600" --diff
 ```
 
@@ -58,6 +61,7 @@ committed. It lives in `tmp/` (gitignored) and has to be reconstructed:
 
 Both sheets are then generated and diffed:
 
+<!-- $MDX skip -->
 ```sh
 "$TW"/node_modules/.bin/tailwindcss -i src/ref-entry.css -o ref_local.css --minify
 "$TW"/_build/default/bin/main.exe --input-css src/globals.css --minify \
@@ -81,6 +85,7 @@ most of a layer.
 **Read the whole diff.** The summary line counts *containers*, not their
 contents, so `4 changed containers` can hide a hundred rule entries. Always:
 
+<!-- $MDX skip -->
 ```sh
 grep -nE "^├─|^└─" diff.txt
 ```

--- a/dune
+++ b/dune
@@ -3,6 +3,11 @@
   (flags
    (:standard %{dune-warnings}))))
 
+; mdx only sees fenced blocks that start at column 0. CLAUDE.md keeps most of
+; its commands inside list items, where mdx cannot reach them; only its
+; column-0 blocks are checked.
+
 (mdx
- (files README.md)
- (libraries tw cascade))
+ (files README.md CLAUDE.md)
+ (libraries tw cascade)
+ (deps %{bin:tw}))


### PR DESCRIPTION
CLAUDE.md and docs/adding-a-new-utility.md still named lib/rules.ml, lib/css/ and lib/tools/css_compare.ml; layer assembly is lib/build.ml and lib/sort.ml, and the CSS AST and the differ are cascade's. docs/parity.md now records the whole-site residual entry by entry and adds the -webkit-text-decoration-color row to the minifier table.