### PR TITLE
Apply opacity to arbitrary shadow colours

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -308,6 +308,15 @@ module Handler = struct
     Css.custom_property ~layer:"utilities" "--tw-shadow-alpha"
       (pp_float percent ^ "%")
 
+  let opacity_css_value opacity =
+    match Color.opacity_var_bare_of opacity with
+    | Some name -> "var(--" ^ name ^ ")"
+    | None -> pp_float (Color.opacity_to_percent opacity) ^ "%"
+
+  let shadow_opacity_decl opacity =
+    Css.custom_property ~layer:"utilities" "--tw-shadow-alpha"
+      (opacity_css_value opacity)
+
   let color_mix_supports decls =
     Css.supports ~condition:Color.color_mix_supports_condition
       [ Css.rule ~selector:(Css.Selector.class_ "_") decls ]
@@ -322,9 +331,9 @@ module Handler = struct
     | Some c -> c
     | None -> make_color_var (Parse.extract_var_name v)
 
-  let relative_oklab_from_var v percent =
+  let relative_oklab_from_color v opacity =
     Css.parse_color
-      (pp_str [ "oklab(from "; v; " l a b / "; pp_float percent; "%)" ])
+      (pp_str [ "oklab(from "; v; " l a b / "; opacity_css_value opacity; ")" ])
 
   let box_shadow_composition v_shadow =
     let v_inset = Var.reference inset_shadow_var in
