### PR TITLE
Honor project theme in CLI generation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -154,18 +154,6 @@ escapes: `strip_tailwind_import_options` (paren counting),
 string inside an `@apply` line still misfires) and `fill_slots` (`@slot`
 literal scan). Port them to the `Scan` module #288 added. Found 2026-08-01.
 
-`drop_unread_inline_tokens` (:975) decides `@theme inline` token liveness by
-asking whether the minified sheet contains the literal needle
-`"var(" ^ name ^ ")"` (:980), so any reference with a fallback is invisible:
-with `@theme inline { --default-font-family: "Satoshi", sans-serif; }` the token
-is dropped from `:root` even though the base layer reads
-`var(--default-font-family, -apple-system, ...)`, and the fallback silently
-wins. The same trick decides self-reference on the next lines. cascade owns this
-analysis - `Variables.var_refs_in_value_string` (variables.mli:21, whose
-docstring says explicitly that it beats a textual scan), `vars_of_declarations`,
-`declaration_uses_var`, `any_var_name` - and tw already passes
-`~prune_unused_custom_props:true` to `Css_compare.diff` at :1120.
-
 - `@theme inline` is smuggled through as the selector `:root inline`:
   `theme_blocks_as_root` (:137) rewrites the raw text and
   `theme_overrides_of_css` recovers the modifier at :199-201 with
@@ -189,15 +177,6 @@ docstring says explicitly that it beats a textual scan), `vars_of_declarations`,
   calls out round-trips), so this is fragility, not a live bug. Do the rewrite
   on the AST: `Selector.as_list`, `Selector.map` replacing the `Class` node with
   `Nesting`, `Selector.list`.
-- `tw -s CLASS --input-css app.css` ignores the project theme: the Native branch
-  calls `parse_classes ~warn:false class_str` (:1154) and
-  `Tw.to_css ~base:include_base styles` (:1159) with no `~theme`, while the Diff
-  branch (:1115/:1117) and `native_files` (:1474/:1481) pass
-  `~theme:opts.theme`. So `tw -s foo --input-css app.css --diff` reports no
-  differences while the plain form emits default-theme CSS, and a token-
-  dependent class can be rejected outright. Debugging affordance only; the file
-  scan is theme-correct. Thread the theme through both calls and through
-  `unknown_class_error` (:1105).
 - `:1698` reconciles the three "mutually exclusive" backend modes with an `if`
   over two bools: `--tailwind --diff` silently drops `--tailwind`.
 - `files path patterns` (:18-27) recurses on `Sys.is_directory` (follows

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1062,22 +1062,14 @@ let hoist_layer_blocks stmts =
 let drop_unread_inline_tokens ~theme stmts =
   if Tw.Scheme.(theme.inline_tokens) = [] then stmts
   else
-    let rendered = Css.to_string ~minify:true (Css.v stmts) in
-    let reads name =
-      let needle = "var(" ^ name ^ ")" in
-      let nl = String.length needle and hl = String.length rendered in
-      let rec at i =
-        i + nl <= hl && (String.sub rendered i nl = needle || at (i + 1))
-      in
-      at 0
+    let reads =
+      Css.vars_of_stylesheet (Css.v stmts) |> List.map Css.any_var_name
     in
     let keep decl =
       match Css.custom_declaration_name decl with
       | Some n when String.length n > 2 ->
           let bare = String.sub n 2 (String.length n - 2) in
-          (not (Tw.Scheme.is_inline_token theme bare))
-          || String.trim (Css.declaration_value decl) = "var(" ^ n ^ ")"
-          || reads n
+          (not (Tw.Scheme.is_inline_token theme bare)) || List.mem n reads
       | _ -> true
     in
     let rec go stmts =
@@ -1188,8 +1180,8 @@ let render_css ~(opts : gen_opts) stylesheet =
 
 (* Surface of_string's specific message (e.g. the actionable arbitrary-property
    feedback) for a single unknown class; fall back to a generic message. *)
