### PR TITLE
lib: name the module a shadowed constructor comes from

### DIFF
--- a/dune
+++ b/dune
@@ -3,8 +3,12 @@
   ; -58 (no-cmx-file): a flambda missed-inlining hint that fires on
   ; dune-build-info's link-time module and other cmx-less dependencies. It is
   ; not a correctness warning.
+  ;
+  ; @45 (open-shadow-label-constructor): dune's default set leaves this off, so
+  ; an `open Css` silently takes over `None`, `Default` and friends. As an error
+  ; it forces those sites to name the type they mean.
   (flags
-   (:standard %{dune-warnings} -w -58)))
+   (:standard %{dune-warnings} -w -58@45)))
  (release
   (flags
    (:standard -w -58))))

--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -28,7 +28,7 @@ module Handler = struct
 
   let to_style _theme = function
     | Forced_color_adjust_auto -> style [ forced_color_adjust Auto ]
-    | Forced_color_adjust_none -> style [ forced_color_adjust None ]
+    | Forced_color_adjust_none -> style [ forced_color_adjust Css.None ]
 
   let suborder = function
     | Forced_color_adjust_auto -> 0

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -57,7 +57,7 @@ module Handler = struct
         in
         let theme_decl, none_var = Var.binding tv none_animation in
         style [ theme_decl; Css.animation (Css.Var none_var) ]
-    | None -> style [ Css.animation None ]
+    | None -> style [ Css.animation Css.None ]
 
   (* Theme variable for animate-spin - order (7, 13) places it after ease (7,
      9-11) *)
@@ -226,7 +226,7 @@ module Handler = struct
                     [
                       Css.Declaration.animation_timing_function
                         (Cubic_bezier (0., 0., 0.2, 1.));
-                      Css.Declaration.transform None;
+                      Css.Declaration.transform Css.None;
                     ];
                 };
               ];

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -616,7 +616,7 @@ module Handler = struct
     style [ Css.webkit_background_clip Text; Css.background_clip Text ]
 
   let bg_inherit' = style [ Css.background_color Inherit ]
-  let bg_none' = style [ Css.background_image None ]
+  let bg_none' = style [ Css.background_image Css.None ]
   let bg_auto' = style [ Css.background_size Auto ]
   let bg_cover' = style [ Css.background_size Cover ]
   let bg_contain' = style [ Css.background_size Contain ]

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -339,7 +339,7 @@ module Handler = struct
   let border_dotted = border_style_util Dotted
   let border_double = border_style_util Double
   let border_hidden = border_style_util Hidden
-  let border_none = border_style_util None
+  let border_none = border_style_util Css.None
 
   (* Border color utilities *)
   let border_color' color shade =

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2468,7 +2468,7 @@ module Handler = struct
     | Int i -> Some (min 255 (max 0 i))
     | Num f -> Some (min 255 (max 0 (Float.to_int (Float.round f))))
     | Pct f -> Some (min 255 (max 0 (Float.to_int (Float.round (f *. 2.55)))))
-    | Var _ | None -> Stdlib.Option.None
+    | Var _ | Css.None -> Stdlib.Option.None
 
   (** How an alpha channel spells inside a hex colour. *)
   type folded_alpha =
@@ -2477,7 +2477,7 @@ module Handler = struct
     | Alpha_unresolvable  (** a var() or calc(), which no hex byte carries *)
 
   let fold_alpha : Css.alpha -> folded_alpha = function
-    | None -> Opaque
+    | Css.None -> Opaque
     | Num f ->
         Alpha_byte (min 255 (max 0 (Float.to_int (Float.round (f *. 255.)))))
     | Pct f ->
@@ -2492,7 +2492,7 @@ module Handler = struct
   let css_color_to_hex (c : Css.color) : Css.color option =
     let hex_of_bytes bytes = Some (Css.hex ("#" ^ shorten_hex_str bytes)) in
     match c with
-    | Rgb (Channels { r; g; b }) -> (
+    | Css.Rgb (Channels { r; g; b }) -> (
         match (channel_to_int r, channel_to_int g, channel_to_int b) with
         | Some r, Some g, Some b ->
             hex_of_bytes (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b)
@@ -2516,7 +2516,7 @@ module Handler = struct
           Cascade.Values.nonkeyword_color
             (Cascade.Values.normalize_color ~in_feature_query:false c)
         with
-        | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
+        | Css.Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
             let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in
             hex_of_bytes (if a = 255 then hex else hex ^ to_hex_byte a)
         | _ -> None)
@@ -2528,7 +2528,7 @@ module Handler = struct
   *)
   let resolve_bracket_css_color (css_color : Css.color) : Css.color =
     match css_color with
-    | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
+    | Css.Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
         let value = hex_string_of_rgb (r, g, b) in
         let value = if a = 255 then value else value ^ to_hex_byte a in
         Css.hex ("#" ^ shorten_hex_str value)

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -40,22 +40,22 @@ module Handler = struct
        rules.ml handles this ordering since container has only media rules and
        base props. *)
     let container_selector = Selector.class_ "container" in
