### PR TITLE
test, bin: match the nullary No_diff cascade now exports

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1159,7 +1159,7 @@ let eval_flag flag ~default =
 
 let print_diff_result label diff =
   match diff.Css_compare.result with
-  | Css_compare.No_diff _ -> Fmt.pr "✓ No differences found%s@." label
+  | Css_compare.No_diff -> Fmt.pr "✓ No differences found%s@." label
   | _ ->
       Fmt.pr "Differences found%s:@.@." label;
       let buf = Buffer.create 256 in

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -102,7 +102,7 @@ let ordering_diff ?(forms = false) utilities =
 
 let check_ordering_fails ?forms utilities =
   match (ordering_diff ?forms utilities).Css_compare.result with
-  | Css_compare.No_diff _ -> false
+  | Css_compare.No_diff -> false
   | _ -> true
 
 (** Delta Debugging (ddmin algorithm by Zeller) Minimizes a failing test case by
@@ -305,7 +305,7 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
 let check_ordering_matches ?forms ~test_name utilities =
   let diff = ordering_diff ?forms utilities in
   match diff.Css_compare.result with
-  | Css_compare.No_diff _ -> ()
+  | Css_compare.No_diff -> ()
   | _ ->
       let buf = Buffer.create 1024 in
       Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -162,7 +162,7 @@ let check_exact_match tw_styles =
     in
     let parity_equal =
       (match diff_result.Css_compare.result with
-        | Css_compare.No_diff _ -> true
+        | Css_compare.No_diff -> true
         | _ -> false)
       || is_allowed_canonicalization_diff diff_result
     in

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -47,7 +47,7 @@ let test_arbitrary_color_opacity_matches_cli () =
         ~prune_unused_custom_props:true cli tw
     in
     match diff.Cascade_diff.Css_compare.result with
-    | Cascade_diff.Css_compare.No_diff _ ->
+    | Cascade_diff.Css_compare.No_diff ->
         check bool (cls ^ ": tw matches live Tailwind CLI") true true
     | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
   in
@@ -81,7 +81,7 @@ let test_arbitrary_url_matches_cli () =
       ~prune_unused_custom_props:true cli tw
   in
   match diff.Cascade_diff.Css_compare.result with
-  | Cascade_diff.Css_compare.No_diff _ ->
+  | Cascade_diff.Css_compare.No_diff ->
       check bool (cls ^ ": tw matches live Tailwind CLI") true true
   | _ -> Alcotest.failf "%s: tw diverges from the live Tailwind CLI" cls
 

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -884,7 +884,7 @@ let run_test_case test () =
       in
       if
         (match result.Css_compare.result with
-          | Css_compare.No_diff _ -> true
+          | Css_compare.No_diff -> true
           | _ -> false)
         || ((not strict) && is_allowed_canonicalization_diff result)
       then ()


### PR DESCRIPTION
`Css_compare.No_diff` no longer carries `canonical_byte_diff`, so the seven `No_diff _` patterns tripped warning 28 and every build against the new cascade pin failed; this unbreaks CI on main and on the open PRs. No site read the payload.