### PR TITLE
tools: write every test scratch file under the repo-local tmp/

### DIFF
--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -70,29 +70,43 @@ let parse_version v =
       | _ -> None)
   | _ -> None
 
+(* Scratch files stay in the repo-local [tmp/], never a system temp directory:
+   it is shared with every other user and run on the machine, and tailwindcss
+   resolves its imports relative to where its input sits. *)
+let tmp_root = "tmp"
+
+let ensure_tmp_root () =
+  (* Another test binary may have created it between the two calls. *)
+  if not (Sys.file_exists tmp_root) then
+    try Sys.mkdir tmp_root 0o755 with Sys_error _ -> ()
+
+let tmp_file prefix suffix =
+  ensure_tmp_root ();
+  Filename.temp_file ~temp_dir:tmp_root prefix suffix
+
+let first_line path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> try Some (input_line ic) with End_of_file -> None)
+
 let tailwindcss_version cmd =
-  (* Try --version first, fall back to --help if needed *)
-  let temp_file = Filename.temp_file "tw_version" ".txt" in
-  let version_cmd = cmd ^ " --version 2>/dev/null > " ^ temp_file in
-  let exit_code = Sys.command version_cmd in
-  let version_line, fallback_used =
-    if exit_code = 0 then (
-      let ic = open_in temp_file in
-      let line = input_line ic in
-      close_in ic;
-      (line, false))
-    else
-      let help_cmd = cmd ^ " --help 2>&1 | head -1 > " ^ temp_file in
-      let help_exit = Sys.command help_cmd in
-      if help_exit = 0 then (
-        let ic = open_in temp_file in
-        let line = input_line ic in
-        close_in ic;
-        (line, true))
-      else failwith "Failed to check tailwindcss version."
+  (* Try --version first, fall back to --help if needed. A command that exits 0
+     and prints nothing has answered nothing, so it counts as no answer and the
+     fallback runs. *)
+  let temp_file = tmp_file "tw_version" ".txt" in
+  let remove () = try Sys.remove temp_file with Sys_error _ -> () in
+  Fun.protect ~finally:remove @@ fun () ->
+  let probe args =
+    if Sys.command (cmd ^ args ^ temp_file) = 0 then first_line temp_file
+    else None
   in
-  Sys.remove temp_file;
-  (version_line, fallback_used)
+  match probe " --version 2>/dev/null > " with
+  | Some line -> (line, false)
+  | None -> (
+      match probe " --help 2>&1 | head -1 > " with
+      | Some line -> (line, true)
+      | None -> failwith "Failed to check tailwindcss version.")
 
 let extract_version_number line =
   (* Extract version number from strings like "tailwindcss v4.0.0" or "4.0.0" *)
@@ -170,11 +184,16 @@ let check_tailwindcss_available () =
       availability_result := Some result;
       match result with Ok () -> () | Error e -> raise e)
 
+(* Establishing the reference build runs commands and reads their output, so it
+   fails on a missing CLI and on an unusable filesystem alike; both mean the
+   same thing here, that there is nothing to compare against. Generation is
+   separate: once the CLI is known good, a [generate] that produces no CSS still
+   raises. *)
 let available () =
   try
     check_tailwindcss_available ();
     true
-  with Failure _ -> false
+  with Failure _ | Sys_error _ -> false
 
 (* Statistics tracking *)
 module Stats = struct
@@ -226,11 +245,9 @@ let with_stats f =
       raise exn
 
 let temp_dir () =
-  (* Ensure tmp directory exists in project root *)
-  if not (Sys.file_exists "tmp") then Unix.mkdir "tmp" 0o755;
-  (* Create unique temp directory in project root so tailwindcss can resolve
-     imports *)
-  let dir = Filename.temp_file ~temp_dir:"tmp" "tw_gen_" "" in
+  (* One directory per generation, in the project root so tailwindcss can
+     resolve imports. *)
+  let dir = tmp_file "tw_gen_" "" in
   Sys.remove dir;
   Sys.mkdir dir 0o755;
   dir

--- a/lib/tools/tailwind_gen.mli
+++ b/lib/tools/tailwind_gen.mli
@@ -25,7 +25,11 @@ val check_tailwindcss_available : unit -> unit
     @raise Failure if Tailwind CSS is not available or not v4. *)
 
 val available : unit -> bool
