### PR TITLE
lib: drop the mirrored constructor prefixes merlint flagged

### DIFF
--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -13,40 +13,37 @@
 
 module Css = Cascade.Css
 open Style
-open Css
 
 module Handler = struct
-  type t = Forced_color_adjust_auto | Forced_color_adjust_none
+  type t = Auto | No_adjust
   type Utility.base += Self of t
 
   let name = "accessibility"
   let priority _ = 29
 
   let to_class = function
-    | Forced_color_adjust_auto -> "forced-color-adjust-auto"
-    | Forced_color_adjust_none -> "forced-color-adjust-none"
+    | Auto -> "forced-color-adjust-auto"
+    | No_adjust -> "forced-color-adjust-none"
 
   let to_style _theme = function
-    | Forced_color_adjust_auto -> style [ forced_color_adjust Auto ]
-    | Forced_color_adjust_none -> style [ forced_color_adjust None ]
+    | Auto -> style [ Css.forced_color_adjust Css.Auto ]
+    | No_adjust -> style [ Css.forced_color_adjust Css.None ]
 
-  let suborder = function
-    | Forced_color_adjust_auto -> 0
-    | Forced_color_adjust_none -> 1
+  let suborder = function Auto -> 0 | No_adjust -> 1
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "forced"; "color"; "adjust"; "auto" ] -> Ok Forced_color_adjust_auto
-    | [ "forced"; "color"; "adjust"; "none" ] -> Ok Forced_color_adjust_none
+    | [ "forced"; "color"; "adjust"; "auto" ] -> Ok Auto
+    | [ "forced"; "color"; "adjust"; "none" ] -> Ok No_adjust
     | _ -> Error (`Msg "Not an accessibility utility")
 
-  let examples = [ Forced_color_adjust_auto ]
+  let examples = [ Auto ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let forced_color_adjust_auto = utility Forced_color_adjust_auto
-let forced_color_adjust_none = utility Forced_color_adjust_none
+let forced_color_adjust_auto = utility Auto
+let forced_color_adjust_none = utility No_adjust

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -20,13 +20,13 @@ module Handler = struct
   open Css
 
   type t =
-    | Animate_none
-    | Animate_spin
-    | Animate_ping
-    | Animate_pulse
-    | Animate_bounce
-    | Animate_bracket of string
-    | Animate_named of string
+    | No_animation
+    | Spin
+    | Ping
+    | Pulse
+    | Bounce
+    | Bracket of string
+    | Named of string
 
   type Utility.base += Self of t
 
@@ -297,61 +297,61 @@ module Handler = struct
     let animate_pulse () = animate_pulse ~theme () in
     let animate_bounce () = animate_bounce ~theme () in
     function
-    | Animate_none -> animate_none ()
-    | Animate_spin -> animate_spin ()
-    | Animate_ping -> animate_ping ()
-    | Animate_pulse -> animate_pulse ()
-    | Animate_bounce -> animate_bounce ()
-    | Animate_bracket value -> animate_bracket value
-    | Animate_named name -> animate_named name
+    | No_animation -> animate_none ()
+    | Spin -> animate_spin ()
+    | Ping -> animate_ping ()
+    | Pulse -> animate_pulse ()
+    | Bounce -> animate_bounce ()
+    | Bracket value -> animate_bracket value
+    | Named name -> animate_named name
 
   let suborder = function
-    | Animate_bracket _ -> 0
-    | Animate_bounce -> 1
-    | Animate_named _ -> 2
-    | Animate_none -> 3
-    | Animate_ping -> 4
-    | Animate_pulse -> 5
-    | Animate_spin -> 6
+    | Bracket _ -> 0
+    | Bounce -> 1
+    | Named _ -> 2
+    | No_animation -> 3
+    | Ping -> 4
+    | Pulse -> 5
+    | Spin -> 6
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "animate"; "none" ] -> Ok Animate_none
-    | [ "animate"; "spin" ] -> Ok Animate_spin
-    | [ "animate"; "ping" ] -> Ok Animate_ping
-    | [ "animate"; "pulse" ] -> Ok Animate_pulse
-    | [ "animate"; "bounce" ] -> Ok Animate_bounce
+    | [ "animate"; "none" ] -> Ok No_animation
+    | [ "animate"; "spin" ] -> Ok Spin
+    | [ "animate"; "ping" ] -> Ok Ping
+    | [ "animate"; "pulse" ] -> Ok Pulse
+    | [ "animate"; "bounce" ] -> Ok Bounce
     | "animate" :: rest ->
         let value = String.concat "-" rest in
         if Parse.is_bracket_value value then
-          Ok (Animate_bracket (Parse.bracket_inner value))
+          Ok (Bracket (Parse.bracket_inner value))
         else
           (* Check if it's a named animation with a theme value *)
           let var_name = "animate-" ^ value in
           if Scheme.theme_value (Some theme) var_name <> None then
-            Ok (Animate_named value)
+            Ok (Named value)
           else Error (`Msg "Not an animation utility")
     | _ -> Error (`Msg "Not an animation utility")
 
   let to_class = function
-    | Animate_none -> "animate-none"
-    | Animate_spin -> "animate-spin"
-    | Animate_ping -> "animate-ping"
-    | Animate_pulse -> "animate-pulse"
-    | Animate_bounce -> "animate-bounce"
-    | Animate_bracket v -> "animate-[" ^ v ^ "]"
-    | Animate_named name -> "animate-" ^ name
+    | No_animation -> "animate-none"
+    | Spin -> "animate-spin"
+    | Ping -> "animate-ping"
+    | Pulse -> "animate-pulse"
+    | Bounce -> "animate-bounce"
+    | Bracket v -> "animate-[" ^ v ^ "]"
+    | Named name -> "animate-" ^ name
 
-  let examples = [ Animate_none ]
+  let examples = [ No_animation ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let animate_none = utility Animate_none
-let animate_spin = utility Animate_spin
-let animate_ping = utility Animate_ping
-let animate_pulse = utility Animate_pulse
-let animate_bounce = utility Animate_bounce
+let animate_none = utility No_animation
+let animate_spin = utility Spin
+let animate_ping = utility Ping
+let animate_pulse = utility Pulse
+let animate_bounce = utility Bounce

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -42,46 +42,51 @@ module Handler = struct
       String.sub s 1 (n - 2)
     else s
 
-  type position_name =
-    | Pos_bottom
-    | Pos_bottom_left
-    | Pos_bottom_right
-    | Pos_center
-    | Pos_left
-    | Pos_left_bottom
-    | Pos_left_top
-    | Pos_right
-    | Pos_right_bottom
-    | Pos_right_top
-    | Pos_top
-    | Pos_top_left
-    | Pos_top_right
+  (* The named background positions, as [bg-<position>] spells them. *)
+  module Position = struct
+    type t =
+      | Bottom
+      | Bottom_left
+      | Bottom_right
+      | Center
+      | Left
+      | Left_bottom
+      | Left_top
+      | Right
+      | Right_bottom
+      | Right_top
+      | Top
+      | Top_left
+      | Top_right
+  end
 
   (* Gradient color source - shared by from/via/to *)
-  type gradient_color_source =
-    | Gc_named of Color.color * int
-    | Gc_named_opacity of Color.color * int * Color.opacity_modifier
-    | Gc_current
-    | Gc_current_opacity of Color.opacity_modifier
-    | Gc_inherit
-    | Gc_transparent
-    | Gc_bracket_hex of string
-    | Gc_bracket_hex_opacity of string * Color.opacity_modifier
-    | Gc_bracket_color_var of string
-    | Gc_bracket_color_var_opacity of string * Color.opacity_modifier
-    | Gc_bracket_var of string
-    | Gc_bracket_var_opacity of string * Color.opacity_modifier
-    | Gc_bracket_color of string
-    | Gc_bracket_color_opacity of string * Color.opacity_modifier
+  module Color_source = struct
+    type t =
+      | Named of Color.color * int
+      | Named_opacity of Color.color * int * Color.opacity_modifier
+      | Current
+      | Current_opacity of Color.opacity_modifier
+      | Inherit
+      | Transparent
+      | Bracket_hex of string
+      | Bracket_hex_opacity of string * Color.opacity_modifier
+      | Bracket_color_var of string
+      | Bracket_color_var_opacity of string * Color.opacity_modifier
+      | Bracket_var of string
+      | Bracket_var_opacity of string * Color.opacity_modifier
+      | Bracket_color of string
+      | Bracket_color_opacity of string * Color.opacity_modifier
+  end
 
   (* Gradient position source *)
-  type gradient_position_source = Gp_pct of float | Gp_bracket of string
-  type gradient_target = Gradient_from | Gradient_via | Gradient_to
+  type gradient_position_source = Percent of float | Bracket of string
+  type gradient_target = From | Via | To
 
   type t =
     | Bg of Color.color * int
     | Bg_gradient_to of direction
-    | Gradient_color of gradient_target * gradient_color_source
+    | Gradient_color of gradient_target * Color_source.t
     | Gradient_stop_position of gradient_target * gradient_position_source
     | Via_none (* via-none: clears the gradient's via stops *)
     | Bg_origin_border
@@ -111,7 +116,7 @@ module Handler = struct
     | Bg_repeat_round
     | Bg_repeat_space
     (* Background position *)
-    | Bg_position of position_name
+    | Bg_position of Position.t
     (* Bracket notation: bg-[contain], bg-[cover] → background-size *)
     | Bg_bracket_contain
     | Bg_bracket_cover
@@ -231,56 +236,51 @@ module Handler = struct
     | Via_none -> "via-none"
     | Gradient_color (target, src) ->
         let prefix =
-          match target with
-          | Gradient_from -> "from-"
-          | Gradient_via -> "via-"
-          | Gradient_to -> "to-"
+          match target with From -> "from-" | Via -> "via-" | To -> "to-"
         in
         let color_class = function
-          | Gc_named (color, shade) ->
+          | Color_source.Named (color, shade) ->
               if Color.is_base_color color || Color.is_custom_color color then
                 Color.pp color
               else Color.pp color ^ "-" ^ string_of_int shade
-          | Gc_named_opacity (color, shade, opacity) ->
+          | Color_source.Named_opacity (color, shade, opacity) ->
               let base =
                 if Color.is_base_color color || Color.is_custom_color color then
                   Color.pp color
                 else Color.pp color ^ "-" ^ string_of_int shade
               in
               base ^ opacity_suffix opacity
-          | Gc_current -> "current"
-          | Gc_current_opacity opacity -> "current" ^ opacity_suffix opacity
-          | Gc_inherit -> "inherit"
-          | Gc_transparent -> "transparent"
-          | Gc_bracket_hex h -> "[#" ^ h ^ "]"
-          | Gc_bracket_hex_opacity (h, opacity) ->
+          | Color_source.Current -> "current"
+          | Color_source.Current_opacity opacity ->
+              "current" ^ opacity_suffix opacity
+          | Color_source.Inherit -> "inherit"
+          | Color_source.Transparent -> "transparent"
+          | Color_source.Bracket_hex h -> "[#" ^ h ^ "]"
+          | Color_source.Bracket_hex_opacity (h, opacity) ->
               "[#" ^ h ^ "]" ^ opacity_suffix opacity
-          | Gc_bracket_color_var v -> "[color:" ^ v ^ "]"
-          | Gc_bracket_color_var_opacity (v, opacity) ->
+          | Color_source.Bracket_color_var v -> "[color:" ^ v ^ "]"
+          | Color_source.Bracket_color_var_opacity (v, opacity) ->
               "[color:" ^ v ^ "]" ^ opacity_suffix opacity
-          | Gc_bracket_var v -> "[" ^ v ^ "]"
-          | Gc_bracket_var_opacity (v, opacity) ->
+          | Color_source.Bracket_var v -> "[" ^ v ^ "]"
+          | Color_source.Bracket_var_opacity (v, opacity) ->
               "[" ^ v ^ "]" ^ opacity_suffix opacity
-          | Gc_bracket_color v -> "[" ^ v ^ "]"
-          | Gc_bracket_color_opacity (v, opacity) ->
+          | Color_source.Bracket_color v -> "[" ^ v ^ "]"
+          | Color_source.Bracket_color_opacity (v, opacity) ->
               "[" ^ v ^ "]" ^ opacity_suffix opacity
         in
         prefix ^ color_class src
     | Gradient_stop_position (target, src) -> (
         let prefix =
-          match target with
-          | Gradient_from -> "from-"
-          | Gradient_via -> "via-"
-          | Gradient_to -> "to-"
+          match target with From -> "from-" | Via -> "via-" | To -> "to-"
         in
         match src with
-        | Gp_pct p ->
+        | Percent p ->
             let p_str =
               if Float.is_integer p then string_of_int (int_of_float p)
               else string_of_float p
             in
             prefix ^ p_str ^ "%"
-        | Gp_bracket v -> prefix ^ "[" ^ v ^ "]")
+        | Bracket v -> prefix ^ "[" ^ v ^ "]")
     | Bg_origin_border -> "bg-origin-border"
     | Bg_origin_padding -> "bg-origin-padding"
     | Bg_origin_content -> "bg-origin-content"
@@ -302,19 +302,19 @@ module Handler = struct
     | Bg_repeat_y -> "bg-repeat-y"
     | Bg_repeat_round -> "bg-repeat-round"
     | Bg_repeat_space -> "bg-repeat-space"
-    | Bg_position Pos_bottom -> "bg-bottom"
-    | Bg_position Pos_bottom_left -> "bg-bottom-left"
-    | Bg_position Pos_bottom_right -> "bg-bottom-right"
-    | Bg_position Pos_center -> "bg-center"
-    | Bg_position Pos_left -> "bg-left"
-    | Bg_position Pos_left_bottom -> "bg-left-bottom"
-    | Bg_position Pos_left_top -> "bg-left-top"
-    | Bg_position Pos_right -> "bg-right"
-    | Bg_position Pos_right_bottom -> "bg-right-bottom"
-    | Bg_position Pos_right_top -> "bg-right-top"
-    | Bg_position Pos_top -> "bg-top"
-    | Bg_position Pos_top_left -> "bg-top-left"
-    | Bg_position Pos_top_right -> "bg-top-right"
+    | Bg_position Position.Bottom -> "bg-bottom"
+    | Bg_position Position.Bottom_left -> "bg-bottom-left"
+    | Bg_position Position.Bottom_right -> "bg-bottom-right"
+    | Bg_position Position.Center -> "bg-center"
+    | Bg_position Position.Left -> "bg-left"
+    | Bg_position Position.Left_bottom -> "bg-left-bottom"
+    | Bg_position Position.Left_top -> "bg-left-top"
+    | Bg_position Position.Right -> "bg-right"
+    | Bg_position Position.Right_bottom -> "bg-right-bottom"
+    | Bg_position Position.Right_top -> "bg-right-top"
+    | Bg_position Position.Top -> "bg-top"
+    | Bg_position Position.Top_left -> "bg-top-left"
+    | Bg_position Position.Top_right -> "bg-top-right"
     | Bg_bracket_contain -> "bg-[contain]"
     | Bg_bracket_cover -> "bg-[cover]"
     | Bg_bracket_size v -> "bg-[size:" ^ v ^ "]"
@@ -1206,9 +1206,9 @@ module Handler = struct
 
   (** Convert gradient target to set_var and prefix *)
   let gradient_target_info = function
-    | Gradient_from -> ("from-", gradient_from_var, gradient_from_position_var)
-    | Gradient_via -> ("via-", gradient_via_var, gradient_via_position_var)
-    | Gradient_to -> ("to-", gradient_to_var, gradient_to_position_var)
+    | From -> ("from-", gradient_from_var, gradient_from_position_var)
+    | Via -> ("via-", gradient_via_var, gradient_via_position_var)
+    | To -> ("to-", gradient_to_var, gradient_to_position_var)
 
   (* Shared @property rules for gradient positions *)
   (* A gradient stop-position utility (from-10% etc.) registers the whole
@@ -1269,28 +1269,32 @@ module Handler = struct
     let vr : Css.color Css.var = Var.bracket bare in
     Var vr
 
-  (** Convert a non-named gradient_color_source to a Css.color *)
-  let css_color_of_source : gradient_color_source -> Css.color = function
-    | Gc_current | Gc_current_opacity _ -> Css.Current
-    | Gc_inherit -> Css.Inherit
-    | Gc_transparent -> Css.Transparent
-    | Gc_bracket_hex h | Gc_bracket_hex_opacity (h, _) -> Css.hex h
-    | Gc_bracket_color_var v | Gc_bracket_color_var_opacity (v, _) ->
+  (** Convert a non-named Color_source.t to a Css.color *)
+  let css_color_of_source : Color_source.t -> Css.color = function
+    | Color_source.Current | Color_source.Current_opacity _ -> Css.Current
+    | Color_source.Inherit -> Css.Inherit
+    | Color_source.Transparent -> Css.Transparent
+    | Color_source.Bracket_hex h | Color_source.Bracket_hex_opacity (h, _) ->
+        Css.hex h
+    | Color_source.Bracket_color_var v
+    | Color_source.Bracket_color_var_opacity (v, _) ->
         color_var_ref v
-    | Gc_bracket_var v | Gc_bracket_var_opacity (v, _) -> color_var_ref v
-    | Gc_bracket_color v | Gc_bracket_color_opacity (v, _) -> (
+    | Color_source.Bracket_var v | Color_source.Bracket_var_opacity (v, _) ->
+        color_var_ref v
+    | Color_source.Bracket_color v | Color_source.Bracket_color_opacity (v, _)
+      -> (
         match Color.parse_bracket_color v with
         | Some c -> c
         | None -> Css.Transparent)
-    | Gc_named _ | Gc_named_opacity _ -> assert false
+    | Color_source.Named _ | Color_source.Named_opacity _ -> assert false
 
-  (** Extract opacity from a gradient_color_source, if present *)
+  (** Extract opacity from a Color_source.t, if present *)
   let opacity_of_source = function
-    | Gc_current_opacity o
-    | Gc_bracket_hex_opacity (_, o)
-    | Gc_bracket_color_var_opacity (_, o)
-    | Gc_bracket_var_opacity (_, o)
-    | Gc_bracket_color_opacity (_, o) ->
+    | Color_source.Current_opacity o
+    | Color_source.Bracket_hex_opacity (_, o)
+    | Color_source.Bracket_color_var_opacity (_, o)
+    | Color_source.Bracket_var_opacity (_, o)
+    | Color_source.Bracket_color_opacity (_, o) ->
         Some o
     | _ -> None
 
@@ -1309,11 +1313,11 @@ module Handler = struct
         let prefix, set_var, _pos_var = gradient_target_info target in
         (* Named colors use the scheme system with theme variables *)
         match src with
-        | Gc_named (color, shade) ->
+        | Color_source.Named (color, shade) ->
             gradient_color ~prefix ~set_var ~shade color
-        | Gc_named_opacity (color, shade, opacity) ->
+        | Color_source.Named_opacity (color, shade, opacity) ->
             gradient_color_opacity ~prefix ~set_var ~shade color opacity
-        | Gc_bracket_hex_opacity (h, opacity) ->
+        | Color_source.Bracket_hex_opacity (h, opacity) ->
             (* Hex is known at compile time: compute oklab directly *)
             let alpha = Color.opacity_to_percent opacity /. 100.0 in
             let color = Color.hex_to_oklab_alpha h alpha in
@@ -1329,8 +1333,8 @@ module Handler = struct
     | Gradient_stop_position (target, src) -> (
         let _prefix, _set_var, pos_var = gradient_target_info target in
         match src with
-        | Gp_pct p -> gradient_position_style pos_var (Pct p)
-        | Gp_bracket v ->
+        | Percent p -> gradient_position_style pos_var (Pct p)
+        | Bracket v ->
             gradient_position_style pos_var (parse_bracket_position_value v))
     | Via_none ->
         let property_rules =
@@ -1363,19 +1367,19 @@ module Handler = struct
     | Bg_position pos ->
         let pos_val : Css.position_value list =
           match pos with
-          | Pos_bottom -> [ Center_bottom ]
-          | Pos_bottom_left -> [ XY (Px 0., Pct 100.) ]
-          | Pos_bottom_right -> [ XY (Pct 100., Pct 100.) ]
-          | Pos_center -> [ Center ]
-          | Pos_left -> [ Single (Px 0.) ]
-          | Pos_left_bottom -> [ XY (Px 0., Pct 100.) ]
-          | Pos_left_top -> [ XY (Px 0., Px 0.) ]
-          | Pos_right -> [ Single (Pct 100.) ]
-          | Pos_right_bottom -> [ XY (Pct 100., Pct 100.) ]
-          | Pos_right_top -> [ XY (Pct 100., Px 0.) ]
-          | Pos_top -> [ Center_top ]
-          | Pos_top_left -> [ XY (Px 0., Px 0.) ]
-          | Pos_top_right -> [ XY (Pct 100., Px 0.) ]
+          | Position.Bottom -> [ Center_bottom ]
+          | Position.Bottom_left -> [ XY (Px 0., Pct 100.) ]
+          | Position.Bottom_right -> [ XY (Pct 100., Pct 100.) ]
+          | Position.Center -> [ Center ]
+          | Position.Left -> [ Single (Px 0.) ]
+          | Position.Left_bottom -> [ XY (Px 0., Pct 100.) ]
+          | Position.Left_top -> [ XY (Px 0., Px 0.) ]
+          | Position.Right -> [ Single (Pct 100.) ]
+          | Position.Right_bottom -> [ XY (Pct 100., Pct 100.) ]
+          | Position.Right_top -> [ XY (Pct 100., Px 0.) ]
+          | Position.Top -> [ Center_top ]
+          | Position.Top_left -> [ XY (Px 0., Px 0.) ]
+          | Position.Top_right -> [ XY (Pct 100., Px 0.) ]
         in
         bg_position' pos_val
     | Bg_bracket_contain -> style [ Css.background_size Contain ]
@@ -1481,14 +1485,14 @@ module Handler = struct
     | Bg_radial_interp _ | Bg_radial_bracket _ ->
         200000
     (* Gradient color utilities *)
-    | Gradient_color (Gradient_from, _) -> 110000
-    | Gradient_color (Gradient_via, _) -> 120000
+    | Gradient_color (From, _) -> 110000
+    | Gradient_color (Via, _) -> 120000
     | Via_none -> 120002
-    | Gradient_color (Gradient_to, _) -> 130000
+    | Gradient_color (To, _) -> 130000
     (* Gradient position utilities *)
-    | Gradient_stop_position (Gradient_from, _) -> 110001
-    | Gradient_stop_position (Gradient_via, _) -> 120001
-    | Gradient_stop_position (Gradient_to, _) -> 130001
+    | Gradient_stop_position (From, _) -> 110001
+    | Gradient_stop_position (Via, _) -> 120001
+    | Gradient_stop_position (To, _) -> 130001
     (* bg-origin utilities *)
     | Bg_origin_border -> 140000
     | Bg_origin_content -> 140001
@@ -1568,17 +1572,17 @@ module Handler = struct
     let gp src = Ok (Gradient_stop_position (target, src)) in
     match rest with
     (* Keywords *)
-    | [ "current" ] -> gc Gc_current
+    | [ "current" ] -> gc Color_source.Current
     | [ current_str ] when String.starts_with ~prefix:"current/" current_str ->
         let _, opacity = Color.parse_opacity_modifier ?theme current_str in
-        gc (Gc_current_opacity opacity)
-    | [ "inherit" ] -> gc Gc_inherit
-    | [ "transparent" ] -> gc Gc_transparent
+        gc (Color_source.Current_opacity opacity)
+    | [ "inherit" ] -> gc Color_source.Inherit
+    | [ "transparent" ] -> gc Color_source.Transparent
     (* Percentage positions: from-0%, from-100% (integer only) *)
     | [ pct_str ] when String.ends_with ~suffix:"%" pct_str -> (
         let num_s = String.sub pct_str 0 (String.length pct_str - 1) in
         match int_of_string_opt num_s with
-        | Some p -> gp (Gp_pct (float_of_int p))
+        | Some p -> gp (Percent (float_of_int p))
         | None -> Error (`Msg "Invalid gradient position"))
     (* Bracket with opacity: [#0088cc]/50, [#0088cc]/[0.5], [var(--x)]/50 *)
     | [ bracket_opacity ] when has_opacity bracket_opacity -> (
@@ -1591,11 +1595,13 @@ module Handler = struct
             let inner = Parse.bracket_inner bracket_opacity in
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
-              gc (Gc_bracket_color_var var_str)
+              gc (Color_source.Bracket_color_var var_str)
             else if is_bracket_hex inner then
-              gc (Gc_bracket_hex (String.sub inner 1 (String.length inner - 1)))
-            else if Parse.is_var inner then gc (Gc_bracket_var inner)
-            else if is_gradient_position inner then gp (Gp_bracket inner)
+              gc
+                (Color_source.Bracket_hex
+                   (String.sub inner 1 (String.length inner - 1)))
+            else if Parse.is_var inner then gc (Color_source.Bracket_var inner)
+            else if is_gradient_position inner then gp (Bracket inner)
             else Error (`Msg "Invalid gradient stop value")
         | Color.No_opacity ->
             Error (`Msg "Invalid gradient bracket with opacity")
@@ -1603,45 +1609,47 @@ module Handler = struct
             let inner = Parse.bracket_inner base in
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
-              gc (Gc_bracket_color_var_opacity (var_str, opacity))
+              gc (Color_source.Bracket_color_var_opacity (var_str, opacity))
             else if is_bracket_hex inner then
               gc
-                (Gc_bracket_hex_opacity
+                (Color_source.Bracket_hex_opacity
                    (String.sub inner 1 (String.length inner - 1), opacity))
             else if Parse.is_var inner then
-              gc (Gc_bracket_var_opacity (inner, opacity))
+              gc (Color_source.Bracket_var_opacity (inner, opacity))
             else if Color.parse_bracket_color inner <> None then
-              gc (Gc_bracket_color_opacity (inner, opacity))
+              gc (Color_source.Bracket_color_opacity (inner, opacity))
             else Error (`Msg "Invalid gradient bracket with opacity")
         | _ -> (
             (* Named color with opacity *)
             match Color.shade_and_opacity_of_strings ?theme rest with
             | Ok (color, shade, opacity) ->
-                gc (Gc_named_opacity (color, shade, opacity))
+                gc (Color_source.Named_opacity (color, shade, opacity))
             | Error e -> Error e))
     (* Bracket notation without opacity *)
     | [ bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
         if String.length inner > 6 && String.sub inner 0 6 = "color:" then
           let var_str = String.sub inner 6 (String.length inner - 6) in
-          gc (Gc_bracket_color_var var_str)
+          gc (Color_source.Bracket_color_var var_str)
         else if is_bracket_hex inner then
-          gc (Gc_bracket_hex (String.sub inner 1 (String.length inner - 1)))
-        else if Parse.is_var inner then gc (Gc_bracket_var inner)
+          gc
+            (Color_source.Bracket_hex
+               (String.sub inner 1 (String.length inner - 1)))
+        else if Parse.is_var inner then gc (Color_source.Bracket_var inner)
         else if Color.parse_bracket_color inner <> None then
-          gc (Gc_bracket_color inner)
-        else if is_gradient_position inner then gp (Gp_bracket inner)
+          gc (Color_source.Bracket_color inner)
+        else if is_gradient_position inner then gp (Bracket inner)
         else Error (`Msg "Invalid gradient stop value")
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (
         match Color.shade_and_opacity_of_strings ?theme rest with
         | Ok (color, shade, opacity) ->
-            gc (Gc_named_opacity (color, shade, opacity))
+            gc (Color_source.Named_opacity (color, shade, opacity))
         | Error e -> Error e)
     (* Named color *)
     | _ -> (
         match Color.shade_of_strings rest with
-        | Ok (color, shade) -> gc (Gc_named (color, shade))
+        | Ok (color, shade) -> gc (Color_source.Named (color, shade))
         | Error _ -> Error (`Msg "Invalid gradient color"))
 
   let of_class theme class_name =
@@ -1690,19 +1698,19 @@ module Handler = struct
     | [ "bg"; "repeat"; "round" ] -> Ok Bg_repeat_round
     | [ "bg"; "repeat"; "space" ] -> Ok Bg_repeat_space
     (* Background position *)
-    | [ "bg"; "bottom" ] -> Ok (Bg_position Pos_bottom)
-    | [ "bg"; "bottom"; "left" ] -> Ok (Bg_position Pos_bottom_left)
-    | [ "bg"; "bottom"; "right" ] -> Ok (Bg_position Pos_bottom_right)
-    | [ "bg"; "center" ] -> Ok (Bg_position Pos_center)
-    | [ "bg"; "left" ] -> Ok (Bg_position Pos_left)
-    | [ "bg"; "left"; "bottom" ] -> Ok (Bg_position Pos_left_bottom)
-    | [ "bg"; "left"; "top" ] -> Ok (Bg_position Pos_left_top)
-    | [ "bg"; "right" ] -> Ok (Bg_position Pos_right)
-    | [ "bg"; "right"; "bottom" ] -> Ok (Bg_position Pos_right_bottom)
-    | [ "bg"; "right"; "top" ] -> Ok (Bg_position Pos_right_top)
-    | [ "bg"; "top" ] -> Ok (Bg_position Pos_top)
-    | [ "bg"; "top"; "left" ] -> Ok (Bg_position Pos_top_left)
-    | [ "bg"; "top"; "right" ] -> Ok (Bg_position Pos_top_right)
+    | [ "bg"; "bottom" ] -> Ok (Bg_position Position.Bottom)
+    | [ "bg"; "bottom"; "left" ] -> Ok (Bg_position Position.Bottom_left)
+    | [ "bg"; "bottom"; "right" ] -> Ok (Bg_position Position.Bottom_right)
+    | [ "bg"; "center" ] -> Ok (Bg_position Position.Center)
+    | [ "bg"; "left" ] -> Ok (Bg_position Position.Left)
+    | [ "bg"; "left"; "bottom" ] -> Ok (Bg_position Position.Left_bottom)
+    | [ "bg"; "left"; "top" ] -> Ok (Bg_position Position.Left_top)
+    | [ "bg"; "right" ] -> Ok (Bg_position Position.Right)
+    | [ "bg"; "right"; "bottom" ] -> Ok (Bg_position Position.Right_bottom)
+    | [ "bg"; "right"; "top" ] -> Ok (Bg_position Position.Right_top)
+    | [ "bg"; "top" ] -> Ok (Bg_position Position.Top)
+    | [ "bg"; "top"; "left" ] -> Ok (Bg_position Position.Top_left)
+    | [ "bg"; "top"; "right" ] -> Ok (Bg_position Position.Top_right)
     (* bg-linear-to-* direction utilities (with optional /interp modifier) *)
     | [ "bg"; "linear"; "to"; dir_mod ] -> (
         let dir_s, interp_opt = split_mod dir_mod in
@@ -1897,10 +1905,10 @@ module Handler = struct
         match Color.shade_of_strings rest with
         | Ok (color, shade) -> Ok (Bg (color, shade))
         | Error _ -> Error (`Msg "Invalid background color"))
-    | "from" :: rest -> parse_gradient_color ~theme Gradient_from rest
+    | "from" :: rest -> parse_gradient_color ~theme From rest
     | [ "via"; "none" ] -> Ok Via_none
-    | "via" :: rest -> parse_gradient_color ~theme Gradient_via rest
-    | "to" :: rest -> parse_gradient_color ~theme Gradient_to rest
+    | "via" :: rest -> parse_gradient_color ~theme Via rest
+    | "to" :: rest -> parse_gradient_color ~theme To rest
     | _ -> Error (`Msg "Unknown background class")
 
   let examples =
@@ -1932,12 +1940,12 @@ let bg_gradient_to dir = utility (Bg_gradient_to dir)
 
 let from_color ?(shade = 500) color =
   Color.check_shade ~utility:"from_color" color shade;
-  utility (Gradient_color (Gradient_from, Gc_named (color, shade)))
+  utility (Gradient_color (From, Color_source.Named (color, shade)))
 
 let via_color ?(shade = 500) color =
   Color.check_shade ~utility:"via_color" color shade;
-  utility (Gradient_color (Gradient_via, Gc_named (color, shade)))
+  utility (Gradient_color (Via, Color_source.Named (color, shade)))
 
 let to_color ?(shade = 500) color =
   Color.check_shade ~utility:"to_color" color shade;
-  utility (Gradient_color (Gradient_to, Gc_named (color, shade)))
+  utility (Gradient_color (To, Color_source.Named (color, shade)))

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -20,22 +20,26 @@ module Css = Cascade.Css
 (* Resolve the optionally-threaded theme, defaulting to the base scheme. *)
 let resolve_scheme = function Some s -> s | None -> Scheme.default
 
-type rounded_position =
-  | Rp_all
-  | Rp_s
-  | Rp_e
-  | Rp_t
-  | Rp_r
-  | Rp_b
-  | Rp_l
-  | Rp_ss
-  | Rp_se
-  | Rp_ee
-  | Rp_es
-  | Rp_tl
-  | Rp_tr
-  | Rp_br
-  | Rp_bl
+(* Which corners a [rounded-*] utility rounds: every corner, one physical or
+   logical side, or a single corner. *)
+module Corner = struct
+  type t =
+    | All
+    | Start
+    | End
+    | Top
+    | Right
+    | Bottom
+    | Left
+    | Start_start
+    | Start_end
+    | End_end
+    | End_start
+    | Top_left
+    | Top_right
+    | Bottom_right
+    | Bottom_left
+end
 
 (* Border-radius t-shirt sizes. [Rsz_default] is the bare [rounded] (no size
    suffix). [Rsz_arbitrary] carries the bracket inner value. The [Rsz_] prefix
@@ -120,9 +124,9 @@ module Handler = struct
     | Border_transparent
     | Border_current
     | (* Border radius utilities. One parametric variant over (position, size);
-         the bare [rounded] is [Rounded (Rp_all, Rsz_default)] and arbitrary
+         the bare [rounded] is [Rounded (Corner.All, Rsz_default)] and arbitrary
          brackets are [Rounded (pos, Rsz_arbitrary inner)]. *)
-      Rounded of rounded_position * rounded_size
+      Rounded of Corner.t * rounded_size
     | (* Outline utilities *)
       Outline
     | Outline_0
@@ -464,34 +468,35 @@ module Handler = struct
      per-side/corner "full" utilities share it. *)
   let radius_full_len : Css.length = Css.Px 3.40282e38
 
-  (* Map a [rounded_position] to the corner/side radius declarations for a given
-     length. Shared by both the sized and arbitrary radius utilities; [Rp_all]
-     uses the [border-radius] shorthand, all others target the matching
+  (* Map a [Corner.t] to the corner/side radius declarations for a given length.
+     Shared by both the sized and arbitrary radius utilities; [Corner.All] uses
+     the [border-radius] shorthand, all others target the matching
      corner/logical properties. *)
   let radius_decls_for_position pos (len : Css.length) : Css.declaration list =
     match pos with
-    | Rp_all -> [ Css.border_radius (radius_value len) ]
-    | Rp_t ->
+    | Corner.All -> [ Css.border_radius (radius_value len) ]
+    | Corner.Top ->
         [ Css.border_top_left_radius len; Css.border_top_right_radius len ]
-    | Rp_r ->
+    | Corner.Right ->
         [ Css.border_top_right_radius len; Css.border_bottom_right_radius len ]
-    | Rp_b ->
+    | Corner.Bottom ->
         [
           Css.border_bottom_right_radius len; Css.border_bottom_left_radius len;
         ]
-    | Rp_l ->
+    | Corner.Left ->
         [ Css.border_top_left_radius len; Css.border_bottom_left_radius len ]
-    | Rp_tl -> [ Css.border_top_left_radius len ]
-    | Rp_tr -> [ Css.border_top_right_radius len ]
-    | Rp_br -> [ Css.border_bottom_right_radius len ]
-    | Rp_bl -> [ Css.border_bottom_left_radius len ]
-    | Rp_s ->
+    | Corner.Top_left -> [ Css.border_top_left_radius len ]
+    | Corner.Top_right -> [ Css.border_top_right_radius len ]
+    | Corner.Bottom_right -> [ Css.border_bottom_right_radius len ]
+    | Corner.Bottom_left -> [ Css.border_bottom_left_radius len ]
+    | Corner.Start ->
         [ Css.border_start_start_radius len; Css.border_end_start_radius len ]
-    | Rp_e -> [ Css.border_start_end_radius len; Css.border_end_end_radius len ]
-    | Rp_ss -> [ Css.border_start_start_radius len ]
-    | Rp_se -> [ Css.border_start_end_radius len ]
-    | Rp_ee -> [ Css.border_end_end_radius len ]
-    | Rp_es -> [ Css.border_end_start_radius len ]
+    | Corner.End ->
+        [ Css.border_start_end_radius len; Css.border_end_end_radius len ]
+    | Corner.Start_start -> [ Css.border_start_start_radius len ]
+    | Corner.Start_end -> [ Css.border_start_end_radius len ]
+    | Corner.End_end -> [ Css.border_end_end_radius len ]
+    | Corner.End_start -> [ Css.border_end_start_radius len ]
 
   (* Per-side/corner "full"/"none" radius: reference var(--radius-X) when the
      active theme defines that radius (e.g. an @theme override, as the upstream
@@ -760,22 +765,22 @@ module Handler = struct
 
   let err_not_utility = Error (`Msg "Not a border utility")
 
-  (* Parse a rounded position token (the side/corner segment of a class). *)
-  let rounded_position_of_string = function
-    | "s" -> Some Rp_s
-    | "e" -> Some Rp_e
-    | "t" -> Some Rp_t
-    | "r" -> Some Rp_r
-    | "b" -> Some Rp_b
-    | "l" -> Some Rp_l
-    | "ss" -> Some Rp_ss
-    | "se" -> Some Rp_se
-    | "ee" -> Some Rp_ee
-    | "es" -> Some Rp_es
-    | "tl" -> Some Rp_tl
-    | "tr" -> Some Rp_tr
-    | "br" -> Some Rp_br
-    | "bl" -> Some Rp_bl
+  (* Parse the side/corner segment of a class into the corners it rounds. *)
+  let corner_of_string = function
+    | "s" -> Some Corner.Start
+    | "e" -> Some Corner.End
+    | "t" -> Some Corner.Top
+    | "r" -> Some Corner.Right
+    | "b" -> Some Corner.Bottom
+    | "l" -> Some Corner.Left
+    | "ss" -> Some Corner.Start_start
+    | "se" -> Some Corner.Start_end
+    | "ee" -> Some Corner.End_end
+    | "es" -> Some Corner.End_start
+    | "tl" -> Some Corner.Top_left
+    | "tr" -> Some Corner.Top_right
+    | "br" -> Some Corner.Bottom_right
+    | "bl" -> Some Corner.Bottom_left
     | _ -> None
 
   (* Parse a rounded size token (the t-shirt segment of a class). *)
@@ -802,21 +807,21 @@ module Handler = struct
            right, then bottom. Values within a group share a suborder and
            tie-break by class name. *)
         match pos with
-        | Rp_all -> 0
-        | Rp_s -> 10
-        | Rp_ss -> 20
-        | Rp_e -> 30
-        | Rp_se -> 40
-        | Rp_ee -> 50
-        | Rp_es -> 60
-        | Rp_t -> 100
-        | Rp_l -> 110
-        | Rp_tl -> 120
-        | Rp_r -> 130
-        | Rp_tr -> 140
-        | Rp_b -> 150
-        | Rp_br -> 160
-        | Rp_bl -> 170)
+        | Corner.All -> 0
+        | Corner.Start -> 10
+        | Corner.Start_start -> 20
+        | Corner.End -> 30
+        | Corner.Start_end -> 40
+        | Corner.End_end -> 50
+        | Corner.End_start -> 60
+        | Corner.Top -> 100
+        | Corner.Left -> 110
+        | Corner.Top_left -> 120
+        | Corner.Right -> 130
+        | Corner.Top_right -> 140
+        | Corner.Bottom -> 150
+        | Corner.Bottom_right -> 160
+        | Corner.Bottom_left -> 170)
     (* Border width utilities (1000-1099) *)
     | Border -> 1000
     | Border_0 -> 1001
@@ -991,26 +996,26 @@ module Handler = struct
     (* Border radius utilities (parametric). [rounded] / [rounded-<size>] target
        all corners; [rounded-<pos>] / [rounded-<pos>-<size>] target a side or
        corner. Sizes and positions are disjoint token sets. *)
-    | [ "rounded" ] -> Ok (Rounded (Rp_all, Rsz_default))
+    | [ "rounded" ] -> Ok (Rounded (Corner.All, Rsz_default))
     | [ "rounded"; v ] when Parse.is_bracket_value v -> (
         let inner = Parse.bracket_inner v in
         match parse_length inner with
-        | Some len -> Ok (Rounded (Rp_all, Rsz_arbitrary (inner, len)))
+        | Some len -> Ok (Rounded (Corner.All, Rsz_arbitrary (inner, len)))
         | None -> err_not_utility)
     | [ "rounded"; tok ] -> (
         match rounded_size_of_string tok with
-        | Some size -> Ok (Rounded (Rp_all, size))
+        | Some size -> Ok (Rounded (Corner.All, size))
         | None -> (
-            match rounded_position_of_string tok with
+            match corner_of_string tok with
             | Some pos -> Ok (Rounded (pos, Rsz_default))
             | None -> err_not_utility))
     | [ "rounded"; pos; v ] when Parse.is_bracket_value v -> (
         let inner = Parse.bracket_inner v in
-        match (rounded_position_of_string pos, parse_length inner) with
+        match (corner_of_string pos, parse_length inner) with
         | Some pos, Some len -> Ok (Rounded (pos, Rsz_arbitrary (inner, len)))
         | _ -> err_not_utility)
     | [ "rounded"; pos; size ] -> (
-        match (rounded_position_of_string pos, rounded_size_of_string size) with
+        match (corner_of_string pos, rounded_size_of_string size) with
         | Some pos, Some size -> Ok (Rounded (pos, size))
         | _ -> err_not_utility)
     | [ "outline" ] -> Ok Outline
@@ -1128,21 +1133,21 @@ module Handler = struct
     | Rounded (pos, size) ->
         let pos_str =
           match pos with
-          | Rp_all -> ""
-          | Rp_s -> "-s"
-          | Rp_e -> "-e"
-          | Rp_t -> "-t"
-          | Rp_r -> "-r"
-          | Rp_b -> "-b"
-          | Rp_l -> "-l"
-          | Rp_ss -> "-ss"
-          | Rp_se -> "-se"
-          | Rp_ee -> "-ee"
-          | Rp_es -> "-es"
-          | Rp_tl -> "-tl"
-          | Rp_tr -> "-tr"
-          | Rp_br -> "-br"
-          | Rp_bl -> "-bl"
+          | Corner.All -> ""
+          | Corner.Start -> "-s"
+          | Corner.End -> "-e"
+          | Corner.Top -> "-t"
+          | Corner.Right -> "-r"
+          | Corner.Bottom -> "-b"
+          | Corner.Left -> "-l"
+          | Corner.Start_start -> "-ss"
+          | Corner.Start_end -> "-se"
+          | Corner.End_end -> "-ee"
+          | Corner.End_start -> "-es"
+          | Corner.Top_left -> "-tl"
+          | Corner.Top_right -> "-tr"
+          | Corner.Bottom_right -> "-br"
+          | Corner.Bottom_left -> "-bl"
         in
         let size_str =
           match size with
@@ -1291,213 +1296,213 @@ let border_full = border_8 (* 8px *)
 
 (** {1 Border Radius Utilities} *)
 
-let rounded = utility (Rounded (Rp_all, Rsz_default))
-let rounded_none = utility (Rounded (Rp_all, Rsz_none))
-let rounded_xs = utility (Rounded (Rp_all, Rsz_xs))
-let rounded_sm = utility (Rounded (Rp_all, Rsz_sm))
-let rounded_md = utility (Rounded (Rp_all, Rsz_md))
-let rounded_lg = utility (Rounded (Rp_all, Rsz_lg))
-let rounded_xl = utility (Rounded (Rp_all, Rsz_xl))
-let rounded_2xl = utility (Rounded (Rp_all, Rsz_2xl))
-let rounded_3xl = utility (Rounded (Rp_all, Rsz_3xl))
-let rounded_4xl = utility (Rounded (Rp_all, Rsz_4xl))
-let rounded_full = utility (Rounded (Rp_all, Rsz_full))
+let rounded = utility (Rounded (Corner.All, Rsz_default))
+let rounded_none = utility (Rounded (Corner.All, Rsz_none))
+let rounded_xs = utility (Rounded (Corner.All, Rsz_xs))
+let rounded_sm = utility (Rounded (Corner.All, Rsz_sm))
+let rounded_md = utility (Rounded (Corner.All, Rsz_md))
+let rounded_lg = utility (Rounded (Corner.All, Rsz_lg))
+let rounded_xl = utility (Rounded (Corner.All, Rsz_xl))
+let rounded_2xl = utility (Rounded (Corner.All, Rsz_2xl))
+let rounded_3xl = utility (Rounded (Corner.All, Rsz_3xl))
+let rounded_4xl = utility (Rounded (Corner.All, Rsz_4xl))
+let rounded_full = utility (Rounded (Corner.All, Rsz_full))
 
 (** {2 Side-specific rounded utilities - top} *)
 
-let rounded_t = utility (Rounded (Rp_t, Rsz_default))
-let rounded_t_none = utility (Rounded (Rp_t, Rsz_none))
-let rounded_t_xs = utility (Rounded (Rp_t, Rsz_xs))
-let rounded_t_sm = utility (Rounded (Rp_t, Rsz_sm))
-let rounded_t_md = utility (Rounded (Rp_t, Rsz_md))
-let rounded_t_lg = utility (Rounded (Rp_t, Rsz_lg))
-let rounded_t_xl = utility (Rounded (Rp_t, Rsz_xl))
-let rounded_t_2xl = utility (Rounded (Rp_t, Rsz_2xl))
-let rounded_t_3xl = utility (Rounded (Rp_t, Rsz_3xl))
-let rounded_t_4xl = utility (Rounded (Rp_t, Rsz_4xl))
-let rounded_t_full = utility (Rounded (Rp_t, Rsz_full))
+let rounded_t = utility (Rounded (Corner.Top, Rsz_default))
+let rounded_t_none = utility (Rounded (Corner.Top, Rsz_none))
+let rounded_t_xs = utility (Rounded (Corner.Top, Rsz_xs))
+let rounded_t_sm = utility (Rounded (Corner.Top, Rsz_sm))
+let rounded_t_md = utility (Rounded (Corner.Top, Rsz_md))
+let rounded_t_lg = utility (Rounded (Corner.Top, Rsz_lg))
+let rounded_t_xl = utility (Rounded (Corner.Top, Rsz_xl))
+let rounded_t_2xl = utility (Rounded (Corner.Top, Rsz_2xl))
+let rounded_t_3xl = utility (Rounded (Corner.Top, Rsz_3xl))
+let rounded_t_4xl = utility (Rounded (Corner.Top, Rsz_4xl))
+let rounded_t_full = utility (Rounded (Corner.Top, Rsz_full))
 
 (** {2 Side-specific rounded utilities - right} *)
 
-let rounded_r = utility (Rounded (Rp_r, Rsz_default))
-let rounded_r_none = utility (Rounded (Rp_r, Rsz_none))
-let rounded_r_xs = utility (Rounded (Rp_r, Rsz_xs))
-let rounded_r_sm = utility (Rounded (Rp_r, Rsz_sm))
-let rounded_r_md = utility (Rounded (Rp_r, Rsz_md))
-let rounded_r_lg = utility (Rounded (Rp_r, Rsz_lg))
-let rounded_r_xl = utility (Rounded (Rp_r, Rsz_xl))
-let rounded_r_2xl = utility (Rounded (Rp_r, Rsz_2xl))
-let rounded_r_3xl = utility (Rounded (Rp_r, Rsz_3xl))
-let rounded_r_4xl = utility (Rounded (Rp_r, Rsz_4xl))
-let rounded_r_full = utility (Rounded (Rp_r, Rsz_full))
+let rounded_r = utility (Rounded (Corner.Right, Rsz_default))
+let rounded_r_none = utility (Rounded (Corner.Right, Rsz_none))
+let rounded_r_xs = utility (Rounded (Corner.Right, Rsz_xs))
+let rounded_r_sm = utility (Rounded (Corner.Right, Rsz_sm))
+let rounded_r_md = utility (Rounded (Corner.Right, Rsz_md))
+let rounded_r_lg = utility (Rounded (Corner.Right, Rsz_lg))
+let rounded_r_xl = utility (Rounded (Corner.Right, Rsz_xl))
+let rounded_r_2xl = utility (Rounded (Corner.Right, Rsz_2xl))
+let rounded_r_3xl = utility (Rounded (Corner.Right, Rsz_3xl))
+let rounded_r_4xl = utility (Rounded (Corner.Right, Rsz_4xl))
+let rounded_r_full = utility (Rounded (Corner.Right, Rsz_full))
 
 (** {2 Side-specific rounded utilities - bottom} *)
 
-let rounded_b = utility (Rounded (Rp_b, Rsz_default))
-let rounded_b_none = utility (Rounded (Rp_b, Rsz_none))
-let rounded_b_xs = utility (Rounded (Rp_b, Rsz_xs))
-let rounded_b_sm = utility (Rounded (Rp_b, Rsz_sm))
-let rounded_b_md = utility (Rounded (Rp_b, Rsz_md))
-let rounded_b_lg = utility (Rounded (Rp_b, Rsz_lg))
-let rounded_b_xl = utility (Rounded (Rp_b, Rsz_xl))
-let rounded_b_2xl = utility (Rounded (Rp_b, Rsz_2xl))
-let rounded_b_3xl = utility (Rounded (Rp_b, Rsz_3xl))
-let rounded_b_4xl = utility (Rounded (Rp_b, Rsz_4xl))
-let rounded_b_full = utility (Rounded (Rp_b, Rsz_full))
+let rounded_b = utility (Rounded (Corner.Bottom, Rsz_default))
+let rounded_b_none = utility (Rounded (Corner.Bottom, Rsz_none))
+let rounded_b_xs = utility (Rounded (Corner.Bottom, Rsz_xs))
+let rounded_b_sm = utility (Rounded (Corner.Bottom, Rsz_sm))
+let rounded_b_md = utility (Rounded (Corner.Bottom, Rsz_md))
+let rounded_b_lg = utility (Rounded (Corner.Bottom, Rsz_lg))
+let rounded_b_xl = utility (Rounded (Corner.Bottom, Rsz_xl))
+let rounded_b_2xl = utility (Rounded (Corner.Bottom, Rsz_2xl))
+let rounded_b_3xl = utility (Rounded (Corner.Bottom, Rsz_3xl))
+let rounded_b_4xl = utility (Rounded (Corner.Bottom, Rsz_4xl))
+let rounded_b_full = utility (Rounded (Corner.Bottom, Rsz_full))
 
 (** {2 Side-specific rounded utilities - left} *)
 
-let rounded_l = utility (Rounded (Rp_l, Rsz_default))
-let rounded_l_none = utility (Rounded (Rp_l, Rsz_none))
-let rounded_l_xs = utility (Rounded (Rp_l, Rsz_xs))
-let rounded_l_sm = utility (Rounded (Rp_l, Rsz_sm))
-let rounded_l_md = utility (Rounded (Rp_l, Rsz_md))
-let rounded_l_lg = utility (Rounded (Rp_l, Rsz_lg))
-let rounded_l_xl = utility (Rounded (Rp_l, Rsz_xl))
-let rounded_l_2xl = utility (Rounded (Rp_l, Rsz_2xl))
-let rounded_l_3xl = utility (Rounded (Rp_l, Rsz_3xl))
-let rounded_l_4xl = utility (Rounded (Rp_l, Rsz_4xl))
-let rounded_l_full = utility (Rounded (Rp_l, Rsz_full))
+let rounded_l = utility (Rounded (Corner.Left, Rsz_default))
+let rounded_l_none = utility (Rounded (Corner.Left, Rsz_none))
+let rounded_l_xs = utility (Rounded (Corner.Left, Rsz_xs))
+let rounded_l_sm = utility (Rounded (Corner.Left, Rsz_sm))
+let rounded_l_md = utility (Rounded (Corner.Left, Rsz_md))
+let rounded_l_lg = utility (Rounded (Corner.Left, Rsz_lg))
+let rounded_l_xl = utility (Rounded (Corner.Left, Rsz_xl))
+let rounded_l_2xl = utility (Rounded (Corner.Left, Rsz_2xl))
+let rounded_l_3xl = utility (Rounded (Corner.Left, Rsz_3xl))
+let rounded_l_4xl = utility (Rounded (Corner.Left, Rsz_4xl))
+let rounded_l_full = utility (Rounded (Corner.Left, Rsz_full))
 
 (** {2 Corner-specific rounded utilities - top-left} *)
 
-let rounded_tl = utility (Rounded (Rp_tl, Rsz_default))
-let rounded_tl_none = utility (Rounded (Rp_tl, Rsz_none))
-let rounded_tl_xs = utility (Rounded (Rp_tl, Rsz_xs))
-let rounded_tl_sm = utility (Rounded (Rp_tl, Rsz_sm))
-let rounded_tl_md = utility (Rounded (Rp_tl, Rsz_md))
-let rounded_tl_lg = utility (Rounded (Rp_tl, Rsz_lg))
-let rounded_tl_xl = utility (Rounded (Rp_tl, Rsz_xl))
-let rounded_tl_2xl = utility (Rounded (Rp_tl, Rsz_2xl))
-let rounded_tl_3xl = utility (Rounded (Rp_tl, Rsz_3xl))
-let rounded_tl_4xl = utility (Rounded (Rp_tl, Rsz_4xl))
-let rounded_tl_full = utility (Rounded (Rp_tl, Rsz_full))
+let rounded_tl = utility (Rounded (Corner.Top_left, Rsz_default))
+let rounded_tl_none = utility (Rounded (Corner.Top_left, Rsz_none))
+let rounded_tl_xs = utility (Rounded (Corner.Top_left, Rsz_xs))
+let rounded_tl_sm = utility (Rounded (Corner.Top_left, Rsz_sm))
+let rounded_tl_md = utility (Rounded (Corner.Top_left, Rsz_md))
+let rounded_tl_lg = utility (Rounded (Corner.Top_left, Rsz_lg))
+let rounded_tl_xl = utility (Rounded (Corner.Top_left, Rsz_xl))
+let rounded_tl_2xl = utility (Rounded (Corner.Top_left, Rsz_2xl))
+let rounded_tl_3xl = utility (Rounded (Corner.Top_left, Rsz_3xl))
+let rounded_tl_4xl = utility (Rounded (Corner.Top_left, Rsz_4xl))
+let rounded_tl_full = utility (Rounded (Corner.Top_left, Rsz_full))
 
 (** {2 Corner-specific rounded utilities - top-right} *)
 
-let rounded_tr = utility (Rounded (Rp_tr, Rsz_default))
-let rounded_tr_none = utility (Rounded (Rp_tr, Rsz_none))
-let rounded_tr_xs = utility (Rounded (Rp_tr, Rsz_xs))
-let rounded_tr_sm = utility (Rounded (Rp_tr, Rsz_sm))
-let rounded_tr_md = utility (Rounded (Rp_tr, Rsz_md))
-let rounded_tr_lg = utility (Rounded (Rp_tr, Rsz_lg))
-let rounded_tr_xl = utility (Rounded (Rp_tr, Rsz_xl))
-let rounded_tr_2xl = utility (Rounded (Rp_tr, Rsz_2xl))
-let rounded_tr_3xl = utility (Rounded (Rp_tr, Rsz_3xl))
-let rounded_tr_4xl = utility (Rounded (Rp_tr, Rsz_4xl))
-let rounded_tr_full = utility (Rounded (Rp_tr, Rsz_full))
+let rounded_tr = utility (Rounded (Corner.Top_right, Rsz_default))
+let rounded_tr_none = utility (Rounded (Corner.Top_right, Rsz_none))
+let rounded_tr_xs = utility (Rounded (Corner.Top_right, Rsz_xs))
+let rounded_tr_sm = utility (Rounded (Corner.Top_right, Rsz_sm))
+let rounded_tr_md = utility (Rounded (Corner.Top_right, Rsz_md))
+let rounded_tr_lg = utility (Rounded (Corner.Top_right, Rsz_lg))
+let rounded_tr_xl = utility (Rounded (Corner.Top_right, Rsz_xl))
+let rounded_tr_2xl = utility (Rounded (Corner.Top_right, Rsz_2xl))
+let rounded_tr_3xl = utility (Rounded (Corner.Top_right, Rsz_3xl))
+let rounded_tr_4xl = utility (Rounded (Corner.Top_right, Rsz_4xl))
+let rounded_tr_full = utility (Rounded (Corner.Top_right, Rsz_full))
 
 (** {2 Corner-specific rounded utilities - bottom-right} *)
 
-let rounded_br = utility (Rounded (Rp_br, Rsz_default))
-let rounded_br_none = utility (Rounded (Rp_br, Rsz_none))
-let rounded_br_xs = utility (Rounded (Rp_br, Rsz_xs))
-let rounded_br_sm = utility (Rounded (Rp_br, Rsz_sm))
-let rounded_br_md = utility (Rounded (Rp_br, Rsz_md))
-let rounded_br_lg = utility (Rounded (Rp_br, Rsz_lg))
-let rounded_br_xl = utility (Rounded (Rp_br, Rsz_xl))
-let rounded_br_2xl = utility (Rounded (Rp_br, Rsz_2xl))
-let rounded_br_3xl = utility (Rounded (Rp_br, Rsz_3xl))
-let rounded_br_4xl = utility (Rounded (Rp_br, Rsz_4xl))
-let rounded_br_full = utility (Rounded (Rp_br, Rsz_full))
+let rounded_br = utility (Rounded (Corner.Bottom_right, Rsz_default))
+let rounded_br_none = utility (Rounded (Corner.Bottom_right, Rsz_none))
+let rounded_br_xs = utility (Rounded (Corner.Bottom_right, Rsz_xs))
+let rounded_br_sm = utility (Rounded (Corner.Bottom_right, Rsz_sm))
+let rounded_br_md = utility (Rounded (Corner.Bottom_right, Rsz_md))
+let rounded_br_lg = utility (Rounded (Corner.Bottom_right, Rsz_lg))
+let rounded_br_xl = utility (Rounded (Corner.Bottom_right, Rsz_xl))
+let rounded_br_2xl = utility (Rounded (Corner.Bottom_right, Rsz_2xl))
+let rounded_br_3xl = utility (Rounded (Corner.Bottom_right, Rsz_3xl))
+let rounded_br_4xl = utility (Rounded (Corner.Bottom_right, Rsz_4xl))
+let rounded_br_full = utility (Rounded (Corner.Bottom_right, Rsz_full))
 
 (** {2 Corner-specific rounded utilities - bottom-left} *)
 
-let rounded_bl = utility (Rounded (Rp_bl, Rsz_default))
-let rounded_bl_none = utility (Rounded (Rp_bl, Rsz_none))
-let rounded_bl_xs = utility (Rounded (Rp_bl, Rsz_xs))
-let rounded_bl_sm = utility (Rounded (Rp_bl, Rsz_sm))
-let rounded_bl_md = utility (Rounded (Rp_bl, Rsz_md))
-let rounded_bl_lg = utility (Rounded (Rp_bl, Rsz_lg))
-let rounded_bl_xl = utility (Rounded (Rp_bl, Rsz_xl))
-let rounded_bl_2xl = utility (Rounded (Rp_bl, Rsz_2xl))
-let rounded_bl_3xl = utility (Rounded (Rp_bl, Rsz_3xl))
-let rounded_bl_4xl = utility (Rounded (Rp_bl, Rsz_4xl))
-let rounded_bl_full = utility (Rounded (Rp_bl, Rsz_full))
+let rounded_bl = utility (Rounded (Corner.Bottom_left, Rsz_default))
+let rounded_bl_none = utility (Rounded (Corner.Bottom_left, Rsz_none))
+let rounded_bl_xs = utility (Rounded (Corner.Bottom_left, Rsz_xs))
+let rounded_bl_sm = utility (Rounded (Corner.Bottom_left, Rsz_sm))
+let rounded_bl_md = utility (Rounded (Corner.Bottom_left, Rsz_md))
+let rounded_bl_lg = utility (Rounded (Corner.Bottom_left, Rsz_lg))
+let rounded_bl_xl = utility (Rounded (Corner.Bottom_left, Rsz_xl))
+let rounded_bl_2xl = utility (Rounded (Corner.Bottom_left, Rsz_2xl))
+let rounded_bl_3xl = utility (Rounded (Corner.Bottom_left, Rsz_3xl))
+let rounded_bl_4xl = utility (Rounded (Corner.Bottom_left, Rsz_4xl))
+let rounded_bl_full = utility (Rounded (Corner.Bottom_left, Rsz_full))
 
 (** {2 Logical property rounded utilities - start} *)
 
-let rounded_s = utility (Rounded (Rp_s, Rsz_default))
-let rounded_s_none = utility (Rounded (Rp_s, Rsz_none))
-let rounded_s_xs = utility (Rounded (Rp_s, Rsz_xs))
-let rounded_s_sm = utility (Rounded (Rp_s, Rsz_sm))
-let rounded_s_md = utility (Rounded (Rp_s, Rsz_md))
-let rounded_s_lg = utility (Rounded (Rp_s, Rsz_lg))
-let rounded_s_xl = utility (Rounded (Rp_s, Rsz_xl))
-let rounded_s_2xl = utility (Rounded (Rp_s, Rsz_2xl))
-let rounded_s_3xl = utility (Rounded (Rp_s, Rsz_3xl))
-let rounded_s_4xl = utility (Rounded (Rp_s, Rsz_4xl))
-let rounded_s_full = utility (Rounded (Rp_s, Rsz_full))
+let rounded_s = utility (Rounded (Corner.Start, Rsz_default))
+let rounded_s_none = utility (Rounded (Corner.Start, Rsz_none))
+let rounded_s_xs = utility (Rounded (Corner.Start, Rsz_xs))
+let rounded_s_sm = utility (Rounded (Corner.Start, Rsz_sm))
+let rounded_s_md = utility (Rounded (Corner.Start, Rsz_md))
+let rounded_s_lg = utility (Rounded (Corner.Start, Rsz_lg))
+let rounded_s_xl = utility (Rounded (Corner.Start, Rsz_xl))
+let rounded_s_2xl = utility (Rounded (Corner.Start, Rsz_2xl))
+let rounded_s_3xl = utility (Rounded (Corner.Start, Rsz_3xl))
+let rounded_s_4xl = utility (Rounded (Corner.Start, Rsz_4xl))
+let rounded_s_full = utility (Rounded (Corner.Start, Rsz_full))
 
 (** {2 Logical property rounded utilities - end} *)
 
-let rounded_e = utility (Rounded (Rp_e, Rsz_default))
-let rounded_e_none = utility (Rounded (Rp_e, Rsz_none))
-let rounded_e_xs = utility (Rounded (Rp_e, Rsz_xs))
-let rounded_e_sm = utility (Rounded (Rp_e, Rsz_sm))
-let rounded_e_md = utility (Rounded (Rp_e, Rsz_md))
-let rounded_e_lg = utility (Rounded (Rp_e, Rsz_lg))
-let rounded_e_xl = utility (Rounded (Rp_e, Rsz_xl))
-let rounded_e_2xl = utility (Rounded (Rp_e, Rsz_2xl))
-let rounded_e_3xl = utility (Rounded (Rp_e, Rsz_3xl))
-let rounded_e_4xl = utility (Rounded (Rp_e, Rsz_4xl))
-let rounded_e_full = utility (Rounded (Rp_e, Rsz_full))
+let rounded_e = utility (Rounded (Corner.End, Rsz_default))
+let rounded_e_none = utility (Rounded (Corner.End, Rsz_none))
+let rounded_e_xs = utility (Rounded (Corner.End, Rsz_xs))
+let rounded_e_sm = utility (Rounded (Corner.End, Rsz_sm))
+let rounded_e_md = utility (Rounded (Corner.End, Rsz_md))
+let rounded_e_lg = utility (Rounded (Corner.End, Rsz_lg))
+let rounded_e_xl = utility (Rounded (Corner.End, Rsz_xl))
+let rounded_e_2xl = utility (Rounded (Corner.End, Rsz_2xl))
+let rounded_e_3xl = utility (Rounded (Corner.End, Rsz_3xl))
+let rounded_e_4xl = utility (Rounded (Corner.End, Rsz_4xl))
+let rounded_e_full = utility (Rounded (Corner.End, Rsz_full))
 
 (** {2 Logical corner rounded utilities - start-start} *)
 
-let rounded_ss = utility (Rounded (Rp_ss, Rsz_default))
-let rounded_ss_none = utility (Rounded (Rp_ss, Rsz_none))
-let rounded_ss_xs = utility (Rounded (Rp_ss, Rsz_xs))
-let rounded_ss_sm = utility (Rounded (Rp_ss, Rsz_sm))
-let rounded_ss_md = utility (Rounded (Rp_ss, Rsz_md))
-let rounded_ss_lg = utility (Rounded (Rp_ss, Rsz_lg))
-let rounded_ss_xl = utility (Rounded (Rp_ss, Rsz_xl))
-let rounded_ss_2xl = utility (Rounded (Rp_ss, Rsz_2xl))
-let rounded_ss_3xl = utility (Rounded (Rp_ss, Rsz_3xl))
-let rounded_ss_4xl = utility (Rounded (Rp_ss, Rsz_4xl))
-let rounded_ss_full = utility (Rounded (Rp_ss, Rsz_full))
+let rounded_ss = utility (Rounded (Corner.Start_start, Rsz_default))
+let rounded_ss_none = utility (Rounded (Corner.Start_start, Rsz_none))
+let rounded_ss_xs = utility (Rounded (Corner.Start_start, Rsz_xs))
+let rounded_ss_sm = utility (Rounded (Corner.Start_start, Rsz_sm))
+let rounded_ss_md = utility (Rounded (Corner.Start_start, Rsz_md))
+let rounded_ss_lg = utility (Rounded (Corner.Start_start, Rsz_lg))
+let rounded_ss_xl = utility (Rounded (Corner.Start_start, Rsz_xl))
+let rounded_ss_2xl = utility (Rounded (Corner.Start_start, Rsz_2xl))
+let rounded_ss_3xl = utility (Rounded (Corner.Start_start, Rsz_3xl))
+let rounded_ss_4xl = utility (Rounded (Corner.Start_start, Rsz_4xl))
+let rounded_ss_full = utility (Rounded (Corner.Start_start, Rsz_full))
 
 (** {2 Logical corner rounded utilities - start-end} *)
 
-let rounded_se = utility (Rounded (Rp_se, Rsz_default))
-let rounded_se_none = utility (Rounded (Rp_se, Rsz_none))
-let rounded_se_xs = utility (Rounded (Rp_se, Rsz_xs))
-let rounded_se_sm = utility (Rounded (Rp_se, Rsz_sm))
-let rounded_se_md = utility (Rounded (Rp_se, Rsz_md))
-let rounded_se_lg = utility (Rounded (Rp_se, Rsz_lg))
-let rounded_se_xl = utility (Rounded (Rp_se, Rsz_xl))
-let rounded_se_2xl = utility (Rounded (Rp_se, Rsz_2xl))
-let rounded_se_3xl = utility (Rounded (Rp_se, Rsz_3xl))
-let rounded_se_4xl = utility (Rounded (Rp_se, Rsz_4xl))
-let rounded_se_full = utility (Rounded (Rp_se, Rsz_full))
+let rounded_se = utility (Rounded (Corner.Start_end, Rsz_default))
+let rounded_se_none = utility (Rounded (Corner.Start_end, Rsz_none))
+let rounded_se_xs = utility (Rounded (Corner.Start_end, Rsz_xs))
+let rounded_se_sm = utility (Rounded (Corner.Start_end, Rsz_sm))
+let rounded_se_md = utility (Rounded (Corner.Start_end, Rsz_md))
+let rounded_se_lg = utility (Rounded (Corner.Start_end, Rsz_lg))
+let rounded_se_xl = utility (Rounded (Corner.Start_end, Rsz_xl))
+let rounded_se_2xl = utility (Rounded (Corner.Start_end, Rsz_2xl))
+let rounded_se_3xl = utility (Rounded (Corner.Start_end, Rsz_3xl))
+let rounded_se_4xl = utility (Rounded (Corner.Start_end, Rsz_4xl))
+let rounded_se_full = utility (Rounded (Corner.Start_end, Rsz_full))
 
 (** {2 Logical corner rounded utilities - end-end} *)
 
-let rounded_ee = utility (Rounded (Rp_ee, Rsz_default))
-let rounded_ee_none = utility (Rounded (Rp_ee, Rsz_none))
-let rounded_ee_xs = utility (Rounded (Rp_ee, Rsz_xs))
-let rounded_ee_sm = utility (Rounded (Rp_ee, Rsz_sm))
-let rounded_ee_md = utility (Rounded (Rp_ee, Rsz_md))
-let rounded_ee_lg = utility (Rounded (Rp_ee, Rsz_lg))
-let rounded_ee_xl = utility (Rounded (Rp_ee, Rsz_xl))
-let rounded_ee_2xl = utility (Rounded (Rp_ee, Rsz_2xl))
-let rounded_ee_3xl = utility (Rounded (Rp_ee, Rsz_3xl))
-let rounded_ee_4xl = utility (Rounded (Rp_ee, Rsz_4xl))
-let rounded_ee_full = utility (Rounded (Rp_ee, Rsz_full))
+let rounded_ee = utility (Rounded (Corner.End_end, Rsz_default))
+let rounded_ee_none = utility (Rounded (Corner.End_end, Rsz_none))
+let rounded_ee_xs = utility (Rounded (Corner.End_end, Rsz_xs))
+let rounded_ee_sm = utility (Rounded (Corner.End_end, Rsz_sm))
+let rounded_ee_md = utility (Rounded (Corner.End_end, Rsz_md))
+let rounded_ee_lg = utility (Rounded (Corner.End_end, Rsz_lg))
+let rounded_ee_xl = utility (Rounded (Corner.End_end, Rsz_xl))
+let rounded_ee_2xl = utility (Rounded (Corner.End_end, Rsz_2xl))
+let rounded_ee_3xl = utility (Rounded (Corner.End_end, Rsz_3xl))
+let rounded_ee_4xl = utility (Rounded (Corner.End_end, Rsz_4xl))
+let rounded_ee_full = utility (Rounded (Corner.End_end, Rsz_full))
 
 (** {2 Logical corner rounded utilities - end-start} *)
 
-let rounded_es = utility (Rounded (Rp_es, Rsz_default))
-let rounded_es_none = utility (Rounded (Rp_es, Rsz_none))
-let rounded_es_xs = utility (Rounded (Rp_es, Rsz_xs))
-let rounded_es_sm = utility (Rounded (Rp_es, Rsz_sm))
-let rounded_es_md = utility (Rounded (Rp_es, Rsz_md))
-let rounded_es_lg = utility (Rounded (Rp_es, Rsz_lg))
-let rounded_es_xl = utility (Rounded (Rp_es, Rsz_xl))
-let rounded_es_2xl = utility (Rounded (Rp_es, Rsz_2xl))
-let rounded_es_3xl = utility (Rounded (Rp_es, Rsz_3xl))
-let rounded_es_4xl = utility (Rounded (Rp_es, Rsz_4xl))
-let rounded_es_full = utility (Rounded (Rp_es, Rsz_full))
+let rounded_es = utility (Rounded (Corner.End_start, Rsz_default))
+let rounded_es_none = utility (Rounded (Corner.End_start, Rsz_none))
+let rounded_es_xs = utility (Rounded (Corner.End_start, Rsz_xs))
+let rounded_es_sm = utility (Rounded (Corner.End_start, Rsz_sm))
+let rounded_es_md = utility (Rounded (Corner.End_start, Rsz_md))
+let rounded_es_lg = utility (Rounded (Corner.End_start, Rsz_lg))
+let rounded_es_xl = utility (Rounded (Corner.End_start, Rsz_xl))
+let rounded_es_2xl = utility (Rounded (Corner.End_start, Rsz_2xl))
+let rounded_es_3xl = utility (Rounded (Corner.End_start, Rsz_3xl))
+let rounded_es_4xl = utility (Rounded (Corner.End_start, Rsz_4xl))
+let rounded_es_full = utility (Rounded (Corner.End_start, Rsz_full))
 
 (** {1 Outline Utilities} *)
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1672,31 +1672,33 @@ let shade_and_opacity_of_strings ?theme = function
 (** {1 Parsing Functions} *)
 
 module Handler = struct
-  (* Per-side border colour: which physical border edge a border-{side}-{color}
-     utility paints. Bs_x is the logical inline axis (border-inline-color) and
-     Bs_y the block axis (border-block-color); Bs_s / Bs_e are the inline start
-     / end edges and Bs_bs / Bs_be the block start / end edges
+  (* Which border edge a border-{side}-{color} utility paints: a physical edge,
+     a logical axis (border-{inline,block}-color) or a logical edge
      (border-{inline,block}-{start,end}-color). *)
-  type border_side =
-    | Bs_t
-    | Bs_r
-    | Bs_b
-    | Bs_l
-    | Bs_x
-    | Bs_y
-    | Bs_s
-    | Bs_e
-    | Bs_bs
-    | Bs_be
+  module Side = struct
+    type t =
+      | Top
+      | Right
+      | Bottom
+      | Left
+      | Inline_axis
+      | Block_axis
+      | Inline_start
+      | Inline_end
+      | Block_start
+      | Block_end
+  end
 
   (* The colour value of a border-{side}-{color}: a named theme colour, an
      arbitrary bracket colour, or a keyword. *)
-  type border_side_color =
-    | Bsc_named of color * int
-    | Bsc_named_opacity of color * int * opacity_modifier
-    | Bsc_bracket of string * Css.color
-    | Bsc_transparent
-    | Bsc_current
+  module Side_color = struct
+    type t =
+      | Named of color * int
+      | Named_opacity of color * int * opacity_modifier
+      | Bracket of string * Css.color
+      | Transparent
+      | Current
+  end
 
   (** Local color utility type *)
   type t =
@@ -1728,7 +1730,7 @@ module Handler = struct
     | Border_current_opacity of opacity_modifier
     | Border_bracket_color of string * Css.color
     | Border_bracket_color_opacity of string * Css.color * opacity_modifier
-    | Border_side_color of border_side * border_side_color
+    | Border_side_color of Side.t * Side_color.t
     (* Accent colors *)
     | Accent of color * int
     | Accent_opacity of color * int * opacity_modifier
@@ -2132,39 +2134,41 @@ module Handler = struct
            | _ -> false -> (
         let bs =
           match side with
-          | "t" -> Bs_t
-          | "r" -> Bs_r
-          | "b" -> Bs_b
-          | "x" -> Bs_x
-          | "y" -> Bs_y
-          | "s" -> Bs_s
-          | "e" -> Bs_e
-          | "bs" -> Bs_bs
-          | "be" -> Bs_be
-          | _ -> Bs_l
+          | "t" -> Side.Top
+          | "r" -> Side.Right
+          | "b" -> Side.Bottom
+          | "x" -> Side.Inline_axis
+          | "y" -> Side.Block_axis
+          | "s" -> Side.Inline_start
+          | "e" -> Side.Inline_end
+          | "bs" -> Side.Block_start
+          | "be" -> Side.Block_end
+          | _ -> Side.Left
         in
         match rest with
-        | [ "transparent" ] -> Ok (Border_side_color (bs, Bsc_transparent))
-        | [ "current" ] -> Ok (Border_side_color (bs, Bsc_current))
+        | [ "transparent" ] ->
+            Ok (Border_side_color (bs, Side_color.Transparent))
+        | [ "current" ] -> Ok (Border_side_color (bs, Side_color.Current))
         | [ v ]
           when String.length v > 0 && v.[0] = '[' && Parse.is_bracket_value v
           -> (
             let inner = Parse.bracket_inner v in
             match parse_bracket_color inner with
             | Some css_color ->
-                Ok (Border_side_color (bs, Bsc_bracket (inner, css_color)))
+                Ok
+                  (Border_side_color (bs, Side_color.Bracket (inner, css_color)))
             | None -> Error (`Msg ("Invalid border side bracket: " ^ v)))
         | color_parts when List.exists has_opacity color_parts -> (
             match shade_and_opacity_of_strings ~theme color_parts with
             | Ok (color, shade, opacity) ->
                 Ok
                   (Border_side_color
-                     (bs, Bsc_named_opacity (color, shade, opacity)))
+                     (bs, Side_color.Named_opacity (color, shade, opacity)))
             | Error e -> Error e)
         | color_parts -> (
             match shade_of_strings color_parts with
             | Ok (color, shade) ->
-                Ok (Border_side_color (bs, Bsc_named (color, shade)))
+                Ok (Border_side_color (bs, Side_color.Named (color, shade)))
             | Error e -> Error e))
     | "border" :: color_parts when List.exists has_opacity color_parts -> (
         match shade_and_opacity_of_strings ~theme color_parts with
@@ -2386,19 +2390,19 @@ module Handler = struct
   let border_current = style [ Css.border_color Current ]
 
   (* Per-side border colour emission. *)
-  let setters_of_side : border_side -> (Css.color -> Css.declaration) list =
-    function
-    | Bs_t -> [ Css.border_top_color ]
-    | Bs_r -> [ Css.border_right_color ]
-    | Bs_b -> [ Css.border_bottom_color ]
-    | Bs_l -> [ Css.border_left_color ]
-    | Bs_x ->
+  let setters_of_side : Side.t -> (Css.color -> Css.declaration) list = function
+    | Side.Top -> [ Css.border_top_color ]
+    | Side.Right -> [ Css.border_right_color ]
+    | Side.Bottom -> [ Css.border_bottom_color ]
+    | Side.Left -> [ Css.border_left_color ]
+    | Side.Inline_axis ->
         [ (fun c -> Css.border_inline_color (Css.logical_border_color c)) ]
-    | Bs_y -> [ (fun c -> Css.border_block_color (Css.logical_border_color c)) ]
-    | Bs_s -> [ Css.border_inline_start_color ]
-    | Bs_e -> [ Css.border_inline_end_color ]
-    | Bs_bs -> [ Css.border_block_start_color ]
-    | Bs_be -> [ Css.border_block_end_color ]
+    | Side.Block_axis ->
+        [ (fun c -> Css.border_block_color (Css.logical_border_color c)) ]
+    | Side.Inline_start -> [ Css.border_inline_start_color ]
+    | Side.Inline_end -> [ Css.border_inline_end_color ]
+    | Side.Block_start -> [ Css.border_block_start_color ]
+    | Side.Block_end -> [ Css.border_block_end_color ]
 
   (** Accent color utilities *)
 
@@ -2745,7 +2749,7 @@ module Handler = struct
     let sides = setters_of_side side in
     let apply c = style (List.map (fun set -> set c) sides) in
     match value with
-    | Bsc_named (color, shade) ->
+    | Side_color.Named (color, shade) ->
         if is_custom_color color then apply (to_css color shade)
         else
           let color_var = color_var color shade in
@@ -2753,11 +2757,11 @@ module Handler = struct
           let decl, color_ref = Var.binding color_var color_value in
           style
             (decl :: List.map (fun set -> set (Var color_ref : Css.color)) sides)
-    | Bsc_named_opacity (color, shade, opacity) ->
+    | Side_color.Named_opacity (color, shade, opacity) ->
         colors_with_opacity_style ~properties:sides color shade opacity
-    | Bsc_bracket (_, css_color) -> apply css_color
-    | Bsc_transparent -> apply (Css.hex "#0000")
-    | Bsc_current -> apply Current
+    | Side_color.Bracket (_, css_color) -> apply css_color
+    | Side_color.Transparent -> apply (Css.hex "#0000")
+    | Side_color.Current -> apply Css.Current
 
   (** Accent color with opacity *)
   let accent_with_opacity ?theme c shade opacity =
@@ -3247,29 +3251,29 @@ module Handler = struct
     | Border_side_color (side, value) ->
         let s =
           match side with
-          | Bs_t -> "t"
-          | Bs_r -> "r"
-          | Bs_b -> "b"
-          | Bs_l -> "l"
-          | Bs_x -> "x"
-          | Bs_y -> "y"
-          | Bs_s -> "s"
-          | Bs_e -> "e"
-          | Bs_bs -> "bs"
-          | Bs_be -> "be"
+          | Side.Top -> "t"
+          | Side.Right -> "r"
+          | Side.Bottom -> "b"
+          | Side.Left -> "l"
+          | Side.Inline_axis -> "x"
+          | Side.Block_axis -> "y"
+          | Side.Inline_start -> "s"
+          | Side.Inline_end -> "e"
+          | Side.Block_start -> "bs"
+          | Side.Block_end -> "be"
         in
         let v =
           match value with
-          | Bsc_named (c, shade) ->
+          | Side_color.Named (c, shade) ->
               if is_base_color c || is_custom_color c then color_to_string c
               else color_to_string c ^ "-" ^ string_of_int shade
-          | Bsc_named_opacity (c, shade, opacity) ->
+          | Side_color.Named_opacity (c, shade, opacity) ->
               (if is_base_color c || is_custom_color c then color_to_string c
                else color_to_string c ^ "-" ^ string_of_int shade)
               ^ opacity_suffix opacity
-          | Bsc_bracket (orig, _) -> "[" ^ orig ^ "]"
-          | Bsc_transparent -> "transparent"
-          | Bsc_current -> "current"
+          | Side_color.Bracket (orig, _) -> "[" ^ orig ^ "]"
+          | Side_color.Transparent -> "transparent"
+          | Side_color.Current -> "current"
         in
         "border-" ^ s ^ "-" ^ v
     | Border_bracket_color_opacity (v, _, opacity) ->

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -165,8 +165,8 @@ let width_range op len =
    Emitting the negated form keeps parity with Tailwind's optimized output. *)
 let width_cond cmp len =
   match cmp with
-  | Style.Cq_min -> width_range Css.Media.Ge len
-  | Style.Cq_max -> Css.Container.Not (width_range Css.Media.Ge len)
+  | Style.Min -> width_range Css.Media.Ge len
+  | Style.Max -> Css.Container.Not (width_range Css.Media.Ge len)
 
 (** Convert a container query modifier to a structured Container.t condition *)
 let rec container_query_to_condition q =

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -7,124 +7,80 @@ module Css = Cascade.Css
 
 module Handler = struct
   open Style
-  open Css
 
-  type t =
-    | Cursor_alias
-    | Cursor_all_scroll
-    | Cursor_auto
-    | Cursor_cell
-    | Cursor_col_resize
-    | Cursor_context_menu
-    | Cursor_copy
-    | Cursor_crosshair
-    | Cursor_default
-    | Cursor_e_resize
-    | Cursor_ew_resize
-    | Cursor_grab
-    | Cursor_grabbing
-    | Cursor_help
-    | Cursor_move
-    | Cursor_n_resize
-    | Cursor_ne_resize
-    | Cursor_nesw_resize
-    | Cursor_no_drop
-    | Cursor_none
-    | Cursor_not_allowed
-    | Cursor_ns_resize
-    | Cursor_nw_resize
-    | Cursor_nwse_resize
-    | Cursor_pointer
-    | Cursor_progress
-    | Cursor_row_resize
-    | Cursor_s_resize
-    | Cursor_se_resize
-    | Cursor_sw_resize
-    | Cursor_text
-    | Cursor_vertical_text
-    | Cursor_w_resize
-    | Cursor_wait
-    | Cursor_zoom_in
-    | Cursor_zoom_out
-    | Cursor_bracket_var of string
-    | Cursor_theme of string
-
+  type t = Keyword of Css.cursor | Bracket_var of string | Theme of string
   type Utility.base += Self of t
 
   let name = "cursor"
   let priority _ = 11
 
-  (* Single source of truth: (handler, class_suffix, css_value) *)
+  (* Single source of truth: (css value, class_suffix) *)
   (* Alphabetically ordered - suborder derived from position *)
-  let cursor_data =
+  let cursor_data : (Css.cursor * string) list =
     [
-      (Cursor_alias, "alias", Alias);
-      (Cursor_all_scroll, "all-scroll", All_scroll);
-      (Cursor_auto, "auto", Auto);
-      (Cursor_cell, "cell", Cell);
-      (Cursor_col_resize, "col-resize", Col_resize);
-      (Cursor_context_menu, "context-menu", Context_menu);
-      (Cursor_copy, "copy", Copy);
-      (Cursor_crosshair, "crosshair", Crosshair);
-      (Cursor_default, "default", Default);
-      (Cursor_e_resize, "e-resize", E_resize);
-      (Cursor_ew_resize, "ew-resize", Ew_resize);
-      (Cursor_grab, "grab", Grab);
-      (Cursor_grabbing, "grabbing", Grabbing);
-      (Cursor_help, "help", Help);
-      (Cursor_move, "move", Move);
-      (Cursor_n_resize, "n-resize", N_resize);
-      (Cursor_ne_resize, "ne-resize", Ne_resize);
-      (Cursor_nesw_resize, "nesw-resize", Nesw_resize);
-      (Cursor_no_drop, "no-drop", No_drop);
-      (Cursor_none, "none", None);
-      (Cursor_not_allowed, "not-allowed", Not_allowed);
-      (Cursor_ns_resize, "ns-resize", Ns_resize);
-      (Cursor_nw_resize, "nw-resize", Nw_resize);
-      (Cursor_nwse_resize, "nwse-resize", Nwse_resize);
-      (Cursor_pointer, "pointer", Pointer);
-      (Cursor_progress, "progress", Progress);
-      (Cursor_row_resize, "row-resize", Row_resize);
-      (Cursor_s_resize, "s-resize", S_resize);
-      (Cursor_se_resize, "se-resize", Se_resize);
-      (Cursor_sw_resize, "sw-resize", Sw_resize);
-      (Cursor_text, "text", Text);
-      (Cursor_vertical_text, "vertical-text", Vertical_text);
-      (Cursor_w_resize, "w-resize", W_resize);
-      (Cursor_wait, "wait", Wait);
-      (Cursor_zoom_in, "zoom-in", Zoom_in);
-      (Cursor_zoom_out, "zoom-out", Zoom_out);
+      (Css.Alias, "alias");
+      (Css.All_scroll, "all-scroll");
+      (Css.Auto, "auto");
+      (Css.Cell, "cell");
+      (Css.Col_resize, "col-resize");
+      (Css.Context_menu, "context-menu");
+      (Css.Copy, "copy");
+      (Css.Crosshair, "crosshair");
+      (Css.Default, "default");
+      (Css.E_resize, "e-resize");
+      (Css.Ew_resize, "ew-resize");
+      (Css.Grab, "grab");
+      (Css.Grabbing, "grabbing");
+      (Css.Help, "help");
+      (Css.Move, "move");
+      (Css.N_resize, "n-resize");
+      (Css.Ne_resize, "ne-resize");
+      (Css.Nesw_resize, "nesw-resize");
+      (Css.No_drop, "no-drop");
+      (Css.None, "none");
+      (Css.Not_allowed, "not-allowed");
+      (Css.Ns_resize, "ns-resize");
+      (Css.Nw_resize, "nw-resize");
+      (Css.Nwse_resize, "nwse-resize");
+      (Css.Pointer, "pointer");
+      (Css.Progress, "progress");
+      (Css.Row_resize, "row-resize");
+      (Css.S_resize, "s-resize");
+      (Css.Se_resize, "se-resize");
+      (Css.Sw_resize, "sw-resize");
+      (Css.Text, "text");
+      (Css.Vertical_text, "vertical-text");
+      (Css.W_resize, "w-resize");
+      (Css.Wait, "wait");
+      (Css.Zoom_in, "zoom-in");
+      (Css.Zoom_out, "zoom-out");
     ]
 
   (* Derived lookup tables *)
   let to_class_map =
-    List.map (fun (t, suffix, _) -> (t, "cursor-" ^ suffix)) cursor_data
+    List.map (fun (v, suffix) -> (v, "cursor-" ^ suffix)) cursor_data
 
-  let to_style_map =
-    List.map (fun (t, _, css_val) -> (t, style [ cursor css_val ])) cursor_data
-
-  let suborder_map =
-    List.mapi (fun i (t, _, _) -> (t, (i + 1) * 10)) cursor_data
+  let suborder_map = List.mapi (fun i (v, _) -> (v, (i + 1) * 10)) cursor_data
 
   let of_class_map =
-    List.map (fun (t, suffix, _) -> ("cursor-" ^ suffix, t)) cursor_data
+    List.map (fun (v, suffix) -> ("cursor-" ^ suffix, Keyword v)) cursor_data
 
   (* Handler functions derived from maps *)
   let to_class = function
-    | Cursor_bracket_var s -> "cursor-[" ^ s ^ "]"
-    | Cursor_theme name -> "cursor-" ^ name
-    | t -> List.assoc t to_class_map
+    | Bracket_var s -> "cursor-[" ^ s ^ "]"
+    | Theme name -> "cursor-" ^ name
+    | Keyword v -> List.assoc v to_class_map
 
   let to_style theme = function
-    | Cursor_bracket_var s ->
+    | Bracket_var s ->
         let inner = Parse.extract_var_name s in
         let ref : Css.cursor Css.var = Var.bracket inner in
-        style [ cursor (Var ref) ]
-    | Cursor_theme name -> (
+        style [ Css.cursor (Css.Var ref) ]
+    | Theme name -> (
         let var_name = "cursor-" ^ name in
         let ref : Css.cursor Css.var =
           Var.theme_ref var_name
-            ~default:(Auto : Css.cursor)
+            ~default:(Css.Auto : Css.cursor)
             ~default_css:"auto"
         in
         match Scheme.theme_value (Some theme) var_name with
@@ -132,13 +88,13 @@ module Handler = struct
             let theme_decl =
               Css.custom_property ~layer:"theme" ("--" ^ var_name) value
             in
-            style [ theme_decl; cursor (Var ref) ]
-        | None -> style [ cursor (Var ref) ])
-    | t -> List.assoc t to_style_map
+            style [ theme_decl; Css.cursor (Css.Var ref) ]
+        | None -> style [ Css.cursor (Css.Var ref) ])
+    | Keyword v -> style [ Css.cursor v ]
 
   (* Sorted suffixes from cursor_data for computing theme suborder *)
   let sorted_suffixes =
-    List.mapi (fun i (_, suffix, _) -> (suffix, (i + 1) * 10)) cursor_data
+    List.mapi (fun i (_, suffix) -> (suffix, (i + 1) * 10)) cursor_data
 
   let theme_suborder name =
     (* Find alphabetical position among known cursors *)
@@ -150,27 +106,27 @@ module Handler = struct
     find sorted_suffixes
 
   let suborder = function
-    | Cursor_bracket_var _ -> -1
-    | Cursor_theme name -> theme_suborder name
-    | t -> List.assoc t suborder_map
+    | Bracket_var _ -> -1
+    | Theme name -> theme_suborder name
+    | Keyword v -> List.assoc v suborder_map
 
   let of_class _theme cls =
     let parts = Parse.split_class cls in
     match parts with
     | [ "cursor"; value ] when Parse.is_bracket_var value ->
-        Ok (Cursor_bracket_var (Parse.bracket_inner value))
+        Ok (Bracket_var (Parse.bracket_inner value))
     | [ "cursor"; name ] when not (List.mem_assoc cls of_class_map) ->
         (* A theme token name is an identifier: [cursor-[<value>]] is not
            one. *)
         if Parse.is_valid_theme_name name && Parse.is_ident name then
-          Ok (Cursor_theme name)
+          Ok (Theme name)
         else Error (`Msg "Not a cursor utility")
     | _ -> (
         match List.assoc_opt cls of_class_map with
         | Some t -> Ok t
         | None -> Error (`Msg "Not a cursor utility"))
 
-  let examples = [ Cursor_auto ]
+  let examples = [ Keyword Css.Auto ]
 end
 
 open Handler
@@ -181,39 +137,39 @@ let () = Utility.register (module Handler)
 (** Public API returning Utility.t *)
 let utility x = Utility.base (Self x)
 
-let cursor_alias = utility Cursor_alias
-let cursor_all_scroll = utility Cursor_all_scroll
-let cursor_auto = utility Cursor_auto
-let cursor_cell = utility Cursor_cell
-let cursor_col_resize = utility Cursor_col_resize
-let cursor_context_menu = utility Cursor_context_menu
-let cursor_copy = utility Cursor_copy
-let cursor_crosshair = utility Cursor_crosshair
-let cursor_default = utility Cursor_default
-let cursor_e_resize = utility Cursor_e_resize
-let cursor_ew_resize = utility Cursor_ew_resize
-let cursor_grab = utility Cursor_grab
-let cursor_grabbing = utility Cursor_grabbing
-let cursor_help = utility Cursor_help
-let cursor_move = utility Cursor_move
-let cursor_n_resize = utility Cursor_n_resize
-let cursor_ne_resize = utility Cursor_ne_resize
-let cursor_nesw_resize = utility Cursor_nesw_resize
-let cursor_no_drop = utility Cursor_no_drop
-let cursor_none = utility Cursor_none
-let cursor_not_allowed = utility Cursor_not_allowed
-let cursor_ns_resize = utility Cursor_ns_resize
-let cursor_nw_resize = utility Cursor_nw_resize
-let cursor_nwse_resize = utility Cursor_nwse_resize
-let cursor_pointer = utility Cursor_pointer
-let cursor_progress = utility Cursor_progress
-let cursor_row_resize = utility Cursor_row_resize
-let cursor_s_resize = utility Cursor_s_resize
-let cursor_se_resize = utility Cursor_se_resize
-let cursor_sw_resize = utility Cursor_sw_resize
-let cursor_text = utility Cursor_text
-let cursor_vertical_text = utility Cursor_vertical_text
-let cursor_w_resize = utility Cursor_w_resize
-let cursor_wait = utility Cursor_wait
-let cursor_zoom_in = utility Cursor_zoom_in
-let cursor_zoom_out = utility Cursor_zoom_out
+let cursor_alias = utility (Keyword Css.Alias)
+let cursor_all_scroll = utility (Keyword Css.All_scroll)
+let cursor_auto = utility (Keyword Css.Auto)
+let cursor_cell = utility (Keyword Css.Cell)
+let cursor_col_resize = utility (Keyword Css.Col_resize)
+let cursor_context_menu = utility (Keyword Css.Context_menu)
+let cursor_copy = utility (Keyword Css.Copy)
+let cursor_crosshair = utility (Keyword Css.Crosshair)
+let cursor_default = utility (Keyword Css.Default)
+let cursor_e_resize = utility (Keyword Css.E_resize)
+let cursor_ew_resize = utility (Keyword Css.Ew_resize)
+let cursor_grab = utility (Keyword Css.Grab)
+let cursor_grabbing = utility (Keyword Css.Grabbing)
+let cursor_help = utility (Keyword Css.Help)
+let cursor_move = utility (Keyword Css.Move)
+let cursor_n_resize = utility (Keyword Css.N_resize)
+let cursor_ne_resize = utility (Keyword Css.Ne_resize)
+let cursor_nesw_resize = utility (Keyword Css.Nesw_resize)
+let cursor_no_drop = utility (Keyword Css.No_drop)
+let cursor_none = utility (Keyword Css.None)
+let cursor_not_allowed = utility (Keyword Css.Not_allowed)
+let cursor_ns_resize = utility (Keyword Css.Ns_resize)
+let cursor_nw_resize = utility (Keyword Css.Nw_resize)
+let cursor_nwse_resize = utility (Keyword Css.Nwse_resize)
+let cursor_pointer = utility (Keyword Css.Pointer)
+let cursor_progress = utility (Keyword Css.Progress)
+let cursor_row_resize = utility (Keyword Css.Row_resize)
+let cursor_s_resize = utility (Keyword Css.S_resize)
+let cursor_se_resize = utility (Keyword Css.Se_resize)
+let cursor_sw_resize = utility (Keyword Css.Sw_resize)
+let cursor_text = utility (Keyword Css.Text)
+let cursor_vertical_text = utility (Keyword Css.Vertical_text)
+let cursor_w_resize = utility (Keyword Css.W_resize)
+let cursor_wait = utility (Keyword Css.Wait)
+let cursor_zoom_in = utility (Keyword Css.Zoom_in)
+let cursor_zoom_out = utility (Keyword Css.Zoom_out)

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -14,22 +14,21 @@ module Handler = struct
   open Css
 
   type t =
-    | Divide_x of int (* divide-x = 1, divide-x-4 = 4 *)
-    | Divide_y of int
-    | Divide_x_arb of Css.border_width (* divide-x-[4px] *)
-    | Divide_y_arb of Css.border_width
-    | Divide_x_reverse
-    | Divide_y_reverse
-    | Divide_color of Color.color * int
-    | Divide_color_opacity of Color.color * int * Color.opacity_modifier
-    | Divide_transparent
-    | Divide_current
-    | Divide_current_opacity of Color.opacity_modifier
-    | Divide_inherit
-    | Divide_bracket_color of string * Css.color
-    | Divide_bracket_color_opacity of
-        string * Css.color * Color.opacity_modifier
-    | Divide_style of Css.border_style
+    | X of int (* divide-x = 1, divide-x-4 = 4 *)
+    | Y of int
+    | X_arb of Css.border_width (* divide-x-[4px] *)
+    | Y_arb of Css.border_width
+    | X_reverse
+    | Y_reverse
+    | Named_color of Color.color * int
+    | Named_color_opacity of Color.color * int * Color.opacity_modifier
+    | Transparent
+    | Current
+    | Current_opacity of Color.opacity_modifier
+    | Inherit
+    | Bracket_color of string * Css.color
+    | Bracket_color_opacity of string * Css.color * Color.opacity_modifier
+    | Line_style of Css.border_style
 
   type Utility.base += Self of t
 
@@ -341,9 +340,9 @@ module Handler = struct
   let has_opacity s = String.contains s '/'
 
   let to_class = function
-    | Divide_x n -> if n = 1 then "divide-x" else "divide-x-" ^ string_of_int n
-    | Divide_y n -> if n = 1 then "divide-y" else "divide-y-" ^ string_of_int n
-    | Divide_x_arb len -> (
+    | X n -> if n = 1 then "divide-x" else "divide-x-" ^ string_of_int n
+    | Y n -> if n = 1 then "divide-y" else "divide-y-" ^ string_of_int n
+    | X_arb len -> (
         match len with
         | Px f ->
             let s = string_of_float f in
@@ -354,7 +353,7 @@ module Handler = struct
             in
             "divide-x-[" ^ s ^ "px]"
         | _ -> "divide-x-[<length>]")
-    | Divide_y_arb len -> (
+    | Y_arb len -> (
         match len with
         | Px f ->
             let s = string_of_float f in
@@ -365,26 +364,25 @@ module Handler = struct
             in
             "divide-y-[" ^ s ^ "px]"
         | _ -> "divide-y-[<length>]")
-    | Divide_x_reverse -> "divide-x-reverse"
-    | Divide_y_reverse -> "divide-y-reverse"
-    | Divide_color (c, shade) ->
+    | X_reverse -> "divide-x-reverse"
+    | Y_reverse -> "divide-y-reverse"
+    | Named_color (c, shade) ->
         if Color.is_shadeless c then "divide-" ^ Color.color_to_string c
         else "divide-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
-    | Divide_color_opacity (c, shade, opacity) ->
+    | Named_color_opacity (c, shade, opacity) ->
         if Color.is_shadeless c then
           "divide-" ^ Color.color_to_string c ^ opacity_suffix opacity
         else
           "divide-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
           ^ opacity_suffix opacity
-    | Divide_transparent -> "divide-transparent"
-    | Divide_current -> "divide-current"
-    | Divide_current_opacity opacity ->
-        "divide-current" ^ opacity_suffix opacity
-    | Divide_inherit -> "divide-inherit"
-    | Divide_bracket_color (v, _) -> "divide-[" ^ v ^ "]"
-    | Divide_bracket_color_opacity (v, _, opacity) ->
+    | Transparent -> "divide-transparent"
+    | Current -> "divide-current"
+    | Current_opacity opacity -> "divide-current" ^ opacity_suffix opacity
+    | Inherit -> "divide-inherit"
+    | Bracket_color (v, _) -> "divide-[" ^ v ^ "]"
+    | Bracket_color_opacity (v, _, opacity) ->
         "divide-[" ^ v ^ "]" ^ opacity_suffix opacity
-    | Divide_style bs -> "divide-" ^ border_style_to_string bs
+    | Line_style bs -> "divide-" ^ border_style_to_string bs
 
   let to_style theme =
     let divide_color_style color shade =
@@ -394,42 +392,40 @@ module Handler = struct
       divide_color_opacity_style ~theme color shade opacity
     in
     function
-    | Divide_x n ->
+    | X n ->
         let class_name =
           if n = 1 then "divide-x" else "divide-x-" ^ string_of_int n
         in
         let w = if n = 1 then theme.Scheme.default_border_width else n in
         divide_x_width_style ~class_name ~width:(Px (float_of_int w))
-    | Divide_y n ->
+    | Y n ->
         let class_name =
           if n = 1 then "divide-y" else "divide-y-" ^ string_of_int n
         in
         let w = if n = 1 then theme.Scheme.default_border_width else n in
         divide_y_width_style ~class_name ~width:(Px (float_of_int w))
-    | Divide_x_arb len ->
-        let class_name = to_class (Divide_x_arb len) in
+    | X_arb len ->
+        let class_name = to_class (X_arb len) in
         divide_x_width_style ~class_name ~width:len
-    | Divide_y_arb len ->
-        let class_name = to_class (Divide_y_arb len) in
+    | Y_arb len ->
+        let class_name = to_class (Y_arb len) in
         divide_y_width_style ~class_name ~width:len
-    | Divide_x_reverse -> divide_x_reverse_style ()
-    | Divide_y_reverse -> divide_y_reverse_style ()
-    | Divide_color (color, shade) -> divide_color_style color shade
-    | Divide_color_opacity (color, shade, opacity) ->
+    | X_reverse -> divide_x_reverse_style ()
+    | Y_reverse -> divide_y_reverse_style ()
+    | Named_color (color, shade) -> divide_color_style color shade
+    | Named_color_opacity (color, shade, opacity) ->
         divide_color_opacity_style color shade opacity
-    | Divide_transparent -> divide_transparent_style ()
-    | Divide_current -> divide_current_style ()
-    | Divide_current_opacity opacity -> divide_current_opacity_style opacity
-    | Divide_inherit -> divide_inherit_style ()
-    | Divide_bracket_color (inner, c) ->
-        let class_name = to_class (Divide_bracket_color (inner, c)) in
+    | Transparent -> divide_transparent_style ()
+    | Current -> divide_current_style ()
+    | Current_opacity opacity -> divide_current_opacity_style opacity
+    | Inherit -> divide_inherit_style ()
+    | Bracket_color (inner, c) ->
+        let class_name = to_class (Bracket_color (inner, c)) in
         divide_bracket_color_style class_name inner c
-    | Divide_bracket_color_opacity (inner, c, opacity) ->
-        let class_name =
-          to_class (Divide_bracket_color_opacity (inner, c, opacity))
-        in
+    | Bracket_color_opacity (inner, c, opacity) ->
+        let class_name = to_class (Bracket_color_opacity (inner, c, opacity)) in
         divide_bracket_color_opacity_style class_name inner c opacity
-    | Divide_style bs -> divide_style_style bs
+    | Line_style bs -> divide_style_style bs
 
   (* Tailwind's order across the family, read off its own output: divide-x,
      divide-x-2, divide-y, divide-y-4, divide-y-reverse, the styles, the
@@ -440,21 +436,21 @@ module Handler = struct
     (* The bare divide-x / divide-y (DEFAULT, n=1) sorts before the numbered
        variants: divide-x, divide-x-0, divide-x-4, ... The "-1" offset keeps the
        default ahead of divide-x-0 (n=0). *)
-    | Divide_x 1 -> -1
-    | Divide_x n -> n
-    | Divide_x_arb _ -> 50000
-    | Divide_y 1 -> 100000 - 1
-    | Divide_y n -> 100000 + n
-    | Divide_y_arb _ -> 100000 + 50000
-    | Divide_y_reverse -> 200000
-    | Divide_style _ -> 300000
+    | X 1 -> -1
+    | X n -> n
+    | X_arb _ -> 50000
+    | Y 1 -> 100000 - 1
+    | Y n -> 100000 + n
+    | Y_arb _ -> 100000 + 50000
+    | Y_reverse -> 200000
+    | Line_style _ -> 300000
     (* All divide color utilities use flat suborder for natural sort *)
-    | Divide_color _ | Divide_color_opacity _ -> 400000
-    | Divide_bracket_color _ | Divide_bracket_color_opacity _ -> 400000
-    | Divide_current | Divide_current_opacity _ -> 400000
-    | Divide_inherit -> 400000
-    | Divide_transparent -> 400000
-    | Divide_x_reverse -> 500000
+    | Named_color _ | Named_color_opacity _ -> 400000
+    | Bracket_color _ | Bracket_color_opacity _ -> 400000
+    | Current | Current_opacity _ -> 400000
+    | Inherit -> 400000
+    | Transparent -> 400000
+    | X_reverse -> 500000
 
   let parse_bracket_width s : Css.border_width option =
     let len = String.length s in
@@ -472,36 +468,36 @@ module Handler = struct
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "divide"; "x" ] -> Ok (Divide_x 1)
-    | [ "divide"; "y" ] -> Ok (Divide_y 1)
-    | [ "divide"; "x"; "reverse" ] -> Ok Divide_x_reverse
-    | [ "divide"; "y"; "reverse" ] -> Ok Divide_y_reverse
+    | [ "divide"; "x" ] -> Ok (X 1)
+    | [ "divide"; "y" ] -> Ok (Y 1)
+    | [ "divide"; "x"; "reverse" ] -> Ok X_reverse
+    | [ "divide"; "y"; "reverse" ] -> Ok Y_reverse
     | [ "divide"; "x"; value ] -> (
         match parse_bracket_width value with
-        | Some w -> Ok (Divide_x_arb w)
+        | Some w -> Ok (X_arb w)
         | None -> (
             match int_of_string_opt value with
-            | Some n when n >= 0 -> Ok (Divide_x n)
+            | Some n when n >= 0 -> Ok (X n)
             | _ -> Error (`Msg "Not a divide utility")))
     | [ "divide"; "y"; value ] -> (
         match parse_bracket_width value with
-        | Some w -> Ok (Divide_y_arb w)
+        | Some w -> Ok (Y_arb w)
         | None -> (
             match int_of_string_opt value with
-            | Some n when n >= 0 -> Ok (Divide_y n)
+            | Some n when n >= 0 -> Ok (Y n)
             | _ -> Error (`Msg "Not a divide utility")))
-    | [ "divide"; "transparent" ] -> Ok Divide_transparent
-    | [ "divide"; "inherit" ] -> Ok Divide_inherit
+    | [ "divide"; "transparent" ] -> Ok Transparent
+    | [ "divide"; "inherit" ] -> Ok Inherit
     | [ "divide"; style_str ]
       when Stdlib.Option.is_some (divide_style_of_string style_str) ->
-        Ok (Divide_style (Stdlib.Option.get (divide_style_of_string style_str)))
+        Ok (Line_style (Stdlib.Option.get (divide_style_of_string style_str)))
     | [ "divide"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
         let base, opacity = Color.parse_opacity_modifier ~theme current_str in
         match opacity with
-        | Color.No_opacity when base = "current" -> Ok Divide_current
+        | Color.No_opacity when base = "current" -> Ok Current
         | Color.No_opacity -> Error (`Msg ("Invalid divide: " ^ current_str))
-        | _ -> Ok (Divide_current_opacity opacity))
+        | _ -> Ok (Current_opacity opacity))
     | [ "divide"; v ]
       when Parse.is_bracket_value (fst (Color.parse_opacity_modifier ~theme v))
       ->
@@ -524,14 +520,14 @@ module Handler = struct
           match css_color with
           | Some c -> (
               match opacity with
-              | Color.No_opacity -> Ok (Divide_bracket_color (inner, c))
-              | _ -> Ok (Divide_bracket_color_opacity (inner, c, opacity)))
+              | Color.No_opacity -> Ok (Bracket_color (inner, c))
+              | _ -> Ok (Bracket_color_opacity (inner, c, opacity)))
           | None -> Error (`Msg ("Invalid divide bracket color: " ^ inner))
         else Error (`Msg ("Invalid divide bracket value: " ^ inner))
     | "divide" :: color_parts when List.exists has_opacity color_parts -> (
         match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
-            Ok (Divide_color_opacity (color, shade, opacity))
+            Ok (Named_color_opacity (color, shade, opacity))
         | Error _ ->
             (* Try as theme-named color *)
             let name = String.concat "-" color_parts in
@@ -540,11 +536,11 @@ module Handler = struct
               Scheme.theme_value (Some theme) ("color-" ^ base) <> None
               || Scheme.theme_value (Some theme) ("border-color-" ^ base)
                  <> None
-            then Ok (Divide_color_opacity (Theme_named base, 500, opacity))
+            then Ok (Named_color_opacity (Theme_named base, 500, opacity))
             else Error (`Msg ("Invalid divide color: " ^ name)))
     | "divide" :: color_parts -> (
         match Color.shade_of_strings color_parts with
-        | Ok (color, shade) -> Ok (Divide_color (color, shade))
+        | Ok (color, shade) -> Ok (Named_color (color, shade))
         | Error _ ->
             (* Try as theme-named color - check both generic and property-scoped
                theme values *)
@@ -553,7 +549,7 @@ module Handler = struct
               Scheme.theme_value (Some theme) ("color-" ^ name) <> None
               || Scheme.theme_value (Some theme) ("border-color-" ^ name)
                  <> None
-            then Ok (Divide_color (Theme_named name, 500))
+            then Ok (Named_color (Theme_named name, 500))
             else Error (`Msg ("Invalid divide color: " ^ name)))
     | _ -> Error (`Msg "Not a divide utility")
 
@@ -564,31 +560,31 @@ open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let divide_x_reverse = utility Divide_x_reverse
-let divide_y_reverse = utility Divide_y_reverse
+let divide_x_reverse = utility X_reverse
+let divide_y_reverse = utility Y_reverse
 
 (** {1 Divide Width Utilities} *)
 
-let divide_x n = utility (Divide_x n)
-let divide_y n = utility (Divide_y n)
-let divide_x_length w = utility (Divide_x_arb w)
-let divide_y_length w = utility (Divide_y_arb w)
+let divide_x n = utility (X n)
+let divide_y n = utility (Y n)
+let divide_x_length w = utility (X_arb w)
+let divide_y_length w = utility (Y_arb w)
 
 (** {1 Divide Colour Utilities} *)
 
 let divide_color ?opacity ?(shade = 500) color =
   Color.check_shade ~utility:"divide_color" color shade;
   match opacity with
-  | None -> utility (Divide_color (color, shade))
+  | None -> utility (Named_color (color, shade))
   | Some pct ->
       utility
-        (Divide_color_opacity
+        (Named_color_opacity
            (color, shade, Color.Opacity_percent (float_of_int pct)))
 
-let divide_transparent = utility Divide_transparent
-let divide_current = utility Divide_current
-let divide_inherit = utility Divide_inherit
+let divide_transparent = utility Transparent
+let divide_current = utility Current
+let divide_inherit = utility Inherit
 
 (** {1 Divide Style Utilities} *)
 
-let divide_style s = utility (Divide_style s)
+let divide_style s = utility (Line_style s)

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -7,19 +7,8 @@ module Css = Cascade.Css
 
 module Handler = struct
   open Style
-  open Css
 
-  type t =
-    (* Direction *)
-    | Flex_row
-    | Flex_row_reverse
-    | Flex_col
-    | Flex_col_reverse
-    (* Wrap *)
-    | Flex_wrap
-    | Flex_wrap_reverse
-    | Flex_nowrap
-
+  type t = Direction of Css.flex_direction | Wrap of Css.flex_wrap
   type Utility.base += Self of t
 
   let name = "flex_layout"
@@ -27,29 +16,23 @@ module Handler = struct
 
   let flex_data =
     [
-      (Flex_col, "col", (fun () -> style [ flex_direction Column ]), 0);
-      ( Flex_col_reverse,
-        "col-reverse",
-        (fun () -> style [ flex_direction Column_reverse ]),
-        1 );
-      (Flex_row, "row", (fun () -> style [ flex_direction Row ]), 2);
-      ( Flex_row_reverse,
-        "row-reverse",
-        (fun () -> style [ flex_direction Row_reverse ]),
-        3 );
-      (Flex_nowrap, "nowrap", (fun () -> style [ flex_wrap Nowrap ]), 10);
-      (Flex_wrap, "wrap", (fun () -> style [ flex_wrap Wrap ]), 11);
-      ( Flex_wrap_reverse,
-        "wrap-reverse",
-        (fun () -> style [ flex_wrap Wrap_reverse ]),
-        12 );
+      (Direction Css.Column, "col", 0);
+      (Direction Css.Column_reverse, "col-reverse", 1);
+      (Direction Css.Row, "row", 2);
+      (Direction Css.Row_reverse, "row-reverse", 3);
+      (Wrap Css.Nowrap, "nowrap", 10);
+      (Wrap Css.Wrap, "wrap", 11);
+      (Wrap Css.Wrap_reverse, "wrap-reverse", 12);
     ]
 
-  let to_class_map = List.map (fun (t, s, _, _) -> (t, "flex-" ^ s)) flex_data
-  let to_style_map = List.map (fun (t, _, f, _) -> (t, f)) flex_data
-  let suborder_map = List.map (fun (t, _, _, o) -> (t, o)) flex_data
-  let of_class_map = List.map (fun (t, s, _, _) -> ("flex-" ^ s, t)) flex_data
-  let to_style _theme t = (List.assoc t to_style_map) ()
+  let to_class_map = List.map (fun (t, s, _) -> (t, "flex-" ^ s)) flex_data
+  let suborder_map = List.map (fun (t, _, o) -> (t, o)) flex_data
+  let of_class_map = List.map (fun (t, s, _) -> ("flex-" ^ s, t)) flex_data
+
+  let to_style _theme = function
+    | Direction d -> style [ Css.flex_direction d ]
+    | Wrap w -> style [ Css.flex_wrap w ]
+
   let suborder t = List.assoc t suborder_map
   let to_class t = List.assoc t to_class_map
 
@@ -58,7 +41,7 @@ module Handler = struct
     | Some t -> Ok t
     | None -> Error (`Msg "Not a flex layout utility")
 
-  let examples = [ Flex_row; Flex_wrap ]
+  let examples = [ Direction Css.Row; Wrap Css.Wrap ]
 end
 
 open Handler
@@ -67,10 +50,10 @@ open Handler
 let () = Utility.register (module Handler)
 
 let utility x = Utility.base (Self x)
-let flex_row = utility Flex_row
-let flex_row_reverse = utility Flex_row_reverse
-let flex_col = utility Flex_col
-let flex_col_reverse = utility Flex_col_reverse
-let flex_wrap = utility Flex_wrap
-let flex_wrap_reverse = utility Flex_wrap_reverse
-let flex_nowrap = utility Flex_nowrap
+let flex_row = utility (Direction Css.Row)
+let flex_row_reverse = utility (Direction Css.Row_reverse)
+let flex_col = utility (Direction Css.Column)
+let flex_col_reverse = utility (Direction Css.Column_reverse)
+let flex_wrap = utility (Wrap Css.Wrap)
+let flex_wrap_reverse = utility (Wrap Css.Wrap_reverse)
+let flex_nowrap = utility (Wrap Css.Nowrap)

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -9,68 +9,71 @@ module Handler = struct
   open Style
   open Css
 
-  type position_keyword =
-    | Pos_bottom
-    | Pos_bottom_left
-    | Pos_bottom_right
-    | Pos_center
-    | Pos_left
-    | Pos_right
-    | Pos_top
-    | Pos_top_left
-    | Pos_top_right
+  (* The position keywords [mask-<position>] accepts. *)
+  module Keyword = struct
+    type t =
+      | Bottom
+      | Bottom_left
+      | Bottom_right
+      | Center
+      | Left
+      | Right
+      | Top
+      | Top_left
+      | Top_right
+  end
 
   type t =
-    | Mask_none
-    | Mask_add
-    | Mask_exclude
-    | Mask_intersect
-    | Mask_subtract
-    | Mask_alpha
-    | Mask_luminance
-    | Mask_match
-    | Mask_type_alpha
-    | Mask_type_luminance
-    | Mask_auto
-    | Mask_contain
-    | Mask_cover
-    | Mask_position of position_keyword
-    | Mask_no_repeat
-    | Mask_repeat
-    | Mask_repeat_round
-    | Mask_repeat_space
-    | Mask_repeat_x
-    | Mask_repeat_y
-    | Mask_clip_border
-    | Mask_clip_padding
-    | Mask_clip_content
-    | Mask_clip_fill
-    | Mask_clip_stroke
-    | Mask_clip_view
-    | Mask_no_clip
-    | Mask_origin_border
-    | Mask_origin_padding
-    | Mask_origin_content
-    | Mask_origin_fill
-    | Mask_origin_stroke
-    | Mask_origin_view
+    | No_mask
+    | Add
+    | Exclude
+    | Intersect
+    | Subtract
+    | Alpha
+    | Luminance
+    | Match
+    | Type_alpha
+    | Type_luminance
+    | Auto
+    | Contain
+    | Cover
+    | Position of Keyword.t
+    | No_repeat
+    | Repeat
+    | Repeat_round
+    | Repeat_space
+    | Repeat_x
+    | Repeat_y
+    | Clip_border
+    | Clip_padding
+    | Clip_content
+    | Clip_fill
+    | Clip_stroke
+    | Clip_view
+    | No_clip
+    | Origin_border
+    | Origin_padding
+    | Origin_content
+    | Origin_fill
+    | Origin_stroke
+    | Origin_view
     (* Bracket notation *)
-    | Mask_bracket_contain
-    | Mask_bracket_cover
-    | Mask_bracket_size of string
-    | Mask_bracket_length of string
-    | Mask_bracket_position of string * Css.position_value list
-    | Mask_bracket_typed_position of string * Css.position_value list
-    | Mask_bracket_image_var of string
-    | Mask_bracket_url of string
-    | Mask_bracket_url_var of string
-    | Mask_bracket_var of string
-    | Mask_bracket_image of string
+    | Bracket_contain
+    | Bracket_cover
+    | Bracket_size of string
+    | Bracket_length of string
+    | Bracket_position of string * Css.position_value list
+    | Bracket_typed_position of string * Css.position_value list
+    | Bracket_image_var of string
+    | Bracket_url of string
+    | Bracket_url_var of string
+    | Bracket_var of string
+    | Bracket_image of string
     (* Sub-property bracket notation: mask-position-[...], mask-size-[...] *)
-    | Mask_position_bracket of string * Css.position_value list
-    | Mask_position_bracket_var of string
-    | Mask_size_bracket of string
-    | Mask_size_bracket_var of string
+    | Position_bracket of string * Css.position_value list
+    | Position_bracket_var of string
+    | Size_bracket of string
+    | Size_bracket_var of string
 
   type Utility.base += Self of t
 
@@ -90,7 +93,7 @@ module Handler = struct
       [
         Css.webkit_mask_composite Source_over;
         Css.webkit_mask_composite Source_over;
-        Css.mask_composite Add;
+        Css.mask_composite Css.Add;
       ]
 
   let mask_exclude =
@@ -98,7 +101,7 @@ module Handler = struct
       [
         Css.webkit_mask_composite Xor;
         Css.webkit_mask_composite Xor;
-        Css.mask_composite Exclude;
+        Css.mask_composite Css.Exclude;
       ]
 
   let mask_intersect =
@@ -106,7 +109,7 @@ module Handler = struct
       [
         Css.webkit_mask_composite Source_in;
         Css.webkit_mask_composite Source_in;
-        Css.mask_composite Intersect;
+        Css.mask_composite Css.Intersect;
       ]
 
   let mask_subtract =
@@ -114,66 +117,69 @@ module Handler = struct
       [
         Css.webkit_mask_composite Source_out;
         Css.webkit_mask_composite Source_out;
-        Css.mask_composite Subtract;
+        Css.mask_composite Css.Subtract;
       ]
 
   let mask_alpha =
     style
       [
-        Css.webkit_mask_source_type Alpha;
-        Css.webkit_mask_source_type Alpha;
-        Css.mask_mode Alpha;
+        Css.webkit_mask_source_type Css.Alpha;
+        Css.webkit_mask_source_type Css.Alpha;
+        Css.mask_mode Css.Alpha;
       ]
 
   let mask_luminance =
     style
       [
-        Css.webkit_mask_source_type Luminance;
-        Css.webkit_mask_source_type Luminance;
-        Css.mask_mode Luminance;
+        Css.webkit_mask_source_type Css.Luminance;
+        Css.webkit_mask_source_type Css.Luminance;
+        Css.mask_mode Css.Luminance;
       ]
 
   let mask_match =
     style
       [
-        Css.webkit_mask_source_type Auto;
-        Css.webkit_mask_source_type Auto;
+        Css.webkit_mask_source_type Css.Auto;
+        Css.webkit_mask_source_type Css.Auto;
         Css.mask_mode Match_source;
       ]
 
-  let mask_type_alpha = style [ Css.mask_type Alpha ]
-  let mask_type_luminance = style [ Css.mask_type Luminance ]
+  let mask_type_alpha = style [ Css.mask_type Css.Alpha ]
+  let mask_type_luminance = style [ Css.mask_type Css.Luminance ]
 
   (* mask-size *)
-  let mask_auto = style [ Css.webkit_mask_size Auto; Css.mask_size Auto ]
+  let mask_auto =
+    style [ Css.webkit_mask_size Css.Auto; Css.mask_size Css.Auto ]
 
   let mask_contain =
-    style [ Css.webkit_mask_size Contain; Css.mask_size Contain ]
+    style [ Css.webkit_mask_size Css.Contain; Css.mask_size Css.Contain ]
 
-  let mask_cover = style [ Css.webkit_mask_size Cover; Css.mask_size Cover ]
+  let mask_cover =
+    style [ Css.webkit_mask_size Css.Cover; Css.mask_size Css.Cover ]
 
   (* mask-position *)
   let mask_position' pos =
     let pos_val : Css.position_value list =
       match pos with
-      | Pos_bottom -> [ Center_bottom ]
-      | Pos_bottom_left -> [ XY (Pct 0., Pct 100.) ]
-      | Pos_bottom_right -> [ XY (Pct 100., Pct 100.) ]
-      | Pos_center -> [ Center ]
-      | Pos_left -> [ Single (Pct 0.) ]
-      | Pos_right -> [ Single (Pct 100.) ]
-      | Pos_top -> [ Center_top ]
-      | Pos_top_left -> [ XY (Pct 0., Pct 0.) ]
-      | Pos_top_right -> [ XY (Pct 100., Pct 0.) ]
+      | Keyword.Bottom -> [ Center_bottom ]
+      | Keyword.Bottom_left -> [ XY (Pct 0., Pct 100.) ]
+      | Keyword.Bottom_right -> [ XY (Pct 100., Pct 100.) ]
+      | Keyword.Center -> [ Center ]
+      | Keyword.Left -> [ Single (Pct 0.) ]
+      | Keyword.Right -> [ Single (Pct 100.) ]
+      | Keyword.Top -> [ Center_top ]
+      | Keyword.Top_left -> [ XY (Pct 0., Pct 0.) ]
+      | Keyword.Top_right -> [ XY (Pct 100., Pct 0.) ]
     in
     style [ Css.webkit_mask_position pos_val; Css.mask_position pos_val ]
 
   (* mask-repeat *)
   let mask_no_repeat' =
-    style [ Css.webkit_mask_repeat No_repeat; Css.mask_repeat No_repeat ]
+    style
+      [ Css.webkit_mask_repeat Css.No_repeat; Css.mask_repeat Css.No_repeat ]
 
   let mask_repeat' =
-    style [ Css.webkit_mask_repeat Repeat; Css.mask_repeat Repeat ]
+    style [ Css.webkit_mask_repeat Css.Repeat; Css.mask_repeat Css.Repeat ]
 
   let mask_repeat_round' =
     style [ Css.webkit_mask_repeat Round; Css.mask_repeat Round ]
@@ -182,10 +188,10 @@ module Handler = struct
     style [ Css.webkit_mask_repeat Space; Css.mask_repeat Space ]
 
   let mask_repeat_x' =
-    style [ Css.webkit_mask_repeat Repeat_x; Css.mask_repeat Repeat_x ]
+    style [ Css.webkit_mask_repeat Css.Repeat_x; Css.mask_repeat Css.Repeat_x ]
 
   let mask_repeat_y' =
-    style [ Css.webkit_mask_repeat Repeat_y; Css.mask_repeat Repeat_y ]
+    style [ Css.webkit_mask_repeat Css.Repeat_y; Css.mask_repeat Css.Repeat_y ]
 
   (* mask-clip utilities *)
   let mask_clip_border =
@@ -207,7 +213,7 @@ module Handler = struct
     style [ Css.webkit_mask_clip View_box; Css.mask_clip View_box ]
 
   let mask_no_clip =
-    style [ Css.webkit_mask_clip No_clip; Css.mask_clip No_clip ]
+    style [ Css.webkit_mask_clip Css.No_clip; Css.mask_clip Css.No_clip ]
 
   (* mask-origin utilities *)
   let mask_origin_border =
@@ -303,56 +309,57 @@ module Handler = struct
     style [ Css.webkit_mask_position positions; Css.mask_position positions ]
 
   let to_style _theme = function
-    | Mask_none -> mask_none
-    | Mask_add -> mask_add
-    | Mask_exclude -> mask_exclude
-    | Mask_intersect -> mask_intersect
-    | Mask_subtract -> mask_subtract
-    | Mask_alpha -> mask_alpha
-    | Mask_luminance -> mask_luminance
-    | Mask_match -> mask_match
-    | Mask_type_alpha -> mask_type_alpha
-    | Mask_type_luminance -> mask_type_luminance
-    | Mask_auto -> mask_auto
-    | Mask_contain -> mask_contain
-    | Mask_cover -> mask_cover
-    | Mask_position pos -> mask_position' pos
-    | Mask_no_repeat -> mask_no_repeat'
-    | Mask_repeat -> mask_repeat'
-    | Mask_repeat_round -> mask_repeat_round'
-    | Mask_repeat_space -> mask_repeat_space'
-    | Mask_repeat_x -> mask_repeat_x'
-    | Mask_repeat_y -> mask_repeat_y'
-    | Mask_clip_border -> mask_clip_border
-    | Mask_clip_padding -> mask_clip_padding
-    | Mask_clip_content -> mask_clip_content
-    | Mask_clip_fill -> mask_clip_fill
-    | Mask_clip_stroke -> mask_clip_stroke
-    | Mask_clip_view -> mask_clip_view
-    | Mask_no_clip -> mask_no_clip
-    | Mask_origin_border -> mask_origin_border
-    | Mask_origin_padding -> mask_origin_padding
-    | Mask_origin_content -> mask_origin_content
-    | Mask_origin_fill -> mask_origin_fill
-    | Mask_origin_stroke -> mask_origin_stroke
-    | Mask_origin_view -> mask_origin_view
+    | No_mask -> mask_none
+    | Add -> mask_add
+    | Exclude -> mask_exclude
+    | Intersect -> mask_intersect
+    | Subtract -> mask_subtract
+    | Alpha -> mask_alpha
+    | Luminance -> mask_luminance
+    | Match -> mask_match
+    | Type_alpha -> mask_type_alpha
+    | Type_luminance -> mask_type_luminance
+    | Auto -> mask_auto
+    | Contain -> mask_contain
+    | Cover -> mask_cover
+    | Position pos -> mask_position' pos
+    | No_repeat -> mask_no_repeat'
+    | Repeat -> mask_repeat'
+    | Repeat_round -> mask_repeat_round'
+    | Repeat_space -> mask_repeat_space'
+    | Repeat_x -> mask_repeat_x'
+    | Repeat_y -> mask_repeat_y'
+    | Clip_border -> mask_clip_border
+    | Clip_padding -> mask_clip_padding
+    | Clip_content -> mask_clip_content
+    | Clip_fill -> mask_clip_fill
+    | Clip_stroke -> mask_clip_stroke
+    | Clip_view -> mask_clip_view
+    | No_clip -> mask_no_clip
+    | Origin_border -> mask_origin_border
+    | Origin_padding -> mask_origin_padding
+    | Origin_content -> mask_origin_content
+    | Origin_fill -> mask_origin_fill
+    | Origin_stroke -> mask_origin_stroke
+    | Origin_view -> mask_origin_view
     (* Bracket notation *)
-    | Mask_bracket_contain ->
-        style [ Css.webkit_mask_size Contain; Css.mask_size Contain ]
-    | Mask_bracket_cover ->
-        style [ Css.webkit_mask_size Cover; Css.mask_size Cover ]
-    | Mask_bracket_size inner -> (
+    | Bracket_contain ->
+        style [ Css.webkit_mask_size Css.Contain; Css.mask_size Css.Contain ]
+    | Bracket_cover ->
+        style [ Css.webkit_mask_size Css.Cover; Css.mask_size Css.Cover ]
+    | Bracket_size inner -> (
         match parse_bracket_size inner with
         | Some decls -> style decls
-        | None -> style [ Css.webkit_mask_size Auto; Css.mask_size Auto ])
-    | Mask_bracket_length inner -> (
+        | None ->
+            style [ Css.webkit_mask_size Css.Auto; Css.mask_size Css.Auto ])
+    | Bracket_length inner -> (
         match parse_bracket_size inner with
         | Some decls -> style decls
-        | None -> style [ Css.webkit_mask_size Auto; Css.mask_size Auto ])
-    | Mask_bracket_position (_, positions) -> mask_position_style positions
-    | Mask_bracket_typed_position (_, positions) ->
-        mask_position_style positions
-    | Mask_bracket_image_var v ->
+        | None ->
+            style [ Css.webkit_mask_size Css.Auto; Css.mask_size Css.Auto ])
+    | Bracket_position (_, positions) -> mask_position_style positions
+    | Bracket_typed_position (_, positions) -> mask_position_style positions
+    | Bracket_image_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style
@@ -361,9 +368,9 @@ module Handler = struct
             Css.webkit_mask_image (Var var_ref);
             Css.mask_image (Var var_ref);
           ]
-    | Mask_bracket_url url ->
+    | Bracket_url url ->
         style [ Css.webkit_mask_image (Url url); Css.mask_image (Url url) ]
-    | Mask_bracket_url_var v ->
+    | Bracket_url_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style
@@ -372,7 +379,7 @@ module Handler = struct
             Css.webkit_mask_image (Var var_ref);
             Css.mask_image (Var var_ref);
           ]
