### PR TITLE
variants: sort a utility routed through a declared variant

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1432,6 +1432,16 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
         Hashtbl.add derived name t;
         t
   in
+  (* A declared variant only decorates the selector: the utility underneath is
+     one the handlers know, so it sorts by its own order - the same one the
+     built-in generator gives it. Reading a slot off the emitted property would
+     lose the value's place within its family ([p-2] before [p-10]). *)
+  let own_order = Hashtbl.create 8 in
+  let record_own_order cls name =
+    match Tw.Utility.base_of_class theme name with
+    | Ok base -> Hashtbl.replace own_order cls (Tw.Utility.order base)
+    | Error _ -> ()
+  in
   let one cls =
     let variants, bare = split_declared_variants defs cls in
     (* [bare] still carries the built-in prefixes; the utility itself is its
@@ -1450,7 +1460,11 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
     | None ->
         let body, top = nested_utilities ~theme [ bare ] in
         add_once hoisted seen top;
-        if body = "" then None else Some (wrapped_block cls variants body)
+        if body = "" then None
+        else begin
+          record_own_order cls name;
+          Some (wrapped_block cls variants body)
+        end
   in
   match List.filter_map one candidates with
   | [] -> (0, [], [])
@@ -1499,9 +1513,10 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
           in
           (* Tailwind sorts a declared utility at the slot of the property it
              declares, so group the rules it produced under their own class and
-             read that slot off the first declaration. A property no handler
-             claims leaves the group without an order; those keep their old
-             place at the end of the layer rather than being dropped. *)
+             read that slot off the first declaration. A utility that carries
+             its own order needs no slot. A property no handler claims leaves
+             the group without either; those keep their old place at the end of
+             the layer rather than being dropped. *)
           let group = Hashtbl.create 8 in
           let order_of = Hashtbl.create 8 in
           let classless = ref [] in
@@ -1514,27 +1529,57 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
                     Stdlib.Option.value ~default:[] (Hashtbl.find_opt group cls)
                   in
                   Hashtbl.replace group cls (prev @ [ stmt ]);
-                  if not (Hashtbl.mem order_of cls) then
+                  if
+                    (not (Hashtbl.mem own_order cls))
+                    && not (Hashtbl.mem order_of cls)
+                  then
                     match slot_of_statement stmt with
                     | Some order -> Hashtbl.add order_of cls order
                     | None -> ()))
             rules;
           (* Two declared utilities can land on the same slot, and their rules
              would then interleave by selector, splitting each one's own rules
-             apart. Offset the suborder per class so each stays contiguous. *)
+             apart. Offset the suborder per class so each stays contiguous. The
+             offset counts along a slot-then-name walk of the groups, not along
+             the hash table's, so it does not depend on the class names' hashes.
+             A utility with an order of its own takes no offset: it already sits
+             where the built-in generator would put it, and nudging it would
+             break the ties the layer resolves by name. *)
+          let slot_of cls =
+            match Hashtbl.find_opt own_order cls with
+            | Some order -> order
+            | None ->
+                Stdlib.Option.value
+                  ~default:(max_int, max_int)
+                  (Hashtbl.find_opt order_of cls)
+          in
+          let by_slot (c1, _) (c2, _) =
+            let p1, s1 = slot_of c1 and p2, s2 = slot_of c2 in
+            let cmp = Int.compare p1 p2 in
+            let cmp = if cmp <> 0 then cmp else Int.compare s1 s2 in
+            if cmp <> 0 then cmp else String.compare c1 c2
+          in
+          let entries =
+            Hashtbl.fold (fun cls stmts acc -> (cls, stmts) :: acc) group []
+            |> List.sort by_slot
+          in
           let nth = ref 0 in
           let ordered, unordered =
-            Hashtbl.fold
-              (fun cls stmts (ordered, unordered) ->
-                match Hashtbl.find_opt order_of cls with
-                | Some (priority, suborder) ->
-                    incr nth;
-                    ( (cls, (priority, suborder + !nth), stmts) :: ordered,
-                      unordered )
-                | None -> (ordered, stmts @ unordered))
-              group
+            List.fold_left
+              (fun (ordered, unordered) (cls, stmts) ->
+                match Hashtbl.find_opt own_order cls with
+                | Some order -> ((cls, order, stmts) :: ordered, unordered)
+                | None -> (
+                    match Hashtbl.find_opt order_of cls with
+                    | Some (priority, suborder) ->
+                        incr nth;
+                        ( (cls, (priority, suborder + !nth), stmts) :: ordered,
+                          unordered )
+                    | None -> (ordered, unordered @ stmts)))
               ([], List.rev !classless)
+              entries
           in
