### PR TITLE
Reject non-canonical numeric candidates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,20 +75,6 @@ now goes through Nest.substitute; port them to the typed selector API.
   `var(--x, var(--y))`. `var( --x )` fails the exact prefix test and falls
   through unchanged. See the blocked-on-cascade section for the shared fix.
 
-Residuals found gating PR #282 (2026-08-01), same symptom on other paths:
-
-- Several utilities read their suffix with a direct `int_of_string_opt` /
-  `float_of_string_opt` instead of `Parse`, so non-decimal spellings still
-  pass: `z-0x10` -> `.z-16` and `-z-0x10` -> `.-z-16` (layout.ml),
-  `order-1_0`, `columns-0x2`, `grid-cols-0x2`, `grid-rows-0x2`, `basis-1_0`,
-  `flex-0x2`, `w-0x4`, `h-0x4`, `border-0x2`. A blanket substitution is not
-  safe - some of these readers also serve bracket values, where CSS does allow
-  `1e3` - so each site needs its class-suffix path separated first.
-- Redundant-zero decimals are accepted although Tailwind rejects them:
-  `p-04` -> `.p-4`, `p-4.0` -> `.p-4`, `p-1.50` -> `.p-1.5`; likewise
-  `aria-[_modal_]` -> `[aria-modal]` where Tailwind rejects the padded
-  spelling. Canonical-form questions rather than base/separator bugs.
-
 ## Sort and priority
 
 Still open:

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -914,7 +914,7 @@ module Handler = struct
     | [ "border"; "4" ] -> Ok Border_4
     | [ "border"; "8" ] -> Ok Border_8
     | [ "border"; n ]
-      when match int_of_string_opt n with Some w -> w > 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w > 0 | None -> false ->
         Ok (Border_width (int_of_string n))
     | [ "border"; "t" ] -> Ok Border_t
     | [ "border"; "r" ] -> Ok Border_r
@@ -923,26 +923,26 @@ module Handler = struct
     | [ "border"; "x" ] -> Ok Border_x
     | [ "border"; "y" ] -> Ok Border_y
     | [ "border"; "x"; n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_x_width (int_of_string n))
     | [ "border"; "y"; n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_y_width (int_of_string n))
     | [ "border"; "s" ] -> Ok Border_s
     | [ "border"; "e" ] -> Ok Border_e
     | [ "border"; "bs" ] -> Ok Border_bs
     | [ "border"; "be" ] -> Ok Border_be
     | [ "border"; "s"; n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_s_width (int_of_string n))
     | [ "border"; "e"; n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_e_width (int_of_string n))
     | [ "border"; "bs"; n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_bs_width (int_of_string n))
     | [ "border"; "be"; n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_be_width (int_of_string n))
     | [ "border"; "t"; "0" ] -> Ok Border_t_0
     | [ "border"; "t"; "2" ] -> Ok Border_t_2
@@ -961,7 +961,7 @@ module Handler = struct
     | [ "border"; "l"; "4" ] -> Ok Border_l_4
     | [ "border"; "l"; "8" ] -> Ok Border_l_8
     | [ "border"; (("t" | "r" | "b" | "l") as side); n ]
-      when match int_of_string_opt n with Some w -> w >= 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w >= 0 | None -> false ->
         Ok (Border_side_width (side, int_of_string n))
     | [ "border"; "solid" ] -> Ok Border_solid
     | [ "border"; "dashed" ] -> Ok Border_dashed
@@ -1021,7 +1021,7 @@ module Handler = struct
     | [ "outline" ] -> Ok Outline
     | [ "outline"; "0" ] -> Ok Outline_0
     | [ "outline"; n ]