-    | Mask_bracket_var v ->
+    | Bracket_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style
@@ -381,7 +388,7 @@ module Handler = struct
             Css.webkit_mask_image (Var var_ref);
             Css.mask_image (Var var_ref);
           ]
-    | Mask_bracket_image v -> (
+    | Bracket_image v -> (
         let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
         match Css.parse_background_image css_str with
         | Some (img :: _) ->
@@ -390,8 +397,8 @@ module Handler = struct
             invalid_arg ("mask-[" ^ v ^ "]: not a valid background-image value")
         )
     (* Sub-property bracket notation *)
-    | Mask_position_bracket (_, positions) -> mask_position_style positions
-    | Mask_position_bracket_var v ->
+    | Position_bracket (_, positions) -> mask_position_style positions
+    | Position_bracket_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.position_value Css.var = Var.bracket bare in
         style
@@ -400,11 +407,12 @@ module Handler = struct
             Css.webkit_mask_position [ Var var_ref ];
             Css.mask_position [ Var var_ref ];
           ]
-    | Mask_size_bracket inner -> (
+    | Size_bracket inner -> (
         match parse_bracket_size inner with
         | Some decls -> style decls
-        | None -> style [ Css.webkit_mask_size Auto; Css.mask_size Auto ])
-    | Mask_size_bracket_var v ->
+        | None ->
+            style [ Css.webkit_mask_size Css.Auto; Css.mask_size Css.Auto ])
+    | Size_bracket_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_size Css.var = Var.bracket bare in
         style
