### PR TITLE
Order sizing values by candidate spelling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,11 +93,6 @@ Residuals found gating PR #282 (2026-08-01), same symptom on other paths:
 
 Still open:
 
-- Within a family, a named theme value sorts before an arbitrary/var() value:
-  `max-w-2xl max-w-(--breakpoint-md)` renders named-first where Tailwind orders
-  by candidate string (`(` before `2`); surfaced on the site as the
-  `@media not (width >= 80rem)` position pair (2026-08-01 measurement). Likely
-  the same shared value-sort model as the digit-led named sizes below.
 - `not-supports-*:X` sorts beside its base utility's property family instead of
   into the `not-*` variant group: `px-4 not-supports-hanging-punctuation:px-4
   flex not-supports-[display:grid]:flex` interleaves where Tailwind puts all
@@ -108,10 +103,6 @@ Still open:
   rules; the stacked `**:`/`first:` order key outranks the `sm:` media
   grouping. Probe with `tw -s "container sm:bg-top **:[svg]:first:sm:size-4
   md:block" --tailwind`. 2026-08-01 measurement.
-- Digit-led named sizes sort wrongly family-wide: Tailwind natural-sorts the
-  value string (`basis-2xl` lands between `basis-2` and `basis-10`); tw puts
-  named sizes after all numerics. `max-w-2xl` and `w-2xl` are each wrong in
-  their own way, so this is one shared value-sort model, not per-family patches.
 - The priority-7 theme-layer emission order differs from real Tailwind behind
   a differ blind spot: ten overlapping slot collisions across
   radius/drop-shadow/ease/animate/perspective, and upstream emits

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -412,25 +412,10 @@ module Handler = struct
     | Basis_fraction (n, m) ->
         "basis-" ^ string_of_int n ^ "/" ^ string_of_int m
     | Basis_named s -> "basis-" ^ s
-    | Basis_arbitrary len -> (
-        match len with
-        | Px n ->
-            let s = string_of_float n in
-            let s =
-              if String.ends_with ~suffix:"." s then
-                String.sub s 0 (String.length s - 1)
-              else s
-            in
-            "basis-[" ^ s ^ "px]"
-        | Rem n ->
-            let s = string_of_float n in
-            let s =
-              if String.ends_with ~suffix:"." s then
-                String.sub s 0 (String.length s - 1)
-              else s
-            in
-            "basis-[" ^ s ^ "rem]"
-        | _ -> "basis-[<length>]")
+    | Basis_arbitrary len ->
+        "basis-["
+        ^ Css.Pp.to_string ~minify:true Css.Properties.pp_flex_basis len
+        ^ "]"
     (* Order *)
     | Order n -> "order-" ^ string_of_int n
     | Neg_order n -> "-order-" ^ string_of_int n

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -304,17 +304,19 @@ module Handler = struct
     | [ "basis"; "full" ] -> Ok Basis_full
     | [ "basis"; value ] when Parse.is_bracket_value value ->
         let inner = Parse.bracket_inner value in