-    let min_width_rem rem = media_min_width_length (Rem rem) in
+    let min_width_rem rem = media_min_width_length (Css.Rem rem) in
     let media_rules =
       [
         media ~condition:(min_width_rem 40.)
-          [ rule ~selector:container_selector [ max_width (Rem 40.) ] ];
+          [ rule ~selector:container_selector [ max_width (Css.Rem 40.) ] ];
         media ~condition:(min_width_rem 48.)
-          [ rule ~selector:container_selector [ max_width (Rem 48.) ] ];
+          [ rule ~selector:container_selector [ max_width (Css.Rem 48.) ] ];
         media ~condition:(min_width_rem 64.)
-          [ rule ~selector:container_selector [ max_width (Rem 64.) ] ];
+          [ rule ~selector:container_selector [ max_width (Css.Rem 64.) ] ];
         media ~condition:(min_width_rem 80.)
-          [ rule ~selector:container_selector [ max_width (Rem 80.) ] ];
+          [ rule ~selector:container_selector [ max_width (Css.Rem 80.) ] ];
         media ~condition:(min_width_rem 96.)
-          [ rule ~selector:container_selector [ max_width (Rem 96.) ] ];
+          [ rule ~selector:container_selector [ max_width (Css.Rem 96.) ] ];
       ]
     in
-    style ~rules:(Some media_rules) [ width (Pct 100.) ]
+    style ~rules:(Some media_rules) [ width (Css.Pct 100.) ]
 
   let container_query = style [ container_type Inline_size ]
   let container_normal_style = style [ container_type Normal ]

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -66,7 +66,7 @@ module Handler = struct
       (Cursor_context_menu, "context-menu", Context_menu);
       (Cursor_copy, "copy", Copy);
       (Cursor_crosshair, "crosshair", Crosshair);
-      (Cursor_default, "default", Default);
+      (Cursor_default, "default", Css.Default);
       (Cursor_e_resize, "e-resize", E_resize);
       (Cursor_ew_resize, "ew-resize", Ew_resize);
       (Cursor_grab, "grab", Grab);
@@ -77,7 +77,7 @@ module Handler = struct
       (Cursor_ne_resize, "ne-resize", Ne_resize);
       (Cursor_nesw_resize, "nesw-resize", Nesw_resize);
       (Cursor_no_drop, "no-drop", No_drop);
-      (Cursor_none, "none", None);
+      (Cursor_none, "none", Css.None);
       (Cursor_not_allowed, "not-allowed", Not_allowed);
       (Cursor_ns_resize, "ns-resize", Ns_resize);
       (Cursor_nw_resize, "nw-resize", Nw_resize);

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -152,6 +152,14 @@ module Handler = struct
     let rule = Css.rule ~selector [ decl ] in
     style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
 
+  (* [:where(.CLASS > :not(:last-child))], the selector every divide utility
+     hangs its declaration on. [Css.Selector.Not] is spelt out because [open
+     Css] brings a different [Not] into scope. *)
+  let divide_children_selector class_name =
+    Css.Selector.(
+      where
+        [ Combined (Class class_name, Child, Css.Selector.Not [ Last_child ]) ])
+
   (* Divide color utilities use nested rules with :where(.divide-X >
      :not(:last-child)) We construct the full class name in the selector like
      space-x-reverse does. *)
@@ -160,10 +168,7 @@ module Handler = struct
       if Color.is_shadeless color then "divide-" ^ Color.color_to_string color
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
     in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     if Color.is_custom_color color then
       let css_color = Color.to_css color shade in
       let rule = Css.rule ~selector [ Css.border_color css_color ] in
@@ -184,27 +189,17 @@ module Handler = struct
       style ~rules:(Some [ rule ]) []
 
   let divide_transparent_style () =
