### PR TITLE
Thread custom breakpoints through the theme

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -103,7 +103,8 @@ let arbitrary_length_class prefix (l : Css.length) cls =
   let len_str = compact_length l in
   Css.Selector.Class (prefix ^ "[" ^ len_str ^ "]:" ^ cls)
 
-(** Registry for custom breakpoint names (set via scheme) *)
+(** Legacy registry for callers of [Modifiers.apply] without an explicit
+    breakpoint list. [Tw.of_string] always supplies its threaded scheme. *)
 let custom_breakpoints : (string * float) list ref = ref []
 
 let register_custom_breakpoints bps = custom_breakpoints := bps
@@ -1540,22 +1541,18 @@ let simple_modifiers =
   ]
 
 (* Try looking up a custom breakpoint (e.g., "10xl", "min-10xl", "max-10xl") *)
-let try_custom_breakpoint s =
+let try_custom_breakpoint breakpoints s =
   (* Direct name: e.g., "10xl" → Custom_responsive *)
-  match List.assoc_opt s !custom_breakpoints with
-  | Some _px -> Some (Custom_responsive s)
-  | None ->
+  match List.mem s breakpoints with
+  | true -> Some (Custom_responsive s)
+  | false ->
       (* min-<name>: e.g., "min-10xl" → Min_custom *)
       if String.length s > 4 && String.sub s 0 4 = "min-" then
         let name = String.sub s 4 (String.length s - 4) in
-        match List.assoc_opt name !custom_breakpoints with
-        | Some _px -> Some (Min_custom name)
-        | None -> None
+        if List.mem name breakpoints then Some (Min_custom name) else None
       else if String.length s > 4 && String.sub s 0 4 = "max-" then
         let name = String.sub s 4 (String.length s - 4) in
-        match List.assoc_opt name !custom_breakpoints with
-        | Some _px -> Some (Max_custom name)
-        | None -> None
+        if List.mem name breakpoints then Some (Max_custom name) else None
       else None
 
 (** Try not-* shorthand patterns that aren't in simple_modifiers or bracket
@@ -1933,7 +1930,7 @@ and try_scoped_container_query s =
         | _ -> None)
 
 (* Parse a modifier string into a typed Style.modifier *)
-let rec parse_modifier s : modifier option =
+let rec parse_modifier ~breakpoints s : modifier option =
   let fns =
     [
       (fun () -> List.assoc_opt s simple_modifiers);
@@ -1941,25 +1938,25 @@ let rec parse_modifier s : modifier option =
       (fun () -> try_bracketed_modifier s);
       (fun () -> try_aria_shorthand s);
       (fun () -> try_has_shorthand s);
-      (fun () -> try_has_variant s);
+      (fun () -> try_has_variant ~breakpoints s);
       (fun () -> try_numeric_nth s);
       (fun () -> try_compound_named_group s);
       (fun () -> try_in_modifier s);
       (fun () -> try_not_in_modifier s);
       (fun () -> try_group_peer_not s);
-      (fun () -> try_group_peer_not_variant s);
+      (fun () -> try_group_peer_not_variant ~breakpoints s);
       (* Before [try_not_modifier]: a container variant handles its own [not-]
          (negating the structural condition), not the generic [Not] wrapper. *)
       (fun () -> try_container_variant s);
       (fun () -> try_not_modifier s);
       (fun () -> try_bare_data_aria s);
       (fun () -> try_prose_element s);
-      (fun () -> try_custom_breakpoint s);
+      (fun () -> try_custom_breakpoint breakpoints s);
       (fun () -> try_custom_variant s);
       (* Last: a [not-] over any other variant negates the selector it produces.
          The readings above come first because several [not-] spellings need
          their own handling. *)
-      (fun () -> try_not_of_modifier s);
+      (fun () -> try_not_of_modifier ~breakpoints s);
     ]
   in
   List.find_map (fun f -> f ()) fns
@@ -1967,7 +1964,7 @@ let rec parse_modifier s : modifier option =
 (* [group-not-has-[...]] and [peer-not-...]: the inner is any variant, read on
    its own. The reading above only knows the simple state names and a bare
    bracket. *)
-and try_group_peer_not_variant s =
+and try_group_peer_not_variant ~breakpoints s =
   let try_prefix prefix make =
     let plen = String.length prefix in
     if String.length s <= plen || String.sub s 0 plen <> prefix then None
