### PR TITLE
var: give every variable the slot its name owns

### DIFF
--- a/lib/var.ml
+++ b/lib/var.ml
@@ -44,11 +44,9 @@ type 'a property_default = ('a, [ `Property_default ]) t
 type 'a channel = ('a, [ `Channel ]) t
 type 'a ref_only = ('a, [ `Ref_only ]) t
 
-(* Global registry to prevent order and name conflicts *)
+(* Global registry of the metadata the layer builders look up by variable name,
+   filled by [v] as each variable definition is evaluated. *)
 module Registry = struct
-  (* Table mapping (priority, suborder) -> variable_name *)
-  let order_registry : (int * int, string) Hashtbl.t = Hashtbl.create 128
-
   (* Table mapping variable_name -> (priority, suborder) *)
   let name_registry : (string, int * int) Hashtbl.t = Hashtbl.create 128
 
@@ -81,19 +79,25 @@ module Registry = struct
   let family_registry : (string, family) Hashtbl.t = Hashtbl.create 128
   let needs_property_registry : (string, bool) Hashtbl.t = Hashtbl.create 128
 
+  (* A slot is shared, not owned: each token family numbers its members from its
+     own base, so several families sit at the same (priority, suborder) — e.g.
+     --radius-4xl, --drop-shadow-md and --ease-out are all (7, 10). The families
+     a project [@theme] names (--font-<name>, --animate-<name>, --inset-<name>)
+     funnel every member into one slot by design. The theme layer breaks a tie
+     on the variable name, so a shared slot is still a total order.
+
+     A name, on the other hand, owns its slot: it is one custom property and one
+     position in the theme layer. The definition that first claims a name fixes
+     that position, and a definition reaching a name that is already placed is
+     answered with the established slot. That is how a project naming one of the
+     built-in tokens lands: [--font-sans] from a project [@theme] arrives
+     through the [--font-<name>] family's shared slot, and keeps (1, 0). *)
   let register_variable ~name ~order =
-    (* Skip registration on order conflict — first registration wins. This can
-       happen when invalid input (e.g. inset-3/4/foo and inset-4/foo) produces
-       variables with the same order slot. *)
-    match Hashtbl.find_opt order_registry order with
-    | Some existing_name when existing_name <> name -> ()
-    | _ -> (
-        (* Also skip on name conflict with different order *)
-        match Hashtbl.find_opt name_registry name with
-        | Some existing_order when existing_order <> order -> ()
-        | _ ->
-            Hashtbl.replace order_registry order name;
-            Hashtbl.replace name_registry name order)
+    match Hashtbl.find_opt name_registry name with
+    | Some established -> established
+    | None ->
+        Hashtbl.replace name_registry name order;
+        order
 
   let register_property_order ~name ~order =
     Hashtbl.replace property_order_registry name order
@@ -237,10 +241,13 @@ let v : type a r.
       failwith ("Variable '" ^ name ^ "' in theme layer must have an order")
   | _ -> ());
 
-  (* Register the variable in the global registry to prevent conflicts *)
-  (match order with
-  | Some ord -> Registry.register_variable ~name ~order:ord
-  | None -> ());
+  (* Claim the name's theme slot, and carry the slot the name settled on: a
+     declaration this variable binds sorts where the name sorts. *)
+  let order =
+    match order with
+    | Some ord -> Some (Registry.register_variable ~name ~order:ord)
+    | None -> None
+  in
 
   (* Register property order if provided *)
   (match property_order with

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -400,7 +400,18 @@ val theme :
     With [~runtime:true] the optimizer keeps [var(name)] references unfolded
     instead of inlining the theme value, so the token stays overridable at
     runtime (matching Tailwind, which leaves e.g. [calc(var(--spacing)*4)]
-    intact rather than baking in the resolved length). *)
+    intact rather than baking in the resolved length).
+
+    Several variables may share an [order]: token families are numbered from
+    their own base, and the families a project [\@theme] names funnel every
+    member into one slot. The theme layer breaks such a tie on the variable
+    name.
+
+    A name, though, owns its slot. [order] places [name] the first time [name]
+    is defined; a later definition of the same name is placed where the name
+    already sits, and the variable it returns carries that slot. So a project
+    [\@theme] naming a built-in token reaches this function through its family's
+    shared slot and still leaves the token where it belongs. *)
 
 val property_default :
   'a Css.kind ->
@@ -471,8 +482,13 @@ val register_property_order : name:string -> order:int -> unit
 *)
 
 val order : string -> (int * int) option
-(** [order name] returns the theme layer order for a variable name. None if no
-    order was set (i.e., not a theme variable). *)
+(** [order name] returns the theme layer order for a variable name, with or
+    without the leading ["--"]. [None] if no variable of that name has been
+    defined, which for the tokens a project [\@theme] names means before the
+    utility reading them has been rendered.
+
+    The answer is where [name] itself sits, never the slot of a variable that
+    shares it. *)
 
 val family : string -> family option
 (** [family name] returns the family for a variable name. None if the variable
@@ -526,7 +542,7 @@ val binding :
 
 val binding_initial :
   ('a, [< `Property_default | `Channel ]) t -> Css.declaration
-(** [binding_initial var] resets the channel to the CSS-wide [initial] keyword
+(** [binding_initial var] resets the channel to the CSS-wide initial keyword
     ([--name: initial]). Used by the [*-initial] and [via-none] utilities, which
     clear a channel var instead of setting it to a typed value. *)
 
@@ -603,9 +619,8 @@ val property_rules : ('a, [< `Property_default ]) t -> Css.t
 
 (** {1 Heterogeneous Collections} *)
 