@@ -593,13 +602,17 @@ module Handler = struct
     | Some { h_offset; v_offset; blur; spread; color } -> (
         let percent = Color.opacity_to_percent opacity in
         let alpha = percent /. 100.0 in
-        let alpha_d = shadow_alpha_decl percent in
+        let dynamic_opacity = Color.opacity_var_bare_of opacity <> None in
+        let alpha_d = shadow_opacity_decl opacity in
         let base_fallback : Css.color =
           match color with
           | Hex c -> Color.hex_to_oklab_alpha c alpha
           | Var v -> make_full_color_var v
-          | Css_color c -> (
-              match Color.css_color_to_hex c with Some h -> h | None -> c)
+          | Css_color c ->
+              let c =
+                match Color.css_color_to_hex c with Some h -> h | None -> c
+              in
+              if dynamic_opacity then c else Color.mix_alpha opacity c
           | None -> Css.Current
         in
         let base_color_ref =
@@ -610,34 +623,35 @@ module Handler = struct
             ~color:(Var base_color_ref) ()
         in
         let d_shadow, v_shadow = Var.binding shadow_var base_shadow in
+        let relative_support origin =
+          match relative_oklab_from_color origin opacity with
+          | Some relative_color ->
+              let enhanced_ref =
+                Var.reference_with_fallback shadow_color_var relative_color
+              in
+              let enhanced_shadow =
+                Css.shadow ~h_offset ~v_offset ?blur ?spread
+                  ~color:(Var enhanced_ref) ()
+              in
+              let d_enhanced, _ = Var.binding shadow_var enhanced_shadow in
+              [
+                Css.supports ~condition:relative_color_supports
+                  [
+                    Css.rule ~selector:(Css.Selector.class_ "_") [ d_enhanced ];
+                  ];
+              ]
+          | None -> []
+        in
         let supports_rules =
           match color with
+          | Hex c when dynamic_opacity -> relative_support c
+          | Css_color c when dynamic_opacity ->
+              let origin = Css.Pp.to_string ~minify:true Css.pp_color c in
+              relative_support origin
           | Hex _ | Css_color _ -> []
-          | Var v -> (
-              match relative_oklab_from_var v percent with
-              | Some relative_color ->
-                  let enhanced_ref =
-                    Var.reference_with_fallback shadow_color_var relative_color
-                  in
-                  let enhanced_shadow =
-                    Css.shadow ~h_offset ~v_offset ?blur ?spread
-                      ~color:(Var enhanced_ref) ()
-                  in
-                  let d_enhanced, _ = Var.binding shadow_var enhanced_shadow in
-                  let supports_block =
-                    Css.supports ~condition:relative_color_supports
-                      [
-                        Css.rule ~selector:(Css.Selector.class_ "_")
-                          [ d_enhanced ];
-                      ]
-                  in
-                  [ supports_block ]
-              | None -> [])
+          | Var v -> relative_support v
           | None ->
-              let color_mix_fallback =
-                Css.color_mix ~in_space:Oklab Css.Current Css.Transparent
-                  ~percent1:percent
-              in
+              let color_mix_fallback = Color.mix_alpha opacity Css.Current in
               let enhanced_ref =
                 Var.reference_with_fallback shadow_color_var color_mix_fallback
               in
@@ -1014,6 +1028,10 @@ module Handler = struct
     Css.custom_property ~layer:"utilities" "--tw-inset-shadow-alpha"
       (pp_float percent ^ "%")
 
+  let inset_shadow_opacity_decl opacity =
+    Css.custom_property ~layer:"utilities" "--tw-inset-shadow-alpha"
+      (opacity_css_value opacity)
+
   let inset_box_shadow_composition v_inset_shadow =
     let v_inset_ring = Var.reference inset_ring_shadow_var in
     let v_ring_offset = Var.reference ring_offset_shadow_var in
@@ -1119,13 +1137,14 @@ module Handler = struct
     | Stdlib.Option.Some parsed_parts -> (
         let percent = Color.opacity_to_percent opacity in
         let alpha = percent /. 100.0 in
-        let alpha_d = inset_shadow_alpha_decl percent in
+        let dynamic_opacity = Color.opacity_var_bare_of opacity <> None in
+        let alpha_d = inset_shadow_opacity_decl opacity in
         (* Check if any part needs @supports FIRST — this affects base
            fallbacks *)
         let needs_supports =
           List.exists
             (fun { color; _ } ->
-              match color with Var _ | None -> true | _ -> false)
+              match color with Var _ | None -> true | _ -> dynamic_opacity)
             parsed_parts
         in
         (* Build base shadow values: when @supports is present, use simple
@@ -1139,10 +1158,13 @@ module Handler = struct
                     if needs_supports then Css.hex (shorten_hex c)
                     else Color.hex_to_oklab_alpha c alpha
                 | Var v -> make_full_color_var v
-                | Css_color c -> (
-                    match Color.css_color_to_hex c with
-                    | Some h -> h
-                    | None -> c)
+                | Css_color c ->
+                    let c =
+                      match Color.css_color_to_hex c with
+                      | Some h -> h
+                      | None -> c
+                    in
+                    if needs_supports then c else Color.mix_alpha opacity c
                 | None -> Css.Current
               in
               let color_ref =
@@ -1170,10 +1192,17 @@ module Handler = struct
                   let enhanced_ref =
                     match color with
                     | Hex c ->
-                        let oklab = Color.hex_to_oklab_alpha c alpha in
-                        Var.reference_with_fallback inset_shadow_color_var oklab
+                        let enhanced =
+                          if dynamic_opacity then
+                            match relative_oklab_from_color c opacity with
+                            | Some relative -> relative
+                            | None -> Css.hex c
+                          else Color.hex_to_oklab_alpha c alpha
+                        in
+                        Var.reference_with_fallback inset_shadow_color_var
+                          enhanced
                     | Var v -> (
-                        match relative_oklab_from_var v percent with
+                        match relative_oklab_from_color v opacity with
                         | Some relative_color ->
                             Var.reference_with_fallback inset_shadow_color_var
                               relative_color
@@ -1181,16 +1210,21 @@ module Handler = struct
                             Var.reference_with_fallback inset_shadow_color_var
                               (make_full_color_var v))
                     | Css_color c ->
-                        let hex_c =
-                          match Color.css_color_to_hex c with
-                          | Some h -> h
-                          | None -> c
+                        let origin =
+                          Css.Pp.to_string ~minify:true Css.pp_color c
                         in
-                        Var.reference_with_fallback inset_shadow_color_var hex_c
+                        let enhanced =
+                          if dynamic_opacity then
+                            match relative_oklab_from_color origin opacity with
+                            | Some relative -> relative
+                            | None -> c
+                          else Color.mix_alpha opacity c
+                        in
+                        Var.reference_with_fallback inset_shadow_color_var
+                          enhanced
                     | None ->
                         let color_mix_fallback =
-                          Css.color_mix ~in_space:Oklab Css.Current
-                            Css.Transparent ~percent1:percent
+                          Color.mix_alpha opacity Css.Current
                         in
                         Var.reference_with_fallback inset_shadow_color_var
                           color_mix_fallback
@@ -1213,7 +1247,7 @@ module Handler = struct
                   match color with Var _ -> true | _ -> false)
                 parsed_parts
             in
-            if has_real_var then
+            if has_real_var || dynamic_opacity then
               let supports_block =
                 Css.supports ~condition:relative_color_supports
                   [

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -70,6 +70,15 @@ module Handler = struct
     Css.custom_property ~layer:"utilities" "--tw-text-shadow-alpha"
       (pp_float percent ^ "%")
 
+  let opacity_css_value opacity =
+    match Color.opacity_var_bare_of opacity with
+    | Some name -> "var(--" ^ name ^ ")"
+    | None -> pp_float (Color.opacity_to_percent opacity) ^ "%"
+
+  let opacity_decl opacity =
+    Css.custom_property ~layer:"utilities" "--tw-text-shadow-alpha"
+      (opacity_css_value opacity)
+
   let color_mix_supports decls =
     Css.supports ~condition:Color.color_mix_supports_condition
       [ Css.rule ~selector:(Css.Selector.class_ "_") decls ]
@@ -84,9 +93,9 @@ module Handler = struct
     | Some c -> c
     | None -> make_color_var (Parse.extract_var_name v)
 
-  let relative_oklab_from_var v percent =
+  let relative_oklab_from_color v opacity =
     Css.parse_color
-      (pp_str [ "oklab(from "; v; " l a b / "; pp_float percent; "%)" ])
+      (pp_str [ "oklab(from "; v; " l a b / "; opacity_css_value opacity; ")" ])
 
   (* ============ Parse arbitrary shadow ============ *)
 
@@ -508,7 +517,8 @@ module Handler = struct
     | Some (h_offset, v_offset, blur, color) ->
         let percent = Color.opacity_to_percent opacity in
         let alpha = percent /. 100.0 in
-        let alpha_d = alpha_decl percent in
+        let dynamic_opacity = Color.opacity_var_bare_of opacity <> None in
+        let alpha_d = opacity_decl opacity in
         let base_fallback : Css.color =
           match color with
           | Hex c -> Color.hex_to_oklab_alpha c alpha
@@ -516,7 +526,8 @@ module Handler = struct
           | Css_color c -> (
               match hex_string_of_css_color c with
               | Some hex -> Color.hex_to_oklab_alpha hex alpha
-              | None -> c)
+              | None -> if dynamic_opacity then c else Color.mix_alpha opacity c
+              )
           | No_color -> Css.Current
         in
         let base_color_ref =
@@ -527,40 +538,42 @@ module Handler = struct
             (Css.Text_shadow
                { h_offset; v_offset; blur; color = Some (Var base_color_ref) })
         in
+        let relative_support origin =
+          match relative_oklab_from_color origin opacity with
+          | Some relative_color ->
+              let enhanced_ref =
+                Var.reference_with_fallback text_shadow_color_var relative_color
+              in
+              let enhanced_shadow =
+                Css.text_shadow
+                  (Css.Text_shadow
+                     {
+                       h_offset;
+                       v_offset;
+                       blur;
+                       color = Some (Var enhanced_ref);
+                     })
+              in
+              Some
+                [
+                  Css.supports ~condition:relative_color_supports
+                    [
+                      Css.rule ~selector:(Css.Selector.class_ "_")
+                        [ enhanced_shadow ];
+                    ];
+                ]
+          | None -> Stdlib.Option.None
+        in
         let rules =
           match color with
+          | Hex c when dynamic_opacity -> relative_support c
+          | Css_color c when dynamic_opacity ->
+              let origin = Css.Pp.to_string ~minify:true Css.pp_color c in
+              relative_support origin
           | Hex _ | Css_color _ -> Stdlib.Option.None
-          | Var_ref v -> (
-              match relative_oklab_from_var v percent with
-              | Some relative_color ->
-                  let enhanced_ref =
-                    Var.reference_with_fallback text_shadow_color_var
-                      relative_color
-                  in
-                  let enhanced_shadow =
-                    Css.text_shadow
-                      (Css.Text_shadow
-                         {
-                           h_offset;
-                           v_offset;
-                           blur;
-                           color = Some (Var enhanced_ref);
-                         })
-                  in
-                  let supports_block =
-                    Css.supports ~condition:relative_color_supports
-                      [
-                        Css.rule ~selector:(Css.Selector.class_ "_")
-                          [ enhanced_shadow ];
-                      ]
-                  in
-                  Some [ supports_block ]
-              | None -> Stdlib.Option.None)
+          | Var_ref v -> relative_support v
           | No_color ->
-              let color_mix_fallback =
-                Css.color_mix ~in_space:Oklab Css.Current Css.Transparent
-                  ~percent1:percent
-              in
+              let color_mix_fallback = Color.mix_alpha opacity Css.Current in
               let enhanced_ref =
                 Var.reference_with_fallback text_shadow_color_var
                   color_mix_fallback

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -331,6 +331,25 @@ let test_arbitrary_shadow_lengths () =
   | Ok _ -> Alcotest.fail "expected shadow-[0_bogus_2px] to be rejected"
   | Error _ -> ()
 
+let test_arbitrary_shadow_colour_opacity () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
+    "var(--tw-shadow-color,color-mix(";
+  has "inset-shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
+    "var(--tw-inset-shadow-color,color-mix(";
+  has "shadow-[0_0_8px_#f00]/[var(--x)]" "--tw-shadow-alpha:var(--x)";
+  has "shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from";
+  has "inset-shadow-[0_0_8px_#f00]/[var(--x)]"
+    "--tw-inset-shadow-alpha:var(--x)";
+  has "inset-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
+
 (* An arbitrary shadow that is not a shadow is not a utility: it used to fall
    back to the zero shadow. *)
 let test_invalid_arbitrary_shadow () =
@@ -396,6 +415,8 @@ let tests =
     test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;
     test_case "arbitrary shadow lengths" `Quick test_arbitrary_shadow_lengths;
+    test_case "arbitrary shadow colour opacity" `Quick
+      test_arbitrary_shadow_colour_opacity;
     test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -107,8 +107,7 @@ let test_arbitrary_colour_opacity () =
   in
   has "text-shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
     "var(--tw-text-shadow-color,color-mix(";
-  has "text-shadow-[0_0_8px_#f00]/[var(--x)]"
-    "--tw-text-shadow-alpha:var(--x)";
+  has "text-shadow-[0_0_8px_#f00]/[var(--x)]" "--tw-text-shadow-alpha:var(--x)";
   has "text-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
 
 (* A [#] value is only a colour when what follows is a hex spelling, both as the

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -96,6 +96,21 @@ let test_arbitrary_color_function () =
     "var(--tw-text-shadow-color,oklab(62.79553606%.22486306 .1258463/.5))";
   rejected "text-shadow-[0_1px_rgb(zz)]"
 
+let test_arbitrary_colour_opacity () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "text-shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
+    "var(--tw-text-shadow-color,color-mix(";
+  has "text-shadow-[0_0_8px_#f00]/[var(--x)]"
+    "--tw-text-shadow-alpha:var(--x)";
+  has "text-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
+
 (* A [#] value is only a colour when what follows is a hex spelling, both as the
    whole bracket and as the colour of an arbitrary shadow. The reader kept the
    text after the [#] as-is and the raising constructor saw it when the sheet
@@ -133,6 +148,8 @@ let tests =
         test_theme_override;
       Alcotest.test_case "arbitrary colour function" `Quick
         test_arbitrary_color_function;
+      Alcotest.test_case "arbitrary colour opacity" `Quick
+        test_arbitrary_colour_opacity;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     ]
 


### PR DESCRIPTION
Fix opacity modifiers on arbitrary box, inset, and text-shadow colours.

Static modifiers now blend non-hex CSS colours, while arbitrary variable modifiers set the Tailwind alpha property and emit a relative-colour enhancement. This applies to oklch(...) and var(...) opacity across all three shadow families.

The remaining red versus #f00 spelling inside relative colours is semantically equivalent and is handled by Cascade canonical comparison in samoht/cascade#313.