-    let selector =
-      Css.Selector.(
-        where
-          [ Combined (Class "divide-transparent", Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector "divide-transparent" in
     let rule = Css.rule ~selector [ Css.border_color (Css.hex "#0000") ] in
     style ~rules:(Some [ rule ]) []
 
   let divide_current_style () =
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class "divide-current", Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector "divide-current" in
     let rule = Css.rule ~selector [ Css.border_color Css.Current ] in
     style ~rules:(Some [ rule ]) []
 
   let divide_inherit_style () =
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class "divide-inherit", Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector "divide-inherit" in
     let rule = Css.rule ~selector [ Css.border_color Css.Inherit ] in
     style ~rules:(Some [ rule ]) []
 
@@ -215,18 +210,12 @@ module Handler = struct
         Css.hex ("#" ^ shortened)
       else match Color.css_color_to_hex c with Some h -> h | None -> c
     in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     let rule = Css.rule ~selector [ Css.border_color color ] in
     style ~rules:(Some [ rule ]) []
 
   let divide_bracket_color_opacity_style class_name inner _c opacity =
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
     if String.length inner > 0 && inner.[0] = '#' then
@@ -271,14 +260,13 @@ module Handler = struct
       style ~rules:(Some [ rule; supports_block ]) []
 
   let divide_style_of_string (s : string) =
-    let open Css in
-    let r : border_style option =
+    let r : Css.border_style option =
       match s with
-      | "dashed" -> Some Dashed
-      | "dotted" -> Some Dotted
-      | "double" -> Some Double
-      | "none" -> Some None
-      | "solid" -> Some Solid
+      | "dashed" -> Some Css.Dashed
+      | "dotted" -> Some Css.Dotted
+      | "double" -> Some Css.Double
+      | "none" -> Some Css.None
+      | "solid" -> Some Css.Solid
       | _ -> Stdlib.Option.none
     in
     r
@@ -288,17 +276,14 @@ module Handler = struct
     | Dashed -> "dashed"
     | Dotted -> "dotted"
     | Double -> "double"
-    | None -> "none"
+    | Css.None -> "none"
     | Solid -> "solid"
     | _ -> "solid"
 
   let divide_style_style (bs : Css.border_style) =
     let name = border_style_to_string bs in
     let class_name = "divide-" ^ name in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     let decl, _ = Var.binding border_style_var bs in
     let rule = Css.rule ~selector [ decl; Css.border_style bs ] in
     style ~rules:(Some [ rule ]) []
@@ -323,18 +308,12 @@ module Handler = struct
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
     in
     let class_name = base_class_name ^ opacity_suffix opacity in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     Color.divide_with_opacity ?theme color shade opacity selector
 
   let divide_current_opacity_style opacity =
     let class_name = "divide-current" ^ opacity_suffix opacity in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     Color.divide_current_with_opacity opacity selector
 
   (* Helper to check if a string contains an opacity modifier *)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1123,7 +1123,7 @@ module Handler = struct
     style ~property_rules:filter_property_rules
       [ filter composable_filter_chain ]
 
-  let filter_none = style [ filter None ]
+  let filter_none = style [ filter Css.None ]
 
   (* Composable backdrop-filter using all the backdrop-filter variables *)
   let backdrop_filter_ =
@@ -1134,7 +1134,7 @@ module Handler = struct
       ]
 
   let backdrop_filter_none =
-    style [ Css.webkit_backdrop_filter None; backdrop_filter None ]
+    style [ Css.webkit_backdrop_filter Css.None; backdrop_filter Css.None ]
 
   let backdrop_filter_arbitrary value =
     style [ Css.webkit_backdrop_filter value; backdrop_filter value ]

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -69,7 +69,7 @@ module Handler = struct
   let flex_1 = style [ flex (Grow (Number 1.0)) ]
   let flex_auto = style [ flex Auto ]
   let flex_initial = style [ flex (Full (Number 0., Number 1., Auto)) ]
-  let flex_none = style [ flex None ]
+  let flex_none = style [ flex Css.None ]
 
   (* flex-N: flex: N *)
   let flex_n_style n = style [ flex (Grow (Number (float_of_int n))) ]

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -128,7 +128,7 @@ module Handler = struct
       [
         rule ~selector:base_sel
           [
-            appearance None;
+            appearance Css.None;
             d_shadow;
             background_color (hex "#fff");
             border_width (Px 1.);
@@ -139,7 +139,7 @@ module Handler = struct
             font_size (Rem 1.);
             line_height (Rem 1.5);
           ];
-        rule ~selector:(compound [ base_sel; Focus ]) input_focus_decls;
+        rule ~selector:(compound [ base_sel; Selector.Focus ]) input_focus_decls;
         rule
           ~selector:(compound [ base_sel; Placeholder ])
           [ color gray_500; opacity (Opacity_number 1.) ];
@@ -199,12 +199,12 @@ module Handler = struct
       [
         rule ~selector:base_sel
           [
-            appearance None;
+            appearance Css.None;
             webkit_print_color_adjust Exact;
             print_color_adjust Exact;
             vertical_align Middle;
-            webkit_user_select None;
-            user_select None;
+            webkit_user_select Css.None;
+            user_select Css.None;
             color blue_600;
             d_shadow;
             background_color (hex "#fff");
@@ -218,9 +218,11 @@ module Handler = struct
             padding [ Px 0. ];
             display Inline_block;
           ];
-        rule ~selector:(compound [ base_sel; Focus ]) checkbox_focus_decls;
         rule
-          ~selector:(compound [ base_sel; Checked ])
+          ~selector:(compound [ base_sel; Selector.Focus ])
+          checkbox_focus_decls;
+        rule
+          ~selector:(compound [ base_sel; Selector.Checked ])
           [
             background_color Current;
             background_image
@@ -237,18 +239,20 @@ module Handler = struct
           ];
         media ~condition:forced_colors_active
           [
-            rule ~selector:(compound [ base_sel; Checked ]) [ appearance Auto ];
+            rule
+              ~selector:(compound [ base_sel; Selector.Checked ])
+              [ appearance Auto ];
           ];
         rule
           ~selector:
             (Selector.list
                [
-                 compound [ base_sel; Checked; Hover ];
-                 compound [ base_sel; Checked; Focus ];
+                 compound [ base_sel; Selector.Checked; Selector.Hover ];
+                 compound [ base_sel; Selector.Checked; Selector.Focus ];
                ])
           [ background_color Current; border_color (hex "#0000") ];
         rule
-          ~selector:(compound [ base_sel; Indeterminate ])
+          ~selector:(compound [ base_sel; Selector.Indeterminate ])
           [
             background_color Current;
             background_image
@@ -265,15 +269,15 @@ module Handler = struct
         media ~condition:forced_colors_active
           [
             rule
-              ~selector:(compound [ base_sel; Indeterminate ])
+              ~selector:(compound [ base_sel; Selector.Indeterminate ])
               [ appearance Auto ];
           ];
         rule
           ~selector:
             (Selector.list
                [
-                 compound [ base_sel; Indeterminate; Hover ];
-                 compound [ base_sel; Indeterminate; Focus ];
+                 compound [ base_sel; Selector.Indeterminate; Selector.Hover ];
+                 compound [ base_sel; Selector.Indeterminate; Selector.Focus ];
                ])
           [ background_color Current; border_color (hex "#0000") ];
       ]
@@ -292,12 +296,12 @@ module Handler = struct
       [
         rule ~selector:base_sel
           [
-            appearance None;
+            appearance Css.None;
             webkit_print_color_adjust Exact;
             print_color_adjust Exact;
             vertical_align Middle;
-            webkit_user_select None;
-            user_select None;
+            webkit_user_select Css.None;
+            user_select Css.None;
             color blue_600;
             d_shadow;
             background_color (hex "#fff");
@@ -311,9 +315,11 @@ module Handler = struct
             padding [ Px 0. ];
             display Inline_block;
           ];
-        rule ~selector:(compound [ base_sel; Focus ]) checkbox_focus_decls;
         rule
-          ~selector:(compound [ base_sel; Checked ])
+          ~selector:(compound [ base_sel; Selector.Focus ])
+          checkbox_focus_decls;
+        rule
+          ~selector:(compound [ base_sel; Selector.Checked ])
           [
             background_color Current;
             background_image
@@ -328,14 +334,16 @@ module Handler = struct
           ];
         media ~condition:forced_colors_active
           [
-            rule ~selector:(compound [ base_sel; Checked ]) [ appearance Auto ];
+            rule
+              ~selector:(compound [ base_sel; Selector.Checked ])
+              [ appearance Auto ];
           ];
         rule
           ~selector:
             (Selector.list
                [
-                 compound [ base_sel; Checked; Hover ];
-                 compound [ base_sel; Checked; Focus ];
+                 compound [ base_sel; Selector.Checked; Selector.Hover ];
+                 compound [ base_sel; Selector.Checked; Selector.Focus ];
                ])
           [ background_color Current; border_color (hex "#0000") ];
       ]
@@ -385,7 +393,7 @@ module Select = struct
       [
         rule ~selector:base_sel
           [
-            appearance None;
+            appearance Css.None;
             d_shadow;
             background_color (hex "#fff");
             border_width (Px 1.);
@@ -395,7 +403,7 @@ module Select = struct
             font_size (Rem 1.);
             line_height (Rem 1.5);
           ];
-        rule ~selector:(compound [ base_sel; Focus ]) input_focus_decls;
+        rule ~selector:(compound [ base_sel; Selector.Focus ]) input_focus_decls;
         rule
           ~selector:(compound [ base_sel; Placeholder ])
           [ color gray_500; opacity (Opacity_number 1.) ];
@@ -423,7 +431,7 @@ module Select = struct
       [
         rule ~selector:base_sel
           [
-            appearance None;
+            appearance Css.None;
             d_shadow;
             background_color (hex "#fff");
             border_width (Px 1.);
@@ -447,7 +455,7 @@ module Select = struct
             background_size (Size (Em 1.5, Em 1.5));
             padding_right (Rem 2.5);
           ];
-        rule ~selector:(compound [ base_sel; Focus ]) input_focus_decls;
+        rule ~selector:(compound [ base_sel; Selector.Focus ]) input_focus_decls;
         rule
           ~selector:
             (compound
@@ -457,9 +465,13 @@ module Select = struct
                    [
                      Compound
                        [
-                         Attribute (None, Regular "size", Presence, None);
-                         Not
-                           [ Attribute (None, Regular "size", Exact "1", None) ];
+                         Selector.Attribute
+                           (None, Regular "size", Presence, None);
+                         Selector.Not
+                           [
+                             Selector.Attribute
+                               (None, Regular "size", Selector.Exact "1", None);
+                           ];
                        ];
                    ];
                ])
@@ -679,7 +691,7 @@ let text_inputs_base () =
   [
     rule ~selector:text_inputs
       [
-        appearance None;
+        appearance Css.None;
         d_shadow;
         background_color (hex "#fff");
         border_width (Px 1.);
@@ -845,11 +857,11 @@ let checkbox_radio_base () =
     rule
       ~selector:Selector.(list [ type_checkbox; type_radio ])
       [
-        appearance None;
+        appearance Css.None;
         print_color_adjust Exact;
         vertical_align Middle;
-        webkit_user_select None;
-        user_select None;
+        webkit_user_select Css.None;
+        user_select Css.None;
         color blue_600;
         d_shadow;
         background_color (hex "#fff");

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -89,7 +89,7 @@ module Handler = struct
     let var_name = "grid-template-columns-none" in
     match Scheme.theme_value theme var_name with
     | Some value -> themed_property var_name Css.grid_template_columns value
-    | None -> style [ Css.grid_template_columns None ]
+    | None -> style [ Css.grid_template_columns Css.None ]
 
   let grid_cols_subgrid = style [ Css.grid_template_columns Subgrid ]
 
@@ -304,7 +304,7 @@ module Handler = struct
     let var_name = "grid-template-rows-none" in
     match Scheme.theme_value theme var_name with
     | Some value -> themed_property var_name Css.grid_template_rows value
-    | None -> style [ Css.grid_template_rows None ]
+    | None -> style [ Css.grid_template_rows Css.None ]
 
   let grid_rows_subgrid = style [ Css.grid_template_rows Subgrid ]
   let grid_flow_row = style [ Css.grid_auto_flow Row ]

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -79,7 +79,9 @@ module Handler = struct
     | Pointer_events_none | Pointer_events_auto -> -1
     | _ -> 31
 
-  let select_none_s = style [ webkit_user_select None; user_select None ]
+  let select_none_s =
+    style [ webkit_user_select Css.None; user_select Css.None ]
+
   let select_text_s = style [ webkit_user_select Text; user_select Text ]
   let select_all_s = style [ webkit_user_select All; user_select All ]
   let select_auto_s = style [ webkit_user_select Auto; user_select Auto ]
@@ -94,7 +96,7 @@ module Handler = struct
   let snap_start_s = style [ scroll_snap_align Start ]
   let snap_end_s = style [ scroll_snap_align End ]
   let snap_center_s = style [ scroll_snap_align Center ]
-  let snap_none_s = style [ scroll_snap_type (Axis None) ]
+  let snap_none_s = style [ scroll_snap_type (Axis Css.None) ]
 
   (* For snap-x, snap-y, snap-both we compose the axis with a variable reference
      to strictness *)
@@ -146,26 +148,26 @@ module Handler = struct
     in
     style ~property_rules (d :: [])
 
-  let snap_align_none_s = style [ scroll_snap_align None ]
+  let snap_align_none_s = style [ scroll_snap_align Css.None ]
   let snap_normal_s = style [ scroll_snap_stop Normal ]
   let snap_always_s = style [ scroll_snap_stop Always ]
-  let resize_none_s = style [ Css.resize None ]
+  let resize_none_s = style [ Css.resize Css.None ]
   let resize_s = style [ Css.resize Both ]
   let resize_x_s = style [ Css.resize Horizontal ]
   let resize_y_s = style [ Css.resize Vertical ]
 
   (* Additional utilities *)
-  let pointer_events_none_s = style [ pointer_events None ]
+  let pointer_events_none_s = style [ pointer_events Css.None ]
   let pointer_events_auto_s = style [ pointer_events Auto ]
   let appearance_auto_s = style [ appearance Auto ]
-  let appearance_none_s = style [ appearance None ]
+  let appearance_none_s = style [ appearance Css.None ]
   let will_change_auto_s = style [ will_change Css.Will_change_auto ]
   let will_change_scroll_s = style [ will_change Css.Scroll_position ]
   let will_change_contents_s = style [ will_change Css.Contents ]
   let will_change_transform_s = style [ will_change Css.Transform ]
   let group_s = style []
   let peer_s = style []
-  let scheme_dark_s = style [ color_scheme Dark ]
+  let scheme_dark_s = style [ color_scheme Css.Dark ]
   let scheme_light_s = style [ color_scheme Light ]
   let scheme_light_dark_s = style [ color_scheme Light_dark ]
   let scheme_normal_s = style [ color_scheme Normal ]

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -466,7 +466,7 @@ module Handler = struct
     | List_item -> style [ display List_item ]
     | Flow_root -> style [ display Flow_root ]
     | Contents -> style [ display Contents ]
-    | Hidden -> style [ display None ]
+    | Hidden -> style [ display Css.None ]
     | Visible -> style [ visibility Visible ]
     | Invisible -> style [ visibility Hidden ]
     | Collapse -> style [ visibility Collapse ]
@@ -494,7 +494,7 @@ module Handler = struct
     | Object_contain -> style [ object_fit Contain ]
     | Object_cover -> style [ object_fit Cover ]
     | Object_fill -> style [ object_fit Fill ]
-    | Object_none -> style [ object_fit None ]
+    | Object_none -> style [ object_fit Css.None ]
     | Object_scale_down -> style [ object_fit Scale_down ]
     | ( Object_center | Object_top | Object_bottom | Object_left | Object_right
       | Object_bottom_left | Object_bottom_right | Object_left_bottom
@@ -544,12 +544,12 @@ module Handler = struct
             style [ object_position (Var pos_ref) ])
     | Float_left -> style [ Css.float Left ]
     | Float_right -> style [ Css.float Right ]
-    | Float_none -> style [ Css.float None ]
+    | Float_none -> style [ Css.float Css.None ]
     | Float_start -> style [ Css.float Inline_start ]
     | Float_end -> style [ Css.float Inline_end ]
     | Clear_left -> style [ Css.clear Left ]
     | Clear_right -> style [ Css.clear Right ]
-    | Clear_none -> style [ Css.clear None ]
+    | Clear_none -> style [ Css.clear Css.None ]
     | Clear_both -> style [ Css.clear Both ]
     | Clear_start -> style [ Css.clear Inline_start ]
     | Clear_end -> style [ Css.clear Inline_end ]

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -218,7 +218,7 @@ let inert_pseudo () =
 (** Helper: open pseudo-selector *)
 let open_pseudo () =
   let open Css.Selector in
-  is_ [ attribute "open" Presence; Popover_open; Open ]
+  is_ [ attribute "open" Presence; Popover_open; Css.Selector.Open ]
 
 let nest_selector ~parent template =
   let open Css.Selector in
@@ -260,8 +260,8 @@ let anchor_hocus_selector ~anchor ~combinator cls label =
     combine
       (is_
          [
-           compound [ where [ anchor ]; Hover ];
-           compound [ where [ anchor ]; Focus ];
+           compound [ where [ anchor ]; Css.Selector.Hover ];
+           compound [ where [ anchor ]; Css.Selector.Focus ];
          ])
       combinator universal
   in
@@ -466,8 +466,8 @@ let structural_selector cls modifier =
   | First -> cp "first" cls Css.Selector.First_child
   | Last -> cp "last" cls Css.Selector.Last_child
   | Only -> cp "only" cls Css.Selector.Only_child
-  | Odd -> cp "odd" cls Css.Selector.(Nth_child (Odd, None))
-  | Even -> cp "even" cls Css.Selector.(Nth_child (Even, None))
+  | Odd -> cp "odd" cls Css.Selector.(Nth_child (Css.Selector.Odd, None))
+  | Even -> cp "even" cls Css.Selector.(Nth_child (Css.Selector.Even, None))
   | First_of_type -> cp "first-of-type" cls Css.Selector.First_of_type
   | Last_of_type -> cp "last-of-type" cls Css.Selector.Last_of_type
   | Only_of_type -> cp "only-of-type" cls Css.Selector.Only_of_type
@@ -584,12 +584,12 @@ let prose_element_inner_selector name =
 let to_selector (modifier : modifier) cls =
   let open Css.Selector in
   match modifier with
-  | Hover -> compound [ hover cls; Hover ]
-  | Focus -> compound [ focus cls; Focus ]
-  | Active -> compound [ active cls; Active ]
-  | Disabled -> compound [ disabled cls; Disabled ]
-  | Focus_within -> compound [ focus_within cls; Focus_within ]
-  | Focus_visible -> compound [ focus_visible cls; Focus_visible ]
+  | Hover -> compound [ hover cls; Css.Selector.Hover ]
+  | Focus -> compound [ focus cls; Css.Selector.Focus ]
+  | Active -> compound [ active cls; Css.Selector.Active ]
+  | Disabled -> compound [ disabled cls; Css.Selector.Disabled ]
+  | Focus_within -> compound [ focus_within cls; Css.Selector.Focus_within ]
+  | Focus_visible -> compound [ focus_visible cls; Css.Selector.Focus_visible ]
   (* Child/descendant selectors *)
   | Children ->
       let child_sel = combine (Class ("*:" ^ cls)) Child universal in
@@ -600,9 +600,17 @@ let to_selector (modifier : modifier) cls =
   | Ltr -> dir_selector "ltr" cls
   | Rtl -> dir_selector "rtl" cls
   (* Hocus/Device_hocus — compound :hover, :focus *)
-  | Hocus -> compound [ Class ("hocus:" ^ cls); is_ [ Hover; Focus ] ]
+  | Hocus ->
+      compound
+        [
+          Class ("hocus:" ^ cls); is_ [ Css.Selector.Hover; Css.Selector.Focus ];
+        ]
   | Device_hocus ->
-      compound [ Class ("device-hocus:" ^ cls); is_ [ Hover; Focus ] ]
+      compound
+        [
+          Class ("device-hocus:" ^ cls);
+          is_ [ Css.Selector.Hover; Css.Selector.Focus ];
+        ]
   (* Prose element variants — outer selector is just the class *)
   | Prose_element name -> Class ("prose-" ^ name ^ ":" ^ cls)
   (* Pseudo-elements, aria/data, structural, media, peer, form state *)
@@ -2233,7 +2241,9 @@ let variant_order_of_prefix prefix =
    dark:group-hover has a nested @media(hover:hover), so its effective inner
    order is 20000, matching standalone hover). *)
 let variant_order_of_media_cond (cond : Css.Media.t) =
-  let open Css.Media in
+  (* The scrutinee's annotation resolves every constructor below, so no [open
+     Css.Media] is needed: an open here would shadow the same-named modifier
+     constructors. *)
   match cond with
   | Cond (Feature (Plain (Hover, Ident Hover))) -> 20000
   | Cond (Feature (Plain (Prefers_reduced_motion, Ident No_preference))) ->

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -42,19 +42,28 @@ module Handler = struct
         "contain",
         (fun () -> style [ overscroll_behavior [ Contain ] ]),
         601 );
-      (None_, "none", (fun () -> style [ overscroll_behavior [ None ] ]), 602);
+      ( None_,
+        "none",
+        (fun () -> style [ overscroll_behavior [ Css.None ] ]),
+        602 );
       (X_auto, "x-auto", (fun () -> style [ overscroll_behavior_x Auto ]), 603);
       ( X_contain,
         "x-contain",
         (fun () -> style [ overscroll_behavior_x Contain ]),
         604 );
-      (X_none, "x-none", (fun () -> style [ overscroll_behavior_x None ]), 605);
+      ( X_none,
+        "x-none",
+        (fun () -> style [ overscroll_behavior_x Css.None ]),
+        605 );
       (Y_auto, "y-auto", (fun () -> style [ overscroll_behavior_y Auto ]), 606);
       ( Y_contain,
         "y-contain",
         (fun () -> style [ overscroll_behavior_y Contain ]),
         607 );
-      (Y_none, "y-none", (fun () -> style [ overscroll_behavior_y None ]), 608);
+      ( Y_none,
+        "y-none",
+        (fun () -> style [ overscroll_behavior_y Css.None ]),
+        608 );
     ]
 
   (* Derived lookup tables *)

--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -39,7 +39,12 @@ let box_resets () =
     rule
       ~selector:
         (Selector.list
-           [ Selector.universal; After Double; Before Double; Backdrop ])
+           [
+             Selector.universal;
+             After Selector.Double;
+             Before Selector.Double;
+             Backdrop;
+           ])
       [
         box_sizing Border_box;
         border ~width:Zero ~style:Solid ();
@@ -285,7 +290,8 @@ let list_resets () =
             ])
       [
         list_style
-          (Shorthand { type_ = Some None; position = None; image = Some None });
+          (Shorthand
+             { type_ = Some Css.None; position = None; image = Some Css.None });
       ];
   ]
 