-(** [available ()] is [true] iff the required tailwindcss CLI is installed. *)
+(** [available ()] is [true] iff the required tailwindcss CLI is installed and
+    could be identified. It is [false] when the CLI is missing, answers with
+    another version, or cannot be probed at all, and it never raises. A CLI that
+    is present and then fails to produce CSS is a separate matter: {!generate}
+    raises on that. *)
 
 val with_stats : (unit -> 'a) -> 'a
 (** [with_stats f] runs function [f] and prints Tailwind CSS generation

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -503,6 +503,32 @@ let check_upstream_positive_fixture_parse filename () =
 
 (* ===== CORE TESTS (renamed to shorter names) ===== *)
 
+(* Debug artefacts are named after the classes under test and belong inside the
+   checkout: a shared system temp directory is written by every user and every
+   concurrent run at once. The name has to separate the runs too - a slug that
+   drops every separator sends [p-4 m-2] and [p4m2] to the same pair of
+   files. *)
+let debug_artefacts () =
+  Alcotest.(check bool)
+    "distinct class lists get distinct slugs" true
+    (slugify "p-4 m-2" <> slugify "p4m2");
+  let is_safe = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | '-' -> true
+    | _ -> false
+  in
+  Alcotest.(check bool)
+    "slug is filesystem-safe" true
+    (String.for_all is_safe (slugify "before:content-['*'] w-1/2"));
+  let tw_file, tailwind_file = debug_files "p-4 m-2" "" "" in
+  let expected_dir = Filename.concat "tmp" "css_debug" in
+  List.iter
+    (fun path ->
+      Alcotest.(check string)
+        "artefact sits in the repo-local tmp" expected_dir
+        (Filename.dirname path);
+      Alcotest.(check bool) (path ^ " was written") true (Sys.file_exists path))
+    [ tw_file; tailwind_file ]
+
 let empty_test () =
   (* Test with no styles to see base output *)
   check_list []
@@ -1241,6 +1267,7 @@ let property_order_cross_family () =
 
 let core_tests =
   [
+    test_case "debug artefacts" `Quick debug_artefacts;
     test_case "empty test" `Quick empty_test;
     test_case "upstream utilities parse parity" `Quick
       (check_upstream_positive_fixture_parse "utilities.txt");

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -66,21 +66,28 @@ let is_allowed_canonicalization_diff diff =
 (* File utilities *)
 let write_file path content =
   let oc = open_out path in
-  output_string oc content;
-  close_out oc
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
 
+(* A file name the class list can be read back out of, and that no other class
+   list shares. The readable half keeps whatever is already safe in a path and
+   folds the rest to [_], which alone collides ([p-4 m-2] and [p_4_m_2]) and is
+   truncated on top; the digest of the full name is what separates them. *)
 let slugify s =
   let b = Buffer.create (String.length s) in
   String.iter
     (fun c ->
-      if
-        (c >= 'a' && c <= 'z')
-        || (c >= 'A' && c <= 'Z')
-        || (c >= '0' && c <= '9')
-        || c = '_'
-      then Buffer.add_char b c)
+      match c with
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '-' | '_' ->
+          Buffer.add_char b c
+      | _ -> Buffer.add_char b '_')
     s;
-  Buffer.contents b
+  let readable = Buffer.contents b in
+  let readable =
+    if String.length readable > 60 then String.sub readable 0 60 else readable
+  in
+  readable ^ "-" ^ String.sub (Digest.to_hex (Digest.string s)) 0 12
 
 (* Test name generation *)
 let test_name_of = function
@@ -90,8 +97,17 @@ let test_name_of = function
       if String.length full_name > 100 then String.sub full_name 0 97 ^ "..."
       else full_name
 
+(* Another test binary may have created it between the two calls. *)
+let mkdir dir =
+  if not (Sys.file_exists dir) then
+    try Sys.mkdir dir 0o755 with Sys_error _ -> ()
+
 let debug_files test_name tw_css tailwind_css =
-  let out_dir = "/tmp" in
+  (* Repo-local, as the debugging docs say: a system temp directory is shared
+     with every other user and run on the machine. *)
+  let out_dir = Filename.concat "tmp" "css_debug" in
+  mkdir "tmp";
+  mkdir out_dir;
   let test_name_slug = slugify test_name in
   let tw_file =
     Filename.concat out_dir ("test_css_tw_" ^ test_name_slug ^ ".css")
@@ -140,9 +156,6 @@ let check_exact_match tw_styles =
     let tailwind_css = canonical_stylesheet_css !tailwind_css_raw in
 
     let test_name = test_name_of classnames in
-    (* Write stripped CSS to test files for better error context *)
-    let tw_file, tailwind_file = debug_files test_name tw_css tailwind_css in
-
     let diff_result =
       Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
         tailwind_css tw_css
@@ -154,6 +167,9 @@ let check_exact_match tw_styles =
       || is_allowed_canonicalization_diff diff_result
     in
     if not parity_equal then (
+      (* Only a failure is worth an artefact: a passing run has nothing to diff
+         by hand. *)
+      let tw_file, tailwind_file = debug_files test_name tw_css tailwind_css in
       report_failure test_name tw_file tailwind_file;
 
       (* Show diff statistics *)
@@ -179,6 +195,10 @@ let check_exact_match tw_styles =
       (if parity_equal then tailwind_css else tw_css)
   with
   | Failure msg -> fail ("Test setup failed: " ^ msg)
+  | Sys_error msg ->
+      (* A filesystem error already names the path and the reason; wrapping it
+         as an unexpected exception buries both. *)
+      fail msg
   | Cascade.Reader.Parse_error err ->
       let details = Cascade.Reader.pp_parse_error err in
       (* Print a more helpful parse error with context and callstack. *)


### PR DESCRIPTION
The tailwindcss version probe wrote into the system temp directory and, when the command answered with nothing, leaked the file and raised `End_of_file` straight past `available ()`. The parity checks wrote their debug CSS to `/tmp` on every run under a slug that collapsed distinct class lists onto one pair of files; both now use a repo-local `tmp/` with an EEXIST-tolerant mkdir, and the parity artefacts land in `tmp/css_debug` on failure only.