@@ -415,62 +423,62 @@ module Handler = struct
           ]
 
   let suborder_in_family = function
-    | Mask_bracket_image_var _ -> 100
-    | Mask_bracket_image _ -> 101
-    | Mask_bracket_url _ -> 102
-    | Mask_bracket_url_var _ -> 103
-    | Mask_bracket_var _ -> 104
-    | Mask_none -> 105
-    | Mask_add -> 200
-    | Mask_exclude -> 201
-    | Mask_intersect -> 202
-    | Mask_subtract -> 203
-    | Mask_alpha -> 300
-    | Mask_luminance -> 301
-    | Mask_match -> 302
-    | Mask_type_alpha -> 303
-    | Mask_type_luminance -> 304
-    | Mask_bracket_contain -> 400
-    | Mask_bracket_cover -> 401
-    | Mask_bracket_length _ -> 402
-    | Mask_bracket_size _ -> 403
-    | Mask_auto -> 404
-    | Mask_contain -> 405
-    | Mask_cover -> 406
-    | Mask_bracket_position _ -> 500
-    | Mask_bracket_typed_position _ -> 501
-    | Mask_position Pos_bottom -> 502
-    | Mask_position Pos_bottom_left -> 503
-    | Mask_position Pos_bottom_right -> 504
-    | Mask_position Pos_center -> 505
-    | Mask_position Pos_left -> 506
-    | Mask_position Pos_right -> 507
-    | Mask_position Pos_top -> 508
-    | Mask_position Pos_top_left -> 509
-    | Mask_position Pos_top_right -> 510
-    | Mask_no_repeat -> 600
-    | Mask_repeat -> 601
-    | Mask_repeat_round -> 602
-    | Mask_repeat_space -> 603
-    | Mask_repeat_x -> 604
-    | Mask_repeat_y -> 605
-    | Mask_clip_border -> 700
-    | Mask_clip_content -> 701
-    | Mask_clip_fill -> 702
-    | Mask_clip_padding -> 703
-    | Mask_clip_stroke -> 704
-    | Mask_clip_view -> 705
-    | Mask_no_clip -> 706
-    | Mask_origin_border -> 800
-    | Mask_origin_content -> 801
-    | Mask_origin_fill -> 802
-    | Mask_origin_padding -> 803
-    | Mask_origin_stroke -> 804
-    | Mask_origin_view -> 805
-    | Mask_position_bracket _ -> 511
-    | Mask_position_bracket_var _ -> 512
-    | Mask_size_bracket _ -> 407
-    | Mask_size_bracket_var _ -> 408
+    | Bracket_image_var _ -> 100
+    | Bracket_image _ -> 101
+    | Bracket_url _ -> 102
+    | Bracket_url_var _ -> 103
+    | Bracket_var _ -> 104
+    | No_mask -> 105
+    | Add -> 200
+    | Exclude -> 201
+    | Intersect -> 202
+    | Subtract -> 203
+    | Alpha -> 300
+    | Luminance -> 301
+    | Match -> 302
+    | Type_alpha -> 303
+    | Type_luminance -> 304
+    | Bracket_contain -> 400
+    | Bracket_cover -> 401
+    | Bracket_length _ -> 402
+    | Bracket_size _ -> 403
+    | Auto -> 404
+    | Contain -> 405
+    | Cover -> 406
+    | Bracket_position _ -> 500
+    | Bracket_typed_position _ -> 501
+    | Position Keyword.Bottom -> 502
+    | Position Keyword.Bottom_left -> 503
+    | Position Keyword.Bottom_right -> 504
+    | Position Keyword.Center -> 505
+    | Position Keyword.Left -> 506
+    | Position Keyword.Right -> 507
+    | Position Keyword.Top -> 508
+    | Position Keyword.Top_left -> 509
+    | Position Keyword.Top_right -> 510
+    | No_repeat -> 600
+    | Repeat -> 601
+    | Repeat_round -> 602
+    | Repeat_space -> 603
+    | Repeat_x -> 604
+    | Repeat_y -> 605
+    | Clip_border -> 700
+    | Clip_content -> 701
+    | Clip_fill -> 702
+    | Clip_padding -> 703
+    | Clip_stroke -> 704
+    | Clip_view -> 705
+    | No_clip -> 706
+    | Origin_border -> 800
+    | Origin_content -> 801
+    | Origin_fill -> 802
+    | Origin_padding -> 803
+    | Origin_stroke -> 804
+    | Origin_view -> 805
+    | Position_bracket _ -> 511
+    | Position_bracket_var _ -> 512
+    | Size_bracket _ -> 407
+    | Size_bracket_var _ -> 408
 
   (* These share a priority with the mask-gradient utilities and sort after
      them, so the two families occupy disjoint suborder bands. *)
