### PR TITLE
test: close three gaps that let the suite pass on nothing

### DIFF
--- a/test/helpers/browser/compare.js
+++ b/test/helpers/browser/compare.js
@@ -1,7 +1,8 @@
 // Differential rendering: the same elements under tw's sheet and Tailwind's,
 // compared on what the browser computes. A property that computes the same is
 // equivalent however the two sheets spell it; one that differs is observable.
-// Exit codes: 0 no differences, 1 differences on stdout, 2 no usable browser.
+// Exit codes: 0 no differences, 1 differences on stdout, 2 no usable browser,
+// 3 the page did not carry the classes asked for, reason on stdout.
 const fs = require('fs');
 
 let chromium;
@@ -19,15 +20,41 @@ const elements = fs.readFileSync(elementsFile, 'utf8').split('\n').filter((l) =>
 // the names the sheets declare and ask for each by hand.
 const customNames = (css) => new Set(css.match(/--[A-Za-z0-9_-]+/g) || []);
 
+// Arbitrary values carry quotes and angle brackets of their own
+// (content-["x"], bg-[url("/img/x.png")]), so the class must be escaped as
+// attribute text or it truncates the attribute it sits in.
+const attr = (s) =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
 const page = (css, classes) =>
   `<!doctype html><meta charset="utf-8"><style>${css}</style>` +
-  `<body>${classes.map((c, i) => `<div id="e${i}" class="${c}"></div>`).join('')}</body>`;
+  `<body>${classes.map((c, i) => `<div id="e${i}" class="${attr(c)}"></div>`).join('')}</body>`;
+
+// What each element is meant to carry, whitespace normalised the way classList
+// reports it.
+const wanted = elements.map((e) => e.trim().split(/\s+/).join(' '));
+
+// An element that lost part of its class attribute is styled by neither sheet,
+// and the two then agree on the same bare element - a pass that says nothing.
+// Report the first element whose classes are not the ones asked for.
+const unusable = (got) => {
+  if (got.length !== wanted.length)
+    return `built ${got.length} elements for ${wanted.length} entries`;
+  for (let i = 0; i < wanted.length; i++)
+    if (got[i] !== wanted[i])
+      return `element e${i} carries [${got[i]}], expected [${wanted[i]}]`;
+  return null;
+};
 
 async function computed(browser, css, names) {
   const p = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   await p.setContent(page(css, elements));
   const out = await p.evaluate((ns) => {
-    const res = {};
+    const res = { styles: {}, classes: [] };
     document.querySelectorAll('div[id^=e]').forEach((el) => {
       const cs = getComputedStyle(el);
       const o = {};
@@ -36,7 +63,8 @@ async function computed(browser, css, names) {
         const v = cs.getPropertyValue(n);
         if (v !== '') o[n] = v;
       }
-      res[el.id] = o;
+      res.styles[el.id] = o;
+      res.classes.push([...el.classList].join(' '));
     });
     return res;
   }, names);
@@ -55,9 +83,17 @@ async function computed(browser, css, names) {
     console.error(e.message);
     process.exit(2);
   }
-  const ta = await computed(browser, a, names);
-  const tb = await computed(browser, b, names);
+  const ra = await computed(browser, a, names);
+  const rb = await computed(browser, b, names);
   await browser.close();
+
+  const broken = unusable(ra.classes) || unusable(rb.classes);
+  if (broken) {
+    console.log(`markup does not carry the intended classes: ${broken}`);
+    process.exit(3);
+  }
+  const ta = ra.styles;
+  const tb = rb.styles;
 
   // A custom property is a token stream: the browser hands back the author's
   // own whitespace and quoting, so two sheets that minify differently differ on

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -289,6 +289,12 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
   match Sys.command cmd with
   | 0 -> ()
   | 1 -> Alcotest.failf "%s\n%s" test_name (read_file out)
+  | 3 ->
+      (* The elements did not carry the classes we asked for, so what they
+         computed compares nothing. Fail: it is a broken harness, not a missing
+         tool. *)
+      Alcotest.failf "%s: browser harness built unusable markup\n%s" test_name
+        (read_file out)
   | _ ->
       (* No usable browser (Chromium not downloaded, sandbox refused to start).
          Report it and skip: it is a missing tool, not a difference. *)

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -67,8 +67,10 @@ val check_rendering_matches :
 (** [check_rendering_matches ?forms ~test_name utilities] renders both sheets in
     headless Chromium and fails on any computed style that differs. Each class
     gets an element of its own, plus one per {!same_property_pairs} pair, which
-    is where an ordering difference shows. Skips when node or Playwright is
-    absent; [TW_BROWSER_TESTS=0] opts out where they are present. *)
+    is where an ordering difference shows. Fails too when an element does not
+    carry the classes it was given, since then the comparison is vacuous. Skips
+    when node or Playwright is absent; [TW_BROWSER_TESTS=0] opts out where they
+    are present. *)
 
 (** {1 CSS Test Helpers} *)
 

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -379,10 +379,14 @@ let suborder_matches_tailwind () =
     ~test_name:"typography suborder matches Tailwind" shuffled
 
 (* text-<size> also sets the line height, so a size and a leading on the same
-   element decide between them what the text is laid out with. *)
+   element decide between them what the text is laid out with. The quoted
+   content values also pin the harness: a class whose arbitrary value carries
+   quotes has to reach the rendered element intact. *)
 let rendering_matches_tailwind () =
   let classes =
     [
+      "content-[\"x\"]";
+      "content-['x']";
       "text-xs";
       "text-base";
       "text-lg";

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -10,15 +10,17 @@ let test_check_available () =
     (* If Tailwind is not installed, that's ok for the test *)
     check bool "tailwindcss check completed" true true
 
+(* A missing CLI is a missing tool, so skip on it. A CLI that is present and
+   fails to produce CSS raises [Failure] too, and that must reach the runner:
+   catching it here would report a broken harness as a pass. *)
+let skip_unless_available () = if not (available ()) then Alcotest.skip ()
+
 let test_generate_simple () =
-  try
-    let css = generate ~minify:true [ "p-4"; "bg-blue-500" ] in
-    check bool "generated CSS not empty" true (String.length css > 0);
-    check bool "contains p-4 class" true
-      (Astring.String.is_infix ~affix:".p-4" css)
-  with Failure _ ->
-    (* Skip if Tailwind not available *)
-    check bool "test skipped (no tailwind)" true true
+  skip_unless_available ();
+  let css = generate ~minify:true [ "p-4"; "bg-blue-500" ] in
+  check bool "generated CSS not empty" true (String.length css > 0);
+  check bool "contains p-4 class" true
+    (Astring.String.is_infix ~affix:".p-4" css)
 
 (* The upstream runner keeps a tiny allowlist for the single arbitrary colour
    ([#0088cc] at 25%/50%) that Tailwind's frozen [*.test.ts] fixtures store as
@@ -29,44 +31,9 @@ let test_generate_simple () =
    changes/fixes the rounding, this fails loudly instead of the allowlist
    silently masking it. Skips when tailwindcss is unavailable. *)
 let test_arbitrary_color_opacity_matches_cli () =
+  skip_unless_available ();
   let check_class cls =
-    try
-      let cli = generate ~minify:true ~optimize:true ~forms:true [ cls ] in
-      let tw =
-        match Tw.of_string cls with
-        | Ok u ->
-            Tw.to_css ~base:true [ u ]
-            |> Tw.Css.optimize ~prune_unused_custom_props:true
-            |> Tw.Css.to_string ~minify:true
-        | Error _ -> Alcotest.failf "tw could not parse %s" cls
-      in
-      let diff =
-        Cascade_diff.Css_compare.diff ~mode:`Canonical
-          ~prune_unused_custom_props:true cli tw
-      in
-      match diff.Cascade_diff.Css_compare.result with
-      | Cascade_diff.Css_compare.No_diff _ ->
-          check bool (cls ^ ": tw matches live Tailwind CLI") true true
-      | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
-    with Failure _ -> check bool "skipped (tailwindcss unavailable)" true true
-  in
-  check_class "accent-[#0088cc]/50";
-  check_class "accent-[#0088cc]/25"
-
-(* Regression: candidates are fed to the real CLI verbatim, not inside an
-   escaped HTML class attribute. The attribute forced single quotes to the HTML
-   entity [&#39;], which the extractor read literally into the selector
-   ([.bg-\[url\(\&\#39\;...\)\]]), diverging from tw's [.bg-\[url\(\'...\'\)\]].
-   Arbitrary url() values with single quotes must round-trip with no entity
-   mangling. Skips when tailwindcss is unavailable. *)
-let test_arbitrary_url_matches_cli () =
-  let cls = "bg-[url('/img/x.svg')]" in
-  try
-    let cli = generate ~minify:true ~optimize:true [ cls ] in
-    check bool
-      (cls ^ ": CLI reference is not HTML-entity mangled")
-      false
-      (Astring.String.is_infix ~affix:"&#39;" cli);
+    let cli = generate ~minify:true ~optimize:true ~forms:true [ cls ] in
     let tw =
       match Tw.of_string cls with
       | Ok u ->
@@ -83,7 +50,40 @@ let test_arbitrary_url_matches_cli () =
     | Cascade_diff.Css_compare.No_diff _ ->
         check bool (cls ^ ": tw matches live Tailwind CLI") true true
     | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
-  with Failure _ -> check bool "skipped (tailwindcss unavailable)" true true
+  in
+  check_class "accent-[#0088cc]/50";
+  check_class "accent-[#0088cc]/25"
+
+(* Regression: candidates are fed to the real CLI verbatim, not inside an
+   escaped HTML class attribute. The attribute forced single quotes to the HTML
+   entity [&#39;], which the extractor read literally into the selector
+   ([.bg-\[url\(\&\#39\;...\)\]]), diverging from tw's [.bg-\[url\(\'...\'\)\]].
+   Arbitrary url() values with single quotes must round-trip with no entity
+   mangling. Skips when tailwindcss is unavailable. *)
+let test_arbitrary_url_matches_cli () =
+  skip_unless_available ();
+  let cls = "bg-[url('/img/x.svg')]" in
+  let cli = generate ~minify:true ~optimize:true [ cls ] in
+  check bool
+    (cls ^ ": CLI reference is not HTML-entity mangled")
+    false
+    (Astring.String.is_infix ~affix:"&#39;" cli);
+  let tw =
+    match Tw.of_string cls with
+    | Ok u ->
+        Tw.to_css ~base:true [ u ]
+        |> Tw.Css.optimize ~prune_unused_custom_props:true
+        |> Tw.Css.to_string ~minify:true
+    | Error _ -> Alcotest.failf "tw could not parse %s" cls
+  in
+  let diff =
+    Cascade_diff.Css_compare.diff ~mode:`Canonical
+      ~prune_unused_custom_props:true cli tw
+  in
+  match diff.Cascade_diff.Css_compare.result with
+  | Cascade_diff.Css_compare.No_diff _ ->
+      check bool (cls ^ ": tw matches live Tailwind CLI") true true
+  | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
 
 let tests =
   [

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -7,4 +7,4 @@
  (name test)
  (modules test)
  (libraries alcotest tw cascade cascade.diff fmt re)
- (deps utilities.txt))
+ (deps utilities.txt variants.txt))

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -972,27 +972,36 @@ let file basename =
   let paths = [ basename; "test/upstream/" ^ basename ] in
   List.find_opt Sys.file_exists paths
 
+(* Both fixtures are checked in and declared as dune deps, so a missing one is a
+   broken checkout rather than an optional extra. A floor on the parsed cases
+   catches the other way this gate can go quiet: a fixture whose format drifts
+   still parses, just into far fewer cases than it holds. The floors are about
+   half the current counts (615 utilities, 166 variants), low enough to absorb
+   upstream churn. *)
+let utilities_floor = 300
+let variants_floor = 80
+
+let load basename floor =
+  match file basename with
+  | None ->
+      Fmt.epr "%s not found. Run extract_tests.exe first.@." basename;
+      exit 1
+  | Some path ->
+      let cases = read_test_cases path in
+      let n = List.length cases in
+      if n < floor then (
+        Fmt.epr "%s yielded %d test cases, fewer than the floor of %d.@." path n
+          floor;
+        exit 1);
+      cases
+
 let () =
-  let utilities_file =
-    file "utilities.txt" |> Option.value ~default:"utilities.txt"
-  in
-  let variants_file = file "variants.txt" in
-
-  if not (Sys.file_exists utilities_file) then (
-    Fmt.epr "No test file found. Run extract_tests.exe first.@.";
-    exit 0);
-
-  let utility_tests = read_test_cases utilities_file in
-  let variant_tests =
-    match variants_file with Some f -> read_test_cases f | None -> []
-  in
-
-  if utility_tests = [] && variant_tests = [] then (
-    Fmt.epr "No test cases with expected CSS found.@.";
-    exit 0);
-
+  let utility_tests = load "utilities.txt" utilities_floor in
+  let variant_tests = load "variants.txt" variants_floor in
   let total = List.length utility_tests + List.length variant_tests in
-  Fmt.epr "Running %d upstream tests...@." total;
+  Fmt.epr "Running %d upstream tests (%d utilities, %d variants)...@." total
+    (List.length utility_tests)
+    (List.length variant_tests);
   at_exit print_parity_report;
 
   let utility_cases =
@@ -1009,7 +1018,10 @@ let () =
     [ test_case "oklab precision truncation" `Quick test_color_tolerance ]
   in
   let suites =
-    [ ("utilities", utility_cases); ("tolerance", tolerance_cases) ]
-    @ if variant_cases <> [] then [ ("variants", variant_cases) ] else []
+    [
+      ("utilities", utility_cases);
+      ("tolerance", tolerance_cases);
+      ("variants", variant_cases);
+    ]
   in
   Alcotest.run "upstream" suites


### PR DESCRIPTION
Three test-infrastructure gates that could report green without checking anything: the tailwindcss CLI parity tests caught generation failures and called them skips, the browser harness interpolated class names into an HTML attribute unescaped so a quoted arbitrary value truncated it, and the upstream runner exited 0 on a missing fixture while variants.txt was not a dune dep.

Each is now a loud failure, and the upstream runner also asserts a floor on the parsed case count.