### PR TITLE
cli: describe what --optimize actually does

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1786,8 +1786,9 @@ let minify_flag =
 
 let optimize_flag =
   let doc =
-    "Pass CSS optimization through to the Tailwind backend. tw output is not \
-     pre-optimized."
+    "Optimize the generated CSS: merge and deduplicate rules, and drop theme \
+     tokens nothing references. Also passed to the Tailwind backend under \
+     --tailwind and --diff."
   in
   Arg.(value & flag & info [ "optimize" ] ~doc)
 


### PR DESCRIPTION
The --optimize help said tw output is not pre-optimized, but the flag runs cascade's optimizer over tw's own sheet before printing and is only handed to the Tailwind backend under --tailwind and --diff.