@@ -488,78 +496,75 @@ module Handler = struct
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "mask"; "none" ] -> Ok Mask_none
-    | [ "mask"; "add" ] -> Ok Mask_add
-    | [ "mask"; "exclude" ] -> Ok Mask_exclude
-    | [ "mask"; "intersect" ] -> Ok Mask_intersect
-    | [ "mask"; "subtract" ] -> Ok Mask_subtract
-    | [ "mask"; "alpha" ] -> Ok Mask_alpha
-    | [ "mask"; "luminance" ] -> Ok Mask_luminance
-    | [ "mask"; "match" ] -> Ok Mask_match
-    | [ "mask"; "type"; "alpha" ] -> Ok Mask_type_alpha
-    | [ "mask"; "type"; "luminance" ] -> Ok Mask_type_luminance
-    | [ "mask"; "auto" ] -> Ok Mask_auto
-    | [ "mask"; "contain" ] -> Ok Mask_contain
-    | [ "mask"; "cover" ] -> Ok Mask_cover
+    | [ "mask"; "none" ] -> Ok No_mask
+    | [ "mask"; "add" ] -> Ok Add
+    | [ "mask"; "exclude" ] -> Ok Exclude
+    | [ "mask"; "intersect" ] -> Ok Intersect
+    | [ "mask"; "subtract" ] -> Ok Subtract
+    | [ "mask"; "alpha" ] -> Ok Alpha
+    | [ "mask"; "luminance" ] -> Ok Luminance
+    | [ "mask"; "match" ] -> Ok Match
+    | [ "mask"; "type"; "alpha" ] -> Ok Type_alpha
+    | [ "mask"; "type"; "luminance" ] -> Ok Type_luminance
+    | [ "mask"; "auto" ] -> Ok Auto
+    | [ "mask"; "contain" ] -> Ok Contain
+    | [ "mask"; "cover" ] -> Ok Cover
     (* mask-position *)