@@ -376,7 +382,7 @@ let form_misc_resets () =
 let webkit_form_resets ?(forms = false) () =
   let base_rules =
     [
-      rule ~selector:Webkit_search_decoration [ webkit_appearance None ];
+      rule ~selector:Webkit_search_decoration [ webkit_appearance Css.None ];
       rule ~selector:Webkit_date_and_time_value
         [ min_height (Lh 1.0); text_align Inherit ];
     ]
@@ -413,7 +419,7 @@ let webkit_form_resets ?(forms = false) () =
 
 (** Firefox-specific form resets *)
 let firefox_form_resets () =
-  [ rule ~selector:Moz_ui_invalid [ box_shadow None ] ]
+  [ rule ~selector:Moz_ui_invalid [ box_shadow Css.None ] ]
 
 (** Buttons need specific styles *)
 let button_specific_resets () =
@@ -434,7 +440,7 @@ let button_resets () =
 
 (** Hidden elements *)
 let hidden_resets () =
-  [ rule ~selector:hidden_not_until_found [ important (display None) ] ]
+  [ rule ~selector:hidden_not_until_found [ important (display Css.None) ] ]
 
 let font_family_ref theme fallback_stack =
   let _, ref = Var.binding theme fallback_stack in

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -520,7 +520,7 @@ let pre_code_rules base =
            [
              with_before (where base pre_code); with_after (where base pre_code);
            ])
