### PR TITLE
ci: check formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,16 @@ jobs:
 
       - name: Test
         run: opam exec -- dune runtest
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4"
+
+      # Reads the pinned version from .ocamlformat and runs dune build @fmt.
+      - uses: ocaml/setup-ocaml/lint-fmt@v3


### PR DESCRIPTION
Nothing in CI ran ocamlformat, so `lib/rule.ml` and `lib/sizing.ml` sat unformatted on main and the pre-commit hook kept dragging the reformat into whichever unrelated commit came next; a Lint job now runs `dune build @fmt` the way cascade's does.

Based on #331, which lands the reformat that makes the new job green.