-    | [ "mask"; "bottom" ] -> Ok (Mask_position Pos_bottom)
-    | [ "mask"; "bottom"; "left" ] -> Ok (Mask_position Pos_bottom_left)
-    | [ "mask"; "bottom"; "right" ] -> Ok (Mask_position Pos_bottom_right)
-    | [ "mask"; "center" ] -> Ok (Mask_position Pos_center)
-    | [ "mask"; "left" ] -> Ok (Mask_position Pos_left)
-    | [ "mask"; "right" ] -> Ok (Mask_position Pos_right)
-    | [ "mask"; "top" ] -> Ok (Mask_position Pos_top)
-    | [ "mask"; "top"; "left" ] -> Ok (Mask_position Pos_top_left)
-    | [ "mask"; "top"; "right" ] -> Ok (Mask_position Pos_top_right)
+    | [ "mask"; "bottom" ] -> Ok (Position Keyword.Bottom)
+    | [ "mask"; "bottom"; "left" ] -> Ok (Position Keyword.Bottom_left)
+    | [ "mask"; "bottom"; "right" ] -> Ok (Position Keyword.Bottom_right)
+    | [ "mask"; "center" ] -> Ok (Position Keyword.Center)
+    | [ "mask"; "left" ] -> Ok (Position Keyword.Left)
+    | [ "mask"; "right" ] -> Ok (Position Keyword.Right)
+    | [ "mask"; "top" ] -> Ok (Position Keyword.Top)
+    | [ "mask"; "top"; "left" ] -> Ok (Position Keyword.Top_left)
+    | [ "mask"; "top"; "right" ] -> Ok (Position Keyword.Top_right)
     (* mask-repeat *)
