### PR TITLE
Make recursive content scans safe

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name tw)
  (name main)
- (libraries tw tw.info cascade cascade.diff tw_tools cmdliner fmt))
+ (libraries tw tw.info cascade cascade.diff tw_tools cmdliner fmt unix))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -14,17 +14,41 @@ let parse_classes ?(warn = true) ?(theme = Tw.Scheme.default) classes_str =
           None)
     class_names
 
-(* Recursively get files in directories *)
+let ignored_scan_entry name =
+  name = "_build" || name = "node_modules" || name = ".git"
+  || String.starts_with ~prefix:"." name
+
+let scan_warning path message =
+  Fmt.epr "Warning: cannot scan %s: %s@." path message
+
+(* Recursively get content files without following directory symlinks or
+   descending into generated/dependency/metadata trees. A bad subtree is local
+   to that path: readable siblings still contribute their candidates. *)
 let rec files path patterns =
-  if Sys.is_directory path then
-    let entries = Sys.readdir path |> Array.to_list in
-    List.concat_map
-      (fun entry -> files (Filename.concat path entry) patterns)
-      entries
-  else if
-    List.exists (fun pattern -> Filename.check_suffix path pattern) patterns
-  then [ path ]
-  else []
+  let regular_file () =
+    if List.exists (fun pattern -> Filename.check_suffix path pattern) patterns
+    then [ path ]
+    else []
+  in
+  try
+    match (Unix.lstat path).st_kind with
+    | Unix.S_DIR ->
+        Sys.readdir path |> Array.to_list
+        |> List.filter (fun entry -> not (ignored_scan_entry entry))
+        |> List.concat_map (fun entry ->
+            files (Filename.concat path entry) patterns)
+    | Unix.S_LNK -> (
+        match (Unix.stat path).st_kind with
+        | Unix.S_DIR -> []
+        | _ -> regular_file ())
+    | _ -> regular_file ()
+  with
+  | Sys_error message ->
+      scan_warning path message;
+      []
+  | Unix.Unix_error (error, _, _) ->
+      scan_warning path (Unix.error_message error);
+      []
 
 (* Generation backend - determines which tool to use *)
 type backend =

--- a/test/cli/scan-content.t
+++ b/test/cli/scan-content.t
@@ -23,3 +23,26 @@ The formats that already worked keep working:
 
   $ tw --minify site | grep -c '\.p-3{'
   1
+
+Recursive scans ignore generated/dependency/metadata trees, dotfiles, and
+symlinked directories instead of importing stale candidates or following a
+cycle:
+
+  $ mkdir -p site/_build site/node_modules site/.hidden external-source
+  $ echo '<div class="p-11"></div>' > site/_build/stale.html
+  $ echo '<div class="p-12"></div>' > site/node_modules/dependency.html
+  $ echo '<div class="p-13"></div>' > site/.hidden/private.html
+  $ echo '<div class="p-14"></div>' > site/.dotfile.html
+  $ echo '<div class="p-15"></div>' > external-source/external.html
+  $ ln -s "$PWD/external-source" site/linked
+  $ tw --minify site | grep -oE '\.p-(11|12|13|14|15)\{' | wc -l | tr -d ' '
+  0
+
+One unreadable subtree does not abort readable siblings:
+
+  $ mkdir -p site/locked
+  $ echo '<div class="p-16"></div>' > site/locked/private.html
+  $ chmod 000 site/locked
+  $ tw --quiet --minify site 2>/dev/null | grep -c '\.p-3{'
+  1
+  $ chmod 755 site/locked


### PR DESCRIPTION
Recursive scans followed directory symlinks, descended into generated and dependency trees, and aborted the whole run when one subtree was unreadable.

This uses lstat-based traversal, refuses symlinked directories, excludes _build, node_modules, .git, and dot entries, and degrades path-local read errors to warnings.