### PR TITLE
merlint: run it from the pre-commit hook, and say what each exclusion is for

### DIFF
--- a/lib/divide.mli
+++ b/lib/divide.mli
@@ -25,11 +25,11 @@ val divide_y : int -> t
 (** [divide_y n] sets the border width between vertical children. *)
 
 val divide_x_length : Css.border_width -> t
-(** [divide_x_length w] is [divide_x] with an arbitrary width, as
+(** [divide_x_length w] is {!val-divide_x} with an arbitrary width, as
     [divide-x-[3px]]. *)
 
 val divide_y_length : Css.border_width -> t
-(** [divide_y_length w] is [divide_y] with an arbitrary width. *)
+(** [divide_y_length w] is {!val-divide_y} with an arbitrary width. *)
 
 (** {1 Divide Colour Utilities} *)
 

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -110,7 +110,7 @@ let checkbox_focus_decls =
 module Handler = struct
   open Style
 
-  type t = Form_input | Form_checkbox | Form_radio
+  type t = Input | Checkbox | Radio
   type Utility.base += Self of t
 
   let name = "forms"
@@ -343,25 +343,22 @@ module Handler = struct
     style ~rules:(Some rules) []
 
   let to_style _theme = function
-    | Form_input -> form_input
-    | Form_checkbox -> form_checkbox
-    | Form_radio -> form_radio
+    | Input -> form_input
+    | Checkbox -> form_checkbox
+    | Radio -> form_radio
 
-  let suborder = function
-    | Form_checkbox -> 0
-    | Form_radio -> 1
-    | Form_input -> 2
+  let suborder = function Checkbox -> 0 | Radio -> 1 | Input -> 2
 
   let of_class _theme = function
-    | "form-input" -> Ok Form_input
-    | "form-checkbox" -> Ok Form_checkbox
-    | "form-radio" -> Ok Form_radio
+    | "form-input" -> Ok Input
+    | "form-checkbox" -> Ok Checkbox
+    | "form-radio" -> Ok Radio
     | _ -> Error (`Msg "Not a form utility")
 
   let to_class = function
-    | Form_input -> "form-input"
-    | Form_checkbox -> "form-checkbox"
-    | Form_radio -> "form-radio"
+    | Input -> "form-input"
+    | Checkbox -> "form-checkbox"
+    | Radio -> "form-radio"
 
   let examples = []
 end
@@ -370,7 +367,7 @@ end
 module Select = struct
   open Style
 
-  type t = Form_select | Form_textarea
+  type t = Select | Textarea
   type Utility.base += Self of t
 
   let name = "forms_select"
@@ -479,19 +476,19 @@ module Select = struct
     style ~rules:(Some rules) []
 
   let to_style _theme = function
-    | Form_select -> form_select
-    | Form_textarea -> form_textarea
+    | Select -> form_select
+    | Textarea -> form_textarea
 
-  let suborder = function Form_select -> 0 | Form_textarea -> 1
+  let suborder = function Select -> 0 | Textarea -> 1
 
   let of_class _theme = function
-    | "form-select" -> Ok Form_select
-    | "form-textarea" -> Ok Form_textarea
+    | "form-select" -> Ok Select
+    | "form-textarea" -> Ok Textarea
     | _ -> Error (`Msg "Not a form select utility")
 
   let to_class = function
-    | Form_select -> "form-select"
-    | Form_textarea -> "form-textarea"
+    | Select -> "form-select"
+    | Textarea -> "form-textarea"
 
   let examples = []
 end
@@ -501,11 +498,11 @@ let () = Utility.register (module Handler)
 let () = Utility.register (module Select)
 
 (* Public API *)
-let form_input = Utility.base (Handler.Self Handler.Form_input)
-let form_checkbox = Utility.base (Handler.Self Handler.Form_checkbox)
-let form_radio = Utility.base (Handler.Self Handler.Form_radio)
-let form_select = Utility.base (Select.Self Select.Form_select)
-let form_textarea = Utility.base (Select.Self Select.Form_textarea)
+let form_input = Utility.base (Handler.Self Handler.Input)
+let form_checkbox = Utility.base (Handler.Self Handler.Checkbox)
+let form_radio = Utility.base (Handler.Self Handler.Radio)
+let form_select = Utility.base (Select.Self Select.Select)
+let form_textarea = Utility.base (Select.Self Select.Textarea)
 
 (* ======================================================================== Base
    layer stylesheet - rules that apply to native HTML form elements when the

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -45,16 +45,16 @@ type indexed_rule = {
       (** Non-zero for modifier-prefixed rules; they sort after base rules. *)
   variant_key : string * int;
       (** Precomputed [(variant prefix, effective inner order)], built with
-          {!variant_sort_key}, so [compare_indexed_rules] does not recompute it
-          per comparison. *)
+          {!variant_sort_key}, so {!val-compare_indexed_rules} does not
+          recompute it per comparison. *)
   variant_orders : (int * int) list;
       (** The rule's variant order keys sorted descending, built with
           {!variant_order_list}. Compared lexicographically by
-          [compare_indexed_rules] so a stacked variant sorts into the group of
-          its highest-order component. *)
+          {!val-compare_indexed_rules} so a stacked variant sorts into the group
+          of its highest-order component. *)
   base_class_key : string;
       (** The rule's base class ([""] when it has none), used by
-          [compare_indexed_rules] as the lexicographic sort key. *)
+          {!val-compare_indexed_rules} as the lexicographic sort key. *)
   media_key : Css.Media.key option;
       (** Precomputed sort key of the rule's own breakpoint condition: the
           [`Media] case of {!field-rule_type}, or the [`Container] case

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -4,11 +4,9 @@ open Cascade
 
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
 
-type container_cmp =
-  | Cq_min
-  | Cq_max
-      (** Container-query direction: [Cq_min] is [width >= v], [Cq_max] is
-          [width < v]. *)
+(** Container-query direction: {!constructor-Cq_min} is [width >= v],
+    {!constructor-Cq_max} is [width < v]. *)
+type container_cmp = Cq_min | Cq_max
 
 (** [@min-[<len>]] / [@max-[<len>]]. *)
 type container_query =

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3429,11 +3429,11 @@ val divide_y : int -> t
 (** [divide_y n] sets the border width between vertical children. *)
 
 val divide_x_length : Css.border_width -> t
-(** [divide_x_length w] is [divide_x] with an arbitrary width, as
+(** [divide_x_length w] is {!val-divide_x} with an arbitrary width, as
     [divide-x-[3px]]. *)
 
 val divide_y_length : Css.border_width -> t
-(** [divide_y_length w] is [divide_y] with an arbitrary width. *)
+(** [divide_y_length w] is {!val-divide_y} with an arbitrary width. *)
 
 val divide_x_reverse : t
 (** [divide_x_reverse] reverses horizontal divide borders for RTL layouts. *)

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -5,23 +5,23 @@ module Css = Cascade.Css
 module Handler = struct
   open Style
 
-  type t = Zoom_pct of float | Zoom_arbitrary of string * Css.zoom
+  type t = Percent of float | Arbitrary of string * Css.zoom
   type Utility.base += Self of t
 
   let name = "zoom"
   let priority _ = 2
-  let suborder = function Zoom_pct _ -> 0 | Zoom_arbitrary _ -> 1
+  let suborder = function Percent _ -> 0 | Arbitrary _ -> 1
 
   let num_to_string n =
     if Float.is_integer n then string_of_int (int_of_float n) else Pp.float n
 
   let to_class = function
-    | Zoom_pct n -> "zoom-" ^ num_to_string n
-    | Zoom_arbitrary (raw, _) -> "zoom-" ^ raw
+    | Percent n -> "zoom-" ^ num_to_string n
+    | Arbitrary (raw, _) -> "zoom-" ^ raw
 
   let to_style _theme = function
-    | Zoom_pct n -> style [ Css.zoom (Pct n) ]
-    | Zoom_arbitrary (_, v) -> style [ Css.zoom v ]
+    | Percent n -> style [ Css.zoom (Pct n) ]
+    | Arbitrary (_, v) -> style [ Css.zoom v ]
 
   (* [zoom-[var(--zoom)]] references a var; other bracket values parse as a
      number or percentage. *)
@@ -44,14 +44,14 @@ module Handler = struct
     match Parse.split_class class_name with
     | [ "zoom"; n ] -> (
         match int_of_string_opt n with
-        | Some i -> Ok (Zoom_pct (float_of_int i))
+        | Some i -> Ok (Percent (float_of_int i))
         | None -> (
             match parse_arbitrary n with
-            | Some v -> Ok (Zoom_arbitrary (n, v))
+            | Some v -> Ok (Arbitrary (n, v))
             | None -> Error (`Msg "Not a zoom utility")))
     | _ -> Error (`Msg "Not a zoom utility")
 
-  let examples = [ Zoom_pct 100. ]
+  let examples = [ Percent 100. ]
 end
 
 let () = Utility.register (module Handler)

--- a/merlint.toml
+++ b/merlint.toml
@@ -1,5 +1,3 @@
-# Modules included in tw.ml intentionally expose prefixed DSL names at the
-# top-level Tw namespace.
 # Utility parsers are intentionally expressed as large Tailwind class matchers.
 max-complexity = 43
 max-nesting = 9
@@ -46,61 +44,56 @@ allowed_words = [
 files = ["cascade/**", "./cascade/**", "mono/**", "./mono/**"]
 exclude = ["*"]
 
-# Modules included in tw.ml are flattened into the top-level Tw namespace, so
-# they intentionally keep prefixed DSL names (E330) and prefixed variant/field
-# constructors (E334): the prefixes disambiguate constructors that would
-# otherwise collide once every module is merged into a single namespace.
+# tw.ml includes each utility module, so a module's public names are the
+# top-level Tw names: Cursor.cursor_pointer is Tw.cursor_pointer, which is
+# the Tailwind class it emits. Only these modules name values after
+# themselves; the rest are under E330.
 [[rules]]
 files = [
   "lib/color.ml*",
-  "lib/backgrounds.ml*",
-  "lib/margin.ml*",
-  "lib/gap.ml*",
-  "lib/padding.ml*",
-  "lib/sizing.ml*",
-  "lib/typography.ml*",
-  "lib/layout.ml*",
-  "lib/overflow.ml*",
-  "lib/overscroll.ml*",
-  "lib/overflow_wrap.ml*",
-  "lib/box_sizing.ml*",
-  "lib/tab.ml*",
-  "lib/scrollbar.ml*",
-  "lib/zoom.ml*",
-  "lib/field_sizing.ml*",
-  "lib/grid.ml*",
-  "lib/grid_item.ml*",
-  "lib/grid_template.ml*",
-  "lib/flex.ml*",
-  "lib/flex_props.ml*",
-  "lib/flex_layout.ml*",
-  "lib/alignment.ml*",
-  "lib/borders.ml*",
-  "lib/effects.ml*",
-  "lib/text_shadow.ml*",
-  "lib/transforms.ml*",
-  "lib/cursor.ml*",
-  "lib/touch.ml*",
-  "lib/divide.ml*",
-  "lib/interactivity.ml*",
-  "lib/containers.ml*",
-  "lib/filters.ml*",
-  "lib/masks.ml*",
-  "lib/mask_gradient.ml*",
-  "lib/clipping.ml*",
-  "lib/position.ml*",
-  "lib/animations.ml*",
-  "lib/transitions.ml*",
-  "lib/forms.ml*",
-  "lib/tables.ml*",
-  "lib/svg.ml*",
-  "lib/accessibility.ml*",
-  "lib/modifiers.ml*",
-  "lib/prose.ml*",
   "lib/columns.ml*",
   "lib/contain.ml*",
+  "lib/cursor.ml*",
+  "lib/divide.ml*",
+  "lib/field_sizing.ml*",
+  "lib/flex.ml*",
+  "lib/gap.ml*",
+  "lib/grid.ml*",
+  "lib/overflow.ml*",
+  "lib/overscroll.ml*",
+  "lib/prose.ml*",
   "lib/scroll.ml*",
-  "lib/arbitrary.ml*",
   "lib/style.ml*",
+  "lib/tab.ml*",
+  "lib/text_shadow.ml*",
+  "lib/touch.ml*",
 ]
-exclude = ["E330", "E334"]
+exclude = ["E330"]
+
+# These modules open Cascade.Css and declare a private Handler variant that
+# mirrors a CSS value enum case for case, so the bare constructor E334 asks
+# for would shadow the Css constructor of the same name in the same scope
+# (Touch_pan_x -> Pan_x shadows Css.Pan_x). Dropping a prefix here means
+# picking a name that does not collide, one family at a time.
+[[rules]]
+files = [
+  "lib/accessibility.ml*",
+  "lib/animations.ml*",
+  "lib/backgrounds.ml*",
+  "lib/borders.ml*",
+  "lib/color.ml*",
+  "lib/cursor.ml*",
+  "lib/divide.ml*",
+  "lib/flex_layout.ml*",
+  "lib/forms.ml*",
+  "lib/mask_gradient.ml*",
+  "lib/masks.ml*",
+  "lib/position.ml*",
+  "lib/prose.ml*",
+  "lib/style.ml*",
+  "lib/text_shadow.ml*",
+  "lib/touch.ml*",
+  "lib/typography.ml*",
+  "lib/zoom.ml*",
+]
+exclude = ["E334"]

--- a/merlint.toml
+++ b/merlint.toml
@@ -85,7 +85,6 @@ files = [
   "lib/cursor.ml*",
   "lib/divide.ml*",
   "lib/flex_layout.ml*",
-  "lib/forms.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
   "lib/position.ml*",
@@ -94,6 +93,5 @@ files = [
   "lib/text_shadow.ml*",
   "lib/touch.ml*",
   "lib/typography.ml*",
-  "lib/zoom.ml*",
 ]
 exclude = ["E334"]

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Pre-commit hook: format the staged OCaml sources, then lint them.
+#
+# Git does not track .git/hooks, so install this by hand after a fresh clone:
+#
+#     ln -s ../../scripts/pre-commit .git/hooks/pre-commit
+#
+# Bypass a single commit with `git commit --no-verify`.
+
+set -u
+
+STAGED_ML=$(git diff --cached --name-only --diff-filter=ACM |
+    grep -E '\.(ml|mli|mll|mly)$' || true)
+
+[ -n "$STAGED_ML" ] || exit 0
+
+# Formatting.
+
+# dune fmt exits non-zero when it reformats something, so its status says
+# nothing about whether it succeeded; the staged files themselves do.
+dune fmt >/dev/null 2>&1 || true
+
+CHANGED=$(git diff --name-only $STAGED_ML 2>/dev/null || true)
+if [ -n "$CHANGED" ]; then
+    echo "Files were reformatted by dune fmt:"
+    echo "$CHANGED"
+    echo ""
+    echo "Please review and stage the changes, then commit again."
+    exit 1
+fi
+
+# Linting.
+
+if ! command -v merlint >/dev/null 2>&1; then
+    echo "warning: merlint is not on PATH, skipping the lint step" >&2
+    exit 0
+fi
+
+# merlint reads each file's typedtree from the .cmt/.cmti dune writes, and an
+# artefact goes stale when the source it was compiled from changes. Only the
+# staged files changed, so building the check alias of the directories holding
+# them is enough, and it costs a fraction of a whole-project @check.
+ALIASES=$(printf '%s\n' "$STAGED_ML" | xargs -n1 dirname | sort -u |
+    while read -r dir; do
+        [ -f "$dir/dune" ] || continue
+        if [ "$dir" = "." ]; then
+            echo "@@check"
+        else
+            echo "@@$dir/check"
+        fi
+    done)
+
+if [ -n "$ALIASES" ]; then
+    # shellcheck disable=SC2086
+    if ! dune build $ALIASES; then
+        echo "" >&2
+        echo "Error: dune build failed, so merlint has no typedtree to read." >&2
+        exit 1
+    fi
+fi
+
+# merlint exits non-zero both for findings and for a run that could not read a
+# .cmt. Failing on either keeps the two apart in the output while denying a
+# skipped run the right to look like a clean one.
+if ! merlint scan $STAGED_ML; then
+    echo "" >&2
+    echo "merlint rejected the staged files." >&2
+    echo "A 'files unchecked' warning above means merlint could not read the" >&2
+    echo "build artefacts: rebuild, or check that merlint and the switch agree" >&2
+    echo "on the compiler version. Bypass with 'git commit --no-verify'." >&2
+    exit 1
+fi
+
+exit 0

--- a/test/info/dune
+++ b/test/info/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries alcotest tw.info))
+ (libraries alcotest fmt tw.info))

--- a/test/info/test_tw_info.ml
+++ b/test/info/test_tw_info.ml
@@ -8,7 +8,7 @@ let test_well_formed () =
   String.iter
     (fun c ->
       let bad = c = '"' || c = '\\' || c = '\n' || c = ' ' in
-      Alcotest.(check bool) (Printf.sprintf "version has no %C" c) false bad)
+      Alcotest.(check bool) (Fmt.str "version has no %C" c) false bad)
     Tw_info.version
 
 let suite =

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -467,7 +467,7 @@ let hex_re = Re.Pcre.regexp {|#[0-9a-fA-F]+|}
 let color_mix_to_oklab s =
   Re.replace color_mix_re s ~f:(fun g ->
       let whole = Re.Group.get g 0 in
-      match Css.of_string (Fmt.str ".x{color:%s}" whole) with
+      match Fmt.kstr Css.of_string ".x{color:%s}" whole with
       | Error _ -> whole
       | Ok { stylesheet; _ } -> (
           let folded = Css.to_string ~minify:true (Css.optimize stylesheet) in


### PR DESCRIPTION
The pre-commit hook now builds the check alias of the directories holding the
staged files and runs merlint over them, failing the commit on findings and on
a run that could not read a .cmt. E330 and E334 were excluded together on fifty
files under a single reason; they are now separate entries listing only the
files that fire, and forms and zoom lost their constructor prefixes outright.