-    | [ "mask"; "no"; "repeat" ] -> Ok Mask_no_repeat
-    | [ "mask"; "repeat" ] -> Ok Mask_repeat
-    | [ "mask"; "repeat"; "round" ] -> Ok Mask_repeat_round
-    | [ "mask"; "repeat"; "space" ] -> Ok Mask_repeat_space
-    | [ "mask"; "repeat"; "x" ] -> Ok Mask_repeat_x
-    | [ "mask"; "repeat"; "y" ] -> Ok Mask_repeat_y
+    | [ "mask"; "no"; "repeat" ] -> Ok No_repeat
+    | [ "mask"; "repeat" ] -> Ok Repeat
+    | [ "mask"; "repeat"; "round" ] -> Ok Repeat_round
+    | [ "mask"; "repeat"; "space" ] -> Ok Repeat_space
+    | [ "mask"; "repeat"; "x" ] -> Ok Repeat_x
+    | [ "mask"; "repeat"; "y" ] -> Ok Repeat_y
     (* mask-clip *)
-    | [ "mask"; "clip"; "border" ] -> Ok Mask_clip_border
-    | [ "mask"; "clip"; "padding" ] -> Ok Mask_clip_padding
-    | [ "mask"; "clip"; "content" ] -> Ok Mask_clip_content
-    | [ "mask"; "clip"; "fill" ] -> Ok Mask_clip_fill
-    | [ "mask"; "clip"; "stroke" ] -> Ok Mask_clip_stroke
-    | [ "mask"; "clip"; "view" ] -> Ok Mask_clip_view
-    | [ "mask"; "no"; "clip" ] -> Ok Mask_no_clip
+    | [ "mask"; "clip"; "border" ] -> Ok Clip_border
+    | [ "mask"; "clip"; "padding" ] -> Ok Clip_padding
+    | [ "mask"; "clip"; "content" ] -> Ok Clip_content
+    | [ "mask"; "clip"; "fill" ] -> Ok Clip_fill
+    | [ "mask"; "clip"; "stroke" ] -> Ok Clip_stroke
+    | [ "mask"; "clip"; "view" ] -> Ok Clip_view
+    | [ "mask"; "no"; "clip" ] -> Ok No_clip
     (* mask-origin *)
