### PR TITLE
Close colour-opacity parity gaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,13 +28,6 @@ pre-existing). Decide whether tw should keep theme value strings verbatim.
 Arbitrary-property findings from the provenance work (2026-08-01, verified
 against Tailwind while gating PR #284):
 
-- Underscore-encoded colour values are rejected on the opacity path: the value
-  is not run through `Parse.decode_arbitrary_value` before `Css.parse_color`,
-  so `[border-color:oklch(0.5_0.2_250)]/[var(--x)]` errors - and that exact
-  class is the documented example in arbitrary.mli:4 - as does
-  `[color:rgb(255_0_0)]/50`. Tailwind emits both. Decode at the two
-  `Css.parse_color` call sites; widens the acceptance surface for every
-  arbitrary colour value, so it needs its own review.
 - The rejection message at tw.ml:268 says plain `[--name:value]` declarations
   and non-colour properties "are not yet supported", but `[--foo:bar]` and
   `[mask-type:luminance]` both work today; the message is wrong guidance for
@@ -43,19 +36,6 @@ against Tailwind while gating PR #284):
 Colour-family findings from the decoration work (2026-08-01, verified against
 Tailwind while gating PR #281):
 
-- `*-transparent/50` and `*-inherit/50` are rejected family-wide (bg, text,
-  border, decoration, ...) while Tailwind emits `color-mix(in oklab,
-  transparent 50%, transparent)` / `... inherit 50% ...`. `Color.color` has no
-  Transparent/Inherit constructor - each family models them as separate
-  variants with no opacity path - so this is one cross-family change, not
-  per-family patches. `*-current/50` already works.
-- `*-white-500/50` is wrongly accepted family-wide and renamed to `*-white/50`:
-  `Color.is_valid_shade` short-circuits to `true` for shadeless colours, so
-  `shade_and_opacity_of_strings` accepts any shade segment. Tailwind rejects
-  `bg-white-500/50`. Reject a shade segment on a shadeless colour.
-- `decoration-<custom-theme-colour>/<opacity>` still fails to parse: divide and
-  backgrounds fall back to `Theme_named` when `Color.of_string` fails,
-  decoration does not.
 - grid_template.ml:192 and modifiers.ml:1076 still call
   `Css.parse_length (Parse.decode_arbitrary_value ...)` inline; same
   `Parse.arbitrary_length` consolidation as PR #281.

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -260,7 +260,7 @@ module Handler = struct
             if Parse.is_var value then
               color_var_opacity_style theme emit value inner
             else
-              match Css.parse_color value with
+              match Css.parse_color (Parse.decode_arbitrary_value value) with
               | Some color -> color_opacity_render theme emit color inner
               | None -> style []))
 
@@ -358,7 +358,9 @@ module Handler = struct
                        rejected (Tailwind blindly color-mixes them, which is
                        meaningless). *)
                     let is_colour_value =
-                      Parse.is_var value || Css.parse_color value <> None
+                      Parse.is_var value
+                      || Css.parse_color (Parse.decode_arbitrary_value value)
+                         <> None
                     in
                     if color_emitter property <> None && is_colour_value then
                       Ok

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1037,69 +1037,83 @@ module Handler = struct
     let hex_of_palette () =
       Color.rgb_to_hex (Color.oklch_to_rgb (Color.to_oklch color shade))
     in
-    match
-      match Scheme.hex_color scheme color_name with
-      | Some _ as h -> h
-      | None -> Some (hex_of_palette ())
-    with
-    | Some hex_value ->
-        (* Scheme color: generate fallback + @supports + stops (same as
-           Tailwind) Tailwind outputs: 1. .from-X/N { --tw-gradient-from:
-           #RRGGBBAA } 2. @supports { .from-X/N { --tw-gradient-from:
-           color-mix(...) } } 3. .from-X/N { --tw-gradient-stops: ... } To
-           match, we put fallback in props, @supports in rules, and stops as
-           separate rule in rules. *)
-        let hex_alpha =
-          if Color.opacity_var_bare_of opacity <> None then hex_value
-          else Color.hex_with_alpha hex_value percent
+    match Color.opacity_keyword color with
+    | Some keyword ->
+        let d_var, _ =
+          Var.binding set_var (Color.apply_alpha opacity keyword)
         in
-        let d_fallback, _ = Var.binding set_var (Css.hex hex_alpha) in
-
-        (* Theme variable for @supports block *)
-        let color_var = Color.color_var color shade in
-        let theme_decl, color_ref = Var.binding color_var (Css.hex hex_value) in
-        let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
-        let d_oklab, _ = Var.binding set_var oklab_color in
-
-        (* Build @supports block with placeholder selector *)
-        let supports_rule =
-          Css.supports ~condition:Color.color_mix_supports_condition
-            [
-              Css.rule ~selector:(Css.Selector.class_ "_")
-                [ theme_decl; d_oklab ];
-            ]
-        in
-
-        (* Build stops rule with placeholder selector (will be replaced) *)
-        let stops_decls =
-          match d_via_stops_opt with
-          | Some d_via_stops -> [ d_via_stops; d_stops ]
-          | None -> [ d_stops ]
-        in
-        let stops_rule =
-          Css.rule ~selector:(Css.Selector.class_ "_") stops_decls
-        in
-
-        (* Three separate rules: fallback, @supports, stops *)
-        let fallback_rule =
-          Css.rule ~selector:(Css.Selector.class_ "_") [ d_fallback ]
-        in
-        style ~property_rules
-          ~rules:(Some [ fallback_rule; supports_rule; stops_rule ])
-          []
-    | None ->
-        (* Non-scheme color: use color-mix directly *)
-        let oklch = Color.to_oklch color shade in
-        let color_value =
-          Color.mix_alpha opacity (Css.oklch oklch.l oklch.c oklch.h)
-        in
-        let d_var, _ = Var.binding set_var color_value in
         let declarations =
           match d_via_stops_opt with
           | Some d_via_stops -> [ d_var; d_via_stops; d_stops ]
           | None -> [ d_var; d_stops ]
         in
         style ~property_rules declarations
+    | None -> (
+        match
+          match Scheme.hex_color scheme color_name with
+          | Some _ as h -> h
+          | None -> Some (hex_of_palette ())
+        with
+        | Some hex_value ->
+            (* Scheme color: generate fallback + @supports + stops (same as
+               Tailwind) Tailwind outputs: 1. .from-X/N { --tw-gradient-from:
+               #RRGGBBAA } 2. @supports { .from-X/N { --tw-gradient-from:
+               color-mix(...) } } 3. .from-X/N { --tw-gradient-stops: ... } To
+               match, we put fallback in props, @supports in rules, and stops as
+               separate rule in rules. *)
+            let hex_alpha =
+              if Color.opacity_var_bare_of opacity <> None then hex_value
+              else Color.hex_with_alpha hex_value percent
+            in
+            let d_fallback, _ = Var.binding set_var (Css.hex hex_alpha) in
+
+            (* Theme variable for @supports block *)
+            let color_var = Color.color_var color shade in
+            let theme_decl, color_ref =
+              Var.binding color_var (Css.hex hex_value)
+            in
+            let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
+            let d_oklab, _ = Var.binding set_var oklab_color in
+
+            (* Build @supports block with placeholder selector *)
+            let supports_rule =
+              Css.supports ~condition:Color.color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_")
+                    [ theme_decl; d_oklab ];
+                ]
+            in
+
+            (* Build stops rule with placeholder selector (will be replaced) *)
+            let stops_decls =
+              match d_via_stops_opt with
+              | Some d_via_stops -> [ d_via_stops; d_stops ]
+              | None -> [ d_stops ]
+            in
+            let stops_rule =
+              Css.rule ~selector:(Css.Selector.class_ "_") stops_decls
+            in
+
+            (* Three separate rules: fallback, @supports, stops *)
+            let fallback_rule =
+              Css.rule ~selector:(Css.Selector.class_ "_") [ d_fallback ]
+            in
+            style ~property_rules
+              ~rules:(Some [ fallback_rule; supports_rule; stops_rule ])
+              []
+        | None ->
+            (* Non-scheme color: use color-mix directly *)
+            let oklch = Color.to_oklch color shade in
+            let color_value =
+              Color.mix_alpha opacity (Css.oklch oklch.l oklch.c oklch.h)
+            in
+            let d_var, _ = Var.binding set_var color_value in
+            let declarations =
+              match d_via_stops_opt with
+              | Some d_via_stops -> [ d_var; d_via_stops; d_stops ]
+              | None -> [ d_var; d_stops ]
+            in
+            style ~property_rules declarations)
 
   (** Build gradient stops declarations for a given prefix (from-/via-/to-).
       Returns (d_stops, d_via_stops_opt) *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1246,6 +1246,8 @@ let to_name color =
           Css.Pp.string ctx ")]"
         in
         Css.Pp.to_string ~minify:false pp_oklch oklch
+    | Css Css.Transparent -> "transparent"
+    | Css Css.Inherit -> "inherit"
     | Css c ->
         (* Serialize CSS color to bracket string for class names *)
         let s = Css.Pp.to_string ~minify:true Css.pp_color c in
@@ -1292,6 +1294,8 @@ let pp color =
           Css.Pp.string ctx ")"
         in
         Css.Pp.to_string ~minify:false pp_oklch_val (l, c, h)
+    | Css Css.Transparent -> "transparent"
+    | Css Css.Inherit -> "inherit"
     | Css c ->
         let s = Css.Pp.to_string ~minify:true Css.pp_color c in
         "Css(" ^ s ^ ")"
@@ -1305,6 +1309,14 @@ let is_base_color = function Black | White -> true | _ -> false
 let is_custom_color = function
   | Hex _ | Rgb _ | Oklch _ | Css _ -> true
   | _ -> false
+
+(* CSS-wide colour keywords need no palette or theme lookup. Keep them out of
+   [of_string]: a few utility families intentionally support only one of
+   them. *)
+let opacity_keyword = function
+  | Css Css.Transparent -> Some Css.Transparent
+  | Css Css.Inherit -> Some Css.Inherit
+  | _ -> None
 
 (* Check if a color is a theme-named color (no shade suffix) *)
 let is_theme_named = function Theme_named _ -> true | _ -> false
@@ -1557,6 +1569,8 @@ let color_to_string (c : color) : string =
           Css.Pp.float ctx o.h;
           Css.Pp.string ctx ")]")
         oklch
