### PR TITLE
filters, backgrounds, masks: parse bracket values in of_class

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -119,9 +119,9 @@ module Handler = struct
     | Bg_bracket_size of string
     (* Bracket notation: bg-[50%], bg-[120px], bg-[120px_120px] →
        background-position *)
-    | Bg_bracket_position of string
+    | Bg_bracket_position of string * Css.position_value
     (* Bracket notation: bg-[position:...] → background-position *)
-    | Bg_bracket_typed_position of string
+    | Bg_bracket_typed_position of string * Css.position_value
     (* Bracket notation: bg-[color:var(--x)] → background-color *)
     | Bg_bracket_color_var of string
     (* Bracket notation: bg-[var(--x)] → background-color *)
@@ -130,7 +130,7 @@ module Handler = struct
     | Bg_bracket_image_var of string
     (* Bracket notation: bg-[image:<gradient/literal>] → background-image, with
        the image: hint kept in the class name *)
-    | Bg_bracket_image of string
+    | Bg_bracket_image of string * Css.background_image
     (* Bracket notation: bg-[url(...)] → background-image *)
     | Bg_bracket_url of string
     (* Bracket notation: bg-[image:url(...)] → background-image (image: hint
@@ -139,7 +139,7 @@ module Handler = struct
     (* Bracket notation: bg-[url:var(--x)] → background-image *)
     | Bg_bracket_url_var of string
     (* Bracket notation: bg-[linear-gradient(...)] → background-image *)
-    | Bg_bracket_linear_gradient of string
+    | Bg_bracket_linear_gradient of string * Css.background_image
     (* bg-linear-to-* direction utilities *)
     | Bg_linear_to of direction
     (* bg-linear-to-*/interp - direction with interpolation modifier *)
@@ -193,7 +193,7 @@ module Handler = struct
     (* bg-[length:...] - explicit length prefix for bracket size *)
     | Bg_bracket_length of string
     (* bg-position-[...] bracket notation *)
-    | Bg_position_bracket of string
+    | Bg_position_bracket of string * Css.position_value
     (* bg-size-[...] bracket notation *)
     | Bg_size_bracket of string
 
@@ -319,16 +319,16 @@ module Handler = struct
     | Bg_bracket_cover -> "bg-[cover]"
     | Bg_bracket_size v -> "bg-[size:" ^ v ^ "]"
     | Bg_bracket_length v -> "bg-[length:" ^ v ^ "]"
-    | Bg_bracket_position v -> "bg-[" ^ v ^ "]"
-    | Bg_bracket_typed_position v -> "bg-[position:" ^ v ^ "]"
+    | Bg_bracket_position (v, _) -> "bg-[" ^ v ^ "]"
+    | Bg_bracket_typed_position (v, _) -> "bg-[position:" ^ v ^ "]"
     | Bg_bracket_color_var v -> "bg-[color:" ^ v ^ "]"
     | Bg_bracket_var v -> "bg-[" ^ v ^ "]"
     | Bg_bracket_image_var v -> "bg-[image:" ^ v ^ "]"
-    | Bg_bracket_image v -> "bg-[image:" ^ v ^ "]"
+    | Bg_bracket_image (v, _) -> "bg-[image:" ^ v ^ "]"
     | Bg_bracket_url v -> "bg-[url(" ^ v ^ ")]"
     | Bg_bracket_image_url v -> "bg-[image:url(" ^ v ^ ")]"
     | Bg_bracket_url_var v -> "bg-[url:" ^ v ^ "]"
-    | Bg_bracket_linear_gradient v -> "bg-[" ^ v ^ "]"
+    | Bg_bracket_linear_gradient (v, _) -> "bg-[" ^ v ^ "]"
     | Bg_bracket_color_var_opacity (v, opacity) ->
         "bg-[color:" ^ v ^ "]" ^ opacity_suffix opacity
     | Bg_bracket_var_opacity (v, opacity) ->
@@ -388,7 +388,7 @@ module Handler = struct
     | Bg_radial -> "bg-radial"
     | Bg_radial_interp interp -> "bg-radial/" ^ interp
     | Bg_radial_bracket v -> "bg-radial-[" ^ v ^ "]"
-    | Bg_position_bracket v -> "bg-position-[" ^ v ^ "]"
+    | Bg_position_bracket (v, _) -> "bg-position-[" ^ v ^ "]"
     | Bg_size_bracket v -> "bg-size-[" ^ v ^ "]"
 
   let to_spec (dir : direction) : Css.gradient_direction =
@@ -657,50 +657,38 @@ module Handler = struct
               (Css.parse_length v))
     | _ -> None
 
-  (* Parse a bracket position value like "120px_120px" or "120px" or "50%" *)
-  let parse_bracket_position inner =
-    let parts =
-      String.split_on_char '_' inner |> List.filter (fun s -> s <> "")
-    in
-    let parse_pos_val s : Css.position_value option =
-      if String.ends_with ~suffix:"px" s then
-        let n = String.sub s 0 (String.length s - 2) |> float_of_string_opt in
-        Option.map (fun f -> (Css.Single (Px f) : Css.position_value)) n
-      else if String.ends_with ~suffix:"%" s then
-        let n = String.sub s 0 (String.length s - 1) |> float_of_string_opt in
-        Option.map (fun f -> (Css.Single (Pct f) : Css.position_value)) n
-      else None
-    in
-    match parts with
-    | [ x; y ] -> (
-        (* Each axis is a keyword edge (left/right/top/bottom/center, normalised
-           to its percentage) or a length. *)
-        let parse_len s : Css.length option =
-          match s with
-          | "left" | "top" -> Some (Css.Pct 0.)
-          | "center" -> Some (Css.Pct 50.)
-          | "right" | "bottom" -> Some (Css.Pct 100.)
-          | _ ->
-              if String.ends_with ~suffix:"px" s then
-                let n =
-                  String.sub s 0 (String.length s - 2) |> float_of_string_opt
-                in
-                Option.map (fun f -> (Css.Px f : Css.length)) n
-              else if String.ends_with ~suffix:"%" s then
-                let n =
-                  String.sub s 0 (String.length s - 1) |> float_of_string_opt
-                in
-                Option.map (fun f -> (Css.Pct f : Css.length)) n
-              else None
-        in
-        let xl = parse_len x in
-        let yl = parse_len y in
-        match (xl, yl) with
-        | Some xv, Some yv -> Some (Css.background_position [ Css.XY (xv, yv) ])
-        | _ -> None)
-    | [ v ] ->
-        Option.map (fun pv -> Css.background_position [ pv ]) (parse_pos_val v)
-    | _ -> None
+  (* A bracket background-position: [120px_120px], [top], [left_10px_top_20px].
+     The whole [<position>] grammar, so the hand-rolled reading that only knew
+     lengths and two-keyword pairs no longer drops [top] on the floor. [None]
+     means the bracket is not a position, which [of_class] rejects. *)
+  let parse_bracket_position inner : Css.position_value option =
+    let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Properties.read_position_value
+        cursor
+    with
+    | Ok pos -> Some pos
+    | Error _ -> None
+
+  (* The bracket forms that also accept a var() reference read it as one. *)
+  let bracket_position_value inner : Css.position_value option =
+    if Parse.is_var inner then
+      let ref : Css.position_value Css.var =
+        Var.bracket (Parse.extract_var_name inner)
+      in
+      Some (Css.Var ref)
+    else parse_bracket_position inner
+
+  (* A bracket background-image: a gradient, a url(), or a comma-separated layer
+     list. [None] means the bracket is not an image, which [of_class] rejects:
+     [bg-[image:nope]] used to parse and then emit an empty rule. *)
+  let parse_bracket_image v : Css.background_image option =
+    let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
+    match Css.parse_background_image css_str with
+    | Some [ img ] -> Some (Css.minify_background_image img)
+    | Some (_ :: _ as imgs) ->
+        Some (Css.List (List.map Css.minify_background_image imgs))
+    | Some [] | None -> None
 
   let gradient_supports_condition =
     Css.Supports.property "background-image" "linear-gradient(in lab, red, red)"
@@ -1396,14 +1384,9 @@ module Handler = struct
         match parse_bracket_size inner with
         | Some decl -> style [ decl ]
         | None -> style [ Css.background_size Auto ])