-      [ content None ];
+      [ content Css.None ];
   ]
 
 (* Code styles *)

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -352,7 +352,7 @@ module Handler = struct
           kw "full" (Pct 100.0) (keyword_off + 1);
           kw "max" Max_content (keyword_off + 3);
           kw "min" Min_content (keyword_off + 5);
-          kw "none" None (keyword_off + 6);
+          kw "none" Css.None (keyword_off + 6);
           kw "prose" (Ch 65.0) (keyword_off + 7);
           themed "screen-2xl" breakpoint_2xl (Rem 96.) (keyword_off + 8);
           themed "screen-lg" breakpoint_lg (Rem 64.) (keyword_off + 9);
@@ -394,7 +394,7 @@ module Handler = struct
           kw "lvh" (Lvh 100.) (keyword_off + 4);
           kw "max" Max_content (keyword_off + 5);
           kw "min" Min_content (keyword_off + 6);
-          kw "none" None (keyword_off + 7);
+          kw "none" Css.None (keyword_off + 7);
           kw "screen" (Vh 100.0) (keyword_off + 8);
           kw "svh" (Svh 100.) (keyword_off + 9);
           kw "px" (Px 1.0) (keyword_off + 9);
@@ -492,7 +492,7 @@ module Handler = struct
           kw "lvw" (Lvw 100.) (keyword_off + 1);
           kw "dvw" (Dvw 100.) (keyword_off + 1);
           kw "max" Max_content (keyword_off + 2);