@@ -1975,7 +1972,7 @@ and try_group_peer_not_variant s =
       let base, name =
         split_name (String.sub s plen (String.length s - plen))
       in
-      match parse_modifier base with
+      match parse_modifier ~breakpoints base with
       | Some m when is_not_compatible m -> Some (make m name)
       | Some _ | None -> None
   in
@@ -1986,22 +1983,29 @@ and try_group_peer_not_variant s =
 (* [has-<variant>]: the argument is any variant, and that variant's own selector
    goes inside [:has()]. The shorthand reading only knows the state names and a
    bracket, so [has-peer-checked] fell through. *)
-and try_has_variant s =
+and try_has_variant ~breakpoints s =
   if String.length s > 4 && String.sub s 0 4 = "has-" then
-    match parse_modifier (String.sub s 4 (String.length s - 4)) with
+    match
+      parse_modifier ~breakpoints (String.sub s 4 (String.length s - 4))
+    with
     | Some m when is_not_compatible m -> Some (Has_variant m)
     | Some _ | None -> None
   else None
 
-and try_not_of_modifier s =
+and try_not_of_modifier ~breakpoints s =
   if not (String.length s > 4 && String.sub s 0 4 = "not-") then None
   else
-    match parse_modifier (String.sub s 4 (String.length s - 4)) with
+    match
+      parse_modifier ~breakpoints (String.sub s 4 (String.length s - 4))
+    with
     | Some m when is_not_compatible m -> Some (Not m)
     | Some _ | None -> None
 
 (* Apply a list of modifier strings to a base utility *)
-let apply modifiers base_utility =
+let apply ?breakpoints modifiers base_utility =
+  let breakpoints =
+    Option.value ~default:(List.map fst !custom_breakpoints) breakpoints
+  in
   (* Convert utility to a list for wrapping *)
   let to_list = function
     | Utility.Group styles -> styles
@@ -2012,7 +2016,7 @@ let apply modifiers base_utility =
     match acc with
     | None -> None
     | Some u -> (
-        match parse_modifier modifier_str with
+        match parse_modifier ~breakpoints modifier_str with
         | Some m -> Some (wrap m (to_list u))
         | None -> None)
   in

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -39,8 +39,9 @@ val normalize_supports_condition : string -> string
     validates its result, so only conditions that parse reach a rule. *)
 
 val register_custom_breakpoints : (string * float) list -> unit
-(** [register_custom_breakpoints bps] sets the custom breakpoint names and their
-    px values for modifier parsing. *)
+(** [register_custom_breakpoints bps] sets the legacy custom breakpoint names
+    used only when {!apply} receives no [breakpoints]. Prefer passing a
+    [Scheme.t] to [Tw.of_string]. *)
 
 val clear_custom_breakpoints : unit -> unit
 (** [clear_custom_breakpoints ()] clears the custom breakpoint registry. *)
@@ -699,9 +700,9 @@ val pp_modifier : modifier -> string
 (** [pp_modifier m] returns the string prefix for a modifier (e.g., "hover" for
     Hover). *)
 
