### PR TITLE
Keep unitless decoration colours inert

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,5 @@
 # TODO
 
-## Bracket-value parity gaps
-
-- Parity gaps #257 left as-is (pre-existing, behaviour unchanged):
-  `decoration-[2]` is a colour in Tailwind (`text-decoration-color: 2`) but a
-  thickness here - the only one visible in `--diff`; `border-[3]` and
-  `outline-[3]` emit `3px` where Tailwind keeps raw `3`; `decoration-[50%]`
-  is `50%` in Tailwind but `.5em` here.
-
 ## Wrong CSS emitted (audit 2026-07-31, verified against source)
 
 Modifier-level silent empties (found 2026-08-01 by a corpus scan over

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1422,6 +1422,7 @@ module Typography_late = struct
     | Decoration_current_opacity of Color.opacity_modifier
     | Decoration_inherit
     | Decoration_bracket_color of string * Css.color
+    | Decoration_bracket_invalid_color of string
     | Decoration_bracket_color_opacity of
         string * Css.color * Color.opacity_modifier
     | Decoration_bracket_var of string
@@ -1677,6 +1678,12 @@ module Typography_late = struct
                 match parse_decoration_pct inner with
                 | Some len -> Ok (Decoration_bracket_pct (inner, len))
                 | None -> err_not_utility
+              else if Result.is_ok (Parse.int_any inner) then
+                (* Tailwind resolves the ambiguous unitless spelling through the
+                   colour candidate path. Its declaration is invalid CSS and
+                   browsers discard it; accepting an inert candidate is
+                   therefore equivalent, while treating it as px is not. *)
+                Ok (Decoration_bracket_invalid_color inner)
               else
                 match parse_decoration_thickness inner with
                 | Some len -> Ok (Decoration_bracket_thickness (inner, len))
@@ -1934,6 +1941,7 @@ module Typography_late = struct
         "decoration-current/" ^ Color.pp_opacity opacity
     | Decoration_inherit -> "decoration-inherit"
     | Decoration_bracket_color (v, _) -> "decoration-[" ^ v ^ "]"
+    | Decoration_bracket_invalid_color v -> "decoration-[" ^ v ^ "]"
     | Decoration_bracket_color_opacity (v, _, opacity) ->
         "decoration-[" ^ v ^ "]/" ^ Color.pp_opacity opacity
     | Decoration_bracket_var v -> "decoration-[" ^ v ^ "]"
@@ -2091,6 +2099,7 @@ module Typography_late = struct
     | Decoration_current_opacity _ -> 5000
     | Decoration_inherit -> 5000
     | Decoration_bracket_color _ -> 4000
+    | Decoration_bracket_invalid_color _ -> 4000
     | Decoration_bracket_color_opacity _ -> 4000
     | Decoration_bracket_color_var _ -> 4100
     | Decoration_bracket_color_var_opacity _ -> 4100
@@ -2923,6 +2932,7 @@ module Typography_late = struct
     | Decoration_inherit -> decoration_inherit
     | Decoration_bracket_color (inner, c) ->
         decoration_bracket_color_style inner c
+    | Decoration_bracket_invalid_color _ -> style []
     | Decoration_bracket_color_opacity (inner, c, opacity) ->
         decoration_bracket_color_with_opacity inner c opacity
     | Decoration_bracket_var v -> decoration_bracket_var_style v

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -581,6 +581,20 @@ let test_decoration_bracket_thickness () =
   rejected "decoration-[.]";
   rejected "decoration-[1e]"
 
+(* Tailwind treats a unitless arbitrary decoration value as a colour candidate.
+   The resulting colour declaration is invalid CSS and has no browser effect; TW
+   must keep the candidate accepted without turning it into a visible pixel
+   thickness. *)
+let test_decoration_bracket_unitless_is_color () =
+  let css =
+    match Tw.of_string "decoration-[2]" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.fail m
+  in
+  Alcotest.(check bool)
+    "does not turn the invalid colour into a thickness" false
+    (Astring.String.is_infix ~affix:"text-decoration-thickness" css)
+
 (* A shadeless decoration colour takes an opacity modifier the same way every
    other colour family does, and keeps its shadeless class name. *)
 let test_decoration_shadeless_opacity () =
@@ -638,6 +652,8 @@ let tests =
       test_invalid_decoration_bracket_hex;
     test_case "decoration bracket thickness" `Quick
       test_decoration_bracket_thickness;
+    test_case "unitless decoration bracket is a colour" `Quick
+      test_decoration_bracket_unitless_is_color;
     test_case "decoration shadeless opacity" `Quick
       test_decoration_shadeless_opacity;
     test_case "bracket list-style" `Quick test_bracket_list_style;


### PR DESCRIPTION
Tailwind classifies `decoration-[2]` as a colour candidate whose invalid declaration browsers discard. Keep the class accepted without turning it into a visible `2px` thickness, and retire the stale bracket-parity note.