-type any_var =
-  | Any : ('a, 'r) t -> any_var
-      (** Existential type for heterogeneous collections of variables *)
+(** Existential type for heterogeneous collections of variables *)
+type any_var = Any : ('a, 'r) t -> any_var
 
 val properties : any_var list -> Css.t
 (** [properties vars] generates deduplicated [@property] rules for all variables

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -46,11 +46,111 @@ let var_in_theme_layer () =
         ]
         (List.sort_uniq String.compare custom_props)
 
+let order = testable Fmt.(option (pair int int)) ( = )
+
+let render ?theme classes =
+  match Tw.of_string ?theme classes with
+  | Ok t -> ignore (Tw.to_css ?theme ~base:false [ t ])
+  | Error (`Msg m) -> fail m
+
+(* A (priority, suborder) slot is not unique to one variable: token families are
+   numbered independently, so several tokens legitimately share a slot. Both
+   sides of a shared slot must keep their order. *)
+let order_of_shared_slot () =
+  let (_ : Css.length Tw.Var.theme) =
+    Tw.Var.theme Css.Length "test-shared-first" ~order:(990, 0)
+  in
+  let (_ : Css.length Tw.Var.theme) =
+    Tw.Var.theme Css.Length "test-shared-second" ~order:(990, 0)
+  in
+  check order "first" (Some (990, 0)) (Tw.Var.order "test-shared-first");
+  check order "second" (Some (990, 0)) (Tw.Var.order "test-shared-second")
+
+(* The in-tree tokens whose slot another family also claims. *)
+let order_of_shared_slot_tokens () =
+  let expect name o = check order name (Some o) (Tw.Var.order name) in
+  expect "ease-linear" (7, 12);
+  expect "drop-shadow-xl" (7, 12);
+  expect "animate-spin" (7, 13);
+  expect "drop-shadow-2xl" (7, 13);
+  expect "perspective-dramatic" (7, 13);
+  expect "default-transition-duration" (8, 0);
+  expect "blur-xs" (8, 0)
+
+(* A project [@theme] may name font families of its own; they all sit at (1,
+   100). Rendering one must not decide the answer for the others. *)
+let order_of_theme_named_tokens () =
+  let theme =
+    {
+      Tw.Scheme.default with
+      token_overrides =
+        [ ("font-alpha", "Alpha, sans-serif"); ("font-beta", "Beta, serif") ];
+    }
+  in
+  render ~theme "font-alpha";
+  render ~theme "font-beta";
+  check order "alpha" (Some (1, 100)) (Tw.Var.order "font-alpha");
+  check order "beta" (Some (1, 100)) (Tw.Var.order "font-beta")
+
+(* A name owns its slot: the first definition places it, and a later definition
+   of the same name is placed there too, the declarations it binds included. *)
+let order_of_redefined_name () =
+  let (_ : Css.length Tw.Var.theme) =
+    Tw.Var.theme Css.Length "test-established" ~order:(991, 0)
+  in
+  let again = Tw.Var.theme Css.Length "test-established" ~order:(991, 1) in
+  let decl, _ = Tw.Var.binding again (Css.Px 1.) in
+  check order "registry" (Some (991, 0)) (Tw.Var.order "test-established");
+  check order "declaration" (Some (991, 0)) (Tw.Var.order_of_declaration decl)
+
+(* A project [@theme] naming a built-in token reaches the [--font-<name>]
+   family's shared slot, and must leave the token in its own. *)
+let order_of_theme_renamed_builtin () =
+  let theme =
+    {
+      Tw.Scheme.default with
+      token_overrides =
+        [ ("font-sans", "Alpha, sans-serif"); ("font-mono", "Beta, monospace") ];
+    }
+  in
+  render ~theme "font-sans";
+  render ~theme "font-mono";
+  check order "font-sans" (Some (1, 0)) (Tw.Var.order "font-sans");
+  check order "font-mono" (Some (1, 2)) (Tw.Var.order "font-mono")
+
+(* [font-weight-bold] reads --font-weight-bold as a family name, so a project
+   naming that token routes a font-weight token through the font family's slot.
+   It keeps its own, and the render goes through. *)
+let order_of_theme_renamed_weight () =
+  let theme =
+    {
+      Tw.Scheme.default with
+      token_overrides = [ ("font-weight-bold", "Alpha, sans-serif") ];
+    }
+  in
+  render ~theme "font-weight-bold";
+  check order "font-weight-bold"
+    (Some (6, 36))
+    (Tw.Var.order "font-weight-bold")
+
+let order_of_unknown_name () =
+  check order "unknown" None (Tw.Var.order "test-never-defined");
+  check order "leading -- stripped" (Some (6, 8)) (Tw.Var.order "--text-xl")
+
 let tests =
   [
     test_case "var CSS output" `Quick var_css_output;
     test_case "var fallback in CSS" `Quick var_fallback_in_css;
     test_case "var in theme layer" `Quick var_in_theme_layer;
+    test_case "order of shared slot" `Quick order_of_shared_slot;
+    test_case "order of shared slot tokens" `Quick order_of_shared_slot_tokens;
+    test_case "order of theme-named tokens" `Quick order_of_theme_named_tokens;
+    test_case "order of redefined name" `Quick order_of_redefined_name;
+    test_case "order of theme-renamed builtin" `Quick
+      order_of_theme_renamed_builtin;
+    test_case "order of theme-renamed weight" `Quick
+      order_of_theme_renamed_weight;
+    test_case "order of unknown name" `Quick order_of_unknown_name;
   ]
 
 let suite = ("var", tests)


### PR DESCRIPTION
Registering a variable whose `(priority, suborder)` slot was already taken dropped it from the name table, so `Var.order` answered `None` forever for `drop-shadow-xl`, `blur-xs`, `perspective-dramatic` and a project's second named font family. The slot table, which nothing else read, is gone, and a name defined twice now settles on the slot it was first placed at — which is how a project `@theme` naming a built-in token keeps that token's own position. Generated CSS is byte-identical across the upstream utility corpus and every example.