-          kw "none" None (keyword_off + 3);
+          kw "none" Css.None (keyword_off + 3);
         ]
         @ container_entries (keyword_off + 4);
     }
@@ -560,7 +560,7 @@ module Handler = struct
           kw "lvh" (Lvh 100.) (keyword_off + 4);
           kw "max" Max_content (keyword_off + 5);
           kw "min" Min_content (keyword_off + 6);
-          kw "none" None (keyword_off + 7);
+          kw "none" Css.None (keyword_off + 7);
           kw "screen" (Vh 100.) (keyword_off + 8);
           kw "svh" (Svh 100.) (keyword_off + 9);
         ];

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -169,7 +169,7 @@ module Handler = struct
       stroke_color_style ~theme color shade
     in
     function
-    | Fill_none -> style Css.[ fill None ]
+    | Fill_none -> style Css.[ fill Css.None ]
     | Fill_inherit -> style Css.[ fill Inherit ]
     | Fill_transparent -> style Css.[ fill (Color (Css.hex "0000")) ]
     | Fill_current -> style ~merge_key:"fill-current" Css.[ fill Current_color ]
@@ -187,7 +187,7 @@ module Handler = struct
     | Fill_bracket_typed_var_opacity (v, opacity) ->
         bracket_var_opacity_style ~property:Css.fill ~merge_key:"fill-" v
           opacity
