### PR TITLE
Order custom border-style utilities correctly

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1539,14 +1539,6 @@ let output_base_class_and_props = function
   | Supports_query { base_class; props; _ } ->
       (base_class, props)
 
-let first_named_property props =
-  List.find_map
-    (fun decl ->
-      match Css.Declaration.property_key decl with
-      | Key (Custom_property _) | Key (Unknown_property _) -> None
-      | key -> Some key)
-    props
-
 (* Tailwind orders utilities that write the same property by candidate name.
    Built-in values carry distinct numeric suborders in TW, so when a declared
    utility joins one of those property families, normalize that family's
@@ -1559,7 +1551,7 @@ let normalize_declared_property_families order_map builtins extra_outputs =
         List.find_map
           (fun output ->
             let _, props = output_base_class_and_props output in
-            first_named_property props)
+            Utility.ordering_property props)
           outputs
       with
       | None -> ()
@@ -1568,7 +1560,7 @@ let normalize_declared_property_families order_map builtins extra_outputs =
             List.filter_map
               (fun output ->
                 let base_class, props = output_base_class_and_props output in
-                match (base_class, first_named_property props) with
+                match (base_class, Utility.ordering_property props) with
                 | Some cls, Some key when key = property ->
                     let base = extract_base_utility cls in
                     Option.map

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -64,6 +64,22 @@ let rec style_declarations (s : Style.t) =
   | Style.Modified (_, inner) -> style_declarations inner
   | Style.Group inner -> List.concat_map style_declarations inner
 
+let is_ordering_carrier decl =
+  match Cascade.Css.Declaration.property_key decl with
+  | Key Border_style ->
+      Cascade.Css.declaration_value ~minify:true decl = "var(--tw-border-style)"
+  | _ -> false
+
+let ordering_property declarations =
+  List.find_map
+    (fun decl ->
+      if is_ordering_carrier decl then None
+      else
+        match Cascade.Css.Declaration.property_key decl with
+        | Key (Custom_property _) | Key (Unknown_property _) -> None
+        | key -> Some key)
+    declarations
+
 let build_property_slots () =
   let tbl = Hashtbl.create 512 in
   let record key order =
@@ -83,10 +99,7 @@ let build_property_slots () =
              -webkit-box] but the display slot belongs to the display utilities,
              which sort elsewhere. *)
           style_declarations (M.to_style Scheme.default example)
-          |> List.find_map (fun d ->
-              match Cascade.Css.Declaration.property_key d with
-              | Key (Custom_property _) | Key (Unknown_property _) -> None
-              | key -> Some key)
+          |> ordering_property
           |> Option.iter (fun key -> record key order))
         M.examples)
     !handlers;

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -135,6 +135,13 @@ val order_of_property : Cascade.Css.Declaration.prop_key -> (int * int) option
     is where a declared [@utility] gets its place: Tailwind sorts one by the
     property it declares, not by its name. *)
 
+val ordering_property :
+  Cascade.Css.declaration list -> Cascade.Css.Declaration.prop_key option
+(** [ordering_property declarations] is the first property that determines a
+    utility's Tailwind family. It skips theme-token declarations and incidental
+    carrier declarations such as the [border-style] reference emitted by a
+    border-width utility. *)
+
 val base_of_class : Scheme.t -> string -> (base, [ `Msg of string ]) result
 (** [base_of_class theme class_name] parses a class name into a base utility
     (without modifiers). For internal use by the Tw module. *)

--- a/test/cli/utility.t
+++ b/test/cli/utility.t
@@ -99,3 +99,23 @@ declared by the project:
   .p-1{padding:var(--spacing)}
   .p-4{padding:calc(var(--spacing)*4)}
   .zebra{padding:2rem}
+
+A border-width utility carries [border-style: var(--tw-border-style)] before
+its width. That carrier does not make it a border-style utility: declared
+border-style utilities join the real style family after the width family.
+
+  $ cat > border-style.css <<EOF
+  > @import "tailwindcss" theme(static);
+  > @utility custom-alpha { border-style: groove }
+  > @utility custom-zebra { border-style: ridge }
+  > EOF
+  $ cat > border-style.html <<EOF
+  > <div class="border border-2 border-dashed border-double custom-alpha custom-zebra"></div>
+  > EOF
+  $ tw --minify --input-css border-style.css border-style.html | grep -oE '\.(custom-(alpha|zebra)|border(-[a-z0-9]+)?)\{[^}]*\}'
+  .border{border-style:var(--tw-border-style);border-width:1px}
+  .border-2{border-style:var(--tw-border-style);border-width:2px}
+  .border-dashed{--tw-border-style:dashed;border-style:dashed}
+  .border-double{--tw-border-style:double;border-style:double}
+  .custom-alpha{border-style:groove}
+  .custom-zebra{border-style:ridge}

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -160,7 +160,12 @@ let test_order_of_property () =
     (option (pair int int))
     "color skips its palette token declaration"
     (Some (order_of "placeholder-transparent"))
-    (order_of_property (Key Color))
+    (order_of_property (Key Color));
+  check
+    (option (pair int int))
+    "border style skips width-utility carrier declarations"
+    (Some (order_of "border-solid"))
+    (order_of_property (Key Border_style))
 
 let tests =
   [


### PR DESCRIPTION
Stacked on #319.

Built-in border-width rules carry border-style: var(--tw-border-style), but that declaration is only a rendering carrier. Ignoring it for property-family classification keeps width utilities in the width slot and places declared border-style utilities with the Tailwind style family.