### PR TITLE
colors: refuse to fold a colour channel that has no byte

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2460,20 +2460,29 @@ module Handler = struct
   let outline_inherit = style [ Css.outline_color Inherit ]
   let outline_transparent = style [ Css.outline_color (Css.hex "#0000") ]
 
-  (** Convert a CSS channel value to an integer 0-255 *)
-  let channel_to_int : Css.channel -> int = function
-    | Int i -> min 255 (max 0 i)
-    | Num f -> min 255 (max 0 (Float.to_int (Float.round f)))
-    | Pct f -> min 255 (max 0 (Float.to_int (Float.round (f *. 2.55))))
-    | Var _ -> 0
-    | None -> 0
-
-  (** Convert a CSS alpha value to an integer 0-255 *)
-  let alpha_to_int : Css.alpha -> int option = function
-    | None -> None
-    | Num f -> Some (min 255 (max 0 (Float.to_int (Float.round (f *. 255.)))))
+  (** The byte an rgb() channel stands for, when it stands for one. A var()
+      reference carries no value here, and CSS Color 4's [none] takes the
+      analogous channel of whatever the colour is combined with rather than
+      standing for zero, so neither has a byte. *)
+  let channel_to_int : Css.channel -> int option = function
+    | Int i -> Some (min 255 (max 0 i))
+    | Num f -> Some (min 255 (max 0 (Float.to_int (Float.round f))))
     | Pct f -> Some (min 255 (max 0 (Float.to_int (Float.round (f *. 2.55)))))
-    | Var _ | Calc _ -> None
+    | Var _ | None -> Stdlib.Option.None
+
+  (** How an alpha channel spells inside a hex colour. *)
+  type folded_alpha =
+    | Opaque  (** no alpha channel at all *)
+    | Alpha_byte of int
+    | Alpha_unresolvable  (** a var() or calc(), which no hex byte carries *)
+
+  let fold_alpha : Css.alpha -> folded_alpha = function
+    | None -> Opaque
+    | Num f ->
+        Alpha_byte (min 255 (max 0 (Float.to_int (Float.round (f *. 255.)))))
+    | Pct f ->
+        Alpha_byte (min 255 (max 0 (Float.to_int (Float.round (f *. 2.55)))))
+    | Var _ | Calc _ -> Alpha_unresolvable
 
   let to_hex_byte n =
     let hex = "0123456789abcdef" in
@@ -2481,24 +2490,23 @@ module Handler = struct
 
   (** Convert a typed CSS color to a hex string for Tailwind parity *)
   let css_color_to_hex (c : Css.color) : Css.color option =
+    let hex_of_bytes bytes = Some (Css.hex ("#" ^ shorten_hex_str bytes)) in
     match c with
