### PR TITLE
Compare modifiers through Style

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2151,7 +2151,8 @@ let handle_modified ?theme util_inner modifier base_style extract_fn =
      .dark\:aria-selected\:... *)
   let inner_util, style =
     match util_inner with
-    | Utility.Modified (inner_mod, u) when inner_mod = modifier ->
+    | Utility.Modified (inner_mod, u)
+      when Style.equal_modifier inner_mod modifier ->
         (* Same modifier - strip it to avoid doubling *)
         (u, base_style)
     | _ ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -260,6 +260,8 @@ type modifier =
           selector targeting specific HTML elements within prose content. E.g.
           [prose-headings:text-white] targets h1-h6,th inside prose. *)
 
+let equal_modifier (a : modifier) b = a = b
+
 type t =
   | Style of {
       props : Css.declaration list;

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -265,6 +265,9 @@ type modifier =
       (** [prose-X:] — prose element variant for targeting specific HTML
           elements within prose content *)
 
+val equal_modifier : modifier -> modifier -> bool
+(** [equal_modifier a b] is whether [a] and [b] describe the same modifier. *)
+
 type t =
   | Style of {
       props : Css.declaration list;

--- a/test/test_style.ml
+++ b/test/test_style.ml
@@ -5,5 +5,17 @@ let test_style_creation () =
   let _t = Tw.Style.style [] in
   check bool "style created" true true
 
-let tests = [ test_case "style creation" `Quick test_style_creation ]
+let test_equal_modifier () =
+  let open Tw.Style in
+  check bool "same nested modifier" true
+    (equal_modifier (Not (Data_state "open")) (Not (Data_state "open")));
+  check bool "different nested modifier" false
+    (equal_modifier (Not (Data_state "open")) (Not (Data_state "closed")))
+
+let tests =
+  [
+    test_case "style creation" `Quick test_style_creation;
+    test_case "modifier equality" `Quick test_equal_modifier;
+  ]
+
 let suite = ("style", tests)


### PR DESCRIPTION
Define and test Style.equal_modifier, then use it where Rule strips a duplicate outer modifier.

This removes the release audit's polymorphic-comparison violation without changing selector behavior or crossing the Style abstraction boundary.

Depends on #301.