### PR TITLE
build: reach a theme token under any at-rule a variant nests

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -562,39 +562,23 @@ module Strings = Set.Make (String)
 (* Helpers for theme layer extraction and ordering *)
 let collect_selector_props tw_classes = List.concat_map Rule.outputs tw_classes
 
-(* Helper to extract theme declarations from nested CSS statements
-   recursively *)
+(* Collect the theme-layer tokens a statement tree declares. A compound variant
+   nests its rule under whichever at-rules its modifiers ask for, so the walk
+   has to reach a declaration under any of them; [Css.Stylesheet]'s pair of
+   exhaustive readers is that walk. *)
 let rec extract_theme_from_statements theme_vars insertion_order statements =
   List.iter
     (fun stmt ->
-      (* Check if this is a rule with declarations *)
-      (match Css.statement_declarations stmt with
-      | Some props ->
-          Css.custom_declarations ~layer:"theme" props
-          |> List.iter (fun decl ->
-              match Css.custom_declaration_name decl with
-              | Some name when not (Hashtbl.mem theme_vars name) ->
-                  Hashtbl.add theme_vars name decl;
-                  insertion_order := decl :: !insertion_order
-              | _ -> ())
-      | None -> ());
-      (* Recurse into nested statements *)
-      (match Css.as_rule stmt with
-      | Some (_, _, nested) ->
-          extract_theme_from_statements theme_vars insertion_order nested
-      | None -> ());
-      (match Css.as_media stmt with
-      | Some (_, content) ->
-          extract_theme_from_statements theme_vars insertion_order content
-      | None -> ());
-      (match Css.as_layer stmt with
-      | Some (_, content) ->
-          extract_theme_from_statements theme_vars insertion_order content
-      | None -> ());
-      match Css.as_container stmt with
-      | Some (_, _, content) ->
-          extract_theme_from_statements theme_vars insertion_order content
-      | None -> ())
+      Css.Stylesheet.statement_declarations stmt
+      |> Css.custom_declarations ~layer:"theme"
+      |> List.iter (fun decl ->
+          match Css.custom_declaration_name decl with
+          | Some name when not (Hashtbl.mem theme_vars name) ->
+              Hashtbl.add theme_vars name decl;
+              insertion_order := decl :: !insertion_order
+          | _ -> ());
+      extract_theme_from_statements theme_vars insertion_order
+        (Css.Stylesheet.statement_children stmt))
     statements
 
 let extract_non_tw_custom_declarations selector_props =

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -97,6 +97,20 @@ let check_compound_variant_theme_var () =
   check bool "theme layer declares --color-white" true
     (has_var_in_layer "--color-white" "theme" css)
 
+(* Regression: a compound [supports-] variant nests its rule in an [@supports]
+   block, and the tokens the utility sets live in there with it. The theme walk
+   used to descend into [@media], [@layer] and [@container] only, so the token
+   went undeclared and the rule read a [var()] nothing defined. *)
+let check_supports_variant_theme_token () =
+  let u =
+    match Tw.of_string "md:supports-[display:grid]:aspect-video" with
+    | Ok u -> u
+    | Error (`Msg m) -> fail m
+  in
+  let css = Tw.to_css ~base:false ~layers:true [ u ] in
+  check bool "theme layer declares --aspect-video" true
+    (has_var_in_layer "--aspect-video" "theme" css)
+
 let check_css_variables_with_base () =
   let config = { Tw.Build.base = true; forms = None; layers = true } in
   let css = Tw.Build.to_css ~config [] in
@@ -916,6 +930,8 @@ let tests =
     test_case "to_css variables with base" `Quick check_css_variables_with_base;
     test_case "compound variant theme var" `Quick
       check_compound_variant_theme_var;
+    test_case "supports variant theme token" `Quick
+      check_supports_variant_theme_token;
     test_case "to_css variables without base" `Quick
       check_css_variables_without_base;
     test_case "to_css inline with base" `Quick check_css_inline_with_base;


### PR DESCRIPTION
A compound `supports-` variant nests its rule, and the theme tokens the utility sets, inside an `@supports` block that the theme-layer walk did not descend into, so `md:supports-[display:grid]:aspect-video` emitted `aspect-ratio: var(--aspect-video)` with nothing declaring that token. The exhaustive walk that replaces it is cascade 1.2.0's, which #349 adopts below this.
