### PR TITLE
Refresh the Node CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
           - "5.2"
           - "5.4"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Tailwind CLI for example comparisons
         # Exact versions come from package-lock.json: the examples are


### PR DESCRIPTION
Move checkout and setup-node to their v7 action releases and run the Tailwind comparison jobs on Node 24 LTS instead of the EOL Node 20 line.

Independent of #301–#305.