-      when match int_of_string_opt n with Some w -> w > 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w > 0 | None -> false ->
         Ok (Outline_width (int_of_string n))
     | [ "outline"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
@@ -1058,7 +1058,7 @@ module Handler = struct
           Ok (Outline_offset_arbitrary inner)
         else err_not_utility
     | [ "outline"; "offset"; n ] -> (
-        match int_of_string_opt n with
+        match Parse.decimal_int n with
         | Some i when i >= 0 -> Ok (Outline_offset i)
         | _ -> err_not_utility)
     (* Negative outline offset: -outline-offset-N starts with empty string *)
@@ -1069,7 +1069,7 @@ module Handler = struct
           if Parse.is_var inner then Ok (Neg_outline_offset_var inner)
           else err_not_utility
         else
-          match int_of_string_opt value with
+          match Parse.decimal_int value with
           | Some i when i > 0 -> Ok (Neg_outline_offset i)
           | _ -> err_not_utility)
     (* ring* handled in Effects *)

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -174,7 +174,7 @@ module Handler = struct
               Ok (Columns_arbitrary_len inner)
           | None -> Error (`Msg "Invalid columns arbitrary value")
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i -> Ok (Columns_count i)
           | None -> Error (`Msg "Invalid columns value"))
     | _ -> Error (`Msg "Not a columns utility")

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -189,13 +189,9 @@ module Handler = struct
     | Basis_arbitrary len -> style [ flex_basis len ]
     | Order n -> order_style n
     | Neg_order n -> style [ order (Int (-n)) ]
-    | Neg_order_arbitrary s -> (
-        match int_of_string_opt s with
-        | Some n -> style [ order (Int (-n)) ]
-        | None ->
-            let o = Css.Properties.read_order (Cascade.Cursor.of_string s) in
-            style [ order (Calc (Css.Calc.mul (Val o) (Css.Calc.float (-1.)))) ]
-        )
+    | Neg_order_arbitrary s ->
+        let o = Css.Properties.read_order (Cascade.Cursor.of_string s) in
+        style [ order (Calc (Css.Calc.mul (Val o) (Css.Calc.float (-1.)))) ]
     | Order_arbitrary s ->
         style [ order (Css.Properties.read_order (Cascade.Cursor.of_string s)) ]
     | Order_first -> order_first ()
@@ -316,7 +312,7 @@ module Handler = struct
           | None -> err_not_utility
         else err_not_utility
     | [ "basis"; value ] -> (
-        match int_of_string_opt value with
+        match Parse.decimal_int value with
         | Some n when n >= 0 -> Ok (Basis_spacing n)
         | _ -> (
             match parse_fraction value with
@@ -341,7 +337,7 @@ module Handler = struct
           let inner = String.sub value 1 (String.length value - 2) in
           Ok (Order_arbitrary inner)
         else
-          match int_of_string_opt value with
+          match Parse.decimal_int value with
           | Some n when n >= 0 -> Ok (Order n)
           | _ -> err_not_utility)
     | "" :: "order" :: rest when rest <> [] -> (
@@ -355,7 +351,7 @@ module Handler = struct
           let inner = String.sub value 1 (String.length value - 2) in
           Ok (Neg_order_arbitrary inner)
         else
-          match int_of_string_opt value with
+          match Parse.decimal_int value with
           | Some n when n >= 1 -> Ok (Neg_order n)
           | _ -> err_not_utility)
     | [ "flex"; value ] when String.length value > 0 && value.[0] = '[' ->
@@ -373,7 +369,7 @@ module Handler = struct
         | Some (n, m) -> Ok (Flex_fraction (n, m))
         | None -> (
             (* Try numeric value (e.g., "99") *)
-            match int_of_string_opt value with
+            match Parse.decimal_int value with
             | Some n when n > 1 -> Ok (Flex_n n)
             | _ -> err_not_utility))
     | _ -> err_not_utility

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -433,7 +433,7 @@ module Handler = struct
           | Some _ -> Ok (Grid_cols_arbitrary inner)
           | None -> err_invalid_cols
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i when i >= 1 && i <= 999 -> Ok (Grid_cols i)
           | Some _ | None -> err_invalid_cols)
     | [ "grid"; "rows"; "none" ] -> Ok Grid_rows_none
@@ -446,7 +446,7 @@ module Handler = struct
           | Some _ -> Ok (Grid_rows_arbitrary inner)
           | None -> err_invalid_rows
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i when i >= 1 && i <= 999 -> Ok (Grid_rows i)
           | Some _ | None -> err_invalid_rows)
     | [ "grid"; "flow"; "row" ] -> Ok Grid_flow_row

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -484,13 +484,9 @@ module Handler = struct
     | Z_arbitrary s ->
         style
           [ z_index (Css.Properties.read_z_index (Cascade.Cursor.of_string s)) ]
-    | Neg_z_arbitrary s -> (
-        match int_of_string_opt s with
-        | Some n -> style [ z_index (Index (-n)) ]
-        | None ->
-            let zi = Css.Properties.read_z_index (Cascade.Cursor.of_string s) in
-            style
-              [ z_index (Calc (Css.Calc.mul (Val zi) (Css.Calc.float (-1.)))) ])
+    | Neg_z_arbitrary s ->
+        let zi = Css.Properties.read_z_index (Cascade.Cursor.of_string s) in
+        style [ z_index (Calc (Css.Calc.mul (Val zi) (Css.Calc.float (-1.)))) ]
     | Object_contain -> style [ object_fit Contain ]
     | Object_cover -> style [ object_fit Cover ]
     | Object_fill -> style [ object_fit Fill ]
@@ -643,7 +639,7 @@ module Handler = struct
         else Error (`Msg ("Invalid z-index arbitrary value: " ^ n))
     | [ "z"; n ] -> (
         (* Dynamic z-index: z-5, z-100, etc. *)
-        match int_of_string_opt n with
+        match Parse.decimal_int n with
         | Some i -> Ok (Z i)
         | None -> Error (`Msg ("Invalid z-index value: " ^ n)))
     | "" :: "z" :: rest when rest <> [] -> (
@@ -657,7 +653,7 @@ module Handler = struct
           let inner = String.sub value 1 (String.length value - 2) in
           Ok (Neg_z_arbitrary inner)
         else
-          match int_of_string_opt value with
+          match Parse.decimal_int value with
           | Some i -> Ok (Neg_z i)
           | None -> Error (`Msg ("Invalid negative z-index value: " ^ value)))
     | [ "object"; "contain" ] -> Ok Object_contain

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1039,7 +1039,8 @@ let is_plain_ident str =
    selector browsers parse and keep although nothing ever matches it, so it is
    not a variant. An underscore stands for a space, so it is empty as well. *)
 let names_attribute expr =