-    | [ "mask"; "origin"; "border" ] -> Ok Mask_origin_border
-    | [ "mask"; "origin"; "padding" ] -> Ok Mask_origin_padding
-    | [ "mask"; "origin"; "content" ] -> Ok Mask_origin_content
-    | [ "mask"; "origin"; "fill" ] -> Ok Mask_origin_fill
-    | [ "mask"; "origin"; "stroke" ] -> Ok Mask_origin_stroke
-    | [ "mask"; "origin"; "view" ] -> Ok Mask_origin_view
+    | [ "mask"; "origin"; "border" ] -> Ok Origin_border
+    | [ "mask"; "origin"; "padding" ] -> Ok Origin_padding
+    | [ "mask"; "origin"; "content" ] -> Ok Origin_content
+    | [ "mask"; "origin"; "fill" ] -> Ok Origin_fill
+    | [ "mask"; "origin"; "stroke" ] -> Ok Origin_stroke
+    | [ "mask"; "origin"; "view" ] -> Ok Origin_view
     (* Sub-property bracket notation: mask-position-[...], mask-size-[...] *)
     | [ "mask"; "position"; bracket ] when Parse.is_bracket_value bracket -> (
         let inner = Parse.bracket_inner bracket in
-        if Parse.is_var inner then Ok (Mask_position_bracket_var inner)
+        if Parse.is_var inner then Ok (Position_bracket_var inner)
         else
           match parse_bracket_position inner with
-          | Some positions -> Ok (Mask_position_bracket (inner, positions))
+          | Some positions -> Ok (Position_bracket (inner, positions))
           | None -> Error (`Msg "Invalid mask-position value"))
     | [ "mask"; "size"; bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
-        if Parse.is_var inner then Ok (Mask_size_bracket_var inner)
+        if Parse.is_var inner then Ok (Size_bracket_var inner)
         else if parse_bracket_size inner = None then
           Error (`Msg "Invalid mask-size value")
-        else Ok (Mask_size_bracket inner)
+        else Ok (Size_bracket inner)
     (* Bracket notation: mask-[...] *)
     | [ "mask"; bracket ] when Parse.is_bracket_value bracket -> (
         let inner = Parse.bracket_inner bracket in
         match inner with
-        | "contain" -> Ok Mask_bracket_contain
-        | "cover" -> Ok Mask_bracket_cover
+        | "contain" -> Ok Bracket_contain
+        | "cover" -> Ok Bracket_cover
         | _ when String.length inner > 7 && String.sub inner 0 7 = "length:" ->
-            Ok
-              (Mask_bracket_length
-                 (String.sub inner 7 (String.length inner - 7)))
+            Ok (Bracket_length (String.sub inner 7 (String.length inner - 7)))
         | _ when String.length inner > 5 && String.sub inner 0 5 = "size:" ->
-            Ok
-              (Mask_bracket_size (String.sub inner 5 (String.length inner - 5)))
+            Ok (Bracket_size (String.sub inner 5 (String.length inner - 5)))
         | _ when String.length inner > 9 && String.sub inner 0 9 = "position:"
           -> (
             (* The [position:] data-type hint forces a mask-position; a value
@@ -567,142 +572,131 @@ module Handler = struct
                a plausible-looking [center]. *)
             let v = String.sub inner 9 (String.length inner - 9) in
             match parse_bracket_position v with
-            | Some positions -> Ok (Mask_bracket_typed_position (v, positions))
+            | Some positions -> Ok (Bracket_typed_position (v, positions))
             | None -> Error (`Msg ("Unknown mask bracket position: " ^ v)))
         | _ when String.length inner > 6 && String.sub inner 0 6 = "image:" ->
             Ok
-              (Mask_bracket_image_var
-                 (String.sub inner 6 (String.length inner - 6)))
+              (Bracket_image_var (String.sub inner 6 (String.length inner - 6)))
         | _ when String.length inner > 4 && String.sub inner 0 4 = "url:" ->
-            Ok
-              (Mask_bracket_url_var
-                 (String.sub inner 4 (String.length inner - 4)))
+            Ok (Bracket_url_var (String.sub inner 4 (String.length inner - 4)))
         (* Before the single-[url(...)] reading below, which takes everything
            between the first [(] and the last [)] and so swallows the comma of a
            layer list. *)
-        | _ when is_image_value inner -> Ok (Mask_bracket_image inner)
+        | _ when is_image_value inner -> Ok (Bracket_image inner)
         | _ when String.length inner > 4 && String.sub inner 0 4 = "url(" ->
             let url_content = String.sub inner 4 (String.length inner - 5) in
-            Ok (Mask_bracket_url url_content)
-        | _ when Parse.is_var inner -> Ok (Mask_bracket_var inner)
+            Ok (Bracket_url url_content)
+        | _ when Parse.is_var inner -> Ok (Bracket_var inner)
         | _ -> (
             match parse_bracket_position inner with
-            | Some positions -> Ok (Mask_bracket_position (inner, positions))
+            | Some positions -> Ok (Bracket_position (inner, positions))
             | None -> Error (`Msg ("Unknown mask bracket value: " ^ inner))))
     | _ -> Error (`Msg "Not a mask utility")
 
   let to_class = function
-    | Mask_none -> "mask-none"
-    | Mask_add -> "mask-add"
-    | Mask_exclude -> "mask-exclude"
-    | Mask_intersect -> "mask-intersect"
-    | Mask_subtract -> "mask-subtract"
-    | Mask_alpha -> "mask-alpha"
-    | Mask_luminance -> "mask-luminance"
-    | Mask_match -> "mask-match"
-    | Mask_type_alpha -> "mask-type-alpha"
-    | Mask_type_luminance -> "mask-type-luminance"
-    | Mask_auto -> "mask-auto"
-    | Mask_contain -> "mask-contain"
-    | Mask_cover -> "mask-cover"
-    | Mask_position Pos_bottom -> "mask-bottom"
-    | Mask_position Pos_bottom_left -> "mask-bottom-left"
-    | Mask_position Pos_bottom_right -> "mask-bottom-right"
-    | Mask_position Pos_center -> "mask-center"
-    | Mask_position Pos_left -> "mask-left"
-    | Mask_position Pos_right -> "mask-right"
-    | Mask_position Pos_top -> "mask-top"
-    | Mask_position Pos_top_left -> "mask-top-left"
-    | Mask_position Pos_top_right -> "mask-top-right"
-    | Mask_no_repeat -> "mask-no-repeat"
-    | Mask_repeat -> "mask-repeat"
-    | Mask_repeat_round -> "mask-repeat-round"
-    | Mask_repeat_space -> "mask-repeat-space"
-    | Mask_repeat_x -> "mask-repeat-x"
-    | Mask_repeat_y -> "mask-repeat-y"
-    | Mask_clip_border -> "mask-clip-border"
-    | Mask_clip_padding -> "mask-clip-padding"
-    | Mask_clip_content -> "mask-clip-content"
-    | Mask_clip_fill -> "mask-clip-fill"
-    | Mask_clip_stroke -> "mask-clip-stroke"
-    | Mask_clip_view -> "mask-clip-view"
-    | Mask_no_clip -> "mask-no-clip"
-    | Mask_origin_border -> "mask-origin-border"
-    | Mask_origin_padding -> "mask-origin-padding"
-    | Mask_origin_content -> "mask-origin-content"
-    | Mask_origin_fill -> "mask-origin-fill"
-    | Mask_origin_stroke -> "mask-origin-stroke"
-    | Mask_origin_view -> "mask-origin-view"
-    | Mask_bracket_contain -> "mask-[contain]"
-    | Mask_bracket_cover -> "mask-[cover]"
-    | Mask_bracket_size v -> "mask-[size:" ^ v ^ "]"
-    | Mask_bracket_length v -> "mask-[length:" ^ v ^ "]"
-    | Mask_bracket_position (v, _) -> "mask-[" ^ v ^ "]"
-    | Mask_bracket_typed_position (v, _) -> "mask-[position:" ^ v ^ "]"
-    | Mask_bracket_image_var v -> "mask-[image:" ^ v ^ "]"
-    | Mask_bracket_url url -> "mask-[url(" ^ url ^ ")]"
-    | Mask_bracket_url_var v -> "mask-[url:" ^ v ^ "]"
-    | Mask_bracket_var v -> "mask-[" ^ v ^ "]"
-    | Mask_bracket_image v -> "mask-[" ^ v ^ "]"
-    | Mask_position_bracket (v, _) -> "mask-position-[" ^ v ^ "]"
-    | Mask_position_bracket_var v -> "mask-position-[" ^ v ^ "]"
-    | Mask_size_bracket v -> "mask-size-[" ^ v ^ "]"
-    | Mask_size_bracket_var v -> "mask-size-[" ^ v ^ "]"
+    | No_mask -> "mask-none"
+    | Add -> "mask-add"
+    | Exclude -> "mask-exclude"
+    | Intersect -> "mask-intersect"
+    | Subtract -> "mask-subtract"
+    | Alpha -> "mask-alpha"
+    | Luminance -> "mask-luminance"
+    | Match -> "mask-match"
+    | Type_alpha -> "mask-type-alpha"
+    | Type_luminance -> "mask-type-luminance"
+    | Auto -> "mask-auto"
+    | Contain -> "mask-contain"
+    | Cover -> "mask-cover"
+    | Position Keyword.Bottom -> "mask-bottom"
+    | Position Keyword.Bottom_left -> "mask-bottom-left"
+    | Position Keyword.Bottom_right -> "mask-bottom-right"
+    | Position Keyword.Center -> "mask-center"
+    | Position Keyword.Left -> "mask-left"
+    | Position Keyword.Right -> "mask-right"
+    | Position Keyword.Top -> "mask-top"
+    | Position Keyword.Top_left -> "mask-top-left"
+    | Position Keyword.Top_right -> "mask-top-right"
+    | No_repeat -> "mask-no-repeat"
+    | Repeat -> "mask-repeat"
+    | Repeat_round -> "mask-repeat-round"
+    | Repeat_space -> "mask-repeat-space"
+    | Repeat_x -> "mask-repeat-x"
+    | Repeat_y -> "mask-repeat-y"
+    | Clip_border -> "mask-clip-border"
+    | Clip_padding -> "mask-clip-padding"
+    | Clip_content -> "mask-clip-content"
+    | Clip_fill -> "mask-clip-fill"
+    | Clip_stroke -> "mask-clip-stroke"
+    | Clip_view -> "mask-clip-view"
+    | No_clip -> "mask-no-clip"
+    | Origin_border -> "mask-origin-border"
+    | Origin_padding -> "mask-origin-padding"
+    | Origin_content -> "mask-origin-content"
+    | Origin_fill -> "mask-origin-fill"
+    | Origin_stroke -> "mask-origin-stroke"
+    | Origin_view -> "mask-origin-view"
+    | Bracket_contain -> "mask-[contain]"
+    | Bracket_cover -> "mask-[cover]"
+    | Bracket_size v -> "mask-[size:" ^ v ^ "]"
+    | Bracket_length v -> "mask-[length:" ^ v ^ "]"
+    | Bracket_position (v, _) -> "mask-[" ^ v ^ "]"
+    | Bracket_typed_position (v, _) -> "mask-[position:" ^ v ^ "]"
+    | Bracket_image_var v -> "mask-[image:" ^ v ^ "]"
+    | Bracket_url url -> "mask-[url(" ^ url ^ ")]"
+    | Bracket_url_var v -> "mask-[url:" ^ v ^ "]"
+    | Bracket_var v -> "mask-[" ^ v ^ "]"
+    | Bracket_image v -> "mask-[" ^ v ^ "]"
+    | Position_bracket (v, _) -> "mask-position-[" ^ v ^ "]"
+    | Position_bracket_var v -> "mask-position-[" ^ v ^ "]"
+    | Size_bracket v -> "mask-size-[" ^ v ^ "]"
+    | Size_bracket_var v -> "mask-size-[" ^ v ^ "]"
 
   let examples =
-    [
-      Mask_none;
-      Mask_clip_border;
-      Mask_origin_border;
-      Mask_repeat;
-      Mask_type_alpha;
-      Mask_add;
-      Mask_alpha;
-    ]
+    [ No_mask; Clip_border; Origin_border; Repeat; Type_alpha; Add; Alpha ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let mask_none = utility Mask_none
-let mask_add = utility Mask_add
-let mask_exclude = utility Mask_exclude
-let mask_intersect = utility Mask_intersect
-let mask_subtract = utility Mask_subtract
-let mask_alpha = utility Mask_alpha
-let mask_luminance = utility Mask_luminance
-let mask_match = utility Mask_match
-let mask_type_alpha = utility Mask_type_alpha
-let mask_type_luminance = utility Mask_type_luminance
-let mask_auto = utility Mask_auto
-let mask_contain = utility Mask_contain
-let mask_cover = utility Mask_cover
-let mask_bottom = utility (Mask_position Pos_bottom)
-let mask_bottom_left = utility (Mask_position Pos_bottom_left)
-let mask_bottom_right = utility (Mask_position Pos_bottom_right)
-let mask_center = utility (Mask_position Pos_center)
-let mask_left = utility (Mask_position Pos_left)
-let mask_right = utility (Mask_position Pos_right)
-let mask_top = utility (Mask_position Pos_top)
-let mask_top_left = utility (Mask_position Pos_top_left)
-let mask_top_right = utility (Mask_position Pos_top_right)
-let mask_no_repeat = utility Mask_no_repeat
-let mask_repeat = utility Mask_repeat
-let mask_repeat_round = utility Mask_repeat_round
-let mask_repeat_space = utility Mask_repeat_space
-let mask_repeat_x = utility Mask_repeat_x
-let mask_repeat_y = utility Mask_repeat_y
-let mask_clip_border = utility Mask_clip_border
-let mask_clip_padding = utility Mask_clip_padding
-let mask_clip_content = utility Mask_clip_content
-let mask_clip_fill = utility Mask_clip_fill
-let mask_clip_stroke = utility Mask_clip_stroke
-let mask_clip_view = utility Mask_clip_view
-let mask_no_clip = utility Mask_no_clip
-let mask_origin_border = utility Mask_origin_border
-let mask_origin_padding = utility Mask_origin_padding
-let mask_origin_content = utility Mask_origin_content
-let mask_origin_fill = utility Mask_origin_fill
-let mask_origin_stroke = utility Mask_origin_stroke
-let mask_origin_view = utility Mask_origin_view
+let mask_none = utility No_mask
+let mask_add = utility Add
+let mask_exclude = utility Exclude
+let mask_intersect = utility Intersect
+let mask_subtract = utility Subtract
+let mask_alpha = utility Alpha
+let mask_luminance = utility Luminance
+let mask_match = utility Match
+let mask_type_alpha = utility Type_alpha
+let mask_type_luminance = utility Type_luminance
+let mask_auto = utility Auto
+let mask_contain = utility Contain
+let mask_cover = utility Cover
+let mask_bottom = utility (Position Keyword.Bottom)
+let mask_bottom_left = utility (Position Keyword.Bottom_left)
+let mask_bottom_right = utility (Position Keyword.Bottom_right)
+let mask_center = utility (Position Keyword.Center)
+let mask_left = utility (Position Keyword.Left)
+let mask_right = utility (Position Keyword.Right)
+let mask_top = utility (Position Keyword.Top)
+let mask_top_left = utility (Position Keyword.Top_left)
+let mask_top_right = utility (Position Keyword.Top_right)
+let mask_no_repeat = utility No_repeat
+let mask_repeat = utility Repeat
+let mask_repeat_round = utility Repeat_round
+let mask_repeat_space = utility Repeat_space
+let mask_repeat_x = utility Repeat_x
+let mask_repeat_y = utility Repeat_y
+let mask_clip_border = utility Clip_border
+let mask_clip_padding = utility Clip_padding
+let mask_clip_content = utility Clip_content
+let mask_clip_fill = utility Clip_fill
+let mask_clip_stroke = utility Clip_stroke
+let mask_clip_view = utility Clip_view
+let mask_no_clip = utility No_clip
+let mask_origin_border = utility Origin_border
+let mask_origin_padding = utility Origin_padding
+let mask_origin_content = utility Origin_content
+let mask_origin_fill = utility Origin_fill
+let mask_origin_stroke = utility Origin_stroke
+let mask_origin_view = utility Origin_view

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1907,12 +1907,12 @@ let rec try_container_query s =
           bracketed "@" (fun raw len -> Container (Container_len (raw, len))));
         (fun () ->
           bracketed "@min-" (fun raw len ->
-              Container (Container_len_cmp (Cq_min, raw, len))));
+              Container (Container_len_cmp (Min, raw, len))));
         (fun () ->
           bracketed "@max-" (fun raw len ->
-              Container (Container_len_cmp (Cq_max, raw, len))));
-        (fun () -> sized "@min-" Cq_min);
-        (fun () -> sized "@max-" Cq_max);
+              Container (Container_len_cmp (Max, raw, len))));
+        (fun () -> sized "@min-" Min);
+        (fun () -> sized "@max-" Max);
         (fun () -> try_scoped_container_query s);
       ]
 

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -109,23 +109,18 @@ let spacing_value ?theme n : Css.declaration * Css.length =
 
 (* The physical/axis inset sides that take the spacing scale, so a fractional
    step (top-2.5) or the px step (left-px) can share one constructor. *)
-type pside =
-  | P_top
-  | P_right
-  | P_bottom
-  | P_left
-  | P_inset
-  | P_inset_x
-  | P_inset_y
+module Side = struct
+  type t = Top | Right | Bottom | Left | Inset | Inset_x | Inset_y
 
-let pside_name = function
-  | P_top -> "top"
-  | P_right -> "right"
-  | P_bottom -> "bottom"
-  | P_left -> "left"
-  | P_inset -> "inset"
-  | P_inset_x -> "inset-x"
-  | P_inset_y -> "inset-y"
+  let name = function
+    | Top -> "top"
+    | Right -> "right"
+    | Bottom -> "bottom"
+    | Left -> "left"
+    | Inset -> "inset"
+    | Inset_x -> "inset-x"
+    | Inset_y -> "inset-y"
+end
 
 (* [top-2.5] / [right-0.5] / [left-px]: a spacing token that is not a plain
    integer (those keep their existing [Top of int] path). *)
@@ -153,13 +148,13 @@ let pos_spacing_style ?theme side (s : Style.spacing) =
   let decls = Option.to_list decl_opt in
   let body =
     match side with
-    | P_top -> [ Css.top len ]
-    | P_right -> [ Css.right len ]
-    | P_bottom -> [ Css.bottom len ]
-    | P_left -> [ Css.left len ]
-    | P_inset -> [ Css.inset [ len ] ]
-    | P_inset_x -> [ Css.inset_inline [ len ] ]
-    | P_inset_y -> [ Css.inset_block [ len ] ]
+    | Side.Top -> [ Css.top len ]
+    | Side.Right -> [ Css.right len ]
+    | Side.Bottom -> [ Css.bottom len ]
+    | Side.Left -> [ Css.left len ]
+    | Side.Inset -> [ Css.inset [ len ] ]
+    | Side.Inset_x -> [ Css.inset_inline [ len ] ]
+    | Side.Inset_y -> [ Css.inset_block [ len ] ]
   in
   Style.style (decls @ body)
 
@@ -175,13 +170,13 @@ let neg_pos_spacing_style ?theme side (s : Style.spacing) =
   let decls = Option.to_list decl_opt in
   let body =
     match side with
-    | P_top -> [ Css.top len ]
-    | P_right -> [ Css.right len ]
-    | P_bottom -> [ Css.bottom len ]
-    | P_left -> [ Css.left len ]
-    | P_inset -> [ Css.inset [ len ] ]
-    | P_inset_x -> [ Css.inset_inline [ len ] ]
-    | P_inset_y -> [ Css.inset_block [ len ] ]
+    | Side.Top -> [ Css.top len ]
+    | Side.Right -> [ Css.right len ]
+    | Side.Bottom -> [ Css.bottom len ]
+    | Side.Left -> [ Css.left len ]
+    | Side.Inset -> [ Css.inset [ len ] ]
+    | Side.Inset_x -> [ Css.inset_inline [ len ] ]
+    | Side.Inset_y -> [ Css.inset_block [ len ] ]
   in
   Style.style (decls @ body)
 
@@ -238,8 +233,8 @@ module Handler = struct
     | Inset_y_full
     | Neg_inset_y_full
     | Inset_y_3_4
-    | Pos_spacing of pside * Style.spacing
-    | Neg_pos_spacing of pside * Style.spacing
+    | Pos_spacing of Side.t * Style.spacing
+    | Neg_pos_spacing of Side.t * Style.spacing
       (* fractional or px spacing step on a physical/axis inset side *)
     | Inset of int
     | Inset_arbitrary of string * Css.length
@@ -547,13 +542,13 @@ module Handler = struct
     | Pos_spacing (side, sp) ->
         let base =
           match side with
-          | P_top -> top
-          | P_right -> right
-          | P_bottom -> bottom
-          | P_left -> left
-          | P_inset -> inset
-          | P_inset_x -> inset_x
-          | P_inset_y -> inset_y
+          | Side.Top -> top
+          | Side.Right -> right
+          | Side.Bottom -> bottom
+          | Side.Left -> left
+          | Side.Inset -> inset
+          | Side.Inset_x -> inset_x
+          | Side.Inset_y -> inset_y
         in
         let scale =
           match sp with `Rem f -> f /. 0.25 | `Px -> 0.05 | _ -> 0.
@@ -562,13 +557,13 @@ module Handler = struct
     | Neg_pos_spacing (side, sp) ->
         let base =
           match side with
-          | P_top -> top
-          | P_right -> right
-          | P_bottom -> bottom
-          | P_left -> left
-          | P_inset -> inset
-          | P_inset_x -> inset_x
-          | P_inset_y -> inset_y
+          | Side.Top -> top
+          | Side.Right -> right
+          | Side.Bottom -> bottom
+          | Side.Left -> left
+          | Side.Inset -> inset
+          | Side.Inset_x -> inset_x
+          | Side.Inset_y -> inset_y
         in
         let scale =
           match sp with `Rem f -> f /. 0.25 | `Px -> 0.05 | _ -> 0.
@@ -733,7 +728,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_x x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_inset_x, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Inset_x, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Inset_x_arbitrary (n, len))
@@ -748,14 +743,14 @@ module Handler = struct
         | Ok x -> Ok (Inset_x (-x))
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (P_inset_x, sp))
+            | Some sp -> Ok (Neg_pos_spacing (Side.Inset_x, sp))
             | None -> Error (`Msg "invalid")))
     | [ "inset"; "y"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_y x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_inset_y, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Inset_y, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Inset_y_arbitrary (n, len))