+  | Css Css.Transparent -> "transparent"
+  | Css Css.Inherit -> "inherit"
   | Css c ->
       let s = Css.Pp.to_string ~minify:true Css.pp_color c in
       let s = String.map (fun ch -> if ch = ' ' then '_' else ch) s in
@@ -1635,7 +1649,10 @@ let shade_of_strings = function
       match of_string color_str with
       | Ok color -> (
           match int_of_string_opt shade_str with
-          | Some shade when shade >= 0 && is_valid_shade color shade ->
+          | Some shade
+            when shade >= 0
+                 && (not (is_shadeless color))
+                 && is_valid_shade color shade ->
               Ok (color, shade)
           | _ -> Error (`Msg ("Invalid shade: " ^ shade_str)))
       | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
@@ -1656,16 +1673,38 @@ let shade_and_opacity_of_strings ?theme = function
       match of_string color_str with
       | Ok color -> (
           match int_of_string_opt shade_str with
-          | Some shade when shade >= 0 && is_valid_shade color shade ->
+          | Some shade
+            when shade >= 0
+                 && (not (is_shadeless color))
+                 && is_valid_shade color shade ->
               Ok (color, shade, opacity)
           | _ -> Error (`Msg ("Invalid shade: " ^ shade_str)))
       | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
   | [ color_str ] -> (
       (* Could be "current/50" or just "black" *)
       let base_str, opacity = parse_opacity_modifier ?theme color_str in
-      match of_string base_str with
-      | Ok color -> Ok (color, 500, opacity)
-      | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
+      let keyword =
+        match (base_str, opacity) with
+        | ( "transparent",
+            ( Opacity_percent _ | Opacity_arbitrary _
+            | Opacity_bracket_percent _ | Opacity_named _ | Opacity_var _ ) ) ->
+            Some Css.Transparent
+        | ( "inherit",
+            ( Opacity_percent _ | Opacity_arbitrary _
+            | Opacity_bracket_percent _ | Opacity_named _ | Opacity_var _ ) ) ->
+            Some Css.Inherit
+        | _ -> None
+      in
+      match keyword with
+      | Some keyword -> Ok (Css keyword, 500, opacity)
+      | None -> (
+          match of_string base_str with
+          | Ok color -> Ok (color, 500, opacity)
+          | Error _
+            when Parse.is_valid_theme_name base_str
+                 && Scheme.theme_value theme ("color-" ^ base_str) <> None ->
+              Ok (Theme_named base_str, 500, opacity)
+          | Error _ -> Error (`Msg ("Invalid color: " ^ color_str))))
   | [] -> Error (`Msg "No color specified")
   | _ -> Error (`Msg "Too many color parts")
 
@@ -1904,8 +1943,13 @@ module Handler = struct
   let property_color_value ?theme ~property_prefix (c : color) shade =
     let color_name = scheme_color_name c shade in
     let prop_name = property_prefix ^ "-" ^ color_name in
+    let parse_theme_color value =
+      match Css.parse_color value with
+      | Some color -> color
+      | None -> invalid_arg ("Invalid theme colour: " ^ value)
+    in
     match Scheme.theme_value theme prop_name with
-    | Some value -> Css.hex value
+    | Some value -> parse_theme_color value
     | None -> (
         match Scheme.hex_color (resolve_scheme theme) color_name with
         | Some hex -> Css.hex hex
@@ -1913,7 +1957,7 @@ module Handler = struct
             (* Check theme value overrides for standard color name *)
             let std_name = "color-" ^ color_name in
             match Scheme.theme_value theme std_name with
-            | Some value -> Css.hex value
+            | Some value -> parse_theme_color value
             | None -> to_css c (if is_base_color c then 500 else shade)))
 
   (* Aliases for color constructors/functions that will be shadowed by open
@@ -2598,6 +2642,13 @@ module Handler = struct
         Css.color_mix ~in_space color Css.Transparent
           ~percent1:(opacity_to_percent opacity)
 
+  (* Multiplying a fully transparent colour by another alpha is still fully
+     transparent. Keep that identity explicit: older cascade releases folded
+     [color-mix(transparent N%, transparent)] to an opaque-alpha black. *)
+  let apply_alpha ?(in_space : Css.color_space = Oklab) opacity = function
+    | Css.Transparent -> Css.Transparent
+    | color -> mix_alpha ~in_space opacity color
+
   (** Condition for progressive enhancement with color-mix in oklab *)
   let color_mix_supports_condition =
     Css.Supports.property "color" "color-mix(in lab, red, red)"
@@ -2614,109 +2665,112 @@ module Handler = struct
       shade opacity =
     let property_decls value = List.map (fun set -> set value) properties in
     let percent = opacity_to_percent opacity in
-    if is_fully_opaque opacity && not (is_custom_color c) then
-      (* At 100% the mix is a no-op, so Tailwind writes the colour itself and
-         needs neither the fallback nor the [@supports] pair. *)
-      let theme_decl, color_ref =
-        Var.binding (color_var c shade) (to_css c shade)
-      in
-      let value : Css.color = Var color_ref in
-      style ?merge_key (theme_decl :: property_decls value)
-    else if is_custom_color c && opacity_var_name opacity <> None then
-      style ?merge_key (property_decls (mix_alpha opacity (to_css c shade)))
-    else if is_custom_color c then
-      (* Custom/arbitrary colors (hex, rgb): output oklab() directly. No theme
-         variables, no @supports, no hex+alpha fallback. *)
-      let ok_l, ok_a, ok_b =
-        match c with
-        | Hex h -> (
-            match hex_to_rgb h with
-            | Some rgb -> rgb_to_oklab rgb
-            | None -> (0.0, 0.0, 0.0))
-        | Rgb { red; green; blue } ->
-            rgb_to_oklab { r = red; g = green; b = blue }
-        | _ -> (0.0, 0.0, 0.0)
-      in
-      let alpha = percent /. 100.0 in
-      let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
-      style ?merge_key (property_decls oklab_value)
-    else
-      let scheme = resolve_scheme theme in
-      let color_name = scheme_color_name c shade in
-      (* Check if color is defined as hex in the scheme *)
-      match Scheme.hex_color scheme color_name with
-      | Some hex_value ->
-          (* Scheme has hex color: use hex+alpha fallback with top-level
-             @supports *)
-          let hex_with_alpha = hex_with_alpha hex_value percent in
-          let fallback_decls = property_decls (Css.hex hex_with_alpha) in
-          (* Theme declaration for the variable *)
-          let color_var = color_var c shade in
-          let theme_decl, color_ref =
-            Var.binding color_var (Css.hex hex_value)
-          in
-          (* Progressive enhancement: color-mix(in oklab, var(--color-X) NN%,
-             transparent) *)
-          let oklab_color =
-            Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-              ~percent1:percent
-          in
-          (* Create @supports block with oklab version as top-level rule. Use
-             placeholder selector that rules.ml replaces with actual class. *)
-          let supports_block =
-            Css.supports ~condition:color_mix_supports_condition
-              [
-                Css.rule ~selector:(Css.Selector.class_ "_")
-                  (property_decls oklab_color);
-              ]
-          in
-          style ?merge_key ~rules:(Some [ supports_block ])
-            (theme_decl :: fallback_decls)
-      | None ->
-          (* Non-scheme color: use property-scoped variable if prefix given *)
-          let color_var =
-            match property_prefix with
-            | Some prefix ->
-                property_color_var ?theme ~property_prefix:prefix c shade
-            | Stdlib.Option.None -> color_var c shade
-          in
-          let color_value =
-            match property_prefix with
-            | Some prefix ->
-                property_color_value ?theme ~property_prefix:prefix c shade
-            | Stdlib.Option.None ->
-                to_css c (if is_base_color c then 500 else shade)
-          in
-          let theme_decl, color_ref = Var.binding color_var color_value in
-          (* An opacity read from a var has no percentage to fold into a hex
-             fallback, so the fallback is the colour at full opacity. *)
-          let fallback_decls =
-            match opacity_var_name opacity with
-            | Some _ -> property_decls (Css.Var color_ref)
-            | None ->
-                let oklch = to_oklch c shade in
-                let rgb = oklch_to_rgb oklch in
-                let hex_value = rgb_to_hex rgb in
-                property_decls (Css.hex (hex_with_alpha hex_value percent))
-          in
-          let oklab_color =
-            match opacity_var_name opacity with
-            | Some var_name ->
-                Css.color_mix_var_percent ~in_space:Oklab ~var_name
-                  (Css.Var color_ref) Css.Transparent
-            | None ->
-                Css.color_mix ~in_space:Oklab (Css.Var color_ref)
-                  Css.Transparent ~percent1:percent
-          in
-          let supports_block =
-            Css.supports ~condition:color_mix_supports_condition
-              [
-                Css.rule ~selector:(Css.Selector.class_ "_")
-                  (property_decls oklab_color);
-              ]
-          in
-          style ?merge_key ~rules:(Some [ supports_block ])
-            (theme_decl :: fallback_decls)
+    match opacity_keyword c with
+    | Some keyword ->
+        style ?merge_key (property_decls (apply_alpha opacity keyword))
+    | None when is_fully_opaque opacity && not (is_custom_color c) ->
+        (* At 100% the mix is a no-op, so Tailwind writes the colour itself and
+           needs neither the fallback nor the [@supports] pair. *)
+        let theme_decl, color_ref =
+          Var.binding (color_var c shade) (to_css c shade)
+        in
+        let value : Css.color = Var color_ref in
+        style ?merge_key (theme_decl :: property_decls value)
+    | None when is_custom_color c && opacity_var_name opacity <> None ->
+        style ?merge_key (property_decls (mix_alpha opacity (to_css c shade)))
+    | None when is_custom_color c ->
+        (* Custom/arbitrary colors (hex, rgb): output oklab() directly. No theme
+           variables, no @supports, no hex+alpha fallback. *)
+        let ok_l, ok_a, ok_b =
+          match c with
+          | Hex h -> (
+              match hex_to_rgb h with
+              | Some rgb -> rgb_to_oklab rgb
+              | None -> (0.0, 0.0, 0.0))
+          | Rgb { red; green; blue } ->
+              rgb_to_oklab { r = red; g = green; b = blue }
+          | _ -> (0.0, 0.0, 0.0)
+        in
+        let alpha = percent /. 100.0 in
+        let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
+        style ?merge_key (property_decls oklab_value)
+    | None -> (
+        let scheme = resolve_scheme theme in
+        let color_name = scheme_color_name c shade in
+        (* Check if color is defined as hex in the scheme *)
+        match Scheme.hex_color scheme color_name with
+        | Some hex_value ->
+            (* Scheme has hex color: use hex+alpha fallback with top-level
+               @supports *)
+            let hex_with_alpha = hex_with_alpha hex_value percent in
+            let fallback_decls = property_decls (Css.hex hex_with_alpha) in
+            (* Theme declaration for the variable *)
+            let color_var = color_var c shade in
+            let theme_decl, color_ref =
+              Var.binding color_var (Css.hex hex_value)
+            in
+            (* Progressive enhancement: color-mix(in oklab, var(--color-X) NN%,
+               transparent) *)
+            let oklab_color =
+              Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
+                ~percent1:percent
+            in
+            (* Create @supports block with oklab version as top-level rule. Use
+               placeholder selector that rules.ml replaces with actual class. *)
+            let supports_block =
+              Css.supports ~condition:color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_")
+                    (property_decls oklab_color);
+                ]
+            in
+            style ?merge_key ~rules:(Some [ supports_block ])
+              (theme_decl :: fallback_decls)
+        | None ->
+            (* Non-scheme color: use property-scoped variable if prefix given *)
+            let color_var =
+              match property_prefix with
+              | Some prefix ->
+                  property_color_var ?theme ~property_prefix:prefix c shade
+              | Stdlib.Option.None -> color_var c shade
+            in
+            let color_value =
+              match property_prefix with
+              | Some prefix ->
+                  property_color_value ?theme ~property_prefix:prefix c shade
+              | Stdlib.Option.None ->
+                  to_css c (if is_base_color c then 500 else shade)
+            in
+            let theme_decl, color_ref = Var.binding color_var color_value in
+            (* An opacity read from a var has no percentage to fold into a hex
+               fallback, so the fallback is the colour at full opacity. *)
+            let fallback_decls =
+              match opacity_var_name opacity with
+              | Some _ -> property_decls (Css.Var color_ref)
+              | None ->
+                  let oklch = to_oklch c shade in
+                  let rgb = oklch_to_rgb oklch in
+                  let hex_value = rgb_to_hex rgb in
+                  property_decls (Css.hex (hex_with_alpha hex_value percent))
+            in
+            let oklab_color =
+              match opacity_var_name opacity with
+              | Some var_name ->
+                  Css.color_mix_var_percent ~in_space:Oklab ~var_name
+                    (Css.Var color_ref) Css.Transparent
+              | None ->
+                  Css.color_mix ~in_space:Oklab (Css.Var color_ref)
+                    Css.Transparent ~percent1:percent
+            in
+            let supports_block =
+              Css.supports ~condition:color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_")
+                    (property_decls oklab_color);
+                ]
+            in
+            style ?merge_key ~rules:(Some [ supports_block ])
+              (theme_decl :: fallback_decls))
 
   let color_with_opacity_style ?theme ~property ?property_prefix ?merge_key c
       shade opacity =
@@ -3447,6 +3501,7 @@ let color_mix_supports_stmts ~stmts =
   Css.supports ~condition:color_mix_supports_condition stmts
 
 let mix_alpha = Handler.mix_alpha
+let apply_alpha = Handler.apply_alpha
 
 let oklab_with_supports ~property ~fallback_decl c shade opacity =
   let cvar = color_var c shade in
@@ -3461,39 +3516,41 @@ let generic_color_with_opacity ?theme ~property c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   let alpha_var = opacity_var_name opacity <> None in
-  if is_fully_opaque opacity && not (is_custom_color c) then
-    (* At 100% the mix is a no-op, so Tailwind writes the colour itself. *)
-    let theme_decl, color_ref =
-      Var.binding (color_var c shade) (to_css c shade)
-    in
-    let value : Css.color = Var color_ref in
-    Style.style [ theme_decl; property value ]
-  else if is_custom_color c then
-    if alpha_var then
-      Style.style [ property (mix_alpha opacity (to_css c shade)) ]
-    else
-      let ok_l, ok_a, ok_b = custom_color_to_oklab c in
-      let oklab_value = Css.oklaba ok_l ok_a ok_b (percent /. 100.0) in
-      Style.style [ property oklab_value ]
-  else
-    let color_name = scheme_color_name c shade in
-    match Scheme.hex_color (resolve_scheme theme) color_name with
-    | Some hex_value ->
-        let fallback_decl =
-          if alpha_var then property (Css.hex hex_value)
-          else property (Css.hex (hex_with_alpha hex_value percent))
-        in
-        oklab_with_supports ~property ~fallback_decl c shade opacity
-    | None ->
-        let oklch = to_oklch c shade in
-        let fallback_color =
-          if alpha_var then css_color_of_oklch oklch
-          else
-            Css.color_mix ~in_space:Srgb (css_color_of_oklch oklch)
-              Css.Transparent ~percent1:percent
-        in
-        oklab_with_supports ~property ~fallback_decl:(property fallback_color) c
-          shade opacity
+  match opacity_keyword c with
+  | Some keyword -> Style.style [ property (apply_alpha opacity keyword) ]
+  | None when is_fully_opaque opacity && not (is_custom_color c) ->
+      (* At 100% the mix is a no-op, so Tailwind writes the colour itself. *)
+      let theme_decl, color_ref =
+        Var.binding (color_var c shade) (to_css c shade)
+      in
+      let value : Css.color = Var color_ref in
+      Style.style [ theme_decl; property value ]
+  | None when is_custom_color c ->
+      if alpha_var then
+        Style.style [ property (mix_alpha opacity (to_css c shade)) ]
+      else
+        let ok_l, ok_a, ok_b = custom_color_to_oklab c in
+        let oklab_value = Css.oklaba ok_l ok_a ok_b (percent /. 100.0) in
+        Style.style [ property oklab_value ]
+  | None -> (
+      let color_name = scheme_color_name c shade in
+      match Scheme.hex_color (resolve_scheme theme) color_name with
+      | Some hex_value ->
+          let fallback_decl =
+            if alpha_var then property (Css.hex hex_value)
+            else property (Css.hex (hex_with_alpha hex_value percent))
+          in
+          oklab_with_supports ~property ~fallback_decl c shade opacity
+      | None ->
+          let oklch = to_oklch c shade in
+          let fallback_color =
+            if alpha_var then css_color_of_oklch oklch
+            else
+              Css.color_mix ~in_space:Srgb (css_color_of_oklch oklch)
+                Css.Transparent ~percent1:percent
+          in
+          oklab_with_supports ~property ~fallback_decl:(property fallback_color)
+            c shade opacity)
 
 let generic_current_with_opacity ?merge_key ~fallback_decl ~property opacity =
   let oklab_color = mix_alpha opacity Css.Current in
@@ -3577,43 +3634,49 @@ let divide_with_opacity_selector ?theme ~selector c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
   let alpha_var = opacity_var_name opacity <> None in
-  if is_fully_opaque opacity && not (is_custom_color c) then
-    let theme_decl, color_ref =
-      Var.binding (color_var c shade) (to_css c shade)
-    in
-    let value : Css.color = Var color_ref in
-    let rule = Css.rule ~selector [ Css.border_color value ] in
-    Style.style ~rules:(Some [ rule ]) [ theme_decl ]
-  else if is_custom_color c then
-    let value =
-      if alpha_var then mix_alpha opacity (to_css c shade)
-      else
-        let ok_l, ok_a, ok_b = custom_color_to_oklab c in
-        Css.oklaba ok_l ok_a ok_b (percent /. 100.0)
-    in
-    let rule = Css.rule ~selector [ Css.border_color value ] in
-    Style.style ~rules:(Some [ rule ]) []
-  else
-    let color_name = scheme_color_name c shade in
-    match Scheme.hex_color (resolve_scheme theme) color_name with
-    | Some hex_value ->
-        let hex_alpha =
-          if alpha_var then hex_value else hex_with_alpha hex_value percent
-        in
-        let fallback_rule =
-          Css.rule ~selector [ Css.border_color (Css.hex hex_alpha) ]
-        in
-        let cvar = color_var c shade in
-        let _theme_decl, color_ref = Var.binding cvar (Css.hex hex_value) in
-        let oklab_color = mix_alpha opacity (Css.Var color_ref) in
-        let supports_rule =
-          Css.rule ~selector [ Css.border_color oklab_color ]
-        in
-        let supports_block =
-          color_mix_supports_stmts ~stmts:[ supports_rule ]
-        in
-        Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
-    | None -> divide_opacity_via_property ?theme ~selector c shade opacity
+  match opacity_keyword c with
+  | Some keyword ->
+      let rule =
+        Css.rule ~selector [ Css.border_color (apply_alpha opacity keyword) ]
+      in
+      Style.style ~rules:(Some [ rule ]) []
+  | None when is_fully_opaque opacity && not (is_custom_color c) ->
+      let theme_decl, color_ref =
+        Var.binding (color_var c shade) (to_css c shade)
+      in
+      let value : Css.color = Var color_ref in
+      let rule = Css.rule ~selector [ Css.border_color value ] in
+      Style.style ~rules:(Some [ rule ]) [ theme_decl ]
+  | None when is_custom_color c ->
+      let value =
+        if alpha_var then mix_alpha opacity (to_css c shade)
+        else
+          let ok_l, ok_a, ok_b = custom_color_to_oklab c in
+          Css.oklaba ok_l ok_a ok_b (percent /. 100.0)
+      in
+      let rule = Css.rule ~selector [ Css.border_color value ] in
+      Style.style ~rules:(Some [ rule ]) []
+  | None -> (
+      let color_name = scheme_color_name c shade in
+      match Scheme.hex_color (resolve_scheme theme) color_name with
+      | Some hex_value ->
+          let hex_alpha =
+            if alpha_var then hex_value else hex_with_alpha hex_value percent
+          in
+          let fallback_rule =
+            Css.rule ~selector [ Css.border_color (Css.hex hex_alpha) ]
+          in
+          let cvar = color_var c shade in
+          let _theme_decl, color_ref = Var.binding cvar (Css.hex hex_value) in
+          let oklab_color = mix_alpha opacity (Css.Var color_ref) in
+          let supports_rule =
+            Css.rule ~selector [ Css.border_color oklab_color ]
+          in
+          let supports_block =
+            color_mix_supports_stmts ~stmts:[ supports_rule ]
+          in
+          Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
+      | None -> divide_opacity_via_property ?theme ~selector c shade opacity)
 
 let divide_with_opacity ?theme c shade opacity selector =
   divide_with_opacity_selector ?theme ~selector c shade opacity
@@ -3640,40 +3703,44 @@ let divide_current_with_opacity opacity selector =
 let bg_with_opacity ?theme c shade opacity =
   let open Handler in
   let percent = opacity_to_percent opacity in
-  if is_fully_opaque opacity then
-    (* 100% opacity = no transparency. Tailwind outputs the plain color var
-       reference, identical to the no-opacity case. *)
-    let cvar = color_var c shade in
-    let color_value = to_css c (if is_base_color c then 500 else shade) in
-    let _d, color_ref = Var.binding cvar color_value in
-    Style.style [ Css.background_color (Var color_ref) ]
-  else if is_custom_color c then
-    let value =
-      if opacity_var_name opacity <> None then
-        mix_alpha opacity (to_css c shade)
-      else
-        let ok_l, ok_a, ok_b = custom_color_to_oklab c in
-        Css.oklaba_none_zeros ok_l ok_a ok_b (percent /. 100.0)
-    in
-    Style.style [ Css.background_color value ]
-  else
-    let color_name = scheme_color_name c shade in
-    match Scheme.hex_color (resolve_scheme theme) color_name with
-    | Some hex_value ->
-        let cvar = color_var c shade in
-        let theme_decl, color_ref = Var.binding cvar (Css.hex hex_value) in
-        let fallback_decl =
-          if opacity_var_name opacity <> None then
-            Css.background_color (Css.Var color_ref)
-          else Css.background_color (Css.hex (hex_with_alpha hex_value percent))
-        in
-        let oklab_decl =
-          Css.background_color (mix_alpha opacity (Css.Var color_ref))
-        in
-        let supports_block = color_mix_supports ~decls:[ oklab_decl ] in
-        Style.style ~rules:(Some [ supports_block ])
-          [ theme_decl; fallback_decl ]
-    | None -> bg_opacity_via_property c shade opacity
+  match opacity_keyword c with
+  | Some keyword ->
+      Style.style [ Css.background_color (apply_alpha opacity keyword) ]
+  | None when is_fully_opaque opacity ->
+      (* 100% opacity = no transparency. Tailwind outputs the plain color var
+         reference, identical to the no-opacity case. *)
+      let cvar = color_var c shade in
+      let color_value = to_css c (if is_base_color c then 500 else shade) in
+      let _d, color_ref = Var.binding cvar color_value in
+      Style.style [ Css.background_color (Var color_ref) ]
+  | None when is_custom_color c ->
+      let value =
+        if opacity_var_name opacity <> None then
+          mix_alpha opacity (to_css c shade)
+        else
+          let ok_l, ok_a, ok_b = custom_color_to_oklab c in
+          Css.oklaba_none_zeros ok_l ok_a ok_b (percent /. 100.0)
+      in
+      Style.style [ Css.background_color value ]
+  | None -> (
+      let color_name = scheme_color_name c shade in
+      match Scheme.hex_color (resolve_scheme theme) color_name with
+      | Some hex_value ->
+          let cvar = color_var c shade in
+          let theme_decl, color_ref = Var.binding cvar (Css.hex hex_value) in
+          let fallback_decl =
+            if opacity_var_name opacity <> None then
+              Css.background_color (Css.Var color_ref)
+            else
+              Css.background_color (Css.hex (hex_with_alpha hex_value percent))
+          in
+          let oklab_decl =
+            Css.background_color (mix_alpha opacity (Css.Var color_ref))
+          in
+          let supports_block = color_mix_supports ~decls:[ oklab_decl ] in
+          Style.style ~rules:(Some [ supports_block ])
+            [ theme_decl; fallback_decl ]
+      | None -> bg_opacity_via_property c shade opacity)
 
 (** Determine the appropriate fallback for an opacity theme variable. If the
     theme defines a concrete value (e.g., "0.5"), use [Fallback (Num f)]. If the

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -201,6 +201,11 @@ val is_base_color : color -> bool
 val is_custom_color : color -> bool
 (** [is_custom_color color] checks if a color is a custom color (hex or rgb). *)
 
+val opacity_keyword : color -> Css.color option
+(** [opacity_keyword color] returns [transparent] or [inherit] when [color] is
+    one of the CSS-wide keywords accepted by opacity-bearing colour utilities.
+*)
+
 val is_shadeless : color -> bool
 (** [is_shadeless color] checks if a color should NOT have a shade suffix in
     class names (base colors, custom colors, or theme-named colors). *)
@@ -349,6 +354,11 @@ val mix_alpha :
 (** [mix_alpha ?in_space opacity color] is [color] with the modifier's alpha
     applied: a percentage folds into the [color-mix], an alpha read from a var
     is referenced by name. *)
+
+val apply_alpha :
+  ?in_space:Css.color_space -> opacity_modifier -> Css.color -> Css.color
+(** [apply_alpha ?in_space opacity color] applies the modifier while preserving
+    the identity that every alpha of [transparent] is still [transparent]. *)
 
 val opacity_of_string : ?theme:Scheme.t -> string -> opacity_modifier option
 (** [opacity_of_string ?theme s] parses the modifier that follows the [/] in a

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -67,6 +67,7 @@ module Handler = struct
     | Shadow_current_opacity of Color.opacity_modifier
     | Shadow_inherit
     | Shadow_transparent
+    | Shadow_transparent_opacity of Color.opacity_modifier
     | Shadow_bracket_color of string * Css.color
     | Shadow_bracket_color_opacity of
         string * Css.color * Color.opacity_modifier
@@ -92,6 +93,7 @@ module Handler = struct
     | Inset_shadow_current_opacity of Color.opacity_modifier
     | Inset_shadow_inherit
     | Inset_shadow_transparent
+    | Inset_shadow_transparent_opacity of Color.opacity_modifier
     | Inset_shadow_bracket_color of string * Css.color
     | Inset_shadow_bracket_color_opacity of
         string * Css.color * Color.opacity_modifier
@@ -115,10 +117,12 @@ module Handler = struct
     | Ring_inset
     | Ring_color of Color.color * int
     | Ring_color_opacity of Color.color * int * Color.opacity_modifier
+    | Ring_keyword_opacity of Css.color * string * Color.opacity_modifier
     | Ring_offset_width of int
     | Ring_offset_bracket_length of string
     | Ring_offset_color of Color.color * int
     | Ring_offset_color_opacity of Color.color * int * Color.opacity_modifier
+    | Ring_offset_keyword_opacity of Css.color * string * Color.opacity_modifier
     | Ring_offset_transparent
     | Ring_offset_current
     | Ring_offset_current_opacity of Color.opacity_modifier
@@ -132,6 +136,7 @@ module Handler = struct
     | Ring_offset_bracket_var_opacity of string * Color.opacity_modifier
     | Inset_ring_color of Color.color * int
     | Inset_ring_color_opacity of Color.color * int * Color.opacity_modifier
+    | Inset_ring_keyword_opacity of Css.color * string * Color.opacity_modifier
     | Inset_ring_transparent
     | Inset_ring_current
     | Inset_ring_current_opacity of Color.opacity_modifier
@@ -775,6 +780,18 @@ module Handler = struct
     style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
       [ base_decl ]
 
+  let set_shadow_transparent_opacity opacity =
+    let base_decl, _ = Var.binding shadow_color_var Css.Transparent in
+    let inner_mix = Color.apply_alpha opacity Css.Transparent in
+    let enhanced_color =
+      Css.color_mix_var_percent ~in_space:Oklab ~var_name:"tw-shadow-alpha"
+        inner_mix Css.Transparent
+    in
+    let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
+    let supports_block = color_mix_supports [ enhanced_decl ] in
+    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
+      [ base_decl ]
+
   let set_shadow_inherit () =
     let base_decl, _ = Var.binding shadow_color_var Css.Inherit in
     style ~property_rules:shadow_property_rules [ base_decl ]
@@ -1347,6 +1364,18 @@ module Handler = struct
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab
         ~var_name:"tw-inset-shadow-alpha" Css.Transparent Css.Transparent
+    in
+    let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
+    let supports_block = color_mix_supports [ enhanced_decl ] in
+    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
+      [ base_decl ]
+
+  let set_inset_shadow_transparent_opacity opacity =
+    let base_decl, _ = Var.binding inset_shadow_color_var Css.Transparent in
+    let inner_mix = Color.apply_alpha opacity Css.Transparent in
+    let enhanced_color =
+      Css.color_mix_var_percent ~in_space:Oklab
+        ~var_name:"tw-inset-shadow-alpha" inner_mix Css.Transparent
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
@@ -1975,6 +2004,16 @@ module Handler = struct
     let d, _ = Var.binding ring_color_var Css.Inherit in
     style [ d ]
 
+  let ring_keyword_with_opacity var keyword opacity =
+    let fallback, _ = Var.binding var keyword in
+    let mixed = Color.apply_alpha opacity keyword in
+    let enhanced, _ = Var.binding var mixed in
+    let supports_block =
+      Css.supports ~condition:Color.color_mix_supports_condition
+        [ Css.rule ~selector:(Css.Selector.class_ "_") [ enhanced ] ]
+    in
+    style ~rules:(Some [ supports_block ]) [ fallback ]
+
   let ring_bracket_color (c : Css.color) =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
     let d, _ = Var.binding ring_color_var c in
@@ -2121,6 +2160,7 @@ module Handler = struct
     | Shadow_current_opacity op -> set_shadow_current_opacity op
     | Shadow_inherit -> set_shadow_inherit ()
     | Shadow_transparent -> set_shadow_transparent ()
+    | Shadow_transparent_opacity op -> set_shadow_transparent_opacity op
     | Shadow_bracket_color (_orig, c) -> set_shadow_bracket_color c
     | Shadow_bracket_color_opacity (_orig, c, op) ->
         set_shadow_bracket_color_opacity c op
@@ -2146,6 +2186,8 @@ module Handler = struct
     | Inset_shadow_current_opacity op -> set_inset_shadow_current_opacity op
     | Inset_shadow_inherit -> set_inset_shadow_inherit ()
     | Inset_shadow_transparent -> set_inset_shadow_transparent ()
+    | Inset_shadow_transparent_opacity op ->
+        set_inset_shadow_transparent_opacity op
     | Inset_shadow_bracket_color (_orig, c) -> set_inset_shadow_bracket_color c
     | Inset_shadow_bracket_color_opacity (_orig, c, op) ->
         set_ishadow_bracket_color_opacity c op
@@ -2174,6 +2216,8 @@ module Handler = struct
     | Ring_color (color, shade) -> ring_color color shade
     | Ring_color_opacity (color, shade, opacity) ->
         ring_color_with_opacity color shade opacity
+    | Ring_keyword_opacity (keyword, _, opacity) ->
+        ring_keyword_with_opacity ring_color_var keyword opacity
     | Ring_transparent -> ring_transparent
     | Ring_current -> ring_current
     | Ring_current_opacity opacity -> ring_current_with_opacity opacity
@@ -2237,6 +2281,8 @@ module Handler = struct
     | Ring_offset_color (color, shade) -> ring_offset_color color shade
     | Ring_offset_color_opacity (color, shade, opacity) ->
         ring_offset_color_with_opacity color shade opacity
+    | Ring_offset_keyword_opacity (keyword, _, opacity) ->
+        ring_keyword_with_opacity ring_offset_color_var keyword opacity
     | Ring_offset_transparent -> ring_offset_transparent
     | Ring_offset_current -> ring_offset_current
     | Ring_offset_current_opacity opacity ->
@@ -2254,6 +2300,8 @@ module Handler = struct
     | Inset_ring_color (color, shade) -> inset_ring_color color shade
     | Inset_ring_color_opacity (color, shade, opacity) ->
         inset_ring_color_with_opacity color shade opacity
+    | Inset_ring_keyword_opacity (keyword, _, opacity) ->
+        ring_keyword_with_opacity inset_ring_color_var keyword opacity
     | Inset_ring_transparent -> inset_ring_transparent
     | Inset_ring_current -> inset_ring_current
     | Inset_ring_current_opacity opacity ->
@@ -2557,6 +2605,7 @@ module Handler = struct
         | "lg", op -> Ok (Shadow_shape_opacity (Lg, op))
         | "xl", op -> Ok (Shadow_shape_opacity (Xl, op))
         | "2xl", op -> Ok (Shadow_shape_opacity (Two_xl, op))
+        | "transparent", op -> Ok (Shadow_transparent_opacity op)
         (* Not a size: a shadeless colour with an alpha, e.g. shadow-white/10 *)
         | base, op -> (
             match Color.shade_of_strings [ base ] with
@@ -2607,6 +2656,7 @@ module Handler = struct
         | "2xs", op -> Ok (Inset_shadow_shape_opacity (Ish_2xs, op))
         | "xs", op -> Ok (Inset_shadow_shape_opacity (Ish_xs, op))
         | "sm", op -> Ok (Inset_shadow_shape_opacity (Ish_sm, op))
+        | "transparent", op -> Ok (Inset_shadow_transparent_opacity op)
         | base, op -> (
             match Color.shade_of_strings [ base ] with
             | Ok (c, s) -> Ok (Inset_shadow_color_opacity (c, s, op))
@@ -2652,6 +2702,15 @@ module Handler = struct
     | [ "ring"; "inset" ] -> Ok Ring_inset
     | [ "ring"; "transparent" ] -> Ok Ring_transparent
     | [ "ring"; "inherit" ] -> Ok Ring_inherit
+    | [ "ring"; value ]
+      when let base, opacity = Color.parse_opacity_modifier ~theme value in
+           opacity <> Color.No_opacity
+           && (base = "transparent" || base = "inherit") ->
+        let base, opacity = Color.parse_opacity_modifier ~theme value in
+        let keyword =
+          if base = "transparent" then Css.Transparent else Css.Inherit
+        in
+        Ok (Ring_keyword_opacity (keyword, base, opacity))
     | [ "ring"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
         let base, opacity = Color.parse_opacity_modifier ~theme current_str in
@@ -2681,6 +2740,15 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "ring"; "offset"; "transparent" ] -> Ok Ring_offset_transparent
     | [ "ring"; "offset"; "inherit" ] -> Ok Ring_offset_inherit
+    | [ "ring"; "offset"; value ]
+      when let base, opacity = Color.parse_opacity_modifier ~theme value in
+           opacity <> Color.No_opacity
+           && (base = "transparent" || base = "inherit") ->
+        let base, opacity = Color.parse_opacity_modifier ~theme value in
+        let keyword =
+          if base = "transparent" then Css.Transparent else Css.Inherit
+        in
+        Ok (Ring_offset_keyword_opacity (keyword, base, opacity))
     | [ "ring"; "offset"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
         let base, opacity = Color.parse_opacity_modifier ~theme current_str in
@@ -2718,6 +2786,15 @@ module Handler = struct
     | [ "inset"; "ring" ] -> Ok Inset_ring_default
     | [ "inset"; "ring"; "transparent" ] -> Ok Inset_ring_transparent
     | [ "inset"; "ring"; "inherit" ] -> Ok Inset_ring_inherit
+    | [ "inset"; "ring"; value ]
+      when let base, opacity = Color.parse_opacity_modifier ~theme value in
+           opacity <> Color.No_opacity
+           && (base = "transparent" || base = "inherit") ->
+        let base, opacity = Color.parse_opacity_modifier ~theme value in
+        let keyword =
+          if base = "transparent" then Css.Transparent else Css.Inherit
+        in
+        Ok (Inset_ring_keyword_opacity (keyword, base, opacity))
     | [ "inset"; "ring"; current_str ]
       when String.starts_with ~prefix:"current" current_str -> (
         let base, opacity = Color.parse_opacity_modifier ~theme current_str in
@@ -2828,6 +2905,8 @@ module Handler = struct
     | Shadow_current_opacity op -> "shadow-current/" ^ Color.pp_opacity op
     | Shadow_inherit -> "shadow-inherit"
     | Shadow_transparent -> "shadow-transparent"
+    | Shadow_transparent_opacity op ->
+        "shadow-transparent/" ^ Color.pp_opacity op
     | Shadow_bracket_color (orig, _c) -> "shadow-[" ^ orig ^ "]"
     | Shadow_bracket_color_opacity (orig, _c, op) ->
         "shadow-[" ^ orig ^ "]/" ^ Color.pp_opacity op
@@ -2858,6 +2937,8 @@ module Handler = struct
         "inset-shadow-current/" ^ Color.pp_opacity op
     | Inset_shadow_inherit -> "inset-shadow-inherit"
     | Inset_shadow_transparent -> "inset-shadow-transparent"
+    | Inset_shadow_transparent_opacity op ->
+        "inset-shadow-transparent/" ^ Color.pp_opacity op
     | Inset_shadow_bracket_color (orig, _c) -> "inset-shadow-[" ^ orig ^ "]"
     | Inset_shadow_bracket_color_opacity (orig, _c, op) ->
         "inset-shadow-[" ^ orig ^ "]/" ^ Color.pp_opacity op
@@ -2887,6 +2968,8 @@ module Handler = struct
           else "ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
         in
         base ^ "/" ^ Color.pp_opacity opacity
+    | Ring_keyword_opacity (_, spelling, opacity) ->
+        "ring-" ^ spelling ^ "/" ^ Color.pp_opacity opacity
     | Ring_transparent -> "ring-transparent"
     | Ring_current -> "ring-current"
     | Ring_current_opacity o -> "ring-current/" ^ Color.pp_opacity o
@@ -2908,6 +2991,8 @@ module Handler = struct
     | Ring_offset_color_opacity (color, shade, opacity) ->
         "ring-offset-" ^ Color.pp color ^ "-" ^ string_of_int shade ^ "/"
         ^ Color.pp_opacity opacity
+    | Ring_offset_keyword_opacity (_, spelling, opacity) ->
+        "ring-offset-" ^ spelling ^ "/" ^ Color.pp_opacity opacity
     | Ring_offset_transparent -> "ring-offset-transparent"
     | Ring_offset_current -> "ring-offset-current"
     | Ring_offset_current_opacity o ->
@@ -2931,6 +3016,8 @@ module Handler = struct
           else "inset-ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
         in
         base ^ "/" ^ Color.pp_opacity opacity
+    | Inset_ring_keyword_opacity (_, spelling, opacity) ->
+        "inset-ring-" ^ spelling ^ "/" ^ Color.pp_opacity opacity
     | Inset_ring_transparent -> "inset-ring-transparent"
     | Inset_ring_current -> "inset-ring-current"
     | Inset_ring_current_opacity o -> "inset-ring-current/" ^ Color.pp_opacity o
@@ -3015,8 +3102,9 @@ module Handler = struct
     (* Shadow color utilities *)
     | Shadow_color _ | Shadow_color_opacity _ | Shadow_current
     | Shadow_current_opacity _ | Shadow_inherit | Shadow_transparent
-    | Shadow_bracket_color _ | Shadow_bracket_color_opacity _
-    | Shadow_bracket_color_var _ | Shadow_bracket_color_var_opacity _ ->
+    | Shadow_transparent_opacity _ | Shadow_bracket_color _
+    | Shadow_bracket_color_opacity _ | Shadow_bracket_color_var _
+    | Shadow_bracket_color_var_opacity _ ->
         35000
     (* Inset shadow opacity utilities — same relative scheme as shadow *)
     | Inset_shadow_arbitrary_opacity (arb, _) ->
@@ -3045,8 +3133,8 @@ module Handler = struct
     | Inset_shadow_color _ | Inset_shadow_color_opacity _ | Inset_shadow_current
     | Inset_shadow_current_opacity _ | Inset_shadow_inherit
     | Inset_shadow_transparent | Inset_shadow_bracket_color _
-    | Inset_shadow_bracket_color_opacity _ | Inset_shadow_bracket_color_var _
-    | Inset_shadow_bracket_cvar_opacity _ ->
+    | Inset_shadow_transparent_opacity _ | Inset_shadow_bracket_color_opacity _
+    | Inset_shadow_bracket_color_var _ | Inset_shadow_bracket_cvar_opacity _ ->
         36000
     (* Background blend modes come after opacity, before mix-blend *)
     | Bg_blend_color -> 22000
@@ -3095,18 +3183,19 @@ module Handler = struct
     | Ring_xl -> 40005
     | Ring_width _ -> 40005
     | Ring_bracket_length _ -> 40010
-    | Ring_color _ | Ring_color_opacity _ | Ring_transparent | Ring_current
-    | Ring_current_opacity _ | Ring_inherit | Ring_bracket_color _
-    | Ring_bracket_color_opacity _ | Ring_bracket_color_var _
-    | Ring_bracket_color_var_opacity _ | Ring_bracket_var _
-    | Ring_bracket_var_opacity _ ->
+    | Ring_color _ | Ring_color_opacity _ | Ring_keyword_opacity _
+    | Ring_transparent | Ring_current | Ring_current_opacity _ | Ring_inherit
+    | Ring_bracket_color _ | Ring_bracket_color_opacity _
+    | Ring_bracket_color_var _ | Ring_bracket_color_var_opacity _
+    | Ring_bracket_var _ | Ring_bracket_var_opacity _ ->
         50000
     | Ring_inset -> 51000
     | Inset_ring_default -> 55000
     | Inset_ring_width n -> 55001 + n
     | Inset_ring_bracket_length _ -> 55100
-    | Inset_ring_color _ | Inset_ring_color_opacity _ | Inset_ring_transparent
-    | Inset_ring_current | Inset_ring_current_opacity _ | Inset_ring_inherit
+    | Inset_ring_color _ | Inset_ring_color_opacity _
+    | Inset_ring_keyword_opacity _ | Inset_ring_transparent | Inset_ring_current
+    | Inset_ring_current_opacity _ | Inset_ring_inherit
     | Inset_ring_bracket_color _ | Inset_ring_bracket_color_opacity _
     | Inset_ring_bracket_color_var _ | Inset_ring_bracket_cvar_opacity _
     | Inset_ring_bracket_var _ | Inset_ring_bracket_var_opacity _ ->
@@ -3114,8 +3203,8 @@ module Handler = struct
     | Ring_offset_width n -> 80000 + n
     | Ring_offset_bracket_length _ -> 80100
     | Ring_offset_color _ | Ring_offset_color_opacity _
-    | Ring_offset_transparent | Ring_offset_current
-    | Ring_offset_current_opacity _ | Ring_offset_inherit
+    | Ring_offset_keyword_opacity _ | Ring_offset_transparent
+    | Ring_offset_current | Ring_offset_current_opacity _ | Ring_offset_inherit
     | Ring_offset_bracket_color _ | Ring_offset_bracket_color_opacity _
     | Ring_offset_bracket_color_var _ | Ring_offset_bracket_cvar_opacity _
     | Ring_offset_bracket_var _ | Ring_offset_bracket_var_opacity _ ->

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -54,6 +54,8 @@ module Handler = struct
     | Drop_shadow_opacity of Color.opacity_modifier
     | Drop_shadow_keyword_color of Css.color * string
       (* drop-shadow-current / -transparent: a colour with no theme token *)
+    | Drop_shadow_keyword_color_opacity of
+        Css.color * string * Color.opacity_modifier
     | Drop_shadow_size_opacity of
         string * (Css.length * Css.length) * Color.opacity_modifier
     | Backdrop_filter
@@ -790,6 +792,27 @@ module Handler = struct
           [ bind_drop_shadow drop_shadow_size_ref ];
       ]
 
+  let drop_shadow_keyword_color_opacity color opacity =
+    let inner = Color.apply_alpha opacity color in
+    let supports_block =
+      Css.supports ~condition:Color.color_mix_supports_condition
+        [
+          Css.rule ~selector:(Css.Selector.class_ "_")
+            [
+              bind_drop_shadow_color
+                (Css.color_mix_var_percent ~in_space:Oklab
+                   ~var_name:"tw-drop-shadow-alpha" inner Css.Transparent);
+            ];
+        ]
+    in
+    Group
+      [
+        style ~rules:(Option.Some [ supports_block ])
+          [ bind_drop_shadow_color color ];
+        style ~property_rules:filter_property_rules
+          [ bind_drop_shadow drop_shadow_size_ref ];
+      ]
+
   let drop_shadow_color_opacity ?theme c shade opacity =
     let color_name = Color.scheme_color_name c shade in
     let scheme = match theme with Some t -> t | None -> Scheme.default in
@@ -1195,6 +1218,8 @@ module Handler = struct
         drop_shadow_color_opacity c shade op
     | Drop_shadow_opacity op -> drop_shadow_opacity op
     | Drop_shadow_keyword_color (c, _) -> drop_shadow_keyword_color c
+    | Drop_shadow_keyword_color_opacity (c, _, opacity) ->
+        drop_shadow_keyword_color_opacity c opacity
     | Drop_shadow_size_opacity (_, geom, op) -> drop_shadow_size_opacity geom op
     | Backdrop_blur_none -> backdrop_blur_none ()
     | Backdrop_blur_xs -> backdrop_blur_xs ()
@@ -1267,8 +1292,8 @@ module Handler = struct
     (* Every drop-shadow colour shares one slot, after the sizes: Tailwind
        orders them among themselves by class name, which the alphabetical
        tie-break already does. *)
-    | Drop_shadow_keyword_color _ | Drop_shadow_inherit | Drop_shadow_color _
-    | Drop_shadow_color_opacity _ ->
+    | Drop_shadow_keyword_color _ | Drop_shadow_keyword_color_opacity _
+    | Drop_shadow_inherit | Drop_shadow_color _ | Drop_shadow_color_opacity _ ->
         2710
     | Filter -> 9000
     | Filter_arbitrary _ -> 9001
@@ -1440,6 +1465,14 @@ module Handler = struct
             | Option.Some geom -> Ok (Drop_shadow_size_opacity (base, geom, op))
             | Option.None -> (
                 if base = "" then Ok (Drop_shadow_opacity op)
+                else if base = "inherit" then
+                  Ok (Drop_shadow_keyword_color_opacity (Css.Inherit, base, op))
+                else if base = "transparent" then
+                  Ok
+                    (Drop_shadow_keyword_color_opacity
+                       (Css.Transparent, base, op))
+                else if base = "current" then
+                  Ok (Drop_shadow_keyword_color_opacity (Css.Current, base, op))
                 else
                   match
                     Color.shade_and_opacity_of_strings
@@ -1595,6 +1628,8 @@ module Handler = struct
         ^ "/" ^ Color.pp_opacity op
     | Drop_shadow_opacity op -> "drop-shadow/" ^ Color.pp_opacity op
     | Drop_shadow_keyword_color (_, name) -> "drop-shadow-" ^ name
+    | Drop_shadow_keyword_color_opacity (_, name, opacity) ->
+        "drop-shadow-" ^ name ^ "/" ^ Color.pp_opacity opacity
     | Drop_shadow_size_opacity (size, _, op) ->
         "drop-shadow-" ^ size ^ "/" ^ Color.pp_opacity op
     | Backdrop_blur_none -> "backdrop-blur-none"

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -30,6 +30,7 @@ module Handler = struct
     | Text_shadow_current_opacity of Color.opacity_modifier
     | Text_shadow_inherit
     | Text_shadow_transparent
+    | Text_shadow_transparent_opacity of Color.opacity_modifier
     | Text_shadow_bracket_hex of string
     | Text_shadow_bracket_hex_opacity of string * Color.opacity_modifier
     | Text_shadow_bracket_color_var of string
@@ -413,6 +414,18 @@ module Handler = struct
     style ~rules:(Some [ supports_block ])
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
+  let set_transparent_opacity opacity =
+    let base_decl, _ = Var.binding text_shadow_color_var Css.Transparent in
+    let inner_mix = Color.apply_alpha opacity Css.Transparent in
+    let enhanced_color =
+      Css.color_mix_var_percent ~in_space:Oklab ~var_name:"tw-text-shadow-alpha"
+        inner_mix Css.Transparent
+    in
+    let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
+    let supports_block = color_mix_supports [ enhanced_decl ] in
+    style ~rules:(Some [ supports_block ])
+      ~property_rules:text_shadow_property_rules [ base_decl ]
+
   let set_inherit () =
     let base_decl, _ = Var.binding text_shadow_color_var Css.Inherit in
     style ~property_rules:text_shadow_property_rules [ base_decl ]
@@ -611,6 +624,7 @@ module Handler = struct
     | Text_shadow_current_opacity opacity -> set_current_opacity opacity
     | Text_shadow_inherit -> set_inherit ()
     | Text_shadow_transparent -> set_transparent ()
+    | Text_shadow_transparent_opacity opacity -> set_transparent_opacity opacity
     | Text_shadow_bracket_hex hex -> set_bracket_hex hex
     | Text_shadow_bracket_hex_opacity (hex, opacity) ->
         set_bracket_hex_opacity hex opacity
@@ -692,9 +706,13 @@ module Handler = struct
         match (shape_opt, opacity) with
         | Some shape, Color.No_opacity -> Ok (Text_shadow_shape shape)
         | Some shape, op -> Ok (Text_shadow_shape_opacity (shape, op))
-        | Stdlib.Option.None, _ when base = "inherit" -> Ok Text_shadow_inherit
-        | Stdlib.Option.None, _ when base = "transparent" ->
+        | Stdlib.Option.None, Color.No_opacity when base = "inherit" ->
+            Ok Text_shadow_inherit
+        | Stdlib.Option.None, _ when base = "inherit" -> err_not_utility
+        | Stdlib.Option.None, Color.No_opacity when base = "transparent" ->
             Ok Text_shadow_transparent
+        | Stdlib.Option.None, op when base = "transparent" ->
+            Ok (Text_shadow_transparent_opacity op)
         | Stdlib.Option.None, _ when starts_with "current" base -> (
             match opacity with
             | Color.No_opacity when base = "current" -> Ok Text_shadow_current
@@ -774,6 +792,8 @@ module Handler = struct
         "text-shadow-current/" ^ Color.pp_opacity opacity
     | Text_shadow_inherit -> "text-shadow-inherit"
     | Text_shadow_transparent -> "text-shadow-transparent"
+    | Text_shadow_transparent_opacity opacity ->
+        "text-shadow-transparent/" ^ Color.pp_opacity opacity
     | Text_shadow_bracket_hex hex -> "text-shadow-[#" ^ hex ^ "]"
     | Text_shadow_bracket_hex_opacity (hex, opacity) ->
         "text-shadow-[#" ^ hex ^ "]/" ^ Color.pp_opacity opacity

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2304,58 +2304,67 @@ module Typography_late = struct
     let percent = Color.opacity_to_percent opacity in
     let scheme = match theme with Some t -> t | None -> Scheme.default in
     let color_name = Color.scheme_color_name color shade in
-    match Scheme.hex_color scheme color_name with
-    | Some hex_value ->
-        (* Scheme has hex: fallback is hex+alpha, @supports has color-mix with
-           webkit *)
-        let hex_with_alpha = Color.hex_with_alpha hex_value percent in
-        let fallback_decl = text_decoration_color (Css.hex hex_with_alpha) in
-        let color_var = Color.color_var color shade in
-        let theme_decl, color_ref = Var.binding color_var (Css.hex hex_value) in
-        let oklab_color =
-          Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-            ~percent1:percent
-        in
-        let webkit_decl = webkit_text_decoration_color oklab_color in
-        let oklab_decl = text_decoration_color oklab_color in
-        let supports_block =
-          Css.supports ~condition:Color.color_mix_supports_condition
-            [
-              Css.rule ~selector:(Css.Selector.class_ "_")
-                [ webkit_decl; oklab_decl ];
-            ]
-        in
-        style ~rules:(Some [ supports_block ]) [ theme_decl; fallback_decl ]
-    | None ->
-        (* No scheme hex: use property-scoped variable *)
-        let color_var =
-          Color.property_color_var ?theme
-            ~property_prefix:"text-decoration-color" color shade
-        in
-        let color_value =
-          Color.property_color_value ~property_prefix:"text-decoration-color"
-            color shade
-        in
-        let oklch = Color.to_oklch color shade in
-        let rgb = Color.oklch_to_rgb oklch in
-        let hex_value = Color.rgb_to_hex rgb in
-        let hex_with_alpha = Color.hex_with_alpha hex_value percent in
-        let fallback_decl = text_decoration_color (Css.hex hex_with_alpha) in
-        let theme_decl, color_ref = Var.binding color_var color_value in
-        let oklab_color =
-          Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-            ~percent1:percent
-        in
-        let webkit_decl = webkit_text_decoration_color oklab_color in
-        let oklab_decl = text_decoration_color oklab_color in
-        let supports_block =
-          Css.supports ~condition:Color.color_mix_supports_condition
-            [
-              Css.rule ~selector:(Css.Selector.class_ "_")
-                [ webkit_decl; oklab_decl ];
-            ]
-        in
-        style ~rules:(Some [ supports_block ]) [ theme_decl; fallback_decl ]
+    match Color.opacity_keyword color with
+    | Some keyword ->
+        let color = Color.apply_alpha opacity keyword in
+        style
+          [ webkit_text_decoration_color color; text_decoration_color color ]
+    | None -> (
+        match Scheme.hex_color scheme color_name with
+        | Some hex_value ->
+            (* Scheme has hex: fallback is hex+alpha, @supports has color-mix
+               with webkit *)
+            let hex_with_alpha = Color.hex_with_alpha hex_value percent in
+            let fallback_decl =
+              text_decoration_color (Css.hex hex_with_alpha)
+            in
+            let color_var = Color.color_var color shade in
+            let theme_decl, color_ref =
+              Var.binding color_var (Css.hex hex_value)
+            in
+            let oklab_color =
+              Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
+                ~percent1:percent
+            in
+            let webkit_decl = webkit_text_decoration_color oklab_color in
+            let oklab_decl = text_decoration_color oklab_color in
+            let supports_block =
+              Css.supports ~condition:Color.color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_")
+                    [ webkit_decl; oklab_decl ];
+                ]
+            in
+            style ~rules:(Some [ supports_block ]) [ theme_decl; fallback_decl ]
+        | None ->
+            (* No scheme hex: use property-scoped variable *)
+            let color_var =
+              Color.property_color_var ?theme
+                ~property_prefix:"text-decoration-color" color shade
+            in
+            let color_value =
+              Color.property_color_value ?theme
+                ~property_prefix:"text-decoration-color" color shade
+            in
+            (* A project token may be any CSS colour, not necessarily a palette
+               colour that can be converted to a compile-time hex fallback. *)
+            let fallback_decl = text_decoration_color color_value in
+            let theme_decl, color_ref = Var.binding color_var color_value in
+            let oklab_color =
+              Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
+                ~percent1:percent
+            in
+            let webkit_decl = webkit_text_decoration_color oklab_color in
+            let oklab_decl = text_decoration_color oklab_color in
+            let supports_block =
+              Css.supports ~condition:Color.color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_")
+                    [ webkit_decl; oklab_decl ];
+                ]
+            in
+            style ~rules:(Some [ supports_block ]) [ theme_decl; fallback_decl ]
+        )
 
   let decoration_transparent = style [ text_decoration_color (Css.hex "#0000") ]
   let decoration_current = style [ text_decoration_color Current ]

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -13,6 +13,8 @@ let of_string_valid () =
   check "[border-color:#ff0000]/25";
   (* var-valued colours and custom properties with /opacity round-trip *)
   check "[color:var(--my-color)]/50";
+  check "[color:rgb(255_0_0)]/50";
+  check "[border-color:oklch(0.5_0.2_250)]/[var(--x)]";
   check "[--x:#ff0000]/50";
   check "[--gradient-bg:var(--color-black)]/15";
   (* Plain custom-property declarations and non-colour standard properties parse
@@ -87,6 +89,18 @@ let test_var_color_opacity () =
     "oklab color-mix on the var" true
     (Astring.String.is_infix
        ~affix:"color-mix(in oklab, var(--my-color) 50%, transparent)" out)
+
+(* Arbitrary-value underscores encode spaces before the colour is parsed. The
+   plain declaration path already decoded them; the /opacity path did not. *)
+let test_encoded_space_color_opacity () =
+  Alcotest.(check bool)
+    "rgb underscores are decoded" true
+    (Astring.String.is_infix ~affix:"rgb(255 0 0)"
+       (css "[color:rgb(255_0_0)]/50"));
+  Alcotest.(check bool)
+    "oklch underscores are decoded" true
+    (Astring.String.is_infix ~affix:"oklch(.5 .2 250)"
+       (css "[border-color:oklch(0.5_0.2_250)]/[var(--x)]"))
 
 (* A custom property with /opacity sets the property to a color-mix via the
    typed [Css.var] form (no token stream). *)
@@ -207,6 +221,8 @@ let tests =
     test_case "property value --alpha()" `Quick test_alpha_fn;
     test_case "theme() dot-notation" `Quick test_theme_dot_notation;
     test_case "var-valued colour with opacity" `Quick test_var_color_opacity;
+    test_case "encoded-space colour with opacity" `Quick
+      test_encoded_space_color_opacity;
     test_case "custom property with opacity" `Quick test_custom_prop_opacity;
     test_case "deferred and var inputs never crash" `Quick test_no_crash;
   ]

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -424,6 +424,66 @@ let test_invalid_shade () =
   ignore (Tw.bg ~shade:200 Tw.gray);
   ignore (Tw.bg ~shade:250 (Tw.hex "#aabbcc"))
 
+(* Colour keywords accept an opacity modifier wherever Tailwind exposes a colour
+   family. Keep the original class spelling: several handlers used to either
+   reject these or silently drop [/50] from the round-trip. *)
+let test_keyword_opacity_families () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u -> Alcotest.(check string) cls cls (Tw.pp u))
+    [
+      "bg-transparent/50";
+      "text-inherit/50";
+      "border-transparent/50";
+      "accent-inherit/50";
+      "caret-transparent/50";
+      "outline-inherit/50";
+      "placeholder-transparent/50";
+      "from-inherit/50";
+      "via-transparent/50";
+      "to-inherit/50";
+      "decoration-inherit/50";
+      "divide-transparent/50";
+      "fill-inherit/50";
+      "stroke-transparent/50";
+      "shadow-transparent/50";
+      "inset-shadow-transparent/50";
+      "ring-inherit/50";
+      "ring-offset-transparent/50";
+      "inset-ring-inherit/50";
+      "drop-shadow-inherit/50";
+      "text-shadow-transparent/50";
+    ];
+  (* Tailwind has no inherited text-shadow-with-opacity candidate. *)
+  match Tw.of_string "text-shadow-inherit/50" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "text-shadow-inherit/50 should be rejected"
+
+(* A palette colour with no shade segment must not absorb one and rename the
+   class. Tailwind rejects the candidate instead. *)
+let test_shadeless_colour_rejects_shade_segment () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error _ -> ()
+      | Ok u -> Alcotest.failf "%s was renamed to %s" cls (Tw.pp u))
+    [ "bg-white-500/50"; "text-black-500/50"; "border-white-500/50" ]
+
+(* A project-defined, shadeless colour follows the same opacity path as the
+   built-in shadeless colours. *)
+let test_decoration_theme_colour_opacity () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-brand", "oklch(55% .2 250)") ]
+  in
+  match Tw.of_string ~theme "decoration-brand/50" with
+  | Error (`Msg m) -> Alcotest.fail m
+  | Ok u ->
+      Alcotest.(check string)
+        "custom theme colour round-trips" "decoration-brand/50" (Tw.pp u)
+
 (* Test suite *)
 (* An achromatic palette colour must keep a [none] hue. A numeric hue renders
    the same but folds to a plain hex, which pins the hue that interpolation is
@@ -560,6 +620,13 @@ let tests =
       test_bracket_rgb_unresolvable_channels );
     ("Alpha from a var", `Quick, test_alpha_from_a_var);
     ("Invalid shades", `Quick, test_invalid_shade);
+    ("Keyword opacity families", `Quick, test_keyword_opacity_families);
+    ( "Shadeless colour rejects a shade segment",
+      `Quick,
+      test_shadeless_colour_rejects_shade_segment );
+    ( "Decoration theme colour opacity",
+      `Quick,
+      test_decoration_theme_colour_opacity );
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);
     ("RGB to hex", `Quick, test_rgb_to_hex);


### PR DESCRIPTION
Support opacity modifiers on transparent and inherit across every Tailwind colour family, including the shadow and ring handlers that bypass the shared colour parser. Decode underscore-spaced arbitrary colours, reject shade segments on shadeless colours, and resolve project-defined decoration colours through their theme values.