-  String.trim (String.map (fun c -> if c = '_' then ' ' else c) expr) <> ""
+  let decoded = String.map (fun c -> if c = '_' then ' ' else c) expr in
+  decoded <> "" && String.equal decoded (String.trim decoded)
 
 (* [group-data-dragging] is [group-data-[dragging]] with a different spelling,
    so it keeps its own class name. *)

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -14,13 +14,15 @@ let is_digits s =
 let without_sign s =
   if s <> "" && s.[0] = '-' then String.sub s 1 (String.length s - 1) else s
 
+let is_canonical_digits s = is_digits s && (String.length s = 1 || s.[0] <> '0')
+
 (* A class suffix is written in plain decimal, but OCaml's literal grammar also
    admits [0x]/[0o]/[0b] bases, [_] digit separators, hex-float exponents and a
    leading [+]. Handing a suffix straight to [int_of_string_opt] therefore reads
    [p-0x4] as 4 and emits [.p-4] — a rule nobody wrote, and not a class Tailwind
    accepts. Both readers below check the spelling first. *)
 let decimal_int s =
-  if is_digits (without_sign s) then int_of_string_opt s else None
+  if is_canonical_digits (without_sign s) then int_of_string_opt s else None
 
 (* Plain decimal: digits, then at most one fractional part with digits of its
    own. [.5], [1.] and [1e2] are not spellings of a class suffix. *)
@@ -28,10 +30,14 @@ let decimal_float s =
   let digits = without_sign s in
   let plain =
     match String.index_opt digits '.' with
-    | None -> is_digits digits
+    | None -> is_canonical_digits digits
     | Some i ->
-        is_digits (String.sub digits 0 i)
-        && is_digits (String.sub digits (i + 1) (String.length digits - i - 1))
+        let whole = String.sub digits 0 i in
+        let fraction =
+          String.sub digits (i + 1) (String.length digits - i - 1)
+        in
+        is_canonical_digits whole && is_digits fraction
+        && fraction.[String.length fraction - 1] <> '0'
   in
   if plain then float_of_string_opt s else None
 

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -10,6 +10,16 @@ val has_prefix : prefix:string -> string -> bool
     [String.starts_with] but allocation-free (no per-call closure), for hot
     prefix tests in ordering. *)
 
