### PR TITLE
Hoist blocks from layer name lists

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1015,25 +1015,14 @@ let merge_named_layers stmts =
    in the slot, so move it there. The declared order already makes this
    cascade-neutral; it is the document shape that differs. *)
 let hoist_layer_blocks stmts =
-  let declared_name stmt =
-    match Css.as_layer stmt with
-    | Some _ -> None
-    | None -> (
-        let s = Css.to_string ~minify:true (Css.v [ stmt ]) in
-        match String.index_opt s ';' with
-        | Some semi
-          when String.length s > 7
-               && String.sub s 0 7 = "@layer "
-               && semi = String.length s - 1 ->
-            let name = String.sub s 7 (semi - 7) in
-            if String.contains name ',' || name = "" then None else Some name
-        | _ -> None)
-  in
+  let declared_names = Css.layer_statement_name_list in
   let block_name stmt =
-    match Css.as_layer stmt with Some (Some n, _) -> Some n | _ -> None
+    match Css.layer_block_name stmt with Some "" | None -> None | name -> name
   in
   let slots =
-    List.filter_map declared_name stmts |> List.sort_uniq String.compare
+    List.filter_map declared_names stmts
+    |> List.concat
+    |> List.sort_uniq String.compare
   in
   let movable =
     List.filter
@@ -1043,14 +1032,25 @@ let hoist_layer_blocks stmts =
   if movable = [] then stmts
   else
     let block_for n = List.find_opt (fun st -> block_name st = Some n) stmts in
-    List.filter_map
+    let emitted = Hashtbl.create 8 in
+    List.concat_map
       (fun stmt ->
-        match declared_name stmt with
-        | Some n when List.mem n movable -> block_for n
+        match declared_names stmt with
+        | Some names when List.exists (fun n -> List.mem n movable) names ->
+            List.filter_map
+              (fun n ->
+                if List.mem n movable then
+                  if Hashtbl.mem emitted n then None
+                  else begin
+                    Hashtbl.add emitted n ();
+                    block_for n
+                  end
+                else Some (Css.layer_decl [ n ]))
+              names
         | _ -> (
             match block_name stmt with
-            | Some n when List.mem n movable -> None
-            | _ -> Some stmt))
+            | Some n when List.mem n movable -> []
+            | _ -> [ stmt ]))
       stmts
 
 (* A token the project declared in an [@theme inline] block has no declaration

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -126,6 +126,20 @@ document, both the way Tailwind emits them:
   .after{color:red}
   @keyframes spin
 
+A statement-form layer list gives each name a slot. A later block fills its
+named slot without discarding the other declarations in the list:
+
+  $ cat > layer-list.css <<EOF
+  > @import "tailwindcss";
+  > @layer aa, bb;
+  > .after-list { color: red }
+  > @layer bb { .card-list { padding: 1rem } }
+  > EOF
+  $ tw --minify --input-css layer-list.css index.html | grep -oE '@layer aa;|@layer bb\{\.card-list\{padding:1rem\}\}|\.after-list\{color:red\}' | tail -3
+  @layer aa;
+  @layer bb{.card-list{padding:1rem}}
+  .after-list{color:red}
+
 A project can declare [@keyframes] inside its [@theme], beside the [--animate-*]
 token that names it. The theme block becomes a [:root] rule, where a nested
 [@keyframes] would be invalid, so it is lifted to the top level:


### PR DESCRIPTION
Statement-form layer lists were serialized and string-matched, so any declaration containing a comma was ignored and a later named block stayed in the wrong document position.

This uses Cascade typed layer-name accessors, splits only lists that contain a movable block, preserves their other layer declarations, and prevents duplicate insertion across repeated slots.