### PR TITLE
Match Tailwind theme namespace order

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -683,7 +683,26 @@ let compare_orders order_a order_b =
   | None, Some _ -> 1
   | None, None -> 0
 
-(* Sort declarations by their Var order metadata, alphabetical fallback *)
+(* Tailwind's independently-numbered priority-7 namespaces overlap. Their
+   declaration order at a shared slot follows namespace registration order,
+   rather than the spelling of the complete token name. *)
+let priority_seven_namespace = function
+  | Some name ->
+      let name =
+        if String.starts_with ~prefix:"--" name then
+          String.sub name 2 (String.length name - 2)
+        else name
+      in
+      if String.starts_with ~prefix:"radius-" name then 0
+      else if String.starts_with ~prefix:"drop-shadow-" name then 1
+      else if String.starts_with ~prefix:"ease-" name then 2
+      else if String.starts_with ~prefix:"animate-" name then 3
+      else if String.starts_with ~prefix:"perspective-" name then 4
+      else 5
+  | None -> 5
+
+(* Sort declarations by their Var order metadata, namespace at a shared slot,
+   then alphabetical fallback. *)
 let sort_by_var_order decls =
   decls
   |> List.map (fun d ->
@@ -696,7 +715,17 @@ let sort_by_var_order decls =
       (d, order, name))
   |> List.sort (fun (_, a, na) (_, b, nb) ->
       let c = compare_orders a b in
-      if c <> 0 then c else compare na nb)
+      if c <> 0 then c
+      else
+        let namespace_cmp =
+          match (a, b) with
+          | Some (7, _), Some (7, _) ->
+              Int.compare
+                (priority_seven_namespace na)
+                (priority_seven_namespace nb)
+          | _ -> 0
+        in
+        if namespace_cmp <> 0 then namespace_cmp else compare na nb)
   |> List.map (fun (d, _, _) -> d)
 
 (* Build theme layer rule from declarations *)

--- a/test/test_theme.ml
+++ b/test/test_theme.ml
@@ -74,7 +74,11 @@ let priority_seven_namespace_order () =
     ]
   in
   let theme =
-    { Tw.Scheme.default with token_overrides = [ ("animate-none", "none") ] }
+    {
+      Tw.Scheme.default with
+      token_overrides =
+        [ ("ease-linear", "steps(4)"); ("animate-none", "none") ];
+    }
   in
   let classes =
     [

--- a/test/test_theme.ml
+++ b/test/test_theme.ml
@@ -48,10 +48,76 @@ let theme_cross_module_vars () =
         ]
         (List.sort String.compare custom_props)
 
+let priority_seven_namespace_order () =
+  let expected =
+    [
+      "--radius-3xl";
+      "--drop-shadow-sm";
+      "--ease-in";
+      "--radius-4xl";
+      "--drop-shadow-md";
+      "--ease-out";
+      "--drop-shadow-lg";
+      "--ease-in-out";
+      "--drop-shadow-xl";
+      "--ease-linear";
+      "--animate-none";
+      "--drop-shadow-2xl";
+      "--animate-spin";
+      "--perspective-dramatic";
+      "--animate-ping";
+      "--perspective-near";
+      "--animate-pulse";
+      "--perspective-normal";
+      "--animate-bounce";
+      "--perspective-midrange";
+    ]
+  in
+  let theme =
+    { Tw.Scheme.default with token_overrides = [ ("animate-none", "none") ] }
+  in
+  let classes =
+    [
+      "rounded-3xl";
+      "rounded-4xl";
+      "drop-shadow-sm";
+      "drop-shadow-md";
+      "drop-shadow-lg";
+      "drop-shadow-xl";
+      "drop-shadow-2xl";
+      "ease-in";
+      "ease-out";
+      "ease-in-out";
+      "ease-linear";
+      "animate-none";
+      "animate-spin";
+      "animate-ping";
+      "animate-pulse";
+      "animate-bounce";
+      "perspective-dramatic";
+      "perspective-near";
+      "perspective-normal";
+      "perspective-midrange";
+    ]
+  in
+  let styles =
+    List.map (fun cls -> Result.get_ok (Tw.of_string ~theme cls)) classes
+  in
+  let actual =
+    match Css.layer_block "theme" (Tw.to_css ~theme ~base:false styles) with
+    | None -> fail "Expected @layer theme"
+    | Some statements ->
+        Css.rules_of_statements statements
+        |> Css.custom_props_of_rules
+        |> List.filter (fun name -> List.mem name expected)
+  in
+  check (list string) "Tailwind namespace order at shared slots" expected actual
+
 let tests =
   [
     test_case "theme layer stable order" `Quick theme_layer_stable_order;
     test_case "theme cross-module vars" `Quick theme_cross_module_vars;
+    test_case "priority-7 namespace order" `Quick priority_seven_namespace_order;
   ]
 
 let suite = ("theme", tests)


### PR DESCRIPTION
Tailwind keeps radius, drop-shadow, easing, animation, and perspective design-token namespaces in registration order when their priority-7 slots collide. TW previously used an alphabetical tiebreak, producing different emitted CSS order that the canonical differ could not detect.

This applies the namespace tiebreak only at priority 7 and retires the release TODO entry.