-val apply : string list -> t -> t option
-(** [apply modifiers style] applies a list of modifier strings to a base style.
-    Returns [None] if any modifier is unrecognized. Example:
+val apply : ?breakpoints:string list -> string list -> t -> t option
+(** [apply ?breakpoints modifiers style] applies a list of modifier strings to a
+    base style. Returns [None] if any modifier is unrecognized. Example:
     [apply ["hover"; "sm"] (bg blue 500)] creates a hover:sm:bg-blue-500 style.
 *)
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -255,19 +255,19 @@ let negate_media = function
   | Css.Media.List _ as media ->
       Css.Media.of_string ("not " ^ Css.Media.to_string media)
 
-(** Get the media condition for a breakpoint, using px from scheme if available,
-    otherwise rem. *)
+(** Get the media condition for a breakpoint, using the scheme override when
+    available, otherwise the default rem value. *)
 let breakpoint_condition ?theme bp =
   let name = string_of_breakpoint bp in
-  match Scheme.breakpoint (resolve_scheme theme) name with
-  | Some px -> media_min_width_px px
+  match Scheme.breakpoint_length (resolve_scheme theme) name with
+  | Some length -> Css.media_min_width_length length
   | None -> media_min_width_rem (breakpoint_rem bp)
 
 (** Get the negated media condition for max-* breakpoints. *)
 let breakpoint_not_condition ?theme bp =
   let name = string_of_breakpoint bp in
-  match Scheme.breakpoint (resolve_scheme theme) name with
-  | Some px -> media_not_min_width_px px
+  match Scheme.breakpoint_length (resolve_scheme theme) name with
+  | Some length -> Css.media_not_min_width_length length
   | None -> media_not_min_width_rem (breakpoint_rem bp)
 
 (** Get the media condition and class prefix for a responsive modifier. *)
@@ -314,26 +314,26 @@ let responsive_modifier_condition ?theme = function
       let len_str = Modifiers.compact_length l in
       (Css.media_not_min_width_length l, "max-[" ^ len_str ^ "]")
   | Style.Custom_responsive name ->
-      let px =
-        match Scheme.breakpoint (resolve_scheme theme) name with
-        | Some px -> px
+      let length =
+        match Scheme.breakpoint_length (resolve_scheme theme) name with
+        | Some length -> length
         | None -> failwith ("unknown custom breakpoint: " ^ name)
       in
-      (media_min_width_px px, name)
+      (Css.media_min_width_length length, name)
   | Style.Min_custom name ->
-      let px =
-        match Scheme.breakpoint (resolve_scheme theme) name with
-        | Some px -> px
+      let length =
+        match Scheme.breakpoint_length (resolve_scheme theme) name with
+        | Some length -> length
         | None -> failwith ("unknown custom breakpoint: " ^ name)
       in
-      (media_min_width_px px, "min-" ^ name)
+      (Css.media_min_width_length length, "min-" ^ name)
   | Style.Max_custom name ->
-      let px =
-        match Scheme.breakpoint (resolve_scheme theme) name with
-        | Some px -> px
+      let length =
+        match Scheme.breakpoint_length (resolve_scheme theme) name with
+        | Some length -> length
         | None -> failwith ("unknown custom breakpoint: " ^ name)
       in
-      (media_not_min_width_px px, "max-" ^ name)
+      (Css.media_not_min_width_length length, "max-" ^ name)
   | _ -> failwith "not a responsive modifier"
 
 let selector_with_data_key selector key value =
@@ -427,30 +427,31 @@ let max_arbitrary_length_rule ?inner_has_hover l base_class selector props =
     l base_class selector props
 
 let custom_breakpoint ?theme name =
-  match Scheme.breakpoint (resolve_scheme theme) name with
-  | Some px -> px
+  match Scheme.breakpoint_length (resolve_scheme theme) name with
+  | Some length -> length
   | None -> failwith ("unknown custom breakpoint: " ^ name)
 
-let custom_media_rule ?theme ?inner_has_hover prefix condition_of_px name
+let custom_media_rule ?theme ?inner_has_hover prefix condition_of_length name
     base_class selector props =
-  let px = custom_breakpoint ?theme name in
-  media_rule_with_prefix ?inner_has_hover (prefix name) (condition_of_px px)
+  let length = custom_breakpoint ?theme name in
+  media_rule_with_prefix ?inner_has_hover (prefix name)
+    (condition_of_length length)
     base_class selector props
 
 let custom_responsive_rule ?theme ?inner_has_hover name base_class selector
     props =
-  custom_media_rule ?theme ?inner_has_hover Fun.id media_min_width_px name
-    base_class selector props
+  custom_media_rule ?theme ?inner_has_hover Fun.id Css.media_min_width_length
+    name base_class selector props
 
 let min_custom_rule ?theme ?inner_has_hover name base_class selector props =
   custom_media_rule ?theme ?inner_has_hover
     (fun name -> "min-" ^ name)
-    media_min_width_px name base_class selector props
+    Css.media_min_width_length name base_class selector props
 
 let max_custom_rule ?theme ?inner_has_hover name base_class selector props =
   custom_media_rule ?theme ?inner_has_hover
     (fun name -> "max-" ^ name)
-    media_not_min_width_px name base_class selector props
+    Css.media_not_min_width_length name base_class selector props
 
 let container_rule ?(inner_has_hover = false) query base_class selector props =
   let prefix = Containers.container_query_to_class_prefix query in

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -125,6 +125,32 @@ let has_explicit_radius scheme name = Option.is_some (radius scheme name)
 (** Lookup a breakpoint px value in the scheme *)
 let breakpoint scheme name = List.assoc_opt name scheme.breakpoints
 
+(** Lookup the exact CSS length of a breakpoint. Entrypoint [@theme] tokens take
+    precedence over the legacy px-only record field. *)
+let breakpoint_length scheme name =
+  match List.assoc_opt ("breakpoint-" ^ name) scheme.token_overrides with
+  | Some value -> Css.parse_length (String.trim value)
+  | None ->
+      Option.map (fun px -> (Css.Px px : Css.length)) (breakpoint scheme name)
+
+let breakpoint_names scheme =
+  let from_tokens =
+    List.filter_map
+      (fun (name, value) ->
+        let prefix = "breakpoint-" in
+        if
+          String.starts_with ~prefix name
+          && Option.is_some (Css.parse_length (String.trim value))
+        then
+          Some
+            (String.sub name (String.length prefix)
+               (String.length name - String.length prefix))
+        else None)
+      scheme.token_overrides
+  in
+  List.sort_uniq String.compare (List.map fst scheme.breakpoints @ from_tokens)
+  |> List.filter (fun name -> Option.is_some (breakpoint_length scheme name))
+
 (** Lookup a per-render theme token override (from a [@theme] block). *)
 let token_override scheme name = List.assoc_opt name scheme.token_overrides
 
@@ -143,8 +169,24 @@ let token scheme name =
 (** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
     on top of any existing token overrides (new entries win). *)
 let with_overrides ?(inline = []) scheme overrides =
+  let breakpoints =
+    List.fold_left
+      (fun breakpoints (name, value) ->
+        let prefix = "breakpoint-" in
+        if String.starts_with ~prefix name then
+          let name =
+            String.sub name (String.length prefix)
+              (String.length name - String.length prefix)
+          in
+          match Css.parse_length (String.trim value) with
+          | Some (Css.Px px) -> (name, px) :: List.remove_assoc name breakpoints
+          | _ -> breakpoints
+        else breakpoints)
+      scheme.breakpoints overrides
+  in
   {
     scheme with
+    breakpoints;
     token_overrides = overrides @ scheme.token_overrides;
     inline_tokens = inline @ scheme.inline_tokens;
   }

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -118,3 +118,12 @@ val has_explicit_radius : t -> string -> bool
 
 val breakpoint : t -> string -> float option
 (** [breakpoint t name] looks up a breakpoint px value in the scheme. *)
+
+val breakpoint_length : t -> string -> Css.length option
+(** [breakpoint_length t name] looks up a breakpoint as its exact CSS length. A
+    [breakpoint-NAME] token override takes precedence over the legacy px-only
+    {!breakpoint} field. *)
+
+val breakpoint_names : t -> string list
+(** [breakpoint_names t] returns the custom breakpoint names available while
+    parsing variants. *)

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -231,7 +231,11 @@ let of_string ?(theme = Scheme.default) class_str =
       | `Suffix -> Utility.important ~suffix:true base_util
       | `None -> base_util
     in
-    match Modifiers.apply modifiers base_util with
+    match
+      Modifiers.apply
+        ~breakpoints:(Scheme.breakpoint_names theme)
+        modifiers base_util
+    with
     | Some u -> Ok u
     | None -> Error (`Msg ("Unknown modifier in: " ^ class_str))
   in

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -173,3 +173,18 @@ guessing:
   $ tw --minify --input-css nope.css index.html | grep -c 'color:red'
   0
   [1]
+
+A breakpoint declared by the entrypoint theme is available while candidates
+are parsed, including candidates discovered by a file scan:
+
+  $ cat > custom-breakpoint.css <<EOF
+  > @import "tailwindcss";
+  > @theme { --breakpoint-10xl: 1600px; }
+  > EOF
+  $ cat > custom-breakpoint.html <<EOF
+  > <div class="10xl:flex"></div>
+  > EOF
+  $ tw --minify --input-css custom-breakpoint.css custom-breakpoint.html | grep -c 'min-width:1600px'
+  1
+  $ tw --minify --input-css custom-breakpoint.css custom-breakpoint.html | grep -c 'display:flex'
+  1

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -179,12 +179,19 @@ are parsed, including candidates discovered by a file scan:
 
   $ cat > custom-breakpoint.css <<EOF
   > @import "tailwindcss";
-  > @theme { --breakpoint-10xl: 1600px; }
+  > @theme {
+  >   --breakpoint-10xl: 1600px;
+  >   --breakpoint-cinema: 100rem;
+  > }
   > EOF
   $ cat > custom-breakpoint.html <<EOF
-  > <div class="10xl:flex"></div>
+  > <div class="10xl:flex cinema:grid"></div>
   > EOF
   $ tw --minify --input-css custom-breakpoint.css custom-breakpoint.html | grep -c 'min-width:1600px'
   1
   $ tw --minify --input-css custom-breakpoint.css custom-breakpoint.html | grep -c 'display:flex'
+  1
+  $ tw --minify --input-css custom-breakpoint.css custom-breakpoint.html | grep -c 'min-width:100rem'
+  1
+  $ tw --minify --input-css custom-breakpoint.css custom-breakpoint.html | grep -c 'display:grid'
   1

--- a/test/test_scheme.ml
+++ b/test/test_scheme.ml
@@ -15,11 +15,21 @@ let test_find_color () =
     "missing color returns none" true
     (Tw.Scheme.hex_color s "blue-500" = None)
 
+let test_breakpoint_override () =
+  let s =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("breakpoint-10xl", "1600px") ]
+  in
+  Alcotest.(check (option (float 0.)))
+    "breakpoint token populates the typed theme" (Some 1600.)
+    (Tw.Scheme.breakpoint s "10xl")
+
 let tests =
   Alcotest.
     [
       test_case "default scheme" `Quick test_default;
       test_case "find color" `Quick test_find_color;
+      test_case "breakpoint override" `Quick test_breakpoint_override;
     ]
 
 let suite = ("scheme", tests)

--- a/test/test_scheme.ml
+++ b/test/test_scheme.ml
@@ -17,8 +17,7 @@ let test_find_color () =
 
 let test_breakpoint_override () =
   let s =
-    Tw.Scheme.with_overrides Tw.Scheme.default
-      [ ("breakpoint-10xl", "1600px") ]
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("breakpoint-10xl", "1600px") ]
   in
   Alcotest.(check (option (float 0.)))
     "breakpoint token populates the typed theme" (Some 1600.)

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -629,7 +629,7 @@ let custom_breakpoint_theme_is_local () =
   let css = Tw.to_css ~theme ~base:false [ utility ] |> Tw.Css.to_string in
   Alcotest.(check bool)
     "custom breakpoint renders" true