+          let ordered = List.rev ordered in
           let unplaced =
             if unordered = [] then []
             else [ Css.layer ~name:"utilities" unordered ]

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1541,12 +1541,17 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
     List.concat_map (Rule.outputs ~theme ~order_tbl:order_map) tw_classes
   in
   (* A declared utility means nothing to the handlers, so its order arrives with
-     it and is seeded under the same key [order_of_base] looks up. *)
+     it and is seeded under the same key [order_of_base] looks up. The key is
+     the base name, which a plain utility of the same name shares: seed it only
+     when it is free, so an incoming order never moves a rule the handlers
+     already placed. *)
   let selector_props =
     selector_props
     @ List.concat_map
         (fun (class_name, order, statements) ->
-          Hashtbl.replace order_map (extract_base_utility class_name) order;
+          let key = extract_base_utility class_name in
+          if not (Hashtbl.mem order_map key) then
+            Hashtbl.add order_map key order;
           List.concat_map
             (outputs_of_statement ~base_class:class_name)
             statements)

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -50,6 +50,35 @@ No [prefers-color-scheme] query is emitted for this selector-only override:
   0
   [1]
 
+Routing through the declared variant leaves the utilities layer in the order
+the built-in generator uses: each family at its own slot, and inside a family
+the scale in numeric order.
+
+  $ cat > darkorder.html <<EOF
+  > <div class="dark:text-zinc-400 dark:text-blue-400 dark:text-sky-400 dark:p-2 dark:p-10 dark:p-1 dark:flex"></div>
+  > EOF
+  $ tw --minify --input-css darkclass.css darkorder.html | grep -oE '\.dark..[a-z0-9-]+:where'
+  .dark\:flex:where
+  .dark\:p-1:where
+  .dark\:p-2:where
+  .dark\:p-10:where
+  .dark\:text-blue-400:where
+  .dark\:text-sky-400:where
+  .dark\:text-zinc-400:where
+
+A routed utility does not displace the plain one it shares a name with:
+[table] keeps the slot its own value gives it, behind [flex].
+
+  $ cat > darkshare.html <<EOF
+  > <div class="block contents flex table dark:table"></div>
+  > EOF
+  $ tw --minify --input-css darkclass.css darkshare.html | grep -oE '\.[a-z\\:-]+[^{]*\{display'
+  .block{display
+  .contents{display
+  .flex{display
+  .table{display
+  .dark\:table:where(.dark,.dark *){display
+
 The declared variant is honoured wherever it sits in the chain, not only when
 it leads: a built-in responsive prefix in front of it keeps its media query
 around the project's selector.

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -79,6 +79,20 @@ A routed utility does not displace the plain one it shares a name with:
   .table{display
   .dark\:table:where(.dark,.dark *){display
 
+That holds when the routed class is one the handlers cannot name, so it
+falls back on the slot of the property it emits: an [!important] marker is
+enough, and the plain [table] still keeps its place.
+
+  $ cat > darkbang.html <<EOF
+  > <div class="block contents flex table dark:!table"></div>
+  > EOF
+  $ tw --minify --input-css darkclass.css darkbang.html | grep -oE '\.[a-z\\!:-]+[^{]*\{display'
+  .block{display
+  .contents{display
+  .flex{display
+  .table{display
+  .dark\:\!table:where(.dark,.dark *){display
+
 The declared variant is honoured wherever it sits in the chain, not only when
 it leads: a built-in responsive prefix in front of it keeps its media query
 around the project's selector.

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -722,6 +722,34 @@ let test_build_utils_layer_order () =
   check bool "two .a rules are not adjacent" true
     (pos_b > pos_a1 && pos_b < pos_a2)
 
+(* An [extra] rule seeds its order under its base utility's name, and a plain
+   utility of the same name reads that key too. [table] sorts behind [flex] on
+   its own suborder, whatever order a routed [dark:!table] arrives with. *)
+let test_extra_keeps_plain_order () =
+  let extra =
+    [
+      ( "dark:!table",
+        (4, 2),
+        [
+          Css.rule
+            ~selector:(Css.Selector.class_ "dark:!table")
+            [ Css.display Css.Table ];
+        ] );
+    ]
+  in
+  let config = { Tw.Build.base = false; forms = None; layers = true } in
+  let css = Tw.Build.to_css ~config ~extra [ Tw.Flex.flex; Tw.Layout.table ] in
+  let css_str = Css.to_string ~minify:true css in
+  let position sub =
+    match Astring.String.find_sub ~sub css_str with
+    | None -> -1
+    | Some pos -> pos
+  in
+  let flex = position ".flex{" and table = position ".table{" in
+  check bool "flex is emitted" true (flex >= 0);
+  check bool "table is emitted" true (table >= 0);
+  check bool "flex before table" true (flex < table)
+
 let test_style_rules_props () =
   (* Test that when a Style has both props and rules, the props are placed after
      the rules *)
@@ -928,6 +956,8 @@ let tests =
     test_case "build_utilities_layer" `Quick test_build_utilities_layer;
     test_case "build_utilities_layer preserves order" `Quick
       test_build_utils_layer_order;
+    test_case "extra keeps a plain utility's order" `Quick
+      test_extra_keeps_plain_order;
     test_case "style with rules and props ordering" `Quick
       test_style_rules_props;
   ]


### PR DESCRIPTION
A utility behind a `@custom-variant` sorted by the property it emitted, offset by its place in a hash table walk, so same-family classes came out scrambled instead of in Tailwind's order. It now carries the order the built-in generator gives it, and an incoming order no longer overwrites the slot of a plain utility sharing its base name.