-    | Rgb (Channels { r; g; b }) ->
-        let hex =
-          to_hex_byte (channel_to_int r)
-          ^ to_hex_byte (channel_to_int g)
-          ^ to_hex_byte (channel_to_int b)
-        in
-        Some (Css.hex ("#" ^ shorten_hex_str hex))
+    | Rgb (Channels { r; g; b }) -> (
+        match (channel_to_int r, channel_to_int g, channel_to_int b) with
+        | Some r, Some g, Some b ->
+            hex_of_bytes (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b)
+        | _ -> None)
     | Rgba { rgb = Channels { r; g; b }; a; _ } -> (
-        let r = channel_to_int r
-        and g = channel_to_int g
-        and b = channel_to_int b in
-        let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in
-        match alpha_to_int a with
-        | Some a_int ->
-            let full_hex = hex ^ to_hex_byte a_int in
-            Some (Css.hex ("#" ^ shorten_hex_str full_hex))
-        | None -> Some (Css.hex ("#" ^ shorten_hex_str hex)))
+        match
+          (channel_to_int r, channel_to_int g, channel_to_int b, fold_alpha a)
+        with
+        | Some r, Some g, Some b, Opaque ->
+            hex_of_bytes (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b)
+        | Some r, Some g, Some b, Alpha_byte a ->
+            hex_of_bytes
+              (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b ^ to_hex_byte a)
+        | _ -> None)
     | Hsl _ -> (
         (* Fold through cascade's own colour path: it knows every hue unit and
            reads a bare number for saturation and lightness as the percentage of
@@ -2510,8 +2518,7 @@ module Handler = struct
         with
         | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
             let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in
-            let hex = if a = 255 then hex else hex ^ to_hex_byte a in
-            Some (Css.hex ("#" ^ shorten_hex_str hex))
+            hex_of_bytes (if a = 255 then hex else hex ^ to_hex_byte a)
         | _ -> None)
     | _ -> None
 

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -14,7 +14,11 @@ module Handler = struct
   type shape = S_2xs | S_xs | S_sm | S_md | S_lg
 
   (* Color in an arbitrary shadow value *)
-  type arb_color = Arb_hex of string | Arb_var of string | Arb_none
+  type arb_color =
+    | Arb_hex of string
+    | Arb_var of string
+    | Arb_css_color of Css.color
+    | Arb_none
 
   type t =
     | Text_shadow_none
@@ -98,6 +102,12 @@ module Handler = struct
           (List.rev acc, Arb_hex x)
       | x :: _rest when String.length x > 4 && String.sub x 0 4 = "var(" ->
           (List.rev acc, Arb_var x)
+      | x :: rest when Parse.is_css_color_fn x -> (
+          (* A colour function may carry spaces, so it runs to the end of the
+             value. *)
+          match Css.parse_color (String.concat " " (x :: rest)) with
+          | Some c -> (List.rev acc, Arb_css_color c)
+          | None -> find_color_and_lengths (x :: acc) rest)
       | x :: rest -> find_color_and_lengths (x :: acc) rest
     in
     let length_strs, color = find_color_and_lengths [] parts in
@@ -184,6 +194,20 @@ module Handler = struct
     | S_md -> "text-shadow-md"
     | S_lg -> "text-shadow-lg"
 
+  (* The hex spelling of a colour, for the colour maths that reads one. A colour
+     the fold refuses - one whose channels are not all bytes, or one in a space
+     with no sRGB spelling - has none. *)
+  let hex_string_of_css_color (c : Css.color) : string option =
+    let spell r g b a =
+      let bh = pp_hex_byte in
+      "#" ^ bh r ^ bh g ^ bh b ^ if a = 255 then "" else bh a
+    in
+    match (Color.css_color_to_hex c, c) with
+    | Some (Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ }), _
+    | _, (Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ }) ->
+        Some (spell r g b a)
+    | _ -> Stdlib.Option.None
+
   (* Parse a theme shadow-list override (e.g. "0px 1px 0px rgb(0 0 0 / 0.1), 0px
      2px 2px rgb(0 0 0 / 0.06)") into the same (h, v, blur, hex) tuples
      [shape_shadows] returns. Splits on top-level commas, then for each shadow
@@ -192,11 +216,7 @@ module Handler = struct
   let hex_string_of_color (s : string) : string =
     match Css.parse_color s with
     | Some c -> (
-        match Color.css_color_to_hex c with
-        | Some (Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ }) ->
-            let bh = pp_hex_byte in
-            "#" ^ bh r ^ bh g ^ bh b ^ if a = 255 then "" else bh a
-        | _ -> s)
+        match hex_string_of_css_color c with Some hex -> hex | None -> s)
     | None -> s
 
   let parse_shadow_list (s : string) :
@@ -468,6 +488,8 @@ module Handler = struct
           match color with
           | Arb_hex c -> Css.hex (shorten_hex c)
           | Arb_var v -> make_full_color_var v
+          | Arb_css_color c -> (
+              match Color.css_color_to_hex c with Some h -> h | None -> c)
           | Arb_none -> Css.Current
         in
         let color_ref =
@@ -491,6 +513,10 @@ module Handler = struct
           match color with
           | Arb_hex c -> Color.hex_to_oklab_alpha c alpha
           | Arb_var v -> make_full_color_var v
+          | Arb_css_color c -> (
+              match hex_string_of_css_color c with
+              | Some hex -> Color.hex_to_oklab_alpha hex alpha
+              | None -> c)
           | Arb_none -> Css.Current
         in
         let base_color_ref =
@@ -503,7 +529,7 @@ module Handler = struct
         in
         let rules =
           match color with
-          | Arb_hex _ -> Stdlib.Option.None
+          | Arb_hex _ | Arb_css_color _ -> Stdlib.Option.None
           | Arb_var v -> (
               match relative_oklab_from_var v percent with
               | Some relative_color ->
@@ -772,7 +798,7 @@ module Handler = struct
         match parse_arbitrary_shadow arb with
         | Some (_, _, _, Arb_var _) -> -3 (* @supports lab *)
         | Some (_, _, _, Arb_none) -> -2 (* @supports color-mix *)
-        | Some (_, _, _, Arb_hex _) -> -1 (* no @supports *)
+        | Some (_, _, _, (Arb_hex _ | Arb_css_color _)) -> -1 (* no @supports *)
         | Stdlib.Option.None -> 0)
     | Text_shadow_shape_opacity _ -> -1 (* no @supports *)
     | _ -> 0

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -367,6 +367,51 @@ let test_hsl_non_percentage_channels () =
             a = None;
           }))
 