-let unknown_class_error class_str =
-  match Tw.of_string class_str with
+let unknown_class_error ~theme class_str =
+  match Tw.of_string ~theme class_str with
   | Error (`Msg m) -> Fmt.str "Error: %s" m
   | Ok _ -> Fmt.str "Error: Unknown class: %s" class_str
 
@@ -1211,7 +1203,7 @@ let diff_single_class class_str ~(opts : gen_opts) =
     | [] when class_str = "" ->
         print_diff_result " (empty/base only)" diff;
         `Ok ()
-    | [] -> `Error (false, unknown_class_error class_str)
+    | [] -> `Error (false, unknown_class_error ~theme:opts.theme class_str)
     | _ ->
         print_diff_result
           (Fmt.str " between Tailwind and tw for '%s'" class_str)
@@ -1227,7 +1219,8 @@ let process_single_class class_str flag ~(opts : gen_opts) =
       try
         let css =
           Tw_tools.Tailwind_gen.generate ~minify:opts.minify
-            ~optimize:opts.optimize ~forms:true [ class_str ]
+            ~optimize:opts.optimize ~forms:true ?input_css:opts.input_css
+            [ class_str ]
         in
         print_string css;
         `Ok ()
@@ -1238,12 +1231,15 @@ let process_single_class class_str flag ~(opts : gen_opts) =
           ))
   | Native -> (
       let include_base = eval_flag flag ~default:false in
-      let tw_styles = parse_classes ~warn:false class_str in
+      let tw_styles = parse_classes ~warn:false ~theme:opts.theme class_str in
       let styles = match tw_styles with [] -> [] | s -> s in
       match tw_styles with
-      | [] when class_str <> "" -> `Error (false, unknown_class_error class_str)
+      | [] when class_str <> "" ->
+          `Error (false, unknown_class_error ~theme:opts.theme class_str)
       | _ ->
-          let stylesheet = Tw.to_css ~base:include_base styles in
+          let stylesheet =
+            Tw.to_css ~theme:opts.theme ~base:include_base styles
+          in
           print_string (render_css ~opts stylesheet);
           `Ok ())
 

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -64,7 +64,7 @@ the token it declared:
 The single-class path reads that same project theme instead of parsing against
 the defaults:
 
-  $ tw --minify --input-css font.css -s font-source | grep -cF '.font-source{font-family:var(--font-source)}'
+  $ tw --minify --input-css font.css -s font-source | grep -cF '.font-source{font-family:Georgia,serif}'
   1
 
 An [@theme inline] token has no declaration of its own: the utility carries

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -61,6 +61,12 @@ the token it declared:
   0
   [1]
 
+The single-class path reads that same project theme instead of parsing against
+the defaults:
+
+  $ tw --minify --input-css font.css -s font-source | grep -cF '.font-source{font-family:var(--font-source)}'
+  1
+
 An [@theme inline] token has no declaration of its own: the utility carries
 the value. A self-referential one is the exception, since inlining it would
 leave the reference dangling.
@@ -204,4 +210,16 @@ settings declared beside it. A project override wins over the built-in default:
   0
   [1]
   $ tw --minify --input-css inl.css inl.html | grep -cF -- '--default-font-family:var(--font-inter),system-ui'
+  1
+
+A fallback reference is still a real read. The base layer reads the default
+font token with a fallback, so an inline project override must remain live:
+
+  $ cat > inl-default.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @theme inline {
+  >   --default-font-family: "Satoshi", sans-serif;
+  > }
+  > EOF
+  $ tw --minify --input-css inl-default.css index.html | grep -cF -- '--default-font-family:"Satoshi",sans-serif'
   1


### PR DESCRIPTION
Two CLI paths ignored valid project-theme reads: single-class native generation parsed against defaults, and inline-token liveness only recognized var() references without fallbacks.

This threads the entrypoint theme through single-class parsing and rendering, and uses Cascade variable analysis for liveness.