### PR TITLE
arbitrary: reject trailing text and keep the --alpha() provenance

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -4,37 +4,6 @@ module Css = Cascade.Css
 
 let err_not_utility = Error (`Msg "Not an arbitrary property utility")
 
-(** Parse a CSS color name string into a typed color value. *)
-let parse_css_color value =
-  match String.lowercase_ascii value with
-  | "red" -> Some (Css.color_name Red)
-  | "blue" -> Some (Css.color_name Blue)
-  | "green" -> Some (Css.color_name Green)
-  | "white" -> Some (Css.color_name White)
-  | "black" -> Some (Css.color_name Black)
-  | "yellow" -> Some (Css.color_name Yellow)
-  | "cyan" -> Some (Css.color_name Cyan)
-  | "magenta" -> Some (Css.color_name Magenta)
-  | "gray" -> Some (Css.color_name Gray)
-  | "grey" -> Some (Css.color_name Grey)
-  | "orange" -> Some (Css.color_name Orange)
-  | "purple" -> Some (Css.color_name Purple)
-  | "pink" -> Some (Css.color_name Pink)
-  | "silver" -> Some (Css.color_name Silver)
-  | "maroon" -> Some (Css.color_name Maroon)
-  | "fuchsia" -> Some (Css.color_name Fuchsia)
-  | "lime" -> Some (Css.color_name Lime)
-  | "olive" -> Some (Css.color_name Olive)
-  | "navy" -> Some (Css.color_name Navy)
-  | "teal" -> Some (Css.color_name Teal)
-  | "aqua" -> Some (Css.color_name Aqua)
-  | "transparent" -> Some Css.Transparent
-  | "currentcolor" -> Some Css.Current
-  (* A [#] prefix only names a colour when what follows is a hex spelling;
-     [Css.hex] raises on anything else, and this runs inside [of_class]. *)
-  | s when String.length s > 0 && s.[0] = '#' -> Css.hex_opt s
-  | _ -> None
-
 (** Map a CSS property name to its declaration constructor (color properties
     only). *)
 let color_property_of_name = function
@@ -52,7 +21,7 @@ let color_property_of_name = function
 (* Tailwind's [--alpha(<color>/<percentage>)]: the colour and the alpha it is
    mixed with. The separating slash is the last one, so a colour that carries
    its own (as [oklch(1 0 0 / 50%)] does) still reads. *)
-let alpha_fn value =
+let alpha_fn_parts value =
   let n = String.length value in
   let prefix = "--alpha(" in
   let plen = String.length prefix in
@@ -71,14 +40,20 @@ let alpha_fn value =
 module Handler = struct
   open Style
 
+  type alpha_fn = {
+    spelling : string;
+        (** the [--alpha(...)] text the class was written with *)
+    alpha : Color.opacity_modifier;  (** the alpha that function applies *)
+  }
+  (** A value written as Tailwind's [--alpha(<color>/<percentage>)]. *)
+
   type t =
     | Color_opacity of {
         property : string;
-        value : string;
+        value : string;  (** the colour, with any [--alpha()] wrapper undone *)
+        alpha_fn : alpha_fn option;
         opacity : Color.opacity_modifier;
-        spelling : string option;
-            (** The [--alpha(...)] the class was written with, when the opacity
-                came from that function rather than a [/] modifier. *)
+            (** the [/] modifier written after the closing bracket *)
       }
     | Parsed_decl of { property : string; value : string }
   (* Plain [property:value] (no /opacity), parsed by cascade into a typed,
@@ -260,17 +235,34 @@ module Handler = struct
         with
         | Some decl -> style [ decl ]
         | None -> style [])
-    | Color_opacity { property; value; opacity; _ } -> (
+    | Color_opacity { property; value; alpha_fn; opacity } -> (
         match color_emitter property with
         (* of_class only accepts renderable colour declarations; defensive. *)
         | None -> style []
         | Some emit -> (
-            match parse_css_color value with
-            | Some color -> color_opacity_render theme emit color opacity
-            | None ->
-                if Parse.is_var value then
-                  color_var_opacity_style theme emit value opacity
-                else style []))
+            (* The [/] modifier applies to the colour the value denotes, which
+               is already a mix when the value was written with [--alpha()], so
+               the two nest. Mixing with [transparent] only scales the alpha,
+               which reads the same in either interpolation space. *)
+            let inner, outer =
+              match alpha_fn with
+              | Some { alpha; _ } -> (alpha, opacity)
+              | None -> (opacity, Color.No_opacity)
+            in
+            let emit c =
+              match outer with
+              | Color.No_opacity -> emit c
+              | o -> emit (Color.mix_alpha ~in_space:Oklab o c)
+            in
+            (* A var reference renders from the theme when it names a palette
+               token, so it is tried before the CSS colour reader (which reads
+               [var()] as an opaque colour). *)
+            if Parse.is_var value then
+              color_var_opacity_style theme emit value inner
+            else
+              match Css.parse_color value with
+              | Some color -> color_opacity_render theme emit color inner
+              | None -> style []))
 
   let suborder _ = 0
 
@@ -287,11 +279,11 @@ module Handler = struct
     | Color.Opacity_var v -> "/" ^ v
 
   let to_class = function
-    | Color_opacity { property; opacity; spelling = Some raw; _ } ->
-        ignore opacity;
-        "[" ^ property ^ ":" ^ raw ^ "]"
-    | Color_opacity { property; value; opacity; spelling = None } ->
-        "[" ^ property ^ ":" ^ value ^ "]" ^ opacity_suffix opacity
+    | Color_opacity { property; value; alpha_fn; opacity } ->
+        let written =
+          match alpha_fn with Some { spelling; _ } -> spelling | None -> value
+        in
+        "[" ^ property ^ ":" ^ written ^ "]" ^ opacity_suffix opacity
     | Parsed_decl { property; value } -> "[" ^ property ^ ":" ^ value ^ "]"
 
   let of_class theme class_name =
@@ -328,8 +320,8 @@ module Handler = struct
               in
               (* [--alpha(C/P)] is the [/opacity] form spelled as a function, so
                  it resolves to the same fallback and [@supports] pair. *)
-              let value, fn_opacity =
-                match alpha_fn raw_value with
+              let value, fn_alpha =
+                match alpha_fn_parts raw_value with
                 | Some (c, p) -> (
                     (* [--alpha()] writes the alpha as a percentage; the [/]
                        modifier writes the bare number. *)
@@ -339,84 +331,49 @@ module Handler = struct
                       else p
                     in
                     match Color.opacity_of_string ~theme bare with
-                    | Some op -> (c, op)
-                    | None -> (raw_value, Color.No_opacity))
-                | None -> (raw_value, Color.No_opacity)
+                    | Some alpha -> (c, Some { spelling = raw_value; alpha })
+                    | None -> (raw_value, None))
+                | None -> (raw_value, None)
               in
-              (* Parse opacity modifier after ] *)
-              let opacity_str =
-                if close_pos + 1 < len then
-                  String.sub class_name (close_pos + 1) (len - close_pos - 1)
-                else ""
+              (* What follows the closing bracket is part of the class name, so
+                 it has to be a [/opacity] modifier in full: a suffix that does
+                 not parse names a class Tailwind does not recognise. *)
+              let suffix =
+                String.sub class_name (close_pos + 1) (len - close_pos - 1)
               in
-              let opacity =
-                if String.length opacity_str > 0 && opacity_str.[0] = '/' then
-                  let op_part =
-                    String.sub opacity_str 1 (String.length opacity_str - 1)
-                  in
-                  (* Parse the opacity part directly (already split after /) *)
-                  if
-                    String.length op_part > 2
-                    && op_part.[0] = '['
-                    && op_part.[String.length op_part - 1] = ']'
-                  then
-                    let inner =
-                      String.sub op_part 1 (String.length op_part - 2)
+              let modifier =
+                if suffix = "" then Some Color.No_opacity
+                else if suffix.[0] = '/' then
+                  Color.opacity_of_string ~theme
+                    (String.sub suffix 1 (String.length suffix - 1))
+                else None
+              in
+              match modifier with
+              | None -> err_not_utility
+              | Some opacity -> (
+                  if fn_alpha <> None || opacity <> Color.No_opacity then
+                    (* The /opacity form wraps the value in color-mix, so it
+                       needs a colour target (known colour property or custom
+                       property) and a colour value. Non-colour cases are
+                       rejected (Tailwind blindly color-mixes them, which is
+                       meaningless). *)
+                    let is_colour_value =
+                      Parse.is_var value || Css.parse_color value <> None
                     in
-                    if String.ends_with ~suffix:"%" inner then
-                      let num_str =
-                        String.sub inner 0 (String.length inner - 1)
-                      in
-                      match float_of_string_opt num_str with
-                      | Some f -> Color.Opacity_bracket_percent f
-                      | None -> Color.No_opacity
-                    else
-                      match float_of_string_opt inner with
-                      | Some f -> Color.Opacity_arbitrary f
-                      | None ->
-                          if Parse.is_var inner then Color.Opacity_var inner
-                          else Color.No_opacity
+                    if color_emitter property <> None && is_colour_value then
+                      Ok
+                        (Color_opacity
+                           { property; value; alpha_fn = fn_alpha; opacity })
+                    else err_not_utility
                   else
-                    match float_of_string_opt op_part with
-                    | Some f when f >= 0. -> Color.Opacity_percent f
-                    | _ ->
-                        if
-                          Parse.is_valid_theme_name op_part
-                          && Scheme.theme_value (Some theme)
-                               ("opacity-" ^ op_part)
-                             <> None
-                        then Color.Opacity_named op_part
-                        else Color.No_opacity
-                else fn_opacity
-              in
-              let is_colour_value =
-                Parse.is_var value || parse_css_color value <> None
-              in
-              if opacity <> Color.No_opacity then
-                (* The /opacity form wraps the value in color-mix, so it needs a
-                   colour target (known colour property or custom property) and
-                   a colour value. Non-colour cases are rejected (Tailwind
-                   blindly color-mixes them, which is meaningless). *)
-                if color_emitter property <> None && is_colour_value then
-                  Ok
-                    (Color_opacity
-                       {
-                         property;
-                         value;
-                         opacity;
-                         spelling =
-                           (if raw_value == value then None else Some raw_value);
-                       })
-                else err_not_utility
-              else
-                (* Plain [property:value]: any property whose value cascade can
-                   parse becomes a typed declaration. *)
-                match
-                  Css.parse_declaration property
-                    (Parse.decode_arbitrary_value value)
-                with
-                | Some _ -> Ok (Parsed_decl { property; value })
-                | None -> err_not_utility))
+                    (* Plain [property:value]: any property whose value cascade
+                       can parse becomes a typed declaration. *)
+                    match
+                      Css.parse_declaration property
+                        (Parse.decode_arbitrary_value value)
+                    with
+                    | Some _ -> Ok (Parsed_decl { property; value })
+                    | None -> err_not_utility)))
 
   let examples = []
 end

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -22,16 +22,27 @@ let of_string_valid () =
   check "[display:flex]";
   check "[color:red]"
 
+let rejected cls =
+  match of_class Tw.Scheme.default cls with
+  | Ok result ->
+      failf "expected %s to be rejected, got %s" cls (to_class result)
+  | Error _ -> ()
+
 let of_string_invalid () =
-  let fail_maybe input =
-    match of_class Tw.Scheme.default input with
-    | Ok _ -> fail ("Expected error for: " ^ input)
-    | Error _ -> ()
-  in
-  fail_maybe "";
-  fail_maybe "color:red";
-  fail_maybe "[invalid]";
-  fail_maybe "[]"
+  rejected "";
+  rejected "color:red";
+  rejected "[invalid]";
+  rejected "[]"
+
+(* What follows the closing bracket is part of the class name, so a suffix that
+   is not a [/opacity] modifier names a class Tailwind does not recognise. *)
+let test_trailing_text () =
+  rejected "[color:red]xyz";
+  rejected "[display:flex]junk";
+  rejected "[color:red]/";
+  rejected "[color:red]/bogus";
+  rejected "[color:red]/-5";
+  rejected "[color:red]/50/50"
 
 let css cls =
   match Tw.of_string cls with
@@ -128,6 +139,41 @@ let test_alpha_fn () =
        (Result.get_ok
           (Tw.of_string "[--checkered-bg:--alpha(var(--color-gray-950)/10%)]")))
 
+(* The [/] modifier applies to the colour the value denotes, so a value written
+   with [--alpha()] mixes twice, and both spellings survive the round-trip. *)
+let test_alpha_fn_with_modifier () =
+  check "[color:--alpha(red/50%)]/25";
+  Alcotest.(check bool)
+    "the modifier mixes the alpha'd colour" true
+    (Astring.String.is_infix
+       ~affix:
+         "color-mix(in oklab, color-mix(in oklab, red 50%, transparent) 25%, \
+          transparent)"
+       (css "[color:--alpha(red/50%)]/25"))
+
+(* An opacity read from a custom property keeps the spelling it was written
+   with, in either the bracket or the parenthesised form. *)
+let test_var_opacity_spelling () =
+  check "[color:red]/[var(--x)]";
+  check "[color:red]/(--x)";
+  Alcotest.(check bool)
+    "the var supplies the mix percentage" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, red var(--x), transparent)"
+       (css "[color:red]/(--x)"))
+
+(* Colour values go through the CSS reader, so every named colour is a colour,
+   not a hand-picked subset of them. *)
+let test_named_colour_value () =
+  check "[color:rebeccapurple]/50";
+  Alcotest.(check bool)
+    "rebeccapurple mixes like any other named colour" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, rebeccapurple 50%, transparent)"
+       (css "[color:rebeccapurple]/50"));
+  (* A value that names no colour has nothing to mix. *)
+  rejected "[color:notacolour]/50"
+
 (* A [#...] value is only a colour when it is a hex spelling. A malformed one
    reaches the raising hex constructor from inside [of_class], so the exception
    escapes the parser itself. *)
@@ -149,6 +195,12 @@ let tests =
     test_case "invalid hex value" `Quick test_invalid_hex_value;
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
     test_case "arbitrary of_string - invalid values" `Quick of_string_invalid;
+    test_case "text after the closing bracket" `Quick test_trailing_text;
+    test_case "--alpha() value with a /opacity modifier" `Quick
+      test_alpha_fn_with_modifier;
+    test_case "var-valued opacity modifier spelling" `Quick
+      test_var_opacity_spelling;
+    test_case "named colour value" `Quick test_named_colour_value;
     test_case "property value calc operators" `Quick
       test_property_calc_operators;
     test_case "property value --spacing()" `Quick test_property_spacing_fn;


### PR DESCRIPTION
A class suffix after the closing bracket now has to parse as a `/opacity` modifier in full, so `[color:red]xyz` no longer emits a rule under a selector that cannot match it.

An `--alpha()` value records its own spelling rather than being inferred from physical equality, and colour values go through `Css.parse_color` instead of a hand-written list of 21 names.