### PR TITLE
test: track cascade keeping runtime var fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+      # dune-project asks for cascade 1.2.0 and that release does not exist
+      # yet. Its development branch carries the version, so the pin is what
+      # the solver has to satisfy the bound with.
+      - name: Pin cascade to its development branch
+        run: opam pin add --no-action -y cascade.1.2.0 git+https://github.com/samoht/cascade.git#main
+
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1012,6 +1012,8 @@ let preload_imports ~transform ~base_url stylesheet =
    redundant. Keep the first, and put them all at the end of the document, where
    Tailwind emits them: spliced at the [@import] instead, they sit ahead of the
    author's own rules and shift every one of them. *)
+let equal_layer = Css.Stylesheet.equal_layer_name
+
 (* A named layer appears once in Tailwind's output. The generated sheet and the
    [@layer properties] blocks each applied utility hoists arrive separately, so
    fold every repeat of a name into the first, dropping content the first
@@ -1047,7 +1049,9 @@ let merge_named_layers stmts =
         let body =
           List.concat_map
             (fun stmt ->
-              if named_layer stmt = Some n then layer_statements stmt else [])
+              match named_layer stmt with
+              | Some m when equal_layer m n -> layer_statements stmt
+              | _ -> [])
             stmts
           |> List.filter (fun st ->
               let key = Css.to_string ~minify:true (Css.v [ st ]) in
@@ -1063,7 +1067,7 @@ let merge_named_layers stmts =
     List.filter_map
       (fun stmt ->
         match named_layer stmt with
-        | Some n when List.mem n repeated ->
+        | Some n when List.exists (equal_layer n) repeated ->
             if Hashtbl.mem emitted n then None
             else begin
               Hashtbl.add emitted n ();
@@ -1079,29 +1083,37 @@ let merge_named_layers stmts =
 let hoist_layer_blocks stmts =
   let declared_names = Css.layer_statement_name_list in
   let block_name stmt =
-    match Css.layer_block_name stmt with Some "" | None -> None | name -> name
+    match Css.layer_block_name stmt with Some [] | None -> None | name -> name
+  in
+  let is_block_of n st =
+    match block_name st with Some m -> equal_layer m n | None -> false
+  in
+  (* Two layer names never share their printed text, so it keys them. *)
+  let by_text a b =
+    String.compare
+      (Css.Stylesheet.string_of_layer_name a)
+      (Css.Stylesheet.string_of_layer_name b)
   in
   let slots =
     List.filter_map declared_names stmts
-    |> List.concat
-    |> List.sort_uniq String.compare
+    |> List.concat |> List.sort_uniq by_text
   in
   let movable =
-    List.filter
-      (fun n -> List.exists (fun st -> block_name st = Some n) stmts)
-      slots
+    List.filter (fun n -> List.exists (is_block_of n) stmts) slots
   in
   if movable = [] then stmts
   else
-    let block_for n = List.find_opt (fun st -> block_name st = Some n) stmts in
+    let block_for n = List.find_opt (is_block_of n) stmts in
     let emitted = Hashtbl.create 8 in
     List.concat_map
       (fun stmt ->
         match declared_names stmt with
-        | Some names when List.exists (fun n -> List.mem n movable) names ->
+        | Some names
+          when List.exists (fun n -> List.exists (equal_layer n) movable) names
+          ->
             List.filter_map
               (fun n ->
-                if List.mem n movable then
+                if List.exists (equal_layer n) movable then
                   if Hashtbl.mem emitted n then None
                   else begin
                     Hashtbl.add emitted n ();
@@ -1111,7 +1123,7 @@ let hoist_layer_blocks stmts =
               names
         | _ -> (
             match block_name stmt with
-            | Some n when List.mem n movable -> []
+            | Some n when List.exists (equal_layer n) movable -> []
             | _ -> [ stmt ]))
       stmts
 
@@ -1616,7 +1628,7 @@ let routed_statements ~block_count ~own_order stmts =
     place_routed_entries ~own_order ~order_of ~classless entries
   in
   let unplaced =
-    if unordered = [] then [] else [ Css.layer ~name:"utilities" unordered ]
+    if unordered = [] then [] else [ Css.layer ~name:[ "utilities" ] unordered ]
   in
   (block_count, ordered, unplaced @ dedup_statements hoisted)
 

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (depends
   (ocaml (>= 5.2))
   dune
-  (cascade (and (>= 1.1.0) (< 1.2.0)))
+  (cascade (and (>= 1.2.0) (< 1.3.0)))
   cmdliner
   dune-build-info
   fmt

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -464,7 +464,7 @@ let utilities_layer ~layers ~statements =
   (* Statements are already in the correct order with media queries interleaved.
      Consecutive media queries with the same condition will be merged by the
      optimizer (css/optimize.ml) while preserving cascade order. *)
-  if layers then Css.v [ Css.layer ~name:"utilities" statements ]
+  if layers then Css.v [ Css.layer ~name:[ "utilities" ] statements ]
   else Css.v statements
 
 (* [@starting-style] carries no condition, so a run of [starting:] utilities is
@@ -730,11 +730,11 @@ let sort_by_var_order decls =
 
 (* Build theme layer rule from declarations *)
 let theme_layer_rule ~layers = function
-  | [] -> if layers then Css.v [ Css.layer ~name:"theme" [] ] else Css.empty
+  | [] -> if layers then Css.v [ Css.layer ~name:[ "theme" ] [] ] else Css.empty
   | decls ->
       let selector = Css.Selector.(list [ Root; host () ]) in
       let rule = Css.rule ~selector decls in
-      if layers then Css.v [ Css.layer ~name:"theme" [ rule ] ]
+      if layers then Css.v [ Css.layer ~name:[ "theme" ] [ rule ] ]
       else Css.v [ rule ]
 
 (* Every var() referenced anywhere in a utility's output (top-level props and
@@ -917,7 +917,7 @@ let base_layer ?supports ?(forms_base = false) () =
     if forms_base then Css.concat [ preflight; Forms.base_stylesheet () ]
     else preflight
   in
-  Css.layer_of ~name:"base" base
+  Css.layer_of ~name:[ "base" ] base
 
 (* Use the centralized conversion function from Var module *)
 
@@ -1124,7 +1124,7 @@ let property_layer_content first_usage_order initial_values other_statements =
   let rule = Css.rule ~selector initial_declarations in
   let supports_stmt = Css.supports ~condition:browser_detection [ rule ] in
   let layer_content = [ supports_stmt ] @ other_statements in
-  Css.v [ Css.layer ~name:"properties" layer_content ]
+  Css.v [ Css.layer ~name:[ "properties" ] layer_content ]
 
 (* Build the properties layer with browser detection for initial values *)
 (* Returns (properties_layer, property_rules) - @property rules are separate *)
@@ -1229,7 +1229,7 @@ let layer_declaration ~has_properties ~include_base =
     if include_base then [ "theme"; "base"; "components"; "utilities" ]
     else [ "theme"; "components"; "utilities" ]
   in
-  Css.v [ Css.layer_decl names ]
+  Css.v [ Css.layer_decl (List.map (fun n -> [ n ]) names) ]
 
 (* Sort [@property] rules using first-usage order. Variables are ordered by when
    they first appear across all utilities. For variables within the same family
@@ -1292,7 +1292,9 @@ let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
   in
   let layers_without_property =
     if layers then
-      let components_declaration = Css.v [ Css.layer_decl [ "components" ] ] in
+      let components_declaration =
+        Css.v [ Css.layer_decl [ [ "components" ] ] ]
+      in
       let layer_names =
         layer_declaration
           ~has_properties:(Option.is_some properties_layer)
@@ -1590,7 +1592,8 @@ let normalize_declared_property_families order_map builtins extra_outputs =
               (fun output ->
                 let base_class, props = output_base_class_and_props output in
                 match (base_class, Utility.ordering_property props) with
-                | Some cls, Some key when key = property ->
+                | Some cls, Some key
+                  when Css.Declaration.equal_prop_key key property ->
                     let base = extract_base_utility cls in
                     Option.map
                       (fun order -> (base, order))

--- a/test/cli/input-css.t
+++ b/test/cli/input-css.t
@@ -146,6 +146,20 @@ named slot without discarding the other declarations in the list:
   @layer bb{.card-list{padding:1rem}}
   .after-list{color:red}
 
+A [<layer-name>] is a dot-separated list of idents, so [a.b] names two of them
+and [a\2e b] names one ident that carries a dot. They are different layers, and
+each block fills its own slot:
+
+  $ cat > layer-dot.css <<EOF
+  > @import "tailwindcss";
+  > @layer a.b, a\2e b;
+  > @layer a\2e b { .escaped { padding: 2rem } }
+  > @layer a.b { .dotted { padding: 1rem } }
+  > EOF
+  $ tw --minify --input-css layer-dot.css index.html | grep -oE '@layer a\.b\{\.dotted\{padding:1rem\}\}|@layer a\\\.b\{\.escaped\{padding:2rem\}\}'
+  @layer a.b{.dotted{padding:1rem}}
+  @layer a\.b{.escaped{padding:2rem}}
+
 A project can declare [@keyframes] inside its [@theme], beside the [--animate-*]
 token that names it. The theme block becomes a [:root] rule, where a nested
 [@keyframes] would be invalid, so it is lifted to the top level:

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -13,7 +13,7 @@ let extract_utilities_layer_rules css =
   List.find_map
     (fun stmt ->
       match Css.as_layer stmt with
-      | Some (Some "utilities", rules) -> Some rules
+      | Some (Some [ "utilities" ], rules) -> Some rules
       | _ -> None)
     stmts
   |> Option.value ~default:[]
@@ -318,12 +318,14 @@ let has_layer name css =
   List.exists
     (fun stmt ->
       match Css.as_layer stmt with
-      | Some (Some layer_name, _) when layer_name = name -> true
+      | Some (Some declared, _)
+        when Css.Stylesheet.equal_layer_name declared [ name ] ->
+          true
       | _ -> false)
     (Css.statements css)
 
 (** Get all custom property names from a layer *)
-let vars_in_layer layer_name css = Css.custom_props ~layer:layer_name css
+let vars_in_layer layer_name css = Css.custom_props ~layer:[ layer_name ] css
 
 (** Check if a variable name exists in a layer *)
 let has_var_in_layer var_name layer_name css =
@@ -332,7 +334,7 @@ let has_var_in_layer var_name layer_name css =
 
 (** Get all selectors from a layer *)
 let selectors_in_layer layer_name css =
-  match Css.layer_block layer_name css with
+  match Css.layer_block [ layer_name ] css with
   | None -> []
   | Some stmts ->
       List.filter_map

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -211,16 +211,18 @@ let check_layer_declaration_and_ordering () =
   let sheet = sheet_of [ Tw.Effects.shadow_sm ] in
   let expected = [ "properties"; "theme"; "components"; "utilities" ] in
   let layer_names =
-    Css.statements sheet |> List.find_map Css.layer_statement_name_list
+    Css.statements sheet
+    |> List.find_map Css.layer_statement_name_list
+    |> Option.map (List.map Css.Stylesheet.string_of_layer_name)
   in
   check (option (list string)) "layer decl order" (Some expected) layer_names;
   check bool "has properties layer block" true
-    (Css.layer_block "properties" sheet <> None)
+    (Css.layer_block [ "properties" ] sheet <> None)
 
 let check_properties_layer_internal_order () =
   let sheet = sheet_of [ Tw.Effects.shadow_sm ] in
   let props =
-    Css.layer_block "properties" sheet
+    Css.layer_block [ "properties" ] sheet
     |> or_fail "Expected a @layer properties block"
   in
   let supports =
@@ -262,7 +264,7 @@ let check_property_rules_order () =
   let util_idx =
     stmt_index sheet (fun s ->
         match Css.as_layer s with
-        | Some (Some "utilities", _) -> true
+        | Some (Some [ "utilities" ], _) -> true
         | _ -> false)
     |> or_fail "Expected a utilities layer"
   in
@@ -458,7 +460,7 @@ let test_theme_layer_media_refs () =
     Tw.Build.theme_layer_of ~default_decls [ sm [ Tw.Typography.text_xl ] ]
   in
   let all_vars =
-    Css.layer_block "theme" theme_layer
+    Css.layer_block [ "theme" ] theme_layer
     |> Option.map Css.rules_of_statements
     |> Option.map Css.custom_props_of_rules
     |> Option.value ~default:[]
@@ -480,7 +482,7 @@ let test_theme_media_refs_md () =
     Tw.Build.theme_layer_of ~default_decls [ md [ Tw.Typography.text_xl ] ]
   in
   let all_vars =
-    Css.layer_block "theme" theme_layer
+    Css.layer_block [ "theme" ] theme_layer
     |> Option.map Css.rules_of_statements
     |> Option.map Css.custom_props_of_rules
     |> Option.value ~default:[]

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -47,7 +47,7 @@ let extract_var_names_with_prefix (prefix : string) (props : string list) :
     props
 
 let extract_theme_color_vars sheet =
-  Css.layer_block "theme" sheet
+  Css.layer_block [ "theme" ] sheet
   |> Option.map Css.rules_of_statements
   |> Option.map Css.custom_props_of_rules
   |> Option.map (extract_var_names_with_prefix "--color-")
@@ -62,7 +62,7 @@ let extract_bg_color_name sel_str =
   else None
 
 let extract_utility_selectors sheet =
-  Css.layer_block "utilities" sheet
+  Css.layer_block [ "utilities" ] sheet
   |> Option.map (fun stmts ->
       Css.rules_of_statements stmts
       |> List.filter_map (fun (sel, _) ->

--- a/test/test_theme.ml
+++ b/test/test_theme.ml
@@ -5,7 +5,7 @@ open Alcotest
 let theme_layer_stable_order () =
   let styles = Tw.[ text_xl; text red; p 4 ] in
   let css = Tw.to_css ~base:false styles in
-  let theme_layer = Css.layer_block "theme" css in
+  let theme_layer = Css.layer_block [ "theme" ] css in
   match theme_layer with
   | None -> fail "Expected @layer theme to be present"
   | Some statements ->
@@ -33,7 +33,7 @@ let theme_cross_module_vars () =
       ]
   in
   let css = Tw.to_css ~base:false styles in
-  let theme_layer = Css.layer_block "theme" css in
+  let theme_layer = Css.layer_block [ "theme" ] css in
   match theme_layer with
   | None -> fail "Expected @layer theme"
   | Some statements ->
@@ -108,7 +108,7 @@ let priority_seven_namespace_order () =
     List.map (fun cls -> Result.get_ok (Tw.of_string ~theme cls)) classes
   in
   let actual =
-    match Css.layer_block "theme" (Tw.to_css ~theme ~base:false styles) with
+    match Css.layer_block [ "theme" ] (Tw.to_css ~theme ~base:false styles) with
     | None -> fail "Expected @layer theme"
     | Some statements ->
         Css.rules_of_statements statements

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -64,7 +64,7 @@ let arbitrary_var_fallbacks () =
 let var_in_theme_layer () =
   let styles = Tw.[ text_xl; text red; p 4 ] in
   let css = Tw.to_css ~base:true styles in
-  let theme_layer = Css.layer_block "theme" css in
+  let theme_layer = Css.layer_block [ "theme" ] css in
 
   match theme_layer with
   | None -> fail "Expected @layer theme"

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -48,17 +48,21 @@ let arbitrary_var_fallbacks () =
   check bool "cursor keeps nested fallback" true
     (Astring.String.is_infix ~affix:"cursor:var(--c,var(--d))"
        (css "cursor-[var(--c,var(--d))]"));
-  (* Closed-world inlining assumes no runtime mutation, so an unresolved outer
-     reference reduces to its fallback. *)
-  check bool "padding inline resolves the outer reference" true
-    (Astring.String.is_infix ~affix:"padding:var(--y)"
+  (* The outer name is the author's own, set from a style attribute or from
+     script, so inlining keeps the reference. Collapsing it to the fallback
+     would answer for an element the sheet never saw. *)
+  check bool "padding inline keeps the override point" true
+    (Astring.String.is_infix ~affix:"padding:var(--x,var(--y))"
        (inline_css "p-[var(--x,var(--y))]"));
-  check bool "cursor inline resolves the outer reference" true
-    (Astring.String.is_infix ~affix:"cursor:var(--d)"
+  check bool "cursor inline keeps the override point" true
+    (Astring.String.is_infix ~affix:"cursor:var(--c,var(--d))"
        (inline_css "cursor-[var(--c,var(--d))]"));
   check (list string) "paren outer reference" [ "--top" ] (refs "top-(--top,0)");
   check bool "paren shorthand keeps its override point" true
-    (Astring.String.is_infix ~affix:"top:var(--top," (css "top-(--top,0)"))
+    (Astring.String.is_infix ~affix:"top:var(--top," (css "top-(--top,0)"));
+  check bool "paren shorthand inline keeps its override point" true
+    (Astring.String.is_infix ~affix:"top:var(--top,"
+       (inline_css "top-(--top,0)"))
 
 (* Test theme layer contains variables *)
 let var_in_theme_layer () =

--- a/tw.opam
+++ b/tw.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
   "ocaml" {>= "5.2"}
   "dune" {>= "3.21"}
-  "cascade" {>= "1.1.0" & < "1.2.0"}
+  "cascade" {>= "1.2.0" & < "1.3.0"}
   "cmdliner"
   "dune-build-info"
   "fmt"


### PR DESCRIPTION
`Css.inline_vars` used to collapse `var(--x, var(--y))` down to `var(--y)`, which erases the browser-time override point tw asks for by marking arbitrary `var()` values runtime; samoht/cascade#315 stops that, and this tracks it.

Merge alongside the cascade release carrying that change: against cascade 1.1.0 the new expectation fails, so the `cascade` lower bound wants bumping to that release at the same time.