-    | Bg_bracket_position inner -> (
-        match parse_bracket_position inner with
-        | Some decl -> style [ decl ]
-        | None -> style [ Css.background_position [ Center ] ])
-    | Bg_bracket_typed_position inner -> (
-        match parse_bracket_position inner with
-        | Some decl -> style [ decl ]
-        | None -> style [ Css.background_position [ Center ] ])
+    | Bg_bracket_position (_, pos) -> style [ Css.background_position [ pos ] ]
+    | Bg_bracket_typed_position (_, pos) ->
+        style [ Css.background_position [ pos ] ]
     | Bg_bracket_color_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.color Css.var = Var.bracket bare in
@@ -1416,18 +1399,7 @@ module Handler = struct
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style [ Css.background_image (Var var_ref) ]
-    | Bg_bracket_image v -> (
-        let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
-        match Css.parse_background_image css_str with
-        | Some [ img ] ->
-            style [ Css.background_image (Css.minify_background_image img) ]
-        | Some imgs ->
-            style
-              [
-                Css.background_image
-                  (Css.List (List.map Css.minify_background_image imgs));
-              ]
-        | None -> style [])
+    | Bg_bracket_image (_, img) -> style [ Css.background_image img ]
     | Bg_bracket_url url ->
         style [ Css.background_image (Url (strip_outer_quotes url)) ]
     | Bg_bracket_image_url url ->
@@ -1436,16 +1408,7 @@ module Handler = struct
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style [ Css.background_image (Var var_ref) ]
-    | Bg_bracket_linear_gradient v -> (
-        let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
-        match Css.parse_background_image css_str with
-        | Some [ img ] ->
-            let img = Css.minify_background_image img in
-            style [ Css.background_image img ]
-        | Some imgs ->
-            let imgs = List.map Css.minify_background_image imgs in
-            style [ Css.background_image (Css.List imgs) ]
-        | None -> style [])
+    | Bg_bracket_linear_gradient (_, img) -> style [ Css.background_image img ]
     | Bg_linear_to dir -> bg_linear_to' dir
     | Bg_linear_to_interp (dir, interp) -> bg_linear_to_interp' dir interp
     | Bg_linear_angle n -> bg_linear_angle' n
@@ -1487,14 +1450,7 @@ module Handler = struct
         match parse_bracket_size inner with
         | Some decl -> style [ decl ]
         | None -> style [ Css.background_size Auto ])