+val decimal_int : string -> int option
+(** [decimal_int s] reads the canonical plain-decimal spelling of an integer.
+    OCaml-only forms such as [0x10] and [1_0], and redundant leading zeroes, are
+    rejected. *)
+
+val decimal_float : string -> float option
+(** [decimal_float s] reads a canonical plain-decimal integer or fraction.
+    Exponents, digit separators, redundant leading or trailing zeroes, and
+    missing digits around the decimal point are rejected. *)
+
 val int_pos : name:string -> string -> (int, [> `Msg of string ]) result
 (** [int_pos ~name s] parses a non-negative integer from [s]. Returns [Ok n] if
     [s] is a decimal integer >= 0, otherwise [Error (`Msg msg)]. [name] is used

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -708,7 +708,7 @@ module Handler = struct
           | Some (raw, len) -> Ok (Sized (prop, Arbitrary (raw, len)))
           | None -> err_invalid_value f.css_name v
         else
-          match float_of_string_opt v with
+          match Parse.decimal_float v with
           | Some n when n >= 0. -> Ok (Sized (prop, Spacing (n *. 0.25)))
           | _ -> err_invalid_value f.css_name v)
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -807,6 +807,15 @@ let test_empty_attribute_brackets () =
   rejected "group-data-_:flex";
   rejected "peer-data-_:flex"
 
+let test_padded_attribute_brackets () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  rejected "aria-[_modal_]:flex";
+  rejected "data-[_state=open_]:flex"
+
 (* The attribute spellings that do name something keep working, including the
    empty-name-with-value form Tailwind also accepts. *)
 let test_attribute_brackets_still_parse () =
@@ -850,6 +859,8 @@ let tests =
         test_invalid_bracket_modifiers;
       test_case "valid bracket modifiers" `Quick test_valid_bracket_modifiers;
       test_case "empty attribute brackets" `Quick test_empty_attribute_brackets;
+      test_case "padded attribute brackets" `Quick
+        test_padded_attribute_brackets;
       test_case "attribute brackets still parse" `Quick
         test_attribute_brackets_still_parse;
       test_case "not-[selector] arbitrary negation" `Quick

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -35,6 +35,16 @@ let test_int_rejects_non_decimal_spellings () =
       "duration-0x4";
       "delay-1_0";
       "rotate-0x4";
+      "z-0x10";
+      "order-1_0";
+      "columns-0x2";
+      "grid-cols-0x2";
+      "grid-rows-0x2";
+      "basis-1_0";
+      "flex-0x2";
+      "w-0x4";
+      "h-0x4";
+      "border-0x2";
       "line-clamp-0x2";
       "opacity-0x10";
     ]
@@ -42,7 +52,7 @@ let test_int_rejects_non_decimal_spellings () =
 (* The sign is stripped before the suffix is read, so a negative utility takes
    the same grammar. *)
 let test_negative_int_rejects_non_decimal_spellings () =
-  List.iter unknown [ "-m-1_0"; "-rotate-0x4"; "-translate-x-0x4" ]
+  List.iter unknown [ "-m-1_0"; "-rotate-0x4"; "-translate-x-0x4"; "-z-0x10" ]
 
 (* [Float.of_string] reads the same non-decimal spellings plus hex-float
    exponents, which would make [p-0x1p4] mean [.p-16]. A fractional suffix needs
@@ -76,6 +86,11 @@ let test_decimal_class_suffixes_round_trip () =
       "-rotate-45";
     ]
 
+(* A valid suffix must also be the canonical decimal spelling. Otherwise the
+   parser would accept one class and emit a selector for a different class. *)
+let test_redundant_zero_spellings_are_rejected () =
+  List.iter unknown [ "p-04"; "p-4.0"; "p-1.50" ]
+
 let tests =
   Alcotest.
     [
@@ -89,6 +104,8 @@ let tests =
         test_decimal_rejects_non_decimal_spellings;
       test_case "decimal class suffixes round-trip" `Quick
         test_decimal_class_suffixes_round_trip;
+      test_case "redundant zero suffixes are rejected" `Quick
+        test_redundant_zero_spellings_are_rejected;
     ]
 
 let suite = ("parse", tests)


### PR DESCRIPTION
Reject OCaml-only numeric spellings and redundant zeroes across family-specific readers.

Bracketed values keep the CSS number grammar, including exponent notation.