### PR TITLE
Preserve arbitrary var fallbacks

### DIFF
--- a/lib/var.ml
+++ b/lib/var.ml
@@ -555,4 +555,28 @@ let properties vars =
   Css.v filtered
 
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]
-let bracket ?fallback name = Css.var_ref ?fallback name
+
+let bracket ?fallback name =
+  let parsed_reference =
+    match fallback with
+    | Some _ -> None
+    | None ->
+        let expression =
+          if Parse.has_prefix ~prefix:"var(" name then Some name
+          else if String.contains name ',' then Some ("var(--" ^ name ^ ")")
+          else None
+        in
+        Option.bind expression (fun expression ->
+            try
+              Some
+                (Css.Variables.read_reference
+                   (Cascade.Cursor.of_string expression))
+            with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> None)
+  in
+  match parsed_reference with
+  | Some (name, Some fallback) ->
+      Css.var_ref ~runtime:true
+        ~fallback:(Css.Values.syntax_fallback fallback)
+        name
+  | Some (name, None) -> Css.var_ref ~runtime:true name
+  | None -> Css.var_ref ?fallback name

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -653,5 +653,6 @@ val property_initial_string : Css.property_info -> string
 
 val bracket : ?fallback:'a Css.fallback -> string -> 'a Css.var
 (** [bracket ?fallback name] creates a reference to a user-supplied CSS variable
-    from bracket notation. The [name] is the bare variable name without [--]
-    prefix. *)
+    from bracket notation. [name] may be the bare variable name without [--],
+    the inner arguments retained by {!Parse.extract_var_name}, or a complete
+    [var()] expression. A fallback in the expression is preserved. *)

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -1129,7 +1129,7 @@ let paren_var_shorthand () =
   (* fallback form keeps the default inside var() *)
   Alcotest.(check bool)
     "top-(--top,0) keeps the fallback" true
-    (Astring.String.is_infix ~affix:"top: var(--top,0)" (css "top-(--top,0)"));
+    (Astring.String.is_infix ~affix:"top: var(--top, 0)" (css "top-(--top,0)"));
   (* typed hint maps to the bracket typed form *)
   Alcotest.(check bool)
     "font-(family-name:--font-x) sets font-family: var(--font-x)" true

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -22,6 +22,44 @@ let var_fallback_in_css () =
   (* Should produce valid CSS *)
   check bool "produces valid CSS" (String.length css_str > 0) true
 
+(* Arbitrary var() values keep the outer variable and its fallback. This is
+   shared by typed utility families, so cover both a length and a keyword-like
+   property. *)
+let arbitrary_var_fallbacks () =
+  let sheet class_name =
+    match Tw.of_string class_name with
+    | Ok utility -> Tw.to_css ~base:false [ utility ]
+    | Error (`Msg msg) -> failf "%s: %s" class_name msg
+  in
+  let refs class_name =
+    sheet class_name |> Css.vars_of_stylesheet |> List.map Css.any_var_name
+  in
+  let css class_name = Css.to_string ~minify:true (sheet class_name) in
+  let inline_css class_name =
+    sheet class_name |> Css.inline_vars |> Css.to_string ~minify:true
+  in
+  check (list string) "padding outer reference" [ "--x" ]
+    (refs "p-[var(--x,var(--y))]");
+  check (list string) "cursor outer reference" [ "--c" ]
+    (refs "cursor-[var(--c,var(--d))]");
+  check bool "padding keeps nested fallback" true
+    (Astring.String.is_infix ~affix:"padding:var(--x,var(--y))"
+       (css "p-[var(--x,var(--y))]"));
+  check bool "cursor keeps nested fallback" true
+    (Astring.String.is_infix ~affix:"cursor:var(--c,var(--d))"
+       (css "cursor-[var(--c,var(--d))]"));
+  (* Closed-world inlining assumes no runtime mutation, so an unresolved outer
+     reference reduces to its fallback. *)
+  check bool "padding inline resolves the outer reference" true
+    (Astring.String.is_infix ~affix:"padding:var(--y)"
+       (inline_css "p-[var(--x,var(--y))]"));
+  check bool "cursor inline resolves the outer reference" true
+    (Astring.String.is_infix ~affix:"cursor:var(--d)"
+       (inline_css "cursor-[var(--c,var(--d))]"));
+  check (list string) "paren outer reference" [ "--top" ] (refs "top-(--top,0)");
+  check bool "paren shorthand keeps its override point" true
+    (Astring.String.is_infix ~affix:"top:var(--top," (css "top-(--top,0)"))
+
 (* Test theme layer contains variables *)
 let var_in_theme_layer () =
   let styles = Tw.[ text_xl; text red; p 4 ] in
@@ -141,6 +179,7 @@ let tests =
   [
     test_case "var CSS output" `Quick var_css_output;
     test_case "var fallback in CSS" `Quick var_fallback_in_css;
+    test_case "arbitrary var fallbacks" `Quick arbitrary_var_fallbacks;
     test_case "var in theme layer" `Quick var_in_theme_layer;
     test_case "order of shared slot" `Quick order_of_shared_slot;
     test_case "order of shared slot tokens" `Quick order_of_shared_slot_tokens;


### PR DESCRIPTION
Parse arbitrary var() expressions structurally so nested and paren-shorthand fallbacks remain attached to the outer runtime reference. This covers padding, cursor, and top-(--top,0).

Depends on samoht/cascade#315, which makes inline_vars honor the runtime metadata produced here.