-    | Bg_position_bracket inner -> (
-        match parse_bracket_position inner with
-        | Some decl -> style [ decl ]
-        | None when Parse.is_var inner ->
-            let var_name = Parse.extract_var_name inner in
-            let ref : Css.position_value Css.var = Var.bracket var_name in
-            style [ Css.background_position [ Var ref ] ]
-        | None -> style [ Css.background_position [ Center ] ])
+    | Bg_position_bracket (_, pos) -> style [ Css.background_position [ pos ] ]
     | Bg_size_bracket inner -> (
         match parse_bracket_size inner with
         | Some decl -> style [ decl ]
@@ -1821,11 +1777,11 @@ module Handler = struct
         let inner = Parse.bracket_inner bracket in
         Ok (Bg_radial_bracket inner)
     (* bg-position-[...] bracket notation *)
-    | [ "bg"; "position"; bracket ] when Parse.is_bracket_value bracket ->
+    | [ "bg"; "position"; bracket ] when Parse.is_bracket_value bracket -> (
         let inner = Parse.bracket_inner bracket in
-        if parse_bracket_position inner = None && not (Parse.is_var inner) then
-          Error (`Msg "Invalid background-position value")
-        else Ok (Bg_position_bracket inner)
+        match bracket_position_value inner with
+        | Some pos -> Ok (Bg_position_bracket (inner, pos))
+        | None -> Error (`Msg "Invalid background-position value"))
     (* bg-size-[...] bracket notation *)
     | [ "bg"; "size"; bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
@@ -1886,15 +1842,20 @@ module Handler = struct
               Ok
                 (Bg_bracket_size (String.sub inner 5 (String.length inner - 5)))
           | _ when String.length inner > 9 && String.sub inner 0 9 = "position:"
-            ->
-              Ok
-                (Bg_bracket_typed_position
-                   (String.sub inner 9 (String.length inner - 9)))
+            -> (
+              (* The [position:] data-type hint forces a background-position; a
+                 value the grammar rejects is not a utility. It used to fall
+                 through to a plausible-looking [center]. *)
+              let v = String.sub inner 9 (String.length inner - 9) in
+              match bracket_position_value v with
+              | Some pos -> Ok (Bg_bracket_typed_position (v, pos))
+              | None -> Error (`Msg ("Unknown bg bracket position: " ^ v)))
           | _ when String.length inner > 6 && String.sub inner 0 6 = "color:" ->
               Ok
                 (Bg_bracket_color_var
                    (String.sub inner 6 (String.length inner - 6)))
-          | _ when String.length inner > 6 && String.sub inner 0 6 = "image:" ->
+          | _ when String.length inner > 6 && String.sub inner 0 6 = "image:"
+            -> (
               (* The [image:] data-type hint forces a background-image. The
                  value is a [url(...)] literal, a [var(...)] reference, or a
                  literal image (e.g. a gradient). *)
@@ -1902,7 +1863,10 @@ module Handler = struct
               if String.length v > 4 && String.sub v 0 4 = "url(" then
                 Ok (Bg_bracket_image_url (String.sub v 4 (String.length v - 5)))
               else if Parse.is_var v then Ok (Bg_bracket_image_var v)
-              else Ok (Bg_bracket_image v)
+              else
+                match parse_bracket_image v with
+                | Some img -> Ok (Bg_bracket_image (v, img))
+                | None -> Error (`Msg ("Unknown bg bracket image: " ^ v)))
           | _ when String.length inner > 4 && String.sub inner 0 4 = "url:" ->
               Ok
                 (Bg_bracket_url_var
@@ -1914,18 +1878,16 @@ module Handler = struct
           | _ -> (
               (* Try parsing as background-image (gradients, urls,
                  comma-separated) *)
-              let normalized =
-                String.map (fun c -> if c = '_' then ' ' else c) inner
-              in
-              match Css.parse_background_image normalized with
-              | Some (_ :: _) -> Ok (Bg_bracket_linear_gradient inner)
-              | _ -> (
+              match parse_bracket_image inner with
+              | Some img -> Ok (Bg_bracket_linear_gradient (inner, img))
+              | None -> (
                   match Color.parse_bracket_color inner with
                   | Some css_color -> Ok (Bg_bracket_color (inner, css_color))
-                  | None ->
-                      if parse_bracket_position inner <> None then
-                        Ok (Bg_bracket_position inner)
-                      else Error (`Msg ("Unknown bg bracket value: " ^ inner))))
+                  | None -> (
+                      match parse_bracket_position inner with
+                      | Some pos -> Ok (Bg_bracket_position (inner, pos))
+                      | None ->
+                          Error (`Msg ("Unknown bg bracket value: " ^ inner)))))
         )
     | "bg" :: rest when List.exists has_opacity rest -> (
         match Color.shade_and_opacity_of_strings ~theme rest with

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -11,7 +11,7 @@ module Handler = struct
   type t =
     | Filter
     | Filter_none
-    | Filter_arbitrary of string
+    | Filter_arbitrary of string * Css.filter
     | Blur_none
     | Blur_xs
     | Blur_sm
@@ -48,16 +48,17 @@ module Handler = struct
     | Drop_shadow_none
     | Drop_shadow_inherit
     | Drop_shadow_named of string
-    | Drop_shadow_arbitrary of string
+    | Drop_shadow_arbitrary of string * Css.filter
     | Drop_shadow_color of Color.color * int
     | Drop_shadow_color_opacity of Color.color * int * Color.opacity_modifier
     | Drop_shadow_opacity of Color.opacity_modifier
     | Drop_shadow_keyword_color of Css.color * string
       (* drop-shadow-current / -transparent: a colour with no theme token *)
-    | Drop_shadow_size_opacity of string * Color.opacity_modifier
+    | Drop_shadow_size_opacity of
+        string * (Css.length * Css.length) * Color.opacity_modifier
     | Backdrop_filter
     | Backdrop_filter_none
-    | Backdrop_filter_arbitrary of string
+    | Backdrop_filter_arbitrary of string * Css.filter
     | Backdrop_blur_none
     | Backdrop_blur_xs
     | Backdrop_blur_sm
@@ -622,15 +623,16 @@ module Handler = struct
          ~color:(Css.Var (drop_shadow_color_ref fallback))
          ())
 
-  (* A theme-token drop-shadow such as [drop-shadow-calc] backed by a custom
-     [--drop-shadow-<name>] theme value. Parses the theme value into one or more
-     shadow bodies, hoists each colour into [--tw-drop-shadow-color], and
-     references the token from [--tw-drop-shadow]. *)
-  let drop_shadow_named ?theme name =
+  (* The [--drop-shadow-<name>] theme value behind [drop-shadow-<name>], split
+     into shadow bodies. [None] means the theme has no such token, or its value
+     is not a shadow: either way the class is not a utility, so [of_class] uses
+     this to gate before [to_style] ever sees the name. *)
+  let drop_shadow_theme_bodies ?theme name :
+      (string * Css.shadow_body list) option =
     let theme_name = "drop-shadow-" ^ name in
     match Scheme.theme_value theme theme_name with
-    | None -> style []
-    | Some value ->
+    | None -> None
+    | Some value -> (
         let cursor = Cascade.Cursor.of_string value in
         let body_of (sh : Css.shadow) : Css.shadow_body option =
           match sh with Css.Shadow body -> Some body | _ -> None
@@ -643,20 +645,33 @@ module Handler = struct
           | Ok sh -> ( match body_of sh with Some b -> [ b ] | None -> [])
           | Error _ -> []
         in
-        if bodies = [] then style []
-        else
-          let size : Css.filter =
-            match List.map drop_shadow_size_of_body bodies with
-            | [ single ] -> single
-            | many -> Css.List many
-          in
-          style ~property_rules:filter_property_rules
-            [
-              Css.custom_property ~layer:"theme" ("--" ^ theme_name) value;
-              bind_drop_shadow_size size;
-              bind_drop_shadow (drop_shadow_theme_ref theme_name);
-              filter composable_filter_chain;
-            ]
+        match bodies with [] -> None | _ -> Some (value, bodies))
+
+  (* A theme-token drop-shadow such as [drop-shadow-calc] backed by a custom
+     [--drop-shadow-<name>] theme value. Parses the theme value into one or more
+     shadow bodies, hoists each colour into [--tw-drop-shadow-color], and
+     references the token from [--tw-drop-shadow]. *)
+  let drop_shadow_named ?theme name =
+    let theme_name = "drop-shadow-" ^ name in
+    match drop_shadow_theme_bodies ?theme name with
+    | None ->
+        (* [of_class] resolves the token against the same theme, so the only way
+           here is a utility built against one theme and rendered against
+           another. *)
+        invalid_arg (theme_name ^ ": no such theme token")
+    | Some (value, bodies) ->
+        let size : Css.filter =
+          match List.map drop_shadow_size_of_body bodies with
+          | [ single ] -> single
+          | many -> Css.List many
+        in
+        style ~property_rules:filter_property_rules
+          [
+            Css.custom_property ~layer:"theme" ("--" ^ theme_name) value;
+            bind_drop_shadow_size size;
+            bind_drop_shadow (drop_shadow_theme_ref theme_name);
+            filter composable_filter_chain;
+          ]
 
   let drop_shadow_multi_ =
     let fallback_a = Css.hex "#0000000d" in
@@ -686,7 +701,11 @@ module Handler = struct
         filter composable_filter_chain;
       ]
 
-  let drop_shadow_arbitrary_impl s =
+  (* The [--tw-drop-shadow-size] filter behind [drop-shadow-[...]]: the last
+     space-separated word is the colour, hoisted into the
+     [--tw-drop-shadow-color] fallback. [None] means the bracket is not a
+     shadow, which [of_class] rejects. *)
+  let drop_shadow_arbitrary_value s : Css.filter option =
     let inner = Parse.bracket_inner s in
     let inner = String.map (fun c -> if c = '_' then ' ' else c) inner in
     let parts = String.split_on_char ' ' inner in
@@ -700,14 +719,16 @@ module Handler = struct
         ("drop-shadow(" ^ non_color ^ " var(--tw-drop-shadow-color, " ^ color
        ^ "))")
     with
-    | Ok size ->
-        style ~property_rules:filter_property_rules
-          [
-            bind_drop_shadow_size size;
-            bind_drop_shadow drop_shadow_size_ref;
-            filter composable_filter_chain;
-          ]
-    | Error _ -> style []
+    | Ok size -> Some size
+    | Error _ -> None
+
+  let drop_shadow_arbitrary_impl size =
+    style ~property_rules:filter_property_rules
+      [
+        bind_drop_shadow_size size;
+        bind_drop_shadow drop_shadow_size_ref;
+        filter composable_filter_chain;
+      ]
 
   let drop_shadow_inherit_ =
     style ~property_rules:filter_property_rules
@@ -859,43 +880,46 @@ module Handler = struct
     | "2xl" -> Option.Some (Css.Px 25., Css.Px 25.)
     | _ -> Option.None
 
-  let drop_shadow_size_opacity size opacity =
-    match drop_shadow_size_geometry size with
-    | Option.None -> style []
-    | Option.Some (v, blur) ->
-        let percent =
-          match opacity with Color.Opacity_percent p -> p | _ -> 100.
-        in
-        let alpha_str =
-          if Float.is_integer percent then
-            string_of_int (int_of_float percent) ^ "%"
-          else Css.Pp.string_of_float percent ^ "%"
-        in
-        let fallback = Color.hex_to_oklab_alpha "#000000" (percent /. 100.) in
-        style ~property_rules:filter_property_rules
-          [
-            Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
-              alpha_str;
-            bind_drop_shadow_size
-              (drop_shadow_filter Zero v (Option.Some blur) fallback);
-            bind_drop_shadow drop_shadow_size_ref;
-            filter composable_filter_chain;
-          ]
+  let drop_shadow_size_opacity (v, blur) opacity =
+    let percent =
+      match opacity with Color.Opacity_percent p -> p | _ -> 100.
+    in
+    let alpha_str =
+      if Float.is_integer percent then
+        string_of_int (int_of_float percent) ^ "%"
+      else Css.Pp.string_of_float percent ^ "%"
+    in
+    let fallback = Color.hex_to_oklab_alpha "#000000" (percent /. 100.) in
+    style ~property_rules:filter_property_rules
+      [
+        Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
+          alpha_str;
+        bind_drop_shadow_size
+          (drop_shadow_filter Zero v (Option.Some blur) fallback);
+        bind_drop_shadow drop_shadow_size_ref;
+        filter composable_filter_chain;
+      ]
 
-  (* Filter arbitrary - direct value *)
-  let filter_arbitrary s =
+  (* The filter list behind [filter-[...]] and [backdrop-filter-[...]]. A
+     bracket spells its spaces with [_], so a chain such as
+     [blur(4px)_saturate(150%)] has to be decoded before the filter grammar sees
+     it. [None] means the bracket is not a filter list, which [of_class]
+     rejects. *)
+  let filter_arbitrary_value s : Css.filter option =
     let inner = Parse.bracket_inner s in
     if Parse.is_var inner then
       let bare = Parse.extract_var_name inner in
       let ref_ : Css.filter Css.var = Var.bracket bare in
-      style [ filter (Var ref_) ]
+      Some (Css.Var ref_)
     else
-      let cursor = Cascade.Cursor.of_string inner in
+      let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
       match
         Cascade.Cursor.try_parse_full_err Css.Properties.read_filter cursor
       with
-      | Ok value -> style [ filter value ]
-      | Error _ -> style []
+      | Ok value -> Some value
+      | Error _ -> None
+
+  let filter_arbitrary value = style [ filter value ]
 
   (* Composable backdrop-filter chain *)
   let composable_backdrop_filter_chain : Css.filter =
@@ -1112,21 +1136,8 @@ module Handler = struct
   let backdrop_filter_none =
     style [ Css.webkit_backdrop_filter None; backdrop_filter None ]
 
-  let backdrop_filter_arbitrary s =
-    let inner = Parse.bracket_inner s in
-    if Parse.is_var inner then
-      let bare = Parse.extract_var_name inner in
-      let ref_ : Css.filter Css.var = Var.bracket bare in
-      style
-        [ Css.webkit_backdrop_filter (Var ref_); backdrop_filter (Var ref_) ]
-    else
-      let cursor = Cascade.Cursor.of_string inner in
-      match
-        Cascade.Cursor.try_parse_full_err Css.Properties.read_filter cursor
-      with
-      | Ok value ->
-          style [ Css.webkit_backdrop_filter value; backdrop_filter value ]
-      | Error _ -> style []
+  let backdrop_filter_arbitrary value =
+    style [ Css.webkit_backdrop_filter value; backdrop_filter value ]
 
   let to_style theme =
     let drop_shadow_color c shade = drop_shadow_color ~theme c shade in
@@ -1141,7 +1152,7 @@ module Handler = struct
     function
     | Filter -> filter_
     | Filter_none -> filter_none
-    | Filter_arbitrary s -> filter_arbitrary s
+    | Filter_arbitrary (_, value) -> filter_arbitrary value
     | Blur_none -> blur_none ()
     | Blur_xs -> blur_xs ()
     | Blur_sm -> blur_sm ()
@@ -1178,13 +1189,13 @@ module Handler = struct
     | Drop_shadow_none -> drop_shadow_none
     | Drop_shadow_inherit -> drop_shadow_inherit_
     | Drop_shadow_named name -> drop_shadow_named name
-    | Drop_shadow_arbitrary s -> drop_shadow_arbitrary_impl s
+    | Drop_shadow_arbitrary (_, size) -> drop_shadow_arbitrary_impl size
     | Drop_shadow_color (c, shade) -> drop_shadow_color c shade
     | Drop_shadow_color_opacity (c, shade, op) ->
         drop_shadow_color_opacity c shade op
     | Drop_shadow_opacity op -> drop_shadow_opacity op
     | Drop_shadow_keyword_color (c, _) -> drop_shadow_keyword_color c
-    | Drop_shadow_size_opacity (size, op) -> drop_shadow_size_opacity size op
+    | Drop_shadow_size_opacity (_, geom, op) -> drop_shadow_size_opacity geom op
     | Backdrop_blur_none -> backdrop_blur_none ()
     | Backdrop_blur_xs -> backdrop_blur_xs ()
     | Backdrop_blur_sm -> backdrop_blur_sm ()
@@ -1218,7 +1229,7 @@ module Handler = struct
         neg_backdrop_hue_rotate_arbitrary angle
     | Backdrop_filter -> backdrop_filter_
     | Backdrop_filter_none -> backdrop_filter_none
-    | Backdrop_filter_arbitrary s -> backdrop_filter_arbitrary s
+    | Backdrop_filter_arbitrary (_, value) -> backdrop_filter_arbitrary value
 
   let ( >|= ) = Parse.( >|= )
   let err_not_utility = Error (`Msg "Not a filter utility")
@@ -1313,11 +1324,16 @@ module Handler = struct
     match parts with
     | [ "filter" ] -> Ok Filter
     | [ "filter"; "none" ] -> Ok Filter_none
-    | [ "filter"; s ] when Parse.is_bracket_value s -> Ok (Filter_arbitrary s)
+    | [ "filter"; s ] when Parse.is_bracket_value s -> (
+        match filter_arbitrary_value s with
+        | Option.Some value -> Ok (Filter_arbitrary (s, value))
+        | Option.None -> err_not_utility)
     | [ "backdrop"; "filter" ] -> Ok Backdrop_filter
     | [ "backdrop"; "filter"; "none" ] -> Ok Backdrop_filter_none
-    | [ "backdrop"; "filter"; s ] when Parse.is_bracket_value s ->
-        Ok (Backdrop_filter_arbitrary s)
+    | [ "backdrop"; "filter"; s ] when Parse.is_bracket_value s -> (
+        match filter_arbitrary_value s with
+        | Option.Some value -> Ok (Backdrop_filter_arbitrary (s, value))
+        | Option.None -> err_not_utility)
     | [ "blur"; "none" ] -> Ok Blur_none
     | [ "blur"; "xs" ] -> Ok Blur_xs
     | [ "blur"; "sm" ] -> Ok Blur_sm
@@ -1388,14 +1404,17 @@ module Handler = struct
         Ok (Drop_shadow_keyword_color (Css.Current, "current"))
     | [ "drop"; "shadow"; "transparent" ] ->
         Ok (Drop_shadow_keyword_color (Css.Transparent, "transparent"))
-    | [ "drop"; "shadow"; s ] when Parse.is_bracket_value s ->
+    | [ "drop"; "shadow"; s ] when Parse.is_bracket_value s -> (
         let inner = Parse.decode_arbitrary_value (Parse.bracket_inner s) in
         (* A drop-shadow bracket is a shadow or a var(); the docs' [<value>]
            placeholder is neither, and it used to reach the sheet as the colour
            of an otherwise empty shadow. *)
-        if Parse.is_var inner || Css.parse_shadow inner <> None then
-          Ok (Drop_shadow_arbitrary s)
-        else err_not_utility
+        if not (Parse.is_var inner || Css.parse_shadow inner <> None) then
+          err_not_utility
+        else
+          match drop_shadow_arbitrary_value s with
+          | Option.Some size -> Ok (Drop_shadow_arbitrary (s, size))
+          | Option.None -> err_not_utility)
     | "drop" :: "shadow" :: rest -> (
         let full = String.concat "-" rest in
         let base, opacity = Color.parse_opacity_modifier ~theme full in
@@ -1410,20 +1429,25 @@ module Handler = struct
                 Ok (Drop_shadow_color (c, shade))
             | Ok (c, shade, op) -> Ok (Drop_shadow_color_opacity (c, shade, op))
             (* Otherwise treat it as a custom [--drop-shadow-<name>] theme
-               token; the theme value is resolved at emission time. *)
-            | Error _ -> Ok (Drop_shadow_named full))
-        | op when drop_shadow_size_geometry base <> Option.None ->
-            Ok (Drop_shadow_size_opacity (base, op))
+               token. Without such a token the class names nothing: it used to
+               parse and then emit an empty rule. *)
+            | Error _ when drop_shadow_theme_bodies ~theme full <> Option.None
+              ->
+                Ok (Drop_shadow_named full)
+            | Error _ -> err_not_utility)
         | op -> (
-            if base = "" then Ok (Drop_shadow_opacity op)
-            else
-              match
-                Color.shade_and_opacity_of_strings
-                  (String.split_on_char '-' base)
-              with
-              | Ok (c, shade, _) ->
-                  Ok (Drop_shadow_color_opacity (c, shade, op))
-              | Error _ -> err_not_utility))
+            match drop_shadow_size_geometry base with
+            | Option.Some geom -> Ok (Drop_shadow_size_opacity (base, geom, op))
+            | Option.None -> (
+                if base = "" then Ok (Drop_shadow_opacity op)
+                else
+                  match
+                    Color.shade_and_opacity_of_strings
+                      (String.split_on_char '-' base)
+                  with
+                  | Ok (c, shade, _) ->
+                      Ok (Drop_shadow_color_opacity (c, shade, op))
+                  | Error _ -> err_not_utility)))
     | [ "backdrop"; "blur"; "none" ] -> Ok Backdrop_blur_none
     | [ "backdrop"; "blur"; "xs" ] -> Ok Backdrop_blur_xs
     | [ "backdrop"; "blur"; "sm" ] -> Ok Backdrop_blur_sm
@@ -1512,10 +1536,10 @@ module Handler = struct
   let to_class = function
     | Filter -> "filter"
     | Filter_none -> "filter-none"
-    | Filter_arbitrary s -> "filter-" ^ s
+    | Filter_arbitrary (s, _) -> "filter-" ^ s
     | Backdrop_filter -> "backdrop-filter"
     | Backdrop_filter_none -> "backdrop-filter-none"
-    | Backdrop_filter_arbitrary s -> "backdrop-filter-" ^ s
+    | Backdrop_filter_arbitrary (s, _) -> "backdrop-filter-" ^ s
     | Blur_none -> "blur-none"
     | Blur_xs -> "blur-xs"
     | Blur_sm -> "blur-sm"
@@ -1562,7 +1586,7 @@ module Handler = struct
     | Drop_shadow_none -> "drop-shadow-none"
     | Drop_shadow_inherit -> "drop-shadow-inherit"
     | Drop_shadow_named name -> "drop-shadow-" ^ name
-    | Drop_shadow_arbitrary s -> "drop-shadow-" ^ s
+    | Drop_shadow_arbitrary (s, _) -> "drop-shadow-" ^ s
     | Drop_shadow_color (c, shade) ->
         "drop-shadow-" ^ Color.scheme_color_name c shade
     | Drop_shadow_color_opacity (c, shade, op) ->
@@ -1571,7 +1595,7 @@ module Handler = struct
         ^ "/" ^ Color.pp_opacity op
     | Drop_shadow_opacity op -> "drop-shadow/" ^ Color.pp_opacity op
     | Drop_shadow_keyword_color (_, name) -> "drop-shadow-" ^ name
-    | Drop_shadow_size_opacity (size, op) ->
+    | Drop_shadow_size_opacity (size, _, op) ->
         "drop-shadow-" ^ size ^ "/" ^ Color.pp_opacity op
     | Backdrop_blur_none -> "backdrop-blur-none"
     | Backdrop_blur_xs -> "backdrop-blur-xs"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -59,15 +59,15 @@ module Handler = struct
     | Mask_bracket_cover
     | Mask_bracket_size of string
     | Mask_bracket_length of string
-    | Mask_bracket_position of string
-    | Mask_bracket_typed_position of string
+    | Mask_bracket_position of string * Css.position_value list
+    | Mask_bracket_typed_position of string * Css.position_value list
     | Mask_bracket_image_var of string
     | Mask_bracket_url of string
     | Mask_bracket_url_var of string
     | Mask_bracket_var of string
     | Mask_bracket_image of string
     (* Sub-property bracket notation: mask-position-[...], mask-size-[...] *)
-    | Mask_position_bracket of string
+    | Mask_position_bracket of string * Css.position_value list
     | Mask_position_bracket_var of string
     | Mask_size_bracket of string
     | Mask_size_bracket_var of string
@@ -280,30 +280,27 @@ module Handler = struct
           (parse_size_val v)
     | _ -> None
 
-  (* A mask position is one or two components. Lengths go through the value
-     parser rather than a hand-rolled unit table, so every unit works. *)
-  let parse_bracket_position inner : Css.declaration list option =
+  (* A bracket mask-position: the whole [<position>] grammar, one position per
+     mask layer, comma-separated. [None] means the bracket is not a position,
+     which [of_class] rejects: [mask-[position:top]] used to fall through the
+     hand-rolled reading to a plausible-looking [center]. *)
+  let parse_bracket_position inner : Css.position_value list option =
     let one entry : Css.position_value option =
+      let cursor = Cascade.Cursor.of_string (Parse.decode_underscores entry) in
       match
-        String.split_on_char '_' entry |> List.filter (fun s -> s <> "")
+        Cascade.Cursor.try_parse_full_err Css.Properties.read_position_value
+          cursor
       with
-      | [ x; y ] -> (
-          match (Css.parse_length x, Css.parse_length y) with
-          | Some xv, Some yv -> Some (XY (xv, yv))
-          | _ -> None)
-      | [ v ] ->
-          Option.map
-            (fun (l : Css.length) : Css.position_value -> Single l)
-            (Css.parse_length v)
-      | _ -> None
+      | Ok pos -> Some pos
+      | Error _ -> None
     in
-    (* One position per mask layer, comma-separated. *)
     let entries = String.split_on_char ',' inner |> List.map String.trim in
     let positions = List.map one entries in
     if List.exists Option.is_none positions then None
-    else
-      let positions = List.filter_map Fun.id positions in
-      Some [ Css.webkit_mask_position positions; Css.mask_position positions ]
+    else Some (List.filter_map Fun.id positions)
+
+  let mask_position_style positions =
+    style [ Css.webkit_mask_position positions; Css.mask_position positions ]
 
   let to_style _theme = function
     | Mask_none -> mask_none
@@ -352,24 +349,9 @@ module Handler = struct
         match parse_bracket_size inner with
         | Some decls -> style decls
         | None -> style [ Css.webkit_mask_size Auto; Css.mask_size Auto ])
-    | Mask_bracket_position inner -> (
-        match parse_bracket_position inner with
-        | Some decls -> style decls
-        | None ->
-            style
-              [
-                Css.webkit_mask_position [ Center ];
-                Css.mask_position [ Center ];
-              ])
-    | Mask_bracket_typed_position inner -> (
-        match parse_bracket_position inner with
-        | Some decls -> style decls
-        | None ->
-            style
-              [
-                Css.webkit_mask_position [ Center ];
-                Css.mask_position [ Center ];
-              ])
+    | Mask_bracket_position (_, positions) -> mask_position_style positions
+    | Mask_bracket_typed_position (_, positions) ->
+        mask_position_style positions
     | Mask_bracket_image_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
@@ -408,15 +390,7 @@ module Handler = struct
             invalid_arg ("mask-[" ^ v ^ "]: not a valid background-image value")
         )
     (* Sub-property bracket notation *)
-    | Mask_position_bracket inner -> (
-        match parse_bracket_position inner with
-        | Some decls -> style decls
-        | None ->
-            style
-              [
-                Css.webkit_mask_position [ Center ];
-                Css.mask_position [ Center ];
-              ])
+    | Mask_position_bracket (_, positions) -> mask_position_style positions
     | Mask_position_bracket_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.position_value Css.var = Var.bracket bare in
@@ -560,12 +534,13 @@ module Handler = struct
     | [ "mask"; "origin"; "stroke" ] -> Ok Mask_origin_stroke
     | [ "mask"; "origin"; "view" ] -> Ok Mask_origin_view
     (* Sub-property bracket notation: mask-position-[...], mask-size-[...] *)
-    | [ "mask"; "position"; bracket ] when Parse.is_bracket_value bracket ->
+    | [ "mask"; "position"; bracket ] when Parse.is_bracket_value bracket -> (
         let inner = Parse.bracket_inner bracket in
         if Parse.is_var inner then Ok (Mask_position_bracket_var inner)
-        else if parse_bracket_position inner = None then
-          Error (`Msg "Invalid mask-position value")
-        else Ok (Mask_position_bracket inner)
+        else
+          match parse_bracket_position inner with
+          | Some positions -> Ok (Mask_position_bracket (inner, positions))
+          | None -> Error (`Msg "Invalid mask-position value"))
     | [ "mask"; "size"; bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
         if Parse.is_var inner then Ok (Mask_size_bracket_var inner)
@@ -586,10 +561,14 @@ module Handler = struct
             Ok
               (Mask_bracket_size (String.sub inner 5 (String.length inner - 5)))
         | _ when String.length inner > 9 && String.sub inner 0 9 = "position:"
-          ->
-            Ok
-              (Mask_bracket_typed_position
-                 (String.sub inner 9 (String.length inner - 9)))
+          -> (
+            (* The [position:] data-type hint forces a mask-position; a value
+               the grammar rejects is not a utility. It used to fall through to
+               a plausible-looking [center]. *)
+            let v = String.sub inner 9 (String.length inner - 9) in
+            match parse_bracket_position v with
+            | Some positions -> Ok (Mask_bracket_typed_position (v, positions))
+            | None -> Error (`Msg ("Unknown mask bracket position: " ^ v)))
         | _ when String.length inner > 6 && String.sub inner 0 6 = "image:" ->
             Ok
               (Mask_bracket_image_var
@@ -606,10 +585,10 @@ module Handler = struct
             let url_content = String.sub inner 4 (String.length inner - 5) in
             Ok (Mask_bracket_url url_content)
         | _ when Parse.is_var inner -> Ok (Mask_bracket_var inner)
-        | _ ->
-            if parse_bracket_position inner <> None then
-              Ok (Mask_bracket_position inner)
-            else Error (`Msg ("Unknown mask bracket value: " ^ inner)))
+        | _ -> (
+            match parse_bracket_position inner with
+            | Some positions -> Ok (Mask_bracket_position (inner, positions))
+            | None -> Error (`Msg ("Unknown mask bracket value: " ^ inner))))
     | _ -> Error (`Msg "Not a mask utility")
 
   let to_class = function
@@ -658,14 +637,14 @@ module Handler = struct
     | Mask_bracket_cover -> "mask-[cover]"
     | Mask_bracket_size v -> "mask-[size:" ^ v ^ "]"
     | Mask_bracket_length v -> "mask-[length:" ^ v ^ "]"
-    | Mask_bracket_position v -> "mask-[" ^ v ^ "]"
-    | Mask_bracket_typed_position v -> "mask-[position:" ^ v ^ "]"
+    | Mask_bracket_position (v, _) -> "mask-[" ^ v ^ "]"
+    | Mask_bracket_typed_position (v, _) -> "mask-[position:" ^ v ^ "]"
     | Mask_bracket_image_var v -> "mask-[image:" ^ v ^ "]"
     | Mask_bracket_url url -> "mask-[url(" ^ url ^ ")]"
     | Mask_bracket_url_var v -> "mask-[url:" ^ v ^ "]"
     | Mask_bracket_var v -> "mask-[" ^ v ^ "]"
     | Mask_bracket_image v -> "mask-[" ^ v ^ "]"
-    | Mask_position_bracket v -> "mask-position-[" ^ v ^ "]"
+    | Mask_position_bracket (v, _) -> "mask-position-[" ^ v ^ "]"
     | Mask_position_bracket_var v -> "mask-position-[" ^ v ^ "]"
     | Mask_size_bracket v -> "mask-size-[" ^ v ^ "]"
     | Mask_size_bracket_var v -> "mask-size-[" ^ v ^ "]"

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -136,9 +136,51 @@ let test_bg_position_bracket_keyword_length () =
     (Astring.String.is_infix ~affix:"background-position: 50% -100px"
        (css "bg-position-[center_-100px]"));
   Alcotest.(check bool)
-    "bg-position-[left_top] normalises keywords" true
-    (Astring.String.is_infix ~affix:"background-position: 0% 0%"
+    "bg-position-[left_top] keeps the edge keywords" true
+    (Astring.String.is_infix ~affix:"background-position: left top"
        (css "bg-position-[left_top]"))
+
+(* A background-position bracket takes the whole CSS grammar: a single edge
+   keyword, and the four-value edge/offset form. Both used to fall through the
+   hand-rolled parser to a silent [center]. *)
+let test_bracket_position_grammar () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "bg-[position:top]" "background-position: top";
+  has "bg-[position:left_10px_top_20px]"
+    "background-position: left 10px top 20px";
+  has "bg-position-[top]" "background-position: top";
+  has "bg-[top]" "background-position: top";
+  (* the lengths form is unchanged *)
+  has "bg-[position:120px_120px]" "background-position: 120px 120px";
+  has "bg-position-[center_-100px]" "background-position: 50% -100px"
+
+(* A bracket value the property cannot take is not a utility. [bg-[image:...]]
+   used to emit an empty rule and [bg-[position:...]] a plausible-looking
+   [center]: no CSS the class asked for, and no diagnostic. *)
+let test_invalid_bracket_value () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "bg-[image:nope]";
+  rejected "bg-[position:nope]";
+  accepted "bg-[image:radial-gradient(white,black)]";
+  accepted "bg-[image:var(--x)]";
+  accepted "bg-[image:url(/a.png)]";
+  accepted "bg-[position:120px_120px]"
 
 let test_bracket_image_literal () =
   let css cls =
@@ -366,6 +408,8 @@ let tests =
     test_case "bracket length keywords" `Quick test_bracket_length_keywords;
     test_case "bg-position bracket keyword+length" `Quick
       test_bg_position_bracket_keyword_length;
+    test_case "bracket position grammar" `Quick test_bracket_position_grammar;
+    test_case "invalid bracket value" `Quick test_invalid_bracket_value;
     test_case "bare radial and conic gradients" `Quick test_radial_conic;
     test_case "gradient colors" `Quick test_gradient_colors;
     test_case "via-none" `Quick test_via_none;

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -180,6 +180,64 @@ let test_invalid_arbitrary_amount () =
   check "saturate-[150%]";
   check "brightness-[var(--x)]"
 
+(* An arbitrary filter spells its spaces with [_], so a multi-function chain
+   like filter-[blur(4px)_saturate(150%)] has to be decoded before it is parsed.
+   Without that the whole class parsed as nothing and emitted an empty rule. *)
+let test_arbitrary_filter_chain () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "filter-[blur(4px)_saturate(150%)]" "filter: blur(4px) saturate(150%)";
+  has "backdrop-filter-[blur(4px)_saturate(150%)]"
+    "-webkit-backdrop-filter: blur(4px) saturate(150%)";
+  has "backdrop-filter-[blur(4px)_saturate(150%)]"
+    "backdrop-filter: blur(4px) saturate(150%)";
+  (* single-function and var() forms are unchanged *)
+  has "filter-[blur(4px)]" "filter: blur(4px)";
+  has "filter-[var(--my-filter)]" "filter: var(--my-filter)";
+  has "backdrop-filter-[blur(4px)]" "backdrop-filter: blur(4px)";
+  has "backdrop-filter-[var(--x)]" "backdrop-filter: var(--x)"
+
+(* A bracket value the filter grammar cannot take is not a utility. It used to
+   parse, then emit an empty rule: no CSS and no diagnostic. Same for a
+   drop-shadow name the theme has no --drop-shadow-<name> token for. *)
+let test_unparseable_arbitrary_filter_rejected () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "filter-[nope(1)]";
+  rejected "backdrop-filter-[nope(1)]";
+  rejected "drop-shadow-nope";
+  check "filter-[blur(4px)]";
+  check "backdrop-filter-[blur(4px)]";
+  check "drop-shadow-xs";
+  check "drop-shadow-red-500"
+
+(* Every filter class the parser accepts renders at least one declaration; an
+   accepted class that emits nothing is the silent-acceptance bug. *)
+let test_no_empty_rules () =
+  let non_empty cls =
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u ->
+        let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string in
+        Alcotest.(check bool)
+          (cls ^ " emits a declaration")
+          true
+          (Astring.String.is_infix ~affix:":" css)
+  in
+  non_empty "filter-[blur(4px)]";
+  non_empty "backdrop-filter-[blur(4px)]";
+  non_empty "drop-shadow-[0_0_2px_red]";
+  non_empty "drop-shadow-xl/25"
+
 (* Filters are the case the text-level comparison cannot judge: a drop-shadow
    colour and a drop-shadow size meet in --tw-drop-shadow-size, so what an
    element ends up filtering by is only visible once rendered. *)
@@ -212,6 +270,10 @@ let tests =
     test_case "filters render like Tailwind" `Slow rendering_matches_tailwind;
     test_case "blur" `Quick test_blur;
     test_case "invalid arbitrary amount" `Quick test_invalid_arbitrary_amount;
+    test_case "arbitrary filter chain" `Quick test_arbitrary_filter_chain;
+    test_case "unparseable arbitrary filter rejected" `Quick
+      test_unparseable_arbitrary_filter_rejected;
+    test_case "accepted filters emit declarations" `Quick test_no_empty_rules;
     test_case "drop-shadow-xs (v4.3.1 size)" `Quick test_drop_shadow_xs;
     test_case "drop-shadow color (default theme)" `Quick test_drop_shadow_color;
     test_case "drop-shadow opacity keeps both layers" `Quick

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -87,7 +87,27 @@ let test_invalid_bracket_value () =
     | Error _ -> ()
   in
   rejected "mask-size-[<value>]";
-  rejected "mask-position-[<value>]"
+  rejected "mask-position-[<value>]";
+  rejected "mask-[position:nope]"
+
+(* A mask-position bracket takes the whole CSS grammar, the same as
+   background-position: a single edge keyword and the edge/offset form. Both
+   used to fall through the hand-rolled parser to a silent [center]. *)
+let test_bracket_position_grammar () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "mask-[position:top]" "mask-position:top";
+  has "mask-position-[top]" "mask-position:top";
+  has "mask-[top]" "mask-position:top";
+  (* the lengths and layer-list forms are unchanged *)
+  has "mask-[position:10px_20px]" "mask-position:10px 20px";
+  has "mask-position-[30%_50%,70%_50%]" "mask-position:30% 50%,70% 50%"
 
 (* Masks sit between the backgrounds and fill/stroke, and the mask-gradient
    utilities lead them. Sharing padding's slot interleaved the two families with
@@ -121,6 +141,8 @@ let tests =
         test_bracket_layer_list;
       Alcotest.test_case "invalid bracket value" `Quick
         test_invalid_bracket_value;
+      Alcotest.test_case "bracket position grammar" `Quick
+        test_bracket_position_grammar;
       Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
     ]
 


### PR DESCRIPTION
Nine to_style sites ended in Error _ -> style [], so a bad arbitrary value was accepted as a known class emitting nothing - and the biggest casualty was ordinary usage: filter-[blur(4px)_saturate(150%)] never decoded underscores and silently produced no CSS. Bracket filters, background/mask positions and images now parse in of_class and ride typed in the constructor; what cascade's grammar rejects is a loud Unknown class, and the duplicated hand-rolled position parser (px/% only, silent center fallback) is replaced by cascade's read_position_value in both files. 28 spellings verified --diff clean.