### PR TITLE
forms: add form-multiselect

### DIFF
--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -367,7 +367,7 @@ end
 module Select = struct
   open Style
 
-  type t = Select | Textarea
+  type t = Select | Textarea | Multiselect
   type Utility.base += Self of t
 
   let name = "forms_select"
@@ -475,20 +475,53 @@ module Select = struct
     in
     style ~rules:(Some rules) []
 
+  (* The class-strategy stand-in for [select:where([multiple])]. It gets the
+     shared field declarations alone: no chevron, and the placeholder rule
+     covers input and textarea only. *)
+  let form_multiselect =
+    let open Css in
+    let open Css.Selector in
+    let base_sel = class_ "form-multiselect" in
+    let d_shadow, _ =
+      Var.binding Effects.shadow_var
+        (shadow ~h_offset:Zero ~v_offset:Zero ~color:(hex "#0000") ())
+    in
+    let rules =
+      [
+        rule ~selector:base_sel
+          [
+            appearance None;
+            d_shadow;
+            background_color (hex "#fff");
+            border_width (Px 1.);
+            border_color gray_500;
+            border_radius (radius Zero);
+            padding [ Rem 0.5; Rem 0.75 ];
+            font_size (Rem 1.);
+            line_height (Rem 1.5);
+          ];
+        rule ~selector:(compound [ base_sel; Focus ]) input_focus_decls;
+      ]
+    in
+    style ~rules:(Some rules) []
+
   let to_style _theme = function
     | Select -> form_select
     | Textarea -> form_textarea
+    | Multiselect -> form_multiselect
 
-  let suborder = function Select -> 0 | Textarea -> 1
+  let suborder = function Select -> 0 | Textarea -> 1 | Multiselect -> 2
 
   let of_class _theme = function
     | "form-select" -> Ok Select
     | "form-textarea" -> Ok Textarea
+    | "form-multiselect" -> Ok Multiselect
     | _ -> Error (`Msg "Not a form select utility")
 
   let to_class = function
     | Select -> "form-select"
     | Textarea -> "form-textarea"
+    | Multiselect -> "form-multiselect"
 
   let examples = []
 end
@@ -503,6 +536,7 @@ let form_checkbox = Utility.base (Handler.Self Handler.Checkbox)
 let form_radio = Utility.base (Handler.Self Handler.Radio)
 let form_select = Utility.base (Select.Self Select.Select)
 let form_textarea = Utility.base (Select.Self Select.Textarea)
+let form_multiselect = Utility.base (Select.Self Select.Multiselect)
 
 (* ======================================================================== Base
    layer stylesheet - rules that apply to native HTML form elements when the

--- a/lib/forms.mli
+++ b/lib/forms.mli
@@ -23,6 +23,10 @@ val form_textarea : t
 val form_select : t
 (** [form_select] applies select dropdown styles with a custom arrow. *)
 
+val form_multiselect : t
+(** [form_multiselect] applies multi-select ([select] with [multiple]) styles.
+*)
+
 val form_checkbox : t
 (** [form_checkbox] applies checkbox input styles. *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3208,6 +3208,10 @@ val form_select : t
 (** [form_select] provides base styles for select dropdowns; normalizes
     appearance across browsers while maintaining native functionality. *)
 
+val form_multiselect : t
+(** [form_multiselect] provides base styles for multi-select lists ([select]
+    with [multiple]); matches the input styling without the dropdown chevron. *)
+
 val form_checkbox : t
 (** [form_checkbox] provides base styles for checkbox inputs; enables custom
     styling while maintaining accessibility. *)

--- a/test/test_forms.ml
+++ b/test/test_forms.ml
@@ -6,9 +6,21 @@ let check class_name =
   | Ok u -> check string "forms class" class_name (Tw.Forms.Handler.to_class u)
   | Error (`Msg msg) -> fail msg
 
+let check_select class_name =
+  match Tw.Forms.Select.of_class Tw.Scheme.default class_name with
+  | Ok u ->
+      Alcotest.check string "forms class" class_name
+        (Tw.Forms.Select.to_class u)
+  | Error (`Msg msg) -> fail msg
+
 let test_inputs () =
   check "form-input";
   check "form-checkbox"
+
+let test_selects () =
+  check_select "form-select";
+  check_select "form-textarea";
+  check_select "form-multiselect"
 
 let test_of_string_invalid () =
   (* Invalid form utilities *)
@@ -42,7 +54,14 @@ let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
     Test_helpers.shuffle
-      [ form_input; form_checkbox; form_radio; form_select; form_textarea ]
+      [
+        form_input;
+        form_checkbox;
+        form_radio;
+        form_select;
+        form_textarea;
+        form_multiselect;
+      ]
   in
   Test_helpers.check_ordering_matches ~forms:true
     ~test_name:"forms suborder matches Tailwind" shuffled
@@ -94,6 +113,7 @@ let class_strategy_spellings () =
 let tests =
   [
     test_case "inputs" `Quick test_inputs;
+    test_case "selects" `Quick test_selects;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "forms suborder matches Tailwind" `Quick suborder_matches_tailwind;
     test_case "base strategy spells print-color-adjust twice" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -581,7 +581,14 @@ let test_suborder_within_group () =
       ( "position",
         [ static; fixed; absolute; relative; sticky; inset 0; top 4; left 2 ] );
       ( "forms",
-        [ form_input; form_checkbox; form_radio; form_select; form_textarea ] );
+        [
+          form_input;
+          form_checkbox;
+          form_radio;
+          form_select;
+          form_textarea;
+          form_multiselect;
+        ] );
       ("transforms", [ translate_x 4; translate_y 2; rotate 90; scale 50 ]);
       ( "interactivity",
         [ select_none; select_text; select_all; scroll_auto; scroll_smooth ] );


### PR DESCRIPTION
The forms plugin's class strategy emits `.form-multiselect` with the same declarations as `.form-input`, but tw answered `Unknown class: form-multiselect`, leaving a `select[multiple]` unstyled. Stacked on #331.