-    | Stroke_none -> style Css.[ stroke None ]
+    | Stroke_none -> style Css.[ stroke Css.None ]
     | Stroke_inherit -> style Css.[ stroke Inherit ]
     | Stroke_transparent -> style Css.[ stroke (Color (Css.hex "0000")) ]
     | Stroke_current ->

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -63,7 +63,7 @@ module Handler = struct
       ( Touch_manipulation,
         "manipulation",
         fun () -> style [ touch_action Manipulation ] );
-      (Touch_none, "none", fun () -> style [ touch_action None ]);
+      (Touch_none, "none", fun () -> style [ touch_action Css.None ]);
       (* x-axis pan utilities come before y-axis *)
       ( Touch_pan_left,
         "pan-left",

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -909,7 +909,7 @@ module Handler = struct
         in
         let decl, r = Var.binding perspective_none_var len in
         style (decl :: [ Css.perspective (Var r) ])
-    | None -> style [ Css.perspective None ]
+    | None -> style [ Css.perspective Css.None ]
 
   let perspective_dramatic =
     let decl, r = Var.binding perspective_dramatic_var (Px 100.0) in
@@ -1106,7 +1106,7 @@ module Handler = struct
           ];
       ]
 
-  let transform_none = style [ Css.transform None ]
+  let transform_none = style [ Css.transform Css.None ]
 
   (* transform-cpu is an alias for transform *)
   let transform_cpu =
