### PR TITLE
typography: bind --font-sans to Tailwind's current default stack

### DIFF
--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -90,28 +90,9 @@ let var_ref (type a)
 
 (** HTML and body defaults *)
 let root_resets ~default_font_ref ~font_feature_ref ~font_variation_ref =
-  (* Mirrors [Typography.default_sans_stack]; Tailwind v4.3.2 system-font
-     stack. *)
-  let fallback_stack : font_family =
-    List
-      [
-        Name "-apple-system";
-        Name "BlinkMacSystemFont";
-        Segoe_ui;
-        Roboto;
-        Helvetica_neue;
-        Noto_sans;
-        Arial;
-        Sans_serif;
-        Apple_color_emoji;
-        Segoe_ui_emoji;
-        Segoe_ui_symbol;
-        Noto_color_emoji;
-      ]
-  in
   (* Add fallback for theme-declared font variable *)
   let default_font_with_fallback =
-    Css.with_fallback default_font_ref fallback_stack
+    Css.with_fallback default_font_ref Typography.default_sans_stack
   in
 
   (* Add fallback for optional customization hooks *)
@@ -440,38 +421,15 @@ let font_family_ref theme fallback_stack =
   let _, ref = Var.binding theme fallback_stack in
   ref
 
-let default_font_stack : font_family =
-  List
-    [
-      Ui_sans_serif;
-      System_ui;
-      Sans_serif;
-      Apple_color_emoji;
-      Segoe_ui_emoji;
-      Segoe_ui_symbol;
-      Noto_color_emoji;
-    ]
-
-let default_mono_stack : font_family =
-  List
-    [
-      Ui_monospace;
-      SFMono_regular;
-      Menlo;
-      Monaco;
-      Consolas;
-      Liberation_mono;
-      Courier_new;
-      Monospace;
-    ]
-
 (* Get default sans-serif font family reference *)
 let default_font_family_ref () =
-  font_family_ref Typography.default_font_family_var default_font_stack
+  font_family_ref Typography.default_font_family_var
+    Typography.default_sans_stack
 
 (* Get default monospace font family reference *)
 let default_mono_family_ref () =
-  font_family_ref Typography.default_mono_font_family_var default_mono_stack
+  font_family_ref Typography.default_mono_font_family_var
+    Typography.default_mono_stack
 
 (* Get all font customization variable references *)
 let font_customization_refs () =

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -919,37 +919,12 @@ module Typography_early = struct
     style [ serif_decl; font_family (Css.Var serif_ref) ]
 
   let font_mono =
-    let mono_decl, mono_ref =
-      Var.binding font_mono_var
-        (List
-           [
-             Ui_monospace;
-             SFMono_regular;
-             Menlo;
-             Monaco;
-             Consolas;
-             Liberation_mono;
-             Courier_new;
-             Monospace;
-           ])
-    in
+    let mono_decl, mono_ref = Var.binding font_mono_var default_mono_stack in
     style [ mono_decl; font_family (Css.Var mono_ref) ]
 
   (* Font family utilities use the font variables directly *)
   let font_sans =
-    let sans_decl, sans_ref =
-      Var.binding font_sans_var
-        (List
-           [
-             Ui_sans_serif;
-             System_ui;
-             Sans_serif;
-             Apple_color_emoji;
-             Segoe_ui_emoji;
-             Segoe_ui_symbol;
-             Noto_color_emoji;
-           ])
-    in
+    let sans_decl, sans_ref = Var.binding font_sans_var default_sans_stack in
     style [ sans_decl; font_family (Css.Var sans_ref) ]
 
   (* [font-source] reads --font-source from the theme; the token has to be

--- a/lib/typography.mli
+++ b/lib/typography.mli
@@ -470,6 +470,13 @@ val font_serif_var : Css.font_family Var.theme
 val font_mono_var : Css.font_family Var.theme
 (** [font_mono_var] is the CSS variable for the monospace font family. *)
 
+val default_sans_stack : Css.font_family
+(** [default_sans_stack] is Tailwind's default [--font-sans] value: the platform
+    system-font stack. *)
+
+val default_mono_stack : Css.font_family
+(** [default_mono_stack] is Tailwind's default [--font-mono] value. *)
+
 val default_font_declarations : Css.declaration list
 (** [default_font_declarations] are the default font variable declarations for
     the theme layer. *)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -19,6 +19,33 @@ let test_font_family () =
   check "font-serif";
   check "font-mono"
 
+(* Tailwind v4.3.2 moved [--font-sans] off [ui-sans-serif, system-ui, ...] to
+   the platform system-font stack; v4.3.3 theme.css still carries that stack,
+   and preflight's [html] fallback has to agree with it. *)
+let test_font_family_default_stack () =
+  let css ?(base = false) cls =
+    match Tw.of_string cls with
+    | Ok u ->
+        Tw.to_css ~base [ u ] |> Tw.Css.inline_vars
+        |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let sans = css "font-sans" in
+  Alcotest.(check bool)
+    "font-sans leads with the platform stack" true
+    (Astring.String.is_infix ~affix:"-apple-system,BlinkMacSystemFont," sans);
+  Alcotest.(check bool)
+    "font-sans dropped ui-sans-serif" false
+    (Astring.String.is_infix ~affix:"ui-sans-serif" sans);
+  let base = css ~base:true "font-sans" in
+  Alcotest.(check bool)
+    "preflight html falls back to the platform stack" true
+    (Astring.String.is_infix
+       ~affix:"font-family:-apple-system,BlinkMacSystemFont," base);
+  Alcotest.(check bool)
+    "preflight html dropped ui-sans-serif" false
+    (Astring.String.is_infix ~affix:"ui-sans-serif" base)
+
 let test_font_size () =
   List.iter
     (fun s -> check ("text-" ^ s))
@@ -664,6 +691,7 @@ let tests =
     test_case "leading-none inline" `Quick test_leading_none_inline;
     test_case "text line-height override" `Quick test_text_line_height_override;
     test_case "font family" `Quick test_font_family;
+    test_case "font family default stack" `Quick test_font_family_default_stack;
     test_case "font size" `Quick test_font_size;
     test_case "font weight" `Quick test_font_weight;
     test_case "text alignment" `Quick test_text_alignment;


### PR DESCRIPTION
The `font-sans` utility still bound `--font-sans` to the pre-v4.3.2 `ui-sans-serif, system-ui, ...` list while `default_sans_stack` already carried the platform system-font stack Tailwind v4.3.3 ships, so `.font-sans` and preflight's inline `html` fallback both emitted a stale value; the utility, preflight and the theme token now read one definition.

The upstream harness cannot catch this: it takes `--font-sans` from each fixture's own `:root` block, so tw's default never enters that comparison.