-    (Astring.String.is_infix ~affix:"min-width:1600px" css);
+    (Astring.String.is_infix ~affix:"1600px" css);
   Alcotest.(check bool)
     "custom breakpoint does not leak into the default theme" true
     (Result.is_error (Tw.of_string "10xl:flex"))

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -616,6 +616,24 @@ let responsive_breakpoints () =
   check (sm [ text_lg ]);
   check (md [ p 8 ])
 
+let custom_breakpoint_theme_is_local () =
+  Tw.Modifiers.clear_custom_breakpoints ();
+  let theme : Tw.Scheme.t =
+    { Tw.Scheme.default with breakpoints = [ ("10xl", 1600.) ] }
+  in
+  let utility =
+    match Tw.of_string ~theme "10xl:flex" with
+    | Ok utility -> utility
+    | Error (`Msg msg) -> Alcotest.fail msg
+  in
+  let css = Tw.to_css ~theme ~base:false [ utility ] |> Tw.Css.to_string in
+  Alcotest.(check bool)
+    "custom breakpoint renders" true
+    (Astring.String.is_infix ~affix:"min-width:1600px" css);
+  Alcotest.(check bool)
+    "custom breakpoint does not leak into the default theme" true
+    (Result.is_error (Tw.of_string "10xl:flex"))
+
 let layout () =
   check static;
   check relative;
@@ -1312,6 +1330,8 @@ let core_tests =
     test_case "hex colors" `Slow hex_colors;
     test_case "gradients" `Slow gradients;
     test_case "responsive breakpoints" `Slow responsive_breakpoints;
+    test_case "custom breakpoint theme is local" `Quick
+      custom_breakpoint_theme_is_local;
     test_case "layout" `Slow layout;
     test_case "opacity" `Slow opacity_effects;
     test_case "extended colors" `Slow extended_colors;


### PR DESCRIPTION
Parse and render custom responsive variants from the same project-local Scheme.t. Entrypoint --breakpoint-* tokens now retain exact CSS length units, scanned candidates are emitted, and legacy global registrations cannot leak into Tw.of_string. This applies to both px and rem breakpoints.