@@ -1204,7 +1204,7 @@ module Handler = struct
     function
     | Rotate n -> rotate n
     | Rotate_arbitrary a -> rotate_arbitrary a
-    | Rotate_none -> style [ Css.rotate None ]
+    | Rotate_none -> style [ Css.rotate Css.None ]
     | Rotate_3d_arbitrary (x, y, z, a) -> rotate_3d_arbitrary x y z a
     | Rotate_bare_var name -> rotate_bare_var name
     | Neg_rotate_bare_var name -> neg_rotate_bare_var name
@@ -1224,7 +1224,7 @@ module Handler = struct
     | Translate n -> translate_spacing n
     | Neg_translate n -> translate_spacing (-n)
     | Translate_full -> translate_full
-    | Translate_none -> style [ Css.translate None ]
+    | Translate_none -> style [ Css.translate Css.None ]
     | Translate_px -> translate_px
     | Translate_1_2 -> translate_1_2
     | Translate_fraction (num, denom) -> translate_fraction num denom
@@ -1260,7 +1260,7 @@ module Handler = struct
     | Scale_z n -> scale_z n
     | Scale_z_arbitrary s -> scale_z_arbitrary s
     | Scale_3d -> scale_3d
-    | Scale_none -> style [ Css.scale None ]
+    | Scale_none -> style [ Css.scale Css.None ]
     | Skew_x n -> skew_x n
     | Skew_x_arbitrary a -> skew_x_arbitrary a
     | Skew_y n -> skew_y n

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2246,7 +2246,7 @@ module Typography_late = struct
   let underline = style [ text_decoration_line Underline ]
   let overline = style [ text_decoration_line Overline ]
   let line_through = style [ text_decoration_line Line_through ]
-  let no_underline = style [ text_decoration_line None ]
+  let no_underline = style [ text_decoration_line Css.None ]
   let decoration_solid = style [ text_decoration_style Solid ]
   let decoration_double = style [ text_decoration_style Double ]
   let decoration_dotted = style [ text_decoration_style Dotted ]
@@ -2520,7 +2520,7 @@ module Typography_late = struct
   let uppercase = style [ text_transform (Case Uppercase) ]
   let lowercase = style [ text_transform (Case Lowercase) ]
   let capitalize = style [ text_transform (Case Capitalize) ]
-  let normal_case = style [ text_transform None ]
+  let normal_case = style [ text_transform Css.None ]
 
   let parse_length_exn v =
     match Css.parse_length v with
@@ -2662,8 +2662,8 @@ module Typography_late = struct
      The set-based auto-collection is suppressed for --tw-content in
      build.ml. *)
   let content_none =
-    let content_decl, _content_ref = Var.binding content_var None in
-    style [ content_decl; content None ]
+    let content_decl, _content_ref = Var.binding content_var Css.None in
+    style [ content_decl; content Css.None ]
 
   let content s =
     (* Convert underscores to spaces in content values *)
@@ -2728,7 +2728,7 @@ module Typography_late = struct
     let var_name = "list-style-type-none" in
     let ref =
       Var.theme_ref var_name
-        ~default:(None : Css.list_style_type)
+        ~default:(Css.None : Css.list_style_type)
         ~default_css:"none"
     in
     match Scheme.theme_value theme var_name with
@@ -2739,7 +2739,7 @@ module Typography_late = struct
         style [ theme_decl; list_style_type (Var ref) ]
     (* Without a theme override Tailwind writes the keyword, not a reference to
        a token nothing declares. *)
-    | None -> style [ list_style_type None ]
+    | None -> style [ list_style_type Css.None ]
 
   let list_bracket_var s =
     let inner = Parse.extract_var_name s in
@@ -2768,7 +2768,7 @@ module Typography_late = struct
     let var_name = "list-style-image-none" in
     let ref =
       Var.theme_ref var_name
-        ~default:(None : Css.list_style_image)
+        ~default:(Css.None : Css.list_style_image)
         ~default_css:"none"
     in
     match Scheme.theme_value theme var_name with
@@ -2777,7 +2777,7 @@ module Typography_late = struct
           Css.custom_property ~layer:"theme" ("--" ^ var_name) value
         in
         style [ theme_decl; list_style_image (Var ref) ]
-    | None -> style [ list_style_image None ]
+    | None -> style [ list_style_image Css.None ]
 
   let text_ellipsis = style [ text_overflow Ellipsis ]
   let text_clip = style [ text_overflow Clip ]
@@ -2796,7 +2796,7 @@ module Typography_late = struct
   let overflow_wrap_normal = style [ overflow_wrap Normal ]
   let overflow_wrap_anywhere = style [ overflow_wrap Anywhere ]
   let overflow_wrap_break_word = style [ overflow_wrap Break_word ]
-  let hyphens_none = style [ webkit_hyphens None; hyphens None ]
+  let hyphens_none = style [ webkit_hyphens Css.None; hyphens Css.None ]
   let hyphens_manual = style [ webkit_hyphens Manual; hyphens Manual ]
   let hyphens_auto = style [ webkit_hyphens Auto; hyphens Auto ]
   let font_stretch_ultra_condensed = style [ font_stretch Ultra_condensed ]


### PR DESCRIPTION
`open Css` and `open Css.Selector` were quietly taking over `None`, `Focus`, `Odd` and friends, so a bare constructor could mean either module's. Warning 45 is now an error and every such use spells out the module it wants.