### PR TITLE
lib: format rule.ml and sizing.ml

### DIFF
--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2288,8 +2288,9 @@ let extract_style_with_rules ~sel ~class_name ?merge_key ~props rule_list =
 let outputs ?(theme = Scheme.default) ?order_tbl util =
   let rec utility_order = function
     | Utility.Base b -> Some (Utility.order b)
-    | Utility.Modified (_, u) | Utility.Important (_, u)
-    | Utility.Aliased (_, u) -> utility_order u
+    | Utility.Modified (_, u) | Utility.Important (_, u) | Utility.Aliased (_, u)
+      ->
+        utility_order u
     | Utility.Group _ -> None
   in
   let rec extract_with_class class_name util_inner = function

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -651,8 +651,7 @@ module Handler = struct
           |> Option.map (fun value ->
               Css.custom_property ~layer:"theme" ("--" ^ bare_name) value)
       in
-      style
-        (Option.to_list theme_decl @ List.map (fun decl -> decl len) f.decls)
+      style (Option.to_list theme_decl @ List.map (fun decl -> decl len) f.decls)
     in
     match v with
     | Keyword k -> set k.length


### PR DESCRIPTION
`lib/rule.ml` and `lib/sizing.ml` are unformatted on main under ocamlformat 0.29.0, so the pre-commit hook re-promotes them into any unrelated commit made in the tree. Landing the formatting on its own keeps it out of feature diffs.