+(* An rgb() channel is a byte only when it is a static number. A var() channel
+   and the [none] sentinel, which adopts another colour's channel rather than
+   standing for zero, both leave the colour with no hex form; so does an alpha
+   the fold cannot read. *)
+let test_rgb_non_numeric_channels () =
+  let fold (c : Css.color) =
+    match Tw.Color.css_color_to_hex c with
+    | Some folded -> Cascade.Pp.to_string Css.pp_color folded
+    | None -> "unfolded"
+  in
+  Alcotest.(check string)
+    "static channels fold" "#ff0000"
+    (fold (Rgb (Channels { r = Int 255; g = Int 0; b = Int 0 })));
+  Alcotest.(check string)
+    "a var() channel does not fold" "unfolded"
+    (fold
+       (Rgb
+          (Channels
+             { r = Var (Cascade.Values.var_ref "x"); g = Int 0; b = Int 0 })));
+  Alcotest.(check string)
+    "a none channel does not fold" "unfolded"
+    (fold (Rgb (Channels { r = None; g = Int 0; b = Int 0 })));
+  Alcotest.(check string)
+    "a var() alpha does not fold" "unfolded"
+    (fold
+       (Rgba
+          {
+            rgb = Channels { r = Int 255; g = Int 0; b = Int 0 };
+            a = Var (Cascade.Values.var_ref "a");
+          }))
+
+(* A bracket colour the fold refuses keeps the authored function. *)
+let test_bracket_rgb_unresolvable_channels () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "bg-[rgb(var(--x)_0_0)]" "background-color: rgb(var(--x) 0 0)";
+  has "bg-[rgb(none_0_0)]" "background-color: rgb(none 0 0)";
+  has "bg-[rgba(255,0,0,var(--a))]" "background-color: rgb(255 0 0 / var(--a))"
+
 let test_invalid_shade () =
   Alcotest.check_raises "bg ~shade:250 gray raises at construction"
     (Invalid_argument
@@ -509,6 +554,10 @@ let tests =
     ("Bracket CSS colors", `Quick, test_bracket_css_colors);
     ("hsl hue units", `Quick, test_hsl_hue_units);
     ("hsl non-percentage channels", `Quick, test_hsl_non_percentage_channels);
+    ("rgb non-numeric channels", `Quick, test_rgb_non_numeric_channels);
+    ( "bracket rgb unresolvable channels",
+      `Quick,
+      test_bracket_rgb_unresolvable_channels );
     ("Alpha from a var", `Quick, test_alpha_from_a_var);
     ("Invalid shades", `Quick, test_invalid_shade);
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -65,6 +65,37 @@ let test_arbitrary_lengths () =
   | Ok _ -> Alcotest.fail "expected text-shadow-[0_bogus_2px] to be rejected"
   | Error _ -> ()
 
+(* An arbitrary text-shadow takes a colour function for its colour, the same as
+   the box-shadow utilities. The reader knew only a [#] hex and a var(), so a
+   function made the whole value stop being a shadow. A static one folds to its
+   hex form; one with a channel that has no byte value stays as written. *)
+let test_arbitrary_color_function () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  emits "text-shadow-[0_1px_rgb(255,0,0)]" "var(--tw-text-shadow-color,#f00)";
+  emits "text-shadow-[0_1px_hsl(180deg_100%_50%)]"
+    "var(--tw-text-shadow-color,#0ff)";
+  emits "text-shadow-[0_1px_oklch(0.5_0.2_180)]"
+    "var(--tw-text-shadow-color,oklch(";
+  emits "text-shadow-[0_1px_rgb(var(--x)_0_0)]"
+    "var(--tw-text-shadow-color,rgb(var(--x) 0 0))";
+  (* An opacity modifier takes the alpha through oklab, the same as a [#] hex
+     colour does. *)
+  emits "text-shadow-[0_1px_rgb(255,0,0)]/50"
+    "var(--tw-text-shadow-color,oklab(62.79553606%.22486306 .1258463/.5))";
+  rejected "text-shadow-[0_1px_rgb(zz)]"
+
 (* A [#] value is only a colour when what follows is a hex spelling, both as the
    whole bracket and as the colour of an arbitrary shadow. The reader kept the
    text after the [#] as-is and the raising constructor saw it when the sheet
@@ -100,6 +131,8 @@ let tests =
       Alcotest.test_case "default scale (v4.3.1)" `Quick test_default_scale;
       Alcotest.test_case "@theme override threads through" `Quick
         test_theme_override;
+      Alcotest.test_case "arbitrary colour function" `Quick
+        test_arbitrary_color_function;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     ]
 


### PR DESCRIPTION
An rgb() channel written as var() or none, and a var() or calc() alpha, used to read as zero and paint the colour black; the authored function now survives the fold. An arbitrary text-shadow also reads a colour function for its colour, which the reader used to reject outright.