### PR TITLE
Prepare the 1.1.0 release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,107 @@
 ## 1.1.0
 
-- Track Tailwind CSS 4.3.3, expanding parity across core utilities, variants,
-  and the official forms and typography plugins.
-- Compile project CSS entrypoints, including imports, `@theme`, `@utility`,
-  `@custom-variant`, `@variant`, and `@apply`.
-- Extend the typed API for logical sizing and borders, masks and mask
-  gradients, shadows, divide utilities, and container queries.
-- Strengthen the parity gates with upstream fixture replay, example stylesheet
-  comparisons, randomized ordering checks, and browser-rendered style checks.
-- Require Cascade 1.1.0 for structural CSS comparison and layer-order
-  reporting.
+### Tailwind CSS 4.3.3
+
+- Track Tailwind CSS 4.3.3, update the system font stack and preflight, write
+  powerless hues as `none`, add the mauve, mist, olive, and taupe palettes,
+  and regenerate the upstream parity corpus
+  (#128, #129, #130, #132, #147, #153).
+
+### CLI and project stylesheets
+
+- Compile complete CSS entrypoints and imports; scan Markdown, MDX,
+  JavaScript, and TypeScript; and expand author-written `@variant`,
+  `@custom-variant`, `--spacing()`, `theme()`, `@apply`, and `@utility`
+  constructs (#136, #137, #138, #139, #140, #141, #143, #195, #206).
+- Carry the entrypoint theme, declared variants, routed utilities, keyframes,
+  layers, properties, static theme scales, and v3 theme paths through class
+  generation (#170, #179, #193, #194, #221, #226, #227, #228, #229, #230,
+  #315, #320).
+- Gate typography utilities on the plugin, ignore candidates that cannot
+  render, recognize source boundaries correctly, tokenize entrypoint rewrites,
+  and make recursive content scans safe
+  (#142, #144, #145, #208, #288, #318, #321).
+- Reject conflicting CLI backends instead of silently selecting one (#317).
+
+### Utility coverage
+
+- Complete container, viewport, fractional, and logical sizing; support the
+  full position and spacing scales, arbitrary fraction denominators, and
+  consistent basis, translate, and size generation
+  (#146, #151, #152, #154, #155, #156, #159, #160, #166, #172, #180, #186,
+  #207, #210, #216, #293).
+- Expand transform, background, grid, typography, transition, and general
+  keyword coverage, including `none`, perspective, text indent, aspect ratio,
+  content, theme-named fonts, and arbitrary grid tracks
+  (#134, #157, #164, #171, #174, #175, #178, #181, #183, #184, #212, #218,
+  #223).
+- Add logical and axis border utilities, arbitrary integer border widths,
+  mask stops and images, mask gradients, and typed divide utilities
+  (#148, #161, #162, #163, #165, #182, #222, #239, #265, #296).
+
+### Arbitrary values and validation
+
+- Parse arbitrary lengths, calculations, theme and spacing functions, grid
+  tracks, colours, list styles, and custom properties through the shared CSS
+  parsers while preserving their original meaning
+  (#168, #171, #174, #175, #176, #177, #178, #187, #188, #189, #190, #191,
+  #192, #205, #212, #217, #218, #236, #241, #257, #266, #277, #278, #287,
+  #325).
+- Report invalid palette shades and arbitrary values as unknown classes rather
+  than crashing or emitting dead selectors; reject trailing text, malformed
+  channels, unitless decoration colours, and non-canonical numeric spellings
+  (#127, #234, #237, #257, #282, #284, #285, #307, #309).
+
+### Colours and effects
+
+- Apply alpha modifiers consistently to theme variables, borders, rings,
+  decorations, strokes, shadows, and drop shadows; support shadeless and
+  `light-dark()` colours and preserve both default drop-shadow layers
+  (#169, #185, #201, #202, #209, #214, #225, #231, #244, #254, #281, #308,
+  #322, #323).
+
+### Variants and selectors
+
+- Compose arbitrary, compound, negated, group, peer, `has`, `in`, container,
+  and at-rule variants with the correct anchors and nesting; parse selector
+  content structurally and support custom-variant selector shorthand
+  (#135, #167, #173, #196, #197, #198, #199, #200, #203, #204, #211, #213,
+  #215, #219, #220, #224, #231, #232, #233, #235, #238, #280, #314).
+
+### CSS ordering and structure
+
+- Match Tailwind's ordering for supports fallbacks, container variants,
+  logical sizing, line clamp, layout, drop shadows, divide, masks, outlines,
+  insets, basis fractions, theme tokens, and routed variants
+  (#242, #243, #249, #250, #251, #253, #261, #262, #263, #264, #267, #268,
+  #269, #291, #292, #310, #311, #312).
+- Group `@apply`, `@property`, `@starting-style`, and layer output correctly,
+  and interleave project utilities with the built-in property family they
+  implement (#194, #220, #226, #228, #255, #256, #271, #313, #316, #319,
+  #324).
+
+### Public OCaml API
+
+- Publish the complete utility surface directly as `Tw.<name>` while keeping
+  implementation modules under the explicitly unstable `Tw.Private` module
+  (#273).
+- Rename `Tw.pp` to `Tw.to_string` and `Tw.str` to `Tw.of_classes_exn`, add the
+  result-returning `Tw.of_classes`, make `Tw.to_css` take `Tw.Config.t`, and
+  rename the public scheme abstraction to `Tw.Theme` (#274).
+- Add typed constructors for logical sizing and borders, divide, masks, and
+  missing background, outline, ring, and blend utilities; use a closed shade
+  type and correct the `Svg.fill` and `Svg.stroke` signatures
+  (#127, #180, #182, #222, #239, #275, #296).
+
+### Documentation, compatibility, and release quality
+
+- Document how Tailwind parity is measured and update the contributor
+  documentation to match the current code layout (#240, #283).
+- Strengthen the fixture, ordering, browser-rendering, and suite-trust gates,
+  including structural and layer-order comparisons
+  (#158, #258, #259, #270, #286, #301).
+- Require Cascade 1.1.0 and its released comparison API, removing the moving
+  CI dependency (#297, #302).
 
 ## 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## 1.1.0
+
+- Track Tailwind CSS 4.3.3, expanding parity across core utilities, variants,
+  and the official forms and typography plugins.
+- Compile project CSS entrypoints, including imports, `@theme`, `@utility`,
+  `@custom-variant`, `@variant`, and `@apply`.
+- Extend the typed API for logical sizing and borders, masks and mask
+  gradients, shadows, divide utilities, and container queries.
+- Strengthen the parity gates with upstream fixture replay, example stylesheet
+  comparisons, randomized ordering checks, and browser-rendered style checks.
+- Require Cascade 1.1.0 for structural CSS comparison and layer-order
+  reporting.
+
 ## 1.0.0
 
 - Initial public release candidate. Type-safe Tailwind CSS v4 in OCaml,

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 `tw` is an OCaml implementation of [Tailwind CSS v4](https://tailwindcss.com/).
 You assemble utilities as ordinary OCaml values and compile them to CSS through
-the same typed variable-and-layer pipeline Tailwind uses, producing
-byte-for-byte identical output. Unknown utilities are caught at compile time,
-and nothing depends on Node.js, PostCSS, or the Tailwind CLI at run time.
+the same typed variable-and-layer pipeline Tailwind uses. The generated output
+is continuously compared against Tailwind CSS 4.3.3. Unknown utilities are
+caught at compile time, and nothing depends on Node.js, PostCSS, or the Tailwind
+CLI at run time.
 
 **Tracked version:** `tw` targets **Tailwind CSS v4.3.3** (the latest release).
-Its generated CSS is checked byte-for-byte against that exact version.
+The upstream utility and variant fixtures and the example stylesheets are
+checked against that exact version; the [parity notes](docs/parity.md) document
+the gates and the remaining equivalent output differences.
 
 ```ocaml
 open Tw
@@ -25,8 +28,8 @@ let card =
 
 ## Features
 
-- **Tailwind v4 parity** — output is checked byte-for-byte against the real
-  Tailwind CSS CLI across the upstream utility and variant test suites.
+- **Tailwind v4 fixture parity** — output is checked against the real Tailwind
+  CSS CLI across the upstream utility and variant suites and example sheets.
 - **Both official plugins** — `@tailwindcss/typography` (`prose`) and
   `@tailwindcss/forms` are fully implemented.
 - **Type-safe** — utilities are typed constructors, so invalid combinations are
@@ -172,9 +175,9 @@ dune exec -- tw -s "bg-blue-500 hover:bg-blue-600" --diff
 
 ### Parity with Tailwind
 
-[docs/parity.md](docs/parity.md) describes how the claim of identical output is
-checked: which comparisons run in `dune runtest`, how to read a diff, and why a
-small residual remains.
+[docs/parity.md](docs/parity.md) describes how output parity is checked: which
+comparisons run in `dune runtest`, how to read a diff, and why a small residual
+remains.
 
 ## License
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -1,8 +1,8 @@
 Title: Measuring parity with Tailwind
 
-`tw` claims to produce the same CSS as Tailwind v4. This doc says how that claim
-is checked, which checks run automatically, how to read their output, and why the
-number does not reach zero.
+`tw` aims to produce the same CSS as Tailwind v4. This document explains how
+that parity is checked, which checks run automatically, how to read their
+output, and why the whole-site comparison does not reach zero.
 
 ## What is gated
 
@@ -10,10 +10,12 @@ Three checks run in CI, all through `dune runtest`.
 
 ### Upstream fixtures - `test/upstream/`
 
-`utilities.txt` and `variants.txt` are Tailwind's own test corpus: a class list
-and the CSS Tailwind emits for it. `test/upstream/test.exe` replays every case
-(782 of them) and fails when tw parses a class Tailwind accepts, or emits
-different CSS for it.
+`utilities.txt` and `variants.txt` are generated from Tailwind's own test corpus:
+a class list and the CSS Tailwind emits for it. `test/upstream/test.exe` replays
+every case and fails when tw's resulting stylesheet differs outside the
+documented canonicalization tolerances. It also reports rejected classes; a
+rejection is harmless when the case's expected CSS is empty or its other
+classes already account for the expected stylesheet.
 
 <!-- $MDX skip -->
 ```sh

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
  (name tw)
  (synopsis "Type-safe Tailwind CSS v4 in OCaml")
  (description
-  "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles to CSS through a strongly-typed variable system that mirrors Tailwind's pipeline, producing byte-for-byte identical output. Supports all core utilities and the official forms and typography plugins.")
+  "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles typed utilities to CSS through a strongly-typed variable and layer pipeline, with generated output continuously compared against Tailwind's upstream fixtures. Supports all core utilities and the official forms and typography plugins.")
  (depends
   (ocaml (>= 5.2))
   dune

--- a/tw.opam
+++ b/tw.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "Type-safe Tailwind CSS v4 in OCaml"
 description:
-  "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles to CSS through a strongly-typed variable system that mirrors Tailwind's pipeline, producing byte-for-byte identical output. Supports all core utilities and the official forms and typography plugins."
+  "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles typed utilities to CSS through a strongly-typed variable and layer pipeline, with generated output continuously compared against Tailwind's upstream fixtures. Supports all core utilities and the official forms and typography plugins."
 maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
 authors: ["Thomas Gazagnaire"]
 license: "ISC"


### PR DESCRIPTION
Prepare TW 1.1.0 with comprehensive, categorized release notes for the user-facing changes merged since 1.0.0. Align the package and README parity wording with the documented fixture guarantees and equivalent whole-site residuals.

Requires Cascade 1.1.0 (#302).