-        if String.ends_with ~suffix:"px" inner then
-          let n = String.sub inner 0 (String.length inner - 2) in
-          match float_of_string_opt n with
-          | Some f -> Ok (Basis_arbitrary (Css.Px f))
-          | None -> err_not_utility
-        else if String.ends_with ~suffix:"rem" inner then
-          let n = String.sub inner 0 (String.length inner - 3) in
-          match float_of_string_opt n with
-          | Some f -> Ok (Basis_arbitrary (Css.Rem f))
-          | None -> err_not_utility
-        else err_not_utility
+        let cursor =
+          Cascade.Cursor.of_string (Parse.decode_arbitrary_value inner)
+        in
+        (match
+           let value = Css.Properties.read_flex_basis cursor in
+           Cascade.Cursor.ws cursor;
+           Cascade.Cursor.expect_eof cursor;
+           Some value
+         with
+          | value -> value
+          | exception Cascade.Cursor.Parse_error _ -> None)
+        |> Option.fold ~none:err_not_utility ~some:(fun value ->
+            Ok (Basis_arbitrary value))
     | [ "basis"; value ] -> (
         match int_of_string_opt value with
         | Some n when n >= 0 -> Ok (Basis_spacing n)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2292,15 +2292,21 @@ let extract_style_with_rules ~sel ~class_name ?merge_key ~props rule_list =
   else base_rule @ ordered_entries
 
 let outputs ?(theme = Scheme.default) ?order_tbl util =
+  let rec utility_order = function
+    | Utility.Base b -> Some (Utility.order b)
+    | Utility.Modified (_, u) | Utility.Important (_, u)
+    | Utility.Aliased (_, u) -> utility_order u
+    | Utility.Group _ -> None
+  in
   let rec extract_with_class class_name util_inner = function
     | Style.Style { props; rules; merge_key; pseudo_suffix; _ } -> (
         (* Record the base utility's order under the class name we already
            built, so the caller does not have to re-derive it from the
            string. *)
-        (match (order_tbl, util_inner) with
-        | Some tbl, Utility.Base b ->
+        (match (order_tbl, utility_order util_inner) with
+        | Some tbl, Some order ->
             if not (Hashtbl.mem tbl class_name) then
-              Hashtbl.add tbl class_name (Utility.order b)
+              Hashtbl.add tbl class_name order
         | _ -> ());
         let sel =
           match pseudo_suffix with

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -642,9 +642,21 @@ module Handler = struct
   let sized_style theme prop v =
     let f = family prop in
     let set len = style (List.map (fun decl -> decl len) f.decls) in
+    let set_arbitrary raw len =
+      let theme_decl : Css.declaration option =
+        let bare_name = Parse.extract_var_name raw in
+        if String.equal bare_name raw then Option.None
+        else
+          Scheme.token theme bare_name
+          |> Option.map (fun value ->
+              Css.custom_property ~layer:"theme" ("--" ^ bare_name) value)
+      in
+      style
+        (Option.to_list theme_decl @ List.map (fun decl -> decl len) f.decls)
+    in
     match v with
     | Keyword k -> set k.length
-    | Arbitrary (_, len) -> set len
+    | Arbitrary (raw, len) -> set_arbitrary raw len
     | Fraction s -> (
         match fraction_pct s with
         | Some pct -> set (Pct pct)

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -632,6 +632,44 @@ let natural_compare s1 s2 =
   in
   compare_at 0 0
 
+(* Tailwind orders the values of sizing and flex-basis candidates by the raw
+   candidate spelling. This naturally interleaves digit-led theme names with
+   numeric values (2, 2xl, 10), and puts the [(--var)] shorthand before both.
+   The handler suborders still separate the property families themselves. *)
+let candidate_value_family base_class =
+  let _, base = Modifiers.of_string base_class in
+  List.find_opt
+    (fun prefix ->
+      let n = String.length prefix in
+      String.length base > n && String.starts_with ~prefix:(prefix ^ "-") base)
+    [
+      "min-inline";
+      "max-inline";
+      "min-block";
+      "max-block";
+      "min-w";
+      "max-w";
+      "min-h";
+      "max-h";
+      "inline";
+      "block";
+      "size";
+      "basis";
+      "w";
+      "h";
+    ]
+
+let compare_candidate_values r1 r2 =
+  if fst r1.order <> fst r2.order then None
+  else
+    match
+      ( candidate_value_family r1.base_class_key,
+        candidate_value_family r2.base_class_key )
+    with
+    | Some f1, Some f2 when String.equal f1 f2 ->
+        Some (natural_compare r1.base_class_key r2.base_class_key)
+    | _ -> None
+
 let compare_late_modifiers r1 r2 kind1 kind2 =
   let k1 = complex_selector_order kind1 and k2 = complex_selector_order kind2 in
   if k1 <> k2 then Int.compare k1 k2 else compare_by_priority_index r1 r2
@@ -739,20 +777,23 @@ let compare_cross_utility_regular r1 r2 =
            kind_str kind2;
            ")\n";
          ]));
-  let same_order = p1 = p2 && s1 = s2 in
-  match
-    if same_order then
-      compare_pseudo_elements kind1 kind2 r1.selector r2.selector
-    else None
-  with
-  | Some cmp -> cmp
-  | None -> (
-      match compare_focus_visible_state r1 r2 kind1 kind2 with
+  match compare_candidate_values r1 r2 with
+  | Some cmp when cmp <> 0 -> cmp
+  | Some _ | None -> (
+      let same_order = p1 = p2 && s1 = s2 in
+      match
+        if same_order then
+          compare_pseudo_elements kind1 kind2 r1.selector r2.selector
+        else None
+      with
       | Some cmp -> cmp
       | None -> (
-          match compare_focus_modifier_ordering r1 r2 kind1 kind2 with
+          match compare_focus_visible_state r1 r2 kind1 kind2 with
           | Some cmp -> cmp
-          | None -> compare_by_prio_sub_late r1 r2 kind1 kind2))
+          | None -> (
+              match compare_focus_modifier_ordering r1 r2 kind1 kind2 with
+              | Some cmp -> cmp
+              | None -> compare_by_prio_sub_late r1 r2 kind1 kind2)))
 
 (** Compare two Regular rules using rule relationship dispatch. *)
 let compare_regular_rules r1 r2 =
