### PR TITLE
Fix compound and negated variant ordering

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1039,24 +1039,17 @@ let has_substring s pat =
   in
   check 0
 
-(** Compute variant_order from base_class and selector. Extracts the modifier
-    prefix from base_class (everything before the last ":") and maps it to a
-    variant order number. For before/after, the base_class is the raw utility
-    name without prefix, so we detect them from the selector content. *)
+(** Compute variant_order from base_class and selector. A stacked candidate is
+    placed by its highest-order modifier, matching the descending key list used
+    by the comparator. For before/after, the base_class is the raw utility name
+    without prefix, so we detect them from the selector content. *)
 let compute_variant_order base_class selector =
   let from_base_class bc =
-    match String.rindex_opt bc ':' with
-    | Some i -> (
-        let prefix = String.sub bc 0 i in
-        let vo = Modifiers.variant_order_of_prefix prefix in
-        if vo > 0 then vo
-        else
-          (* For compound prefixes like "dark:group-focus", try the outermost
-             modifier (before the first colon in the prefix). *)
-          match String.index_opt prefix ':' with
-          | Some j -> Modifiers.variant_order_of_prefix (String.sub prefix 0 j)
-          | None -> 0)
-    | None -> 0
+    let modifiers, _ = Modifiers.of_string bc in
+    List.fold_left
+      (fun order modifier ->
+        Int.max order (Modifiers.variant_order_of_prefix modifier))
+      0 modifiers
   in
   let vo = match base_class with None -> 0 | Some bc -> from_base_class bc in
   (* If no variant_order from base_class, check selector for modifier-based

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -829,23 +829,28 @@ let compare_by_base_class r1 r2 =
   let class_cmp = String.compare r1.base_class_key r2.base_class_key in
   if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
 
-(* Sort key for supports modifier variants: named before bracket *)
+let supports_suffix s =
+  if String.length s > 9 && String.sub s 0 9 = "supports-" then
+    Some (String.sub s 9 (String.length s - 9))
+  else if String.length s > 13 && String.sub s 0 13 = "not-supports-" then
+    Some (String.sub s 13 (String.length s - 13))
+  else None
+
+(* Sort key for supports modifier variants: named before bracket. Negating a
+   supports variant changes its condition, not its position within this
+   group. *)
 let supports_sort_key bc =
-  match bc with
-  | Some s when String.length s > 9 && String.sub s 0 9 = "supports-" ->
-      let after = String.sub s 9 (String.length s - 9) in
+  match Option.bind bc supports_suffix with
+  | Some after ->
       if String.length after > 0 && after.[0] = '[' then (1, after)
       else (0, after)
-  | Some s -> (0, s)
   | None -> (0, "")
 
 (* A [supports-*] variant rule, whose @supports condition is the variant itself.
    A colour utility's progressive-enhancement @supports carries the colour's own
    base class and must not be ordered by this key. *)
 let is_modifier_supports bc =
-  match bc with
-  | Some s -> String.length s > 9 && String.sub s 0 9 = "supports-"
-  | None -> false
+  match bc with Some s -> Option.is_some (supports_suffix s) | None -> false
 
 (* Compare supports modifier rules by sort key *)
 let compare_supports_by_key r1 r2 =
@@ -1190,8 +1195,18 @@ let compare_indexed_rules r1 r2 =
   else if r1.variant_order > 0 then 1
   else if r2.variant_order > 0 then -1
   else if r1.not_order > 0 || r2.not_order > 0 then
-    let order_cmp = compare r1.order r2.order in
-    if order_cmp <> 0 then order_cmp else compare_by_base_class r1 r2
+    if r1.not_order = 0 then -1
+    else if r2.not_order = 0 then 1
+    else
+      let not_cmp = Int.compare r1.not_order r2.not_order in
+      if not_cmp <> 0 then not_cmp
+      else
+        match (r1.rule_type, r2.rule_type) with
+        | `Supports _, `Supports _
+          when is_modifier_supports r1.base_class
+               && is_modifier_supports r2.base_class ->
+            compare_supports_by_key r1 r2
+        | _ -> compare_by_base_class r1 r2
   else
     let type_cmp =
       Int.compare (rule_type_order r1.rule_type) (rule_type_order r2.rule_type)

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1051,6 +1051,59 @@ let test_stacked_variant_outline_order () =
   Test_helpers.check_ordering_matches ~test_name:"stacked variant outline order"
     utilities
 
+let test_not_supports_variant_order () =
+  let classes =
+    [
+      "px-4";
+      "not-supports-hanging-punctuation:px-4";
+      "flex";
+      "not-supports-[display:grid]:flex";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let position needle =
+    match Astring.String.find_sub ~sub:needle css with
+    | Some i -> i
+    | None -> Alcotest.failf "%s not found in %s" needle css
+  in
+  let positions =
+    List.map position
+      [
+        ".flex{";
+        ".px-4{";
+        "not-supports-hanging-punctuation";
+        "not-supports-\\[display";
+      ]
+  in
+  Alcotest.(check (list int))
+    "emission order"
+    (List.sort Int.compare positions)
+    positions;
+  Test_helpers.check_ordering_matches
+    ~test_name:"not-supports variants follow base utilities" utilities
+
+let test_stacked_responsive_variant_order () =
+  let classes =
+    [ "container"; "sm:bg-top"; "**:[svg]:first:sm:size-4"; "md:block" ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let position needle =
+    match Astring.String.find_sub ~sub:needle css with
+    | Some i -> i
+    | None -> Alcotest.failf "%s not found in %s" needle css
+  in
+  let positions =
+    List.map position [ "sm\\:bg-top"; "md\\:block"; "\\*\\*\\:\\[svg\\]" ]
+  in
+  Alcotest.(check (list int))
+    "emission order"
+    (List.sort Int.compare positions)
+    positions;
+  Test_helpers.check_ordering_matches
+    ~test_name:"stacked variants retain their highest-order component" utilities
+
 let test_rounded_position_order () =
   (* Border-radius position groups sort by the CSS corners they write, matching
      Tailwind: the physical ones grouped by first corner clockwise -- top, then
@@ -1553,6 +1606,9 @@ let tests =
       test_bracket_value_holding_a_colon;
     test_case "stacked variant outline order" `Slow
       test_stacked_variant_outline_order;
+    test_case "not-supports variant order" `Slow test_not_supports_variant_order;
+    test_case "stacked responsive variant order" `Slow
+      test_stacked_responsive_variant_order;
     test_case "rounded position order" `Slow test_rounded_position_order;
     test_case "color-mix @supports companion order" `Slow
       test_color_mix_supports_companion_order;


### PR DESCRIPTION
Tailwind places unvarianted utilities before the not-* group, orders named not-supports variants before bracket variants, and places stacked variants by their highest-order component.

This aligns the comparator keys with those ordering rules and retires the corresponding release TODO entries.