@@ -768,7 +763,7 @@ module Handler = struct
         | Ok x -> Ok (Inset_y (-x))
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (P_inset_y, sp))
+            | Some sp -> Ok (Neg_pos_spacing (Side.Inset_y, sp))
             | None -> Error (`Msg "invalid")))
     (* inset-s = inset-inline-start *)
     | [ "inset"; "s"; "auto" ] -> Ok Inset_s_auto
@@ -845,7 +840,7 @@ module Handler = struct
         | Ok x -> Ok (Inset x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_inset, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Inset, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Inset_arbitrary (n, len))
@@ -859,7 +854,7 @@ module Handler = struct
         | Ok x -> Ok (Inset (-x))
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (P_inset, sp))
+            | Some sp -> Ok (Neg_pos_spacing (Side.Inset, sp))
             | None -> Error (`Msg "invalid")))
     | [ "top"; frac ] when frac_valid frac -> Ok (Top_fraction frac)
     | [ "top"; "auto" ] -> Ok Top_auto
@@ -870,7 +865,7 @@ module Handler = struct
         | Ok x -> Ok (Top x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_top, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Top, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Top_arbitrary (n, len))
@@ -884,7 +879,7 @@ module Handler = struct
         | Ok x -> Ok (Top (-x))
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (P_top, sp))
+            | Some sp -> Ok (Neg_pos_spacing (Side.Top, sp))
             | None -> Error (`Msg "invalid")))
     | [ "right"; frac ] when frac_valid frac -> Ok (Right_fraction frac)
     | [ "right"; "auto" ] -> Ok Right_auto
@@ -895,7 +890,7 @@ module Handler = struct
         | Ok x -> Ok (Right x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_right, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Right, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Right_arbitrary (n, len))
@@ -909,7 +904,7 @@ module Handler = struct
         | Ok x -> Ok (Right (-x))
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (P_right, sp))
+            | Some sp -> Ok (Neg_pos_spacing (Side.Right, sp))
             | None -> Error (`Msg "invalid")))
     | [ "bottom"; "3/4" ] -> Ok Bottom_3_4
     | [ "bottom"; "auto" ] -> Ok Bottom_auto
@@ -920,7 +915,7 @@ module Handler = struct
         | Ok x -> Ok (Bottom x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_bottom, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Bottom, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Bottom_arbitrary (n, len))
@@ -933,7 +928,7 @@ module Handler = struct
         | Ok x -> Ok (Bottom (-x))
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (P_bottom, sp))
+            | Some sp -> Ok (Neg_pos_spacing (Side.Bottom, sp))
             | None -> Error (`Msg "invalid")))
     | [ "left"; frac ] when frac_valid frac -> Ok (Left_fraction frac)
     | [ "left"; "auto" ] -> Ok Left_auto
@@ -944,7 +939,7 @@ module Handler = struct
         | Ok x -> Ok (Left x)
         | Error _ -> (
             match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (P_left, sp))
+            | Some sp -> Ok (Pos_spacing (Side.Left, sp))
             | None -> (
                 match parse_bracket_length n with
                 | Ok len -> Ok (Left_arbitrary (n, len))
@@ -961,7 +956,7 @@ module Handler = struct
             | Some len -> Ok (Neg_left_arbitrary (n, len))
             | None -> (
                 match parse_pos_spacing n with
-                | Some sp -> Ok (Neg_pos_spacing (P_left, sp))
+                | Some sp -> Ok (Neg_pos_spacing (Side.Left, sp))
                 | None -> Error (`Msg "invalid"))))
     | [ "start"; "3/4" ] -> Ok Start_3_4
     | [ "start"; "auto" ] -> Ok Start_auto
@@ -1002,9 +997,9 @@ module Handler = struct
     | Neg_inset_y_full -> "-inset-y-full"
     | Inset_y_3_4 -> "inset-y-3/4"
     | Pos_spacing (side, sp) ->
-        pside_name side ^ "-" ^ Spacing.pp_spacing_suffix sp
+        Side.name side ^ "-" ^ Spacing.pp_spacing_suffix sp
     | Neg_pos_spacing (side, sp) ->
-        "-" ^ pside_name side ^ "-" ^ Spacing.pp_spacing_suffix sp
+        "-" ^ Side.name side ^ "-" ^ Spacing.pp_spacing_suffix sp
     | Inset n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-" ^ string_of_int (abs n)

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2090,15 +2090,8 @@ end
 
 (* Handler for prose color variants - priority 21 *)
 module Color_Handler = struct
-  (** Local prose utility type for color variants *)
-  type t =
-    | Prose_gray
-    | Prose_slate
-    | Prose_zinc
-    | Prose_neutral
-    | Prose_stone
-    | Prose_invert
-    | Prose_orange
+  type t = [ `Gray | `Slate | `Zinc | `Neutral | `Stone | `Invert | `Orange ]
+  (** The prose colour variants, as {!prose_style} names them. *)
 
   (** Extensible variant for prose color utilities *)
   type Utility.base += Self of t
@@ -2110,47 +2103,40 @@ module Color_Handler = struct
 
   (** {1 Utility Conversion Functions} *)
 
-  let to_style _theme = function
-    | Prose_gray -> prose_style `Gray
-    | Prose_slate -> prose_style `Slate
-    | Prose_zinc -> prose_style `Zinc
-    | Prose_neutral -> prose_style `Neutral
-    | Prose_stone -> prose_style `Stone
-    | Prose_invert -> prose_style `Invert
-    | Prose_orange -> prose_style `Orange
+  let to_style _theme variant = prose_style variant
 
   let to_class = function
-    | Prose_gray -> "prose-gray"
-    | Prose_slate -> "prose-slate"
-    | Prose_zinc -> "prose-zinc"
-    | Prose_neutral -> "prose-neutral"
-    | Prose_stone -> "prose-stone"
-    | Prose_invert -> "prose-invert"
-    | Prose_orange -> "prose-orange"
+    | `Gray -> "prose-gray"
+    | `Slate -> "prose-slate"
+    | `Zinc -> "prose-zinc"
+    | `Neutral -> "prose-neutral"
+    | `Stone -> "prose-stone"
+    | `Invert -> "prose-invert"
+    | `Orange -> "prose-orange"
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "prose"; "gray" ] -> Ok Prose_gray
-    | [ "prose"; "slate" ] -> Ok Prose_slate
-    | [ "prose"; "zinc" ] -> Ok Prose_zinc
-    | [ "prose"; "neutral" ] -> Ok Prose_neutral
-    | [ "prose"; "stone" ] -> Ok Prose_stone
-    | [ "prose"; "invert" ] -> Ok Prose_invert
-    | [ "prose"; "orange" ] -> Ok Prose_orange
+    | [ "prose"; "gray" ] -> Ok `Gray
+    | [ "prose"; "slate" ] -> Ok `Slate
+    | [ "prose"; "zinc" ] -> Ok `Zinc
+    | [ "prose"; "neutral" ] -> Ok `Neutral
+    | [ "prose"; "stone" ] -> Ok `Stone
+    | [ "prose"; "invert" ] -> Ok `Invert
+    | [ "prose"; "orange" ] -> Ok `Orange
     | _ -> Error (`Msg "Not a prose color utility")
 
   let suborder = function
     (* Prose color utilities come after text colors (20000-29999). The gray
        ramps sort alphabetically by class name, matching Tailwind's order (gray,
        neutral, slate, stone, zinc), then invert and orange. *)
-    | Prose_gray -> 30000
-    | Prose_neutral -> 30001
-    | Prose_slate -> 30002
-    | Prose_stone -> 30003
-    | Prose_zinc -> 30004
-    | Prose_invert -> 30005
-    | Prose_orange -> 30006
+    | `Gray -> 30000
+    | `Neutral -> 30001
+    | `Slate -> 30002
+    | `Stone -> 30003
+    | `Zinc -> 30004
+    | `Invert -> 30005
+    | `Orange -> 30006
 
   let examples = []
 end
@@ -2169,12 +2155,12 @@ let prose_sm = utility Handler.Prose_sm
 let prose_lg = utility Handler.Prose_lg
 let prose_xl = utility Handler.Prose_xl
 let prose_2xl = utility Handler.Prose_2xl
-let prose_gray = color_utility Color_Handler.Prose_gray
-let prose_slate = color_utility Color_Handler.Prose_slate
-let prose_zinc = color_utility Color_Handler.Prose_zinc
-let prose_neutral = color_utility Color_Handler.Prose_neutral
-let prose_stone = color_utility Color_Handler.Prose_stone
-let prose_invert = color_utility Color_Handler.Prose_invert
-let prose_orange = color_utility Color_Handler.Prose_orange
+let prose_gray = color_utility `Gray
+let prose_slate = color_utility `Slate
+let prose_zinc = color_utility `Zinc
+let prose_neutral = color_utility `Neutral
+let prose_stone = color_utility `Stone
+let prose_invert = color_utility `Invert
+let prose_orange = color_utility `Orange
 let prose_lead = utility Handler.Lead
 let not_prose = utility Handler.Not_prose

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -3,7 +3,7 @@
 module Css = Cascade.Css
 
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
-type container_cmp = Cq_min | Cq_max
+type container_cmp = Min | Max
 
 type container_query =
   | Container_3xs
@@ -334,7 +334,7 @@ let is_numeric s = s <> "" && String.for_all (fun c -> c >= '0' && c <= '9') s
 let pp_nth prefix expr =
   if is_numeric expr then prefix ^ "-" ^ expr else prefix ^ "-[" ^ expr ^ "]"
 
-let container_cmp_prefix = function Cq_min -> "min-" | Cq_max -> "max-"
+let container_cmp_prefix = function Min -> "min-" | Max -> "max-"
 
 (* The class-name suffix (after the leading [@]) for a container query. *)
 let rec container_size_name = function

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -4,9 +4,9 @@ open Cascade
 
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
 
-(** Container-query direction: {!constructor-Cq_min} is [width >= v],
-    {!constructor-Cq_max} is [width < v]. *)
-type container_cmp = Cq_min | Cq_max
+(** Container-query direction: {!constructor-Min} is [width >= v],
+    {!constructor-Max} is [width < v]. *)
+type container_cmp = Min | Max
 
 (** [@min-[<len>]] / [@max-[<len>]]. *)
 type container_query =

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -9,18 +9,7 @@ module Handler = struct
   open Style
   open Css
 
-  type t =
-    | Touch_auto
-    | Touch_none
-    | Touch_manipulation
-    | Touch_pan_x
-    | Touch_pan_y
-    | Touch_pan_left
-    | Touch_pan_right
-    | Touch_pan_up
-    | Touch_pan_down
-    | Touch_pinch_zoom
-
+  type t = Action of Css.touch_action
   type Utility.base += Self of t
 
   let name = "touch"
@@ -55,67 +44,67 @@ module Handler = struct
     let decl, _ = Var.binding var value in
     style ~property_rules:touch_props [ decl; composable_touch_action () ]
 
-  (* Single source of truth: (handler, class_suffix, style_fn) *)
+  (* Single source of truth: (touch-action value, class_suffix, style_fn) *)
   (* Alphabetically ordered - suborder derived from position *)
-  let touch_data =
+  let touch_data : (Css.touch_action * string * (unit -> Style.t)) list =
     [
-      (Touch_auto, "auto", fun () -> style [ touch_action Auto ]);
-      ( Touch_manipulation,
+      (Css.Auto, "auto", fun () -> style [ touch_action Css.Auto ]);
+      ( Css.Manipulation,
         "manipulation",
-        fun () -> style [ touch_action Manipulation ] );
-      (Touch_none, "none", fun () -> style [ touch_action None ]);
+        fun () -> style [ touch_action Css.Manipulation ] );
+      (Css.None, "none", fun () -> style [ touch_action Css.None ]);
       (* x-axis pan utilities come before y-axis *)
-      ( Touch_pan_left,
+      ( Css.Pan_left,
         "pan-left",
-        fun () -> composable_style tw_pan_x_var Pan_left );
-      ( Touch_pan_right,
+        fun () -> composable_style tw_pan_x_var Css.Pan_left );
+      ( Css.Pan_right,
         "pan-right",
-        fun () -> composable_style tw_pan_x_var Pan_right );
-      (Touch_pan_x, "pan-x", fun () -> composable_style tw_pan_x_var Pan_x);
-      ( Touch_pan_down,
+        fun () -> composable_style tw_pan_x_var Css.Pan_right );
+      (Css.Pan_x, "pan-x", fun () -> composable_style tw_pan_x_var Css.Pan_x);
+      ( Css.Pan_down,
         "pan-down",
-        fun () -> composable_style tw_pan_y_var Pan_down );
-      (Touch_pan_up, "pan-up", fun () -> composable_style tw_pan_y_var Pan_up);
-      (Touch_pan_y, "pan-y", fun () -> composable_style tw_pan_y_var Pan_y);
-      ( Touch_pinch_zoom,
+        fun () -> composable_style tw_pan_y_var Css.Pan_down );
+      (Css.Pan_up, "pan-up", fun () -> composable_style tw_pan_y_var Css.Pan_up);
+      (Css.Pan_y, "pan-y", fun () -> composable_style tw_pan_y_var Css.Pan_y);
+      ( Css.Pinch_zoom,
         "pinch-zoom",
-        fun () -> composable_style tw_pinch_zoom_var Pinch_zoom );
+        fun () -> composable_style tw_pinch_zoom_var Css.Pinch_zoom );
     ]
 
   (* Derived lookup tables *)
   let to_class_map =
-    List.map (fun (t, suffix, _) -> (t, "touch-" ^ suffix)) touch_data
+    List.map (fun (v, suffix, _) -> (v, "touch-" ^ suffix)) touch_data
 
-  let to_style_map = List.map (fun (t, _, style_fn) -> (t, style_fn)) touch_data
-  let suborder_map = List.mapi (fun i (t, _, _) -> (t, i)) touch_data
+  let to_style_map = List.map (fun (v, _, style_fn) -> (v, style_fn)) touch_data
+  let suborder_map = List.mapi (fun i (v, _, _) -> (v, i)) touch_data
 
   let of_class_map =
-    List.map (fun (t, suffix, _) -> ("touch-" ^ suffix, t)) touch_data
+    List.map (fun (v, suffix, _) -> ("touch-" ^ suffix, Action v)) touch_data
 
   (* Handler functions derived from maps *)
-  let to_class t = List.assoc t to_class_map
-  let to_style _theme t = (List.assoc t to_style_map) ()
-  let suborder t = List.assoc t suborder_map
+  let to_class (Action v) = List.assoc v to_class_map
+  let to_style _theme (Action v) = (List.assoc v to_style_map) ()
+  let suborder (Action v) = List.assoc v suborder_map
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not a touch-action utility")
 
-  let examples = [ Touch_auto ]
+  let examples = [ Action Css.Auto ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let touch_auto = utility Touch_auto
-let touch_none = utility Touch_none
-let touch_manipulation = utility Touch_manipulation
-let touch_pan_x = utility Touch_pan_x
-let touch_pan_y = utility Touch_pan_y
-let touch_pan_left = utility Touch_pan_left
-let touch_pan_right = utility Touch_pan_right
-let touch_pan_up = utility Touch_pan_up
-let touch_pan_down = utility Touch_pan_down
-let touch_pinch_zoom = utility Touch_pinch_zoom
+let touch_auto = utility (Action Css.Auto)
+let touch_none = utility (Action Css.None)
+let touch_manipulation = utility (Action Css.Manipulation)
+let touch_pan_x = utility (Action Css.Pan_x)
+let touch_pan_y = utility (Action Css.Pan_y)
+let touch_pan_left = utility (Action Css.Pan_left)
+let touch_pan_right = utility (Action Css.Pan_right)
+let touch_pan_up = utility (Action Css.Pan_up)
+let touch_pan_down = utility (Action Css.Pan_down)
+let touch_pinch_zoom = utility (Action Css.Pinch_zoom)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -393,10 +393,10 @@ module Typography_early = struct
       Text_bracket_fs_lh of string * lh_modifier
 
   and lh_modifier =
-    | Lh_int of int (* /6 → calc(var(--spacing) * 6) *)
-    | Lh_none (* /none → line-height: 1 *)
-    | Lh_named of string (* /snug → var(--leading-snug) *)
-    | Lh_bracket of string (* /[4px] → 4px *)
+    | Spacing of int (* /6 → calc(var(--spacing) * 6) *)
+    | No_leading (* /none → line-height: 1 *)
+    | Named of string (* /snug → var(--leading-snug) *)
+    | Bracket of string (* /[4px] → 4px *)
 
   type Utility.base += Self of t
 
@@ -530,14 +530,14 @@ module Typography_early = struct
     [ "none"; "tight"; "snug"; "normal"; "relaxed"; "loose" ]
 
   let parse_lh_modifier s =
-    if s = "none" then Stdlib.Option.Some Lh_none
+    if s = "none" then Stdlib.Option.Some No_leading
     else if Parse.is_bracket_value s then
-      Stdlib.Option.Some (Lh_bracket (Parse.bracket_inner s))
+      Stdlib.Option.Some (Bracket (Parse.bracket_inner s))
     else
       match int_of_string_opt s with
-      | Stdlib.Option.Some n when n >= 0 -> Stdlib.Option.Some (Lh_int n)
+      | Stdlib.Option.Some n when n >= 0 -> Stdlib.Option.Some (Spacing n)
       | _ ->
-          if List.mem s known_leading_names then Stdlib.Option.Some (Lh_named s)
+          if List.mem s known_leading_names then Stdlib.Option.Some (Named s)
           else Stdlib.Option.None
 
   (* A font family the project named in its [@theme]. Gated on the token being
@@ -671,10 +671,10 @@ module Typography_early = struct
     | _ -> err_not_utility
 
   let lh_to_string = function
-    | Lh_int n -> string_of_int n
-    | Lh_none -> "none"
-    | Lh_named name -> name
-    | Lh_bracket v -> "[" ^ v ^ "]"
+    | Spacing n -> string_of_int n
+    | No_leading -> "none"
+    | Named name -> name
+    | Bracket v -> "[" ^ v ^ "]"
 
   let to_class = function
     | Text_xs -> "text-xs"
@@ -1105,7 +1105,7 @@ module Typography_early = struct
   (** Convert a line-height modifier to (extra_declarations, line_height_value).
   *)
   let lh_modifier_to_css = function
-    | Lh_int n ->
+    | Spacing n ->
         let spacing_decl, _spacing_ref =
           Var.binding Theme.spacing_var (Css.Rem 0.25)
         in
@@ -1114,8 +1114,8 @@ module Typography_early = struct
           Calc (Css.Calc.mul (Var lh_spacing_ref) (Num (float_of_int n)))
         in
         ([ spacing_decl ], lh)
-    | Lh_none -> ([], Num 1.0)
-    | Lh_named name -> (
+    | No_leading -> ([], Num 1.0)
+    | Named name -> (
         let leading_data =
           [
             ("none", leading_none_var, (Num 1.0 : Css.line_height));
@@ -1136,7 +1136,7 @@ module Typography_early = struct
               Var.bracket ("leading-" ^ name)
             in
             ([], Var ref_))
-    | Lh_bracket value ->
+    | Bracket value ->
         (* Parse bracket value as line-height *)
         let lh =
           if String.ends_with ~suffix:"px" value then

--- a/merlint.toml
+++ b/merlint.toml
@@ -86,7 +86,6 @@ files = [
   "lib/masks.ml*",
   "lib/position.ml*",
   "lib/prose.ml*",
-  "lib/style.ml*",
   "lib/text_shadow.ml*",
   "lib/touch.ml*",
 ]

--- a/merlint.toml
+++ b/merlint.toml
@@ -84,7 +84,6 @@ files = [
   "lib/divide.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
-  "lib/prose.ml*",
   "lib/text_shadow.ml*",
   "lib/touch.ml*",
 ]

--- a/merlint.toml
+++ b/merlint.toml
@@ -77,7 +77,6 @@ exclude = ["E330"]
 # picking a name that does not collide, one family at a time.
 [[rules]]
 files = [
-  "lib/cursor.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
   "lib/text_shadow.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -85,6 +85,5 @@ files = [
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
   "lib/text_shadow.ml*",
-  "lib/touch.ml*",
 ]
 exclude = ["E334"]

--- a/merlint.toml
+++ b/merlint.toml
@@ -81,7 +81,6 @@ files = [
   "lib/borders.ml*",
   "lib/color.ml*",
   "lib/cursor.ml*",
-  "lib/divide.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
   "lib/text_shadow.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -89,6 +89,5 @@ files = [
   "lib/style.ml*",
   "lib/text_shadow.ml*",
   "lib/touch.ml*",
-  "lib/typography.ml*",
 ]
 exclude = ["E334"]

--- a/merlint.toml
+++ b/merlint.toml
@@ -84,7 +84,6 @@ files = [
   "lib/divide.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
-  "lib/position.ml*",
   "lib/prose.ml*",
   "lib/text_shadow.ml*",
   "lib/touch.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -78,7 +78,6 @@ exclude = ["E330"]
 [[rules]]
 files = [
   "lib/backgrounds.ml*",
-  "lib/color.ml*",
   "lib/cursor.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -83,7 +83,6 @@ files = [
   "lib/color.ml*",
   "lib/cursor.ml*",
   "lib/divide.ml*",
-  "lib/flex_layout.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",
   "lib/position.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -78,7 +78,6 @@ exclude = ["E330"]
 [[rules]]
 files = [
   "lib/backgrounds.ml*",
-  "lib/borders.ml*",
   "lib/color.ml*",
   "lib/cursor.ml*",
   "lib/mask_gradient.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -77,7 +77,6 @@ exclude = ["E330"]
 # picking a name that does not collide, one family at a time.
 [[rules]]
 files = [
-  "lib/accessibility.ml*",
   "lib/animations.ml*",
   "lib/backgrounds.ml*",
   "lib/borders.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -77,7 +77,6 @@ exclude = ["E330"]
 # picking a name that does not collide, one family at a time.
 [[rules]]
 files = [
-  "lib/animations.ml*",
   "lib/backgrounds.ml*",
   "lib/borders.ml*",
   "lib/color.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -78,7 +78,6 @@ exclude = ["E330"]
 [[rules]]
 files = [
   "lib/mask_gradient.ml*",
-  "lib/masks.ml*",
   "lib/text_shadow.ml*",
 ]
 exclude = ["E334"]

--- a/merlint.toml
+++ b/merlint.toml
@@ -77,7 +77,6 @@ exclude = ["E330"]
 # picking a name that does not collide, one family at a time.
 [[rules]]
 files = [
-  "lib/backgrounds.ml*",
   "lib/cursor.ml*",
   "lib/mask_gradient.ml*",
   "lib/masks.ml*",

--- a/merlint.toml
+++ b/merlint.toml
@@ -70,11 +70,8 @@ files = [
 ]
 exclude = ["E330"]
 
-# These modules open Cascade.Css and declare a private Handler variant that
-# mirrors a CSS value enum case for case, so the bare constructor E334 asks
-# for would shadow the Css constructor of the same name in the same scope
-# (Touch_pan_x -> Pan_x shadows Css.Pan_x). Dropping a prefix here means
-# picking a name that does not collide, one family at a time.
+# Both files are being rewritten elsewhere: mask_gradient is mid typed port and
+# text_shadow is mid rename, so their prefixes come off with those changes.
 [[rules]]
 files = [
   "lib/mask_gradient.ml*",


### PR DESCRIPTION
Drains the E334 exclusion queue from 16 modules to 2. Where a private variant
mirrored a `Cascade.Css` enum case for case, the constructor now carries the
typed Css value instead of duplicating it; the rest are renamed prefix-free
with `Css.` qualification at the collision sites.

The two entries left in `merlint.toml` are held for files another PR is
rewriting: `mask_gradient.ml` (#296) and `text_shadow.ml`.

`dune build @runtest` exits 0. merlint reports Naming Conventions 0 issues; the
7 findings that remain are the pre-existing `bin/main.ml` ones already tracked
in TODO.md.