### PR TITLE
Place custom utilities by named property

### DIFF
--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -76,18 +76,18 @@ let build_property_slots () =
       List.iter
         (fun example ->
           let order = (M.priority example, M.suborder example) in
-          (* The property a utility claims is the one it writes first: the one
-             it is named for. A later declaration is incidental - line-clamp
-             ends with [display: -webkit-box] but the display slot belongs to
-             the display utilities, which sort elsewhere. *)
-          match style_declarations (M.to_style Scheme.default example) with
-          | [] -> ()
-          | d :: _ -> (
+          (* The property a utility claims is the first named property it
+             writes: the one it is named for. Theme-token declarations that make
+             that value available are not slots of their own. A later named
+             declaration is incidental - line-clamp ends with [display:
+             -webkit-box] but the display slot belongs to the display utilities,
+             which sort elsewhere. *)
+          style_declarations (M.to_style Scheme.default example)
+          |> List.find_map (fun d ->
               match Cascade.Css.Declaration.property_key d with
-              (* An author's own variable is not a slot: only the properties
-                 Tailwind orders utilities by are. *)
-              | Key (Custom_property _) | Key (Unknown_property _) -> ()
-              | key -> record key order))
+              | Key (Custom_property _) | Key (Unknown_property _) -> None
+              | key -> Some key)
+          |> Option.iter (fun key -> record key order))
         M.examples)
     !handlers;
   tbl

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -154,12 +154,12 @@ let test_order_of_property () =
   check
     (option (pair int int))
     "margin skips its spacing token declaration"
-    (Some (order_of "m-4"))
+    (Some (order_of "m-auto"))
     (order_of_property (Key Margin));
   check
     (option (pair int int))
     "color skips its palette token declaration"
-    (Some (order_of "text-red-500"))
+    (Some (order_of "placeholder-transparent"))
     (order_of_property (Key Color))
 
 let tests =

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -145,7 +145,22 @@ let test_order_of_property () =
     (option (pair int int))
     "isolation keeps its own slot, not the display family's"
     (Some (order_of "isolate"))
-    (order_of_property (Key Isolation))
+    (order_of_property (Key Isolation));
+  check
+    (option (pair int int))
+    "padding skips its spacing token declaration"
+    (Some (order_of "p-4"))
+    (order_of_property (Key Padding));
+  check
+    (option (pair int int))
+    "margin skips its spacing token declaration"
+    (Some (order_of "m-4"))
+    (order_of_property (Key Margin));
+  check
+    (option (pair int int))
+    "color skips its palette token declaration"
+    (Some (order_of "text-red-500"))
+    (order_of_property (Key Color))
 
 let tests =
   [


### PR DESCRIPTION
Custom utility slot inference stopped at a leading theme-token declaration, so spacing and colour families returned no slot and project utilities landed at the utilities-layer tail.

This teaches inference to skip custom-property declarations and use the first named CSS property across padding, margin, colour, and the existing property families.