### PR TITLE
Interleave custom utilities with property families

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1526,7 +1526,6 @@ let ordered_routed_entries ~own_order ~order_of group =
   |> List.sort (compare_routed_entries ~own_order ~order_of)
 
 let place_routed_entries ~own_order ~order_of ~classless entries =
-  let offset = ref 0 in
   let ordered, unordered =
     List.fold_left
       (fun (ordered, unordered) (cls, stmts) ->
@@ -1535,9 +1534,7 @@ let place_routed_entries ~own_order ~order_of ~classless entries =
         | None -> (
             match Hashtbl.find_opt order_of cls with
             | Some (priority, suborder) ->
-                incr offset;
-                ( (cls, (priority, suborder + !offset), stmts) :: ordered,
-                  unordered )
+                ((cls, (priority, suborder), stmts) :: ordered, unordered)
             | None -> (ordered, unordered @ stmts)))
       ([], classless) entries
   in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1531,13 +1531,79 @@ let outputs_of_statement ~base_class stmt =
                     inner
               | _ -> [])))
 
+let output_base_class_and_props = function
+  | Output.Regular { base_class; props; _ }
+  | Media_query { base_class; props; _ }
+  | Container_query { base_class; props; _ }
+  | Starting_style { base_class; props; _ }
+  | Supports_query { base_class; props; _ } ->
+      (base_class, props)
+
+let first_named_property props =
+  List.find_map
+    (fun decl ->
+      match Css.Declaration.property_key decl with
+      | Key (Custom_property _) | Key (Unknown_property _) -> None
+      | key -> Some key)
+    props
+
+(* Tailwind orders utilities that write the same property by candidate name.
+   Built-in values carry distinct numeric suborders in TW, so when a declared
+   utility joins one of those property families, normalize that family's
+   suborder for this render and let the existing candidate-name tiebreaker
+   interleave both kinds of utility. *)
+let normalize_declared_property_families order_map builtins extra_outputs =
+  List.iter
+    (fun (class_name, (priority, _), outputs) ->
+      match
+        List.find_map
+          (fun output ->
+            let _, props = output_base_class_and_props output in
+            first_named_property props)
+          outputs
+      with
+      | None -> ()
+      | Some property ->
+          let family =
+            List.filter_map
+              (fun output ->
+                let base_class, props = output_base_class_and_props output in
+                match (base_class, first_named_property props) with
+                | Some cls, Some key when key = property ->
+                    let base = extract_base_utility cls in
+                    Option.map
+                      (fun order -> (base, order))
+                      (Hashtbl.find_opt order_map base)
+                | _ -> None)
+              builtins
+          in
+          let suborder =
+            List.fold_left
+              (fun acc (_, (p, s)) ->
+                if p <> priority then acc
+                else Some (Option.fold ~none:s ~some:(Int.min s) acc))
+              None family
+          in
+          Option.iter
+            (fun suborder ->
+              List.iter
+                (fun (base, (p, _)) ->
+                  if p = priority then
+                    Hashtbl.replace order_map base (priority, suborder))
+                family;
+              Hashtbl.replace order_map
+                (extract_base_utility class_name)
+                (priority, suborder))
+            suborder)
+    extra_outputs
+
 let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
     tw_classes =
   (* [Rule.outputs ~order_tbl] records each base utility's order under the class
      name it already builds, so [order_of_base] looks it up instead of
      re-parsing the class string while building/sorting rules. *)
   let order_map = Hashtbl.create 256 in
-  let selector_props =
+  let builtin_selector_props =
     List.concat_map (Rule.outputs ~theme ~order_tbl:order_map) tw_classes
   in
   (* A declared utility means nothing to the handlers, so its order arrives with
@@ -1545,17 +1611,23 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
      the base name, which a plain utility of the same name shares: seed it only
      when it is free, so an incoming order never moves a rule the handlers
      already placed. *)
-  let selector_props =
-    selector_props
-    @ List.concat_map
-        (fun (class_name, order, statements) ->
-          let key = extract_base_utility class_name in
-          if not (Hashtbl.mem order_map key) then
-            Hashtbl.add order_map key order;
+  let extra_outputs =
+    List.map
+      (fun (class_name, order, statements) ->
+        let key = extract_base_utility class_name in
+        if not (Hashtbl.mem order_map key) then Hashtbl.add order_map key order;
+        ( class_name,
+          order,
           List.concat_map
             (outputs_of_statement ~base_class:class_name)
-            statements)
-        extra
+            statements ))
+      extra
+  in
+  normalize_declared_property_families order_map builtin_selector_props
+    extra_outputs;
+  let selector_props =
+    builtin_selector_props
+    @ List.concat_map (fun (_, _, outputs) -> outputs) extra_outputs
   in
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute

--- a/test/cli/utility.t
+++ b/test/cli/utility.t
@@ -81,3 +81,21 @@ that only [Tw.of_string] knows.
   1
   $ tw --minify --input-css line.css line.html | grep -cF '.hover\:line-t:hover:before{'
   1
+
+Declaration-only utilities join the property family they write. Within that
+family Tailwind orders every utility by class name, whether it is built in or
+declared by the project:
+
+  $ cat > order.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @utility alpha { padding: 1rem }
+  > @utility zebra { padding: 2rem }
+  > EOF
+  $ cat > order.html <<EOF
+  > <div class="p-1 p-4 alpha zebra"></div>
+  > EOF
+  $ tw --minify --input-css order.css order.html | grep -oE '\.(alpha|p-1|p-4|zebra)\{[^}]*\}'
+  .alpha{padding:1rem}
+  .p-1{padding:var(--spacing)}
+  .p-4{padding:calc(var(--spacing)*4)}
+  .zebra{padding:2rem}


### PR DESCRIPTION
Stacked on #313.

Tailwind class-sorts declaration-only @utility rules together with built-ins that write the same property. Normalize only the affected property family during a render so custom and built-in candidates interleave correctly.

This also retires two stale custom-utility residuals already covered by existing behavior.