### PR TITLE
Recognize light-dark() stroke colors

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -278,7 +278,7 @@ let is_css_color_fn s =
   in
   starts "rgb" || starts "rgba" || starts "hsl" || starts "hsla" || starts "hwb"
   || starts "oklch" || starts "oklab" || starts "lch" || starts "lab"
-  || starts "color" || starts "color-mix"
+  || starts "color" || starts "color-mix" || starts "light-dark"
 
 (** Check if a string is a bare var reference like "(--name)" *)
 let is_bare_var s =

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -28,10 +28,25 @@ let stroke_shadeless_colors () =
     "stroke-2 stays a width" true
     (Astring.String.is_infix ~affix:"stroke-width:2px" (css "stroke-2"))
 
+let stroke_light_dark_color () =
+  let cls = "stroke-[light-dark(red,blue)]" in
+  match Tw.of_string cls with
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  | Ok u ->
+      Alcotest.(check string) "class" cls (Tw.pp u);
+      let css =
+        Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+      in
+      Alcotest.(check bool)
+        "light-dark() is routed as a stroke colour" true
+        (Astring.String.is_infix
+           ~affix:"stroke:light-dark(red,blue)" css)
+
 let tests =
   [
     test_case "basic svg" `Quick basic_svg;
     test_case "stroke shadeless colors" `Quick stroke_shadeless_colors;
+    test_case "stroke light-dark color" `Quick stroke_light_dark_color;
   ]
 
 let suite = ("svg", tests)

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -34,13 +34,10 @@ let stroke_light_dark_color () =
   | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   | Ok u ->
       Alcotest.(check string) "class" cls (Tw.pp u);
-      let css =
-        Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-      in
+      let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true in
       Alcotest.(check bool)
         "light-dark() is routed as a stroke colour" true
-        (Astring.String.is_infix
-           ~affix:"stroke:light-dark(red,blue)" css)
+        (Astring.String.is_infix ~affix:"stroke:light-dark(red,blue)" css)
 
 let tests =
   [


### PR DESCRIPTION
Route stroke-[light-dark(...)] through the colour parser instead of the stroke-width parser. This keeps the candidate as a colour utility and retires the demonstrated TODO gap.