@@ -1037,29 +1078,35 @@ let nested_order rule_type nested =
 (* Last resort for two rules that share a variant group, a breakpoint and a
    prefix: the utility's own priority, then the selector. *)
 let compare_variant_tail r1 r2 =
-  let p1, s1 = r1.order and p2, s2 = r2.order in
-  let prio_cmp = Int.compare p1 p2 in
-  if prio_cmp <> 0 then prio_cmp
-  else
-    let sub_cmp = Int.compare s1 s2 in
-    if sub_cmp <> 0 then sub_cmp
-    else
-      match (r1.selector_kind, r2.selector_kind) with
-      | Simple, Simple ->
-          (* Same priority/suborder simple rules (e.g. two arbitrary bg colors)
-             break ties by selector like the regular layer, matching Tailwind's
-             alphabetical order. *)
-          natural_compare r1.selector_str r2.selector_str
-      | _ ->
-          (* Complex rules (prose's descendant selectors) keep base class +
-             source order so a component stays one block. Arbitrary values in a
-             variant, e.g. hover:from-[rgba(5,...)] vs
-             hover:from-[rgba(14,...)], share a prefix and differ only in the
-             numeric part, so order those numerically like Tailwind. Identical
-             base classes (prose's :where rules all key on "prose") tie at 0 and
-             fall back to source order, unchanged. *)
-          let class_cmp = natural_compare r1.base_class_key r2.base_class_key in
-          if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
+  match compare_candidate_values r1 r2 with
+  | Some cmp when cmp <> 0 -> cmp
+  | Some _ | None -> (
+      let p1, s1 = r1.order and p2, s2 = r2.order in
+      let prio_cmp = Int.compare p1 p2 in
+      if prio_cmp <> 0 then prio_cmp
+      else
+        let sub_cmp = Int.compare s1 s2 in
+        if sub_cmp <> 0 then sub_cmp
+        else
+          match (r1.selector_kind, r2.selector_kind) with
+          | Simple, Simple ->
+              (* Same priority/suborder simple rules (e.g. two arbitrary bg
+                 colors) break ties by selector like the regular layer, matching
+                 Tailwind's alphabetical order. *)
+              natural_compare r1.selector_str r2.selector_str
+          | _ ->
+              (* Complex rules (prose's descendant selectors) keep base class +
+                 source order so a component stays one block. Arbitrary values
+                 in a variant, e.g. hover:from-[rgba(5,...)] vs
+                 hover:from-[rgba(14,...)], share a prefix and differ only in
+                 the numeric part, so order those numerically like Tailwind.
+                 Identical base classes (prose's :where rules all key on
+                 "prose") tie at 0 and fall back to source order, unchanged. *)
+              let class_cmp =
+                natural_compare r1.base_class_key r2.base_class_key
+              in
+              if class_cmp <> 0 then class_cmp
+              else Int.compare r1.index r2.index)
 
 let compare_variant_ordered r1 r2 =
   match (r1.rule_type, r2.rule_type) with

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -988,6 +988,32 @@ let test_arbitrary_named_by_suffix () =
   Test_helpers.check_ordering_matches
     ~test_name:"arbitrary value sorts by suffix within family" utilities
 
+let test_sizing_values_natural_order () =
+  let classes =
+    [
+      "w-(--w)";
+      "w-2";
+      "w-2xl";
+      "w-10";
+      "w-[50%]";
+      "w-auto";
+      "max-w-(--breakpoint-md)";
+      "max-w-2xl";
+      "max-w-10";
+      "max-w-[50%]";
+      "max-w-sm";
+      "basis-(--basis)";
+      "basis-2";
+      "basis-2xl";
+      "basis-10";
+      "basis-[50%]";
+      "basis-auto";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  Test_helpers.check_ordering_matches
+    ~test_name:"sizing values use natural candidate order" utilities
+
 let test_bracket_value_holding_a_colon () =
   (* An arbitrary value can hold a colon, so the variant prefix has to be taken
      with the modifier parser: splitting on the last ':' reads the prefix of
@@ -1521,6 +1547,8 @@ let tests =
       test_arbitrary_vs_named_order;
     test_case "arbitrary value sorts by suffix within family" `Slow
       test_arbitrary_named_by_suffix;
+    test_case "sizing values use natural candidate order" `Slow
+      test_sizing_values_natural_order;
     test_case "bracket value holding a colon" `Slow
       test_bracket_value_holding_a_colon;
     test_case "stacked variant outline order" `Slow


### PR DESCRIPTION
Natural-sort sizing and flex-basis values by their raw candidate spelling, including digit-led theme names and parenthesized variables.

Also accepts the full CSS flex-basis grammar in brackets.