### PR TITLE
Require the Cascade 1.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,6 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - name: Make Cascade 1.1.0 available before opam publication
-        run: |
-          if ! opam show cascade.1.1.0 >/dev/null 2>&1; then
-            opam pin add -n cascade.1.1.0 \
-              https://github.com/samoht/cascade.git#1.1.0
-          fi
-
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,6 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      # tw and cascade are developed together, so CI tracks cascade's main
-      # rather than its last opam release. Drop this once a release carries
-      # what tw needs.
-      - name: Pin cascade to main
-        run: opam pin add -n cascade https://github.com/samoht/cascade.git#main
-
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+      - name: Make Cascade 1.1.0 available before opam publication
+        run: |
+          if ! opam show cascade.1.1.0 >/dev/null 2>&1; then
+            opam pin add -n cascade.1.1.0 \
+              https://github.com/samoht/cascade.git#1.1.0
+          fi
+
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (depends
   (ocaml (>= 5.2))
   dune
-  (cascade (>= 1.0.0))
+  (cascade (>= 1.1.0))
   cmdliner
   dune-build-info
   fmt

--- a/tw.opam
+++ b/tw.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
   "ocaml" {>= "5.2"}
   "dune" {>= "3.21"}
-  "cascade" {>= "1.0.0"}
+  "cascade" {>= "1.1.0"}
   "cmdliner"
   "dune-build-info"
   "fmt"


### PR DESCRIPTION
Raise TW's minimum Cascade dependency to 1.1.0 and remove the temporary CI pin to Cascade's main branch.

This makes builds reproducible against the released API and lets opam resolve the supported TW and Cascade pairing.