### PR TITLE
Preserve layer-order parity with Cascade 1.1

### DIFF
--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -59,7 +59,7 @@ let is_allowed_canonicalization_diff diff =
     | _ -> false
   in
   match Css_compare.as_tree_diff diff with
-  | Some Tree_diff.{ rules = []; containers; layer_order = _ } ->
+  | Some Tree_diff.{ rules = []; containers; layer_order = None } ->
       containers <> [] && List.for_all allowed_container containers
   | _ -> false
 

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -59,9 +59,19 @@ let is_allowed_canonicalization_diff diff =
     | _ -> false
   in
   match Css_compare.as_tree_diff diff with
-  | Some Tree_diff.{ rules = []; containers } ->
+  | Some Tree_diff.{ rules = []; containers; layer_order = _ } ->
       containers <> [] && List.for_all allowed_container containers
   | _ -> false
+
+let test_layer_order_not_tolerated () =
+  let expected =
+    "@layer weak, strong;@media (width >= 1px){.x{--font-sans:a}}"
+  in
+  let actual = "@layer strong, weak;@media (width >= 1px){.x{--font-sans:b}}" in
+  let diff = Css_compare.diff ~mode:`Tree expected actual in
+  Alcotest.(check bool)
+    "a tolerated declaration cannot hide a layer-order change" false
+    (is_allowed_canonicalization_diff diff)
 
 (* File utilities *)
 let write_file path content =
@@ -1287,6 +1297,8 @@ let property_order_cross_family () =
 
 let core_tests =
   [
+    test_case "canonical tolerance rejects layer order" `Quick
+      test_layer_order_not_tolerated;
     test_case "debug artefacts" `Quick debug_artefacts;
     test_case "empty test" `Quick empty_test;
     test_case "upstream utilities parse parity" `Quick

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -534,11 +534,21 @@ let is_allowed_canonicalization_diff diff =
     | _ -> false
   in
   match Css_compare.as_tree_diff diff with
-  | Some Tree_diff.{ rules; containers } ->
+  | Some Tree_diff.{ rules; containers; layer_order = _ } ->
       (rules <> [] || containers <> [])
       && List.for_all allowed_rule_change rules
       && List.for_all allowed_container containers
   | _ -> false
+
+let test_layer_order_not_tolerated () =
+  let expected =
+    "@layer weak, strong;@media (width >= 1px){.x{--font-sans:a}}"
+  in
+  let actual = "@layer strong, weak;@media (width >= 1px){.x{--font-sans:b}}" in
+  let diff = Css_compare.diff ~mode:`Tree expected actual in
+  Alcotest.(check bool)
+    "a tolerated declaration cannot hide a layer-order change" false
+    (is_allowed_canonicalization_diff diff)
 
 (** Extract var(--name, fallback) patterns from expected CSS. Returns (name,
     fallback) pairs where name is without the -- prefix. Handles both concrete
@@ -1015,7 +1025,11 @@ let () =
       variant_tests
   in
   let tolerance_cases =
-    [ test_case "oklab precision truncation" `Quick test_color_tolerance ]
+    [
+      test_case "oklab precision truncation" `Quick test_color_tolerance;
+      test_case "canonical tolerance rejects layer order" `Quick
+        test_layer_order_not_tolerated;
+    ]
   in
   let suites =
     [

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -534,7 +534,7 @@ let is_allowed_canonicalization_diff diff =
     | _ -> false
   in
   match Css_compare.as_tree_diff diff with
-  | Some Tree_diff.{ rules; containers; layer_order = _ } ->
+  | Some Tree_diff.{ rules; containers; layer_order = None } ->
       (rules <> [] || containers <> [])
       && List.for_all allowed_rule_change rules
       && List.for_all allowed_container containers


### PR DESCRIPTION
Require parity-test canonicalization tolerances to reject Cascade layer-order differences.

Cascade 1.1.0 adds layer_order to Tree_diff.t. Without checking it, a tolerated declaration or container difference can hide a real @layer ordering regression.

The two-commit series records the failing regression before the fix.