### PR TITLE
test: read upstream test blocks nested in a describe

### DIFF
--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -40,3 +40,20 @@
  (alias runtest)
  (action
   (diff empty_expect_expected.txt empty_expect_actual.txt)))
+
+; Pins the [test(] scan on the block shapes utilities.test.ts uses: a block
+; indented inside one or more [describe(...)] blocks, the three quote styles a
+; name can take, a [test.each([...])(...)] block staying out, and a block
+; defining its own [@utility] dropped whole.
+
+(rule
+ (action
+  (with-stdout-to
+   test_blocks_actual.txt
+   (ignore-stderr
+    (run %{exe:extract_tests.exe} %{dep:test_blocks_input.ts})))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff test_blocks_expected.txt test_blocks_actual.txt)))

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -319,6 +319,67 @@ let is_empty_string_arg arg =
   in
   arg = "''" || arg = {|""|}
 
+(* A [test(...)] block opens with the call's own indentation and closes at the
+   [})] sitting at that same indentation: Prettier indents every line of the
+   body further, so the pair is unambiguous, and a block nested in one or more
+   [describe(...)] blocks is read like any other. The name is a character stream
+   from the opening paren, so a [(], a [)] or a quote of another style inside
+   the name closes nothing, and the three quote styles are all read.
+
+   [test.each([...])(name, fn)] is not a [test(] head and stays out: the three
+   such blocks in v4.3.3 assert on Tailwind's own JS helpers
+   ([isValidStaticUtilityName], [compoundsForSelectors]), never call [run] and
+   compile no CSS. *)
+let test_open_re = Re.Pcre.regexp {|^([ \t]*)test[ \t]*\(|}
+
+(* Read the quoted first argument of a [test(] call from [start], just past the
+   opening paren, and return it as it is spelled in the source. [None] when the
+   argument is not a string literal closed on this line. *)
+let test_name line ~start =
+  let len = String.length line in
+  let i = ref start in
+  while !i < len && (line.[!i] = ' ' || line.[!i] = '\t') do
+    incr i
+  done;
+  if !i >= len then None
+  else
+    match line.[!i] with
+    | ('\'' | '"' | '`') as quote ->
+        let buf = Buffer.create 64 in
+        let closed = ref false in
+        incr i;
+        while (not !closed) && !i < len do
+          let c = line.[!i] in
+          if c = '\\' && !i + 1 < len then (
+            Buffer.add_char buf c;
+            Buffer.add_char buf line.[!i + 1];
+            i := !i + 2)
+          else if c = quote then (
+            closed := true;
+            incr i)
+          else (
+            Buffer.add_char buf c;
+            incr i)
+        done;
+        if !closed then Some (Buffer.contents buf) else None
+    | _ -> None
+
+(* [Some (indent, name)] when [line] opens a test block. *)
+let test_open line =
+  match Re.exec_opt test_open_re line with
+  | None -> None
+  | Some g ->
+      let start = snd (Re.Group.offset g 0) in
+      Option.map (fun name -> (Re.Group.get g 1, name)) (test_name line ~start)
+
+(* [true] when [line] is the [})] closing a block opened at [indent]. *)
+let test_close ~indent line =
+  let n = String.length indent in
+  String.length line >= n + 2
+  && String.sub line 0 n = indent
+  && line.[n] = '}'
+  && line.[n + 1] = ')'
+
 type parse_state =
   | Outside
   | In_test of string
@@ -332,7 +393,6 @@ let parse_file filename =
 
   let tests = ref [] in
   let lines = String.split_on_char '\n' content in
-  let test_pattern = Re.Pcre.regexp {|^test\('([^']+)'|} in
   (* Match array content between [ and ], handling ] inside quoted strings *)
   let run_pattern =
     Re.Pcre.regexp {|run\(\[((?:[^\]'"]|'[^']*'|"[^"]*")*)\]|}
@@ -358,6 +418,19 @@ let parse_file filename =
   let theme_re = Re.Pcre.regexp {|@theme\s*\{|} in
 
   let state = ref Outside in
+  (* Indentation of the [test(] opening the block being read, so its own [})] is
+     told apart from one closing a [describe(...)] around it. *)
+  let test_indent = ref "" in
+  (* Cases produced by the block being read, held back until it ends. A block
+     that defines its own [@utility] is dropped whole: the extractor carries a
+     candidate list and the [@theme] tokens, not the CSS around them, so the
+     expected snapshot of such a block holds rules for utilities the runner is
+     never told about and no run can produce. In v4.3.3 that is the
+     [describe('custom utilities')] block and the one [@utility container]
+     case. *)
+  let block_tests = ref [] in
+  let saw_custom_utility = ref false in
+  let utility_def_re = Re.Pcre.regexp {|@utility\s|} in
   let current_classes = ref [] in
   let current_config = ref No_theme in
   (* A single test can mix a keep [@theme { ... }] block with an inline [@theme
@@ -394,7 +467,7 @@ let parse_file filename =
       |> List.filter_map (fun n -> Hashtbl.find_opt variant_defs n)
     in
     if classes <> [] then
-      tests :=
+      block_tests :=
         {
           name;
           config = !current_config;
@@ -403,7 +476,7 @@ let parse_file filename =
           variants;
           theme_vars = List.rev !current_theme_vars;
         }
-        :: !tests;
+        :: !block_tests;
     current_classes := [];
     current_variant_names := [];
     current_theme_vars := [];
@@ -411,17 +484,26 @@ let parse_file filename =
     in_expect := None
   in
 
+  let close_block () =
+    if not !saw_custom_utility then tests := !block_tests @ !tests;
+    block_tests := [];
+    saw_custom_utility := false
+  in
+
   List.iter
     (fun line ->
+      if Re.execp utility_def_re line then saw_custom_utility := true;
       match !state with
       | Outside -> (
-          match Re.exec_opt test_pattern line with
-          | Some groups ->
+          match test_open line with
+          | Some (indent, name) ->
               current_config := No_theme;
               saw_keep_theme := false;
-              state := In_test (Re.Group.get groups 1)
+              saw_custom_utility := false;
+              test_indent := indent;
+              state := In_test name
           | None -> ())
-      | In_test name ->
+      | In_test name -> (
           (* Detect compileCss/run calls to track theme configuration.
              compileCss() resets config (each call has its own @theme). run()
              uses built-in defaults. *)
@@ -530,19 +612,23 @@ let parse_file filename =
           else if Re.execp snapshot_start line then
             state := In_snapshot (name, !current_classes, Buffer.create 256)
             (* Check for new test *)
-          else if Astring.String.is_prefix ~affix:"test('" line then (
-            flush_test name None;
-            current_classes := [];
-            current_config := No_theme;
-            match Re.exec_opt test_pattern line with
-            | Some groups -> state := In_test (Re.Group.get groups 1)
-            | None -> state := Outside
-            (* Check for test end without snapshot *))
-          else if Astring.String.is_prefix ~affix:"})" line then (
-            flush_test name None;
-            current_classes := [];
-            current_config := No_theme;
-            state := Outside)
+          else
+            match test_open line with
+            | Some (indent, next) ->
+                flush_test name None;
+                close_block ();
+                current_classes := [];
+                current_config := No_theme;
+                test_indent := indent;
+                state := In_test next
+            (* Check for test end without snapshot *)
+            | None ->
+                if test_close ~indent:!test_indent line then (
+                  flush_test name None;
+                  close_block ();
+                  current_classes := [];
+                  current_config := No_theme;
+                  state := Outside))
       | In_array name ->
           current_classes :=
             List.rev_append (extract_quoted_strings line) !current_classes;
@@ -573,6 +659,7 @@ let parse_file filename =
             Buffer.add_string buf line;
             Buffer.add_char buf '\n'))
     lines;
+  close_block ();
 
   List.rev !tests
 

--- a/test/upstream/test_blocks_expected.txt
+++ b/test/upstream/test_blocks_expected.txt
@@ -1,0 +1,54 @@
+# top level
+@config run
+top-level
+---
+
+    .top-level {
+      display: block;
+    }
+    
+<<<>>>
+# indented once
+@config run
+indented-once
+---
+
+      .indented-once {
+        display: flex;
+      }
+      
+<<<>>>
+# double quoted name (with a paren in it)
+@config run
+double-quoted
+---
+
+<<<>>>
+# backtick name
+@config run
+backtick
+---
+
+<<<>>>
+# indented twice
+@config run
+indented-twice
+---
+
+        .indented-twice {
+          display: grid;
+        }
+        
+<<<>>>
+# after the inner block
+@config run
+after-inner
+---
+
+<<<>>>
+# after the outer block
+@config run
+after-outer
+---
+
+<<<>>>

--- a/test/upstream/test_blocks_input.ts
+++ b/test/upstream/test_blocks_input.ts
@@ -1,0 +1,79 @@
+// Not upstream Tailwind: a hand-written stand-in for the block shapes
+// utilities.test.ts uses, so the test( scan is pinned on blocks that sit
+// inside one or more describe( blocks.
+test('top level', async () => {
+  expect(await run(['top-level'])).toMatchInlineSnapshot(`
+    "
+    .top-level {
+      display: block;
+    }
+    "
+  `)
+})
+
+describe('outer', () => {
+  test('indented once', async () => {
+    expect(await run(['indented-once'])).toMatchInlineSnapshot(`
+      "
+      .indented-once {
+        display: flex;
+      }
+      "
+    `)
+  })
+
+  test("double quoted name (with a paren in it)", async () => {
+    expect(await run(['double-quoted'])).toEqual('')
+  })
+
+  test(`backtick name`, async () => {
+    expect(await run(['backtick'])).toEqual('')
+  })
+
+  test.each([
+    ['a', true],
+    ['b', false],
+  ])('name %s is valid (%s)', (name, valid) => {
+    expect(isValidName(name)).toBe(valid)
+  })
+
+  test('defines its own utility', async () => {
+    expect(
+      await run(
+        ['custom-thing'],
+        css`
+          @utility custom-thing {
+            display: grid;
+          }
+          @tailwind utilities;
+        `,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .custom-thing {
+        display: grid;
+      }
+      "
+    `)
+  })
+
+  describe('inner', () => {
+    test('indented twice', async () => {
+      expect(await run(['indented-twice'])).toMatchInlineSnapshot(`
+        "
+        .indented-twice {
+          display: grid;
+        }
+        "
+      `)
+    })
+  })
+
+  test('after the inner block', async () => {
+    expect(await run(['after-inner'])).toEqual('')
+  })
+})
+
+test('after the outer block', async () => {
+  expect(await run(['after-outer'])).toEqual('')
+})

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -3099,6 +3099,122 @@ max-block-4 max-block-[4px] max-block-dvh max-block-fit max-block-full max-block
 ---
 
 <<<>>>
+# creates the right media queries and sorts it before width
+@config theme
+@theme-var breakpoint-sm 40rem
+@theme-var breakpoint-md 48rem
+@theme-var breakpoint-lg 64rem
+@theme-var breakpoint-xl 80rem
+@theme-var breakpoint-2xl 96rem
+container max-w-[var(--breakpoint-sm)] w-1/2
+---
+
+      :root, :host {
+        --breakpoint-sm: 40rem;
+      }
+
+      .container {
+        width: 100%;
+      }
+
+      @media (min-width: 40rem) {
+        .container {
+          max-width: 40rem;
+        }
+      }
+
+      @media (min-width: 48rem) {
+        .container {
+          max-width: 48rem;
+        }
+      }
+
+      @media (min-width: 64rem) {
+        .container {
+          max-width: 64rem;
+        }
+      }
+
+      @media (min-width: 80rem) {
+        .container {
+          max-width: 80rem;
+        }
+      }
+
+      @media (min-width: 96rem) {
+        .container {
+          max-width: 96rem;
+        }
+      }
+
+      .w-1\/2 {
+        width: 50%;
+      }
+
+      .max-w-\[var\(--breakpoint-sm\)\] {
+        max-width: var(--breakpoint-sm);
+      }
+      
+<<<>>>
+# sorts breakpoints based on unit and then in ascending aOrder
+@config theme-reference
+@theme-var breakpoint-lg 64rem
+@theme-var breakpoint-xl 80rem
+@theme-var breakpoint-3xl 1600px
+@theme-var breakpoint-sm 40em
+@theme-var breakpoint-2xl 96rem
+@theme-var breakpoint-xs 30px
+@theme-var breakpoint-md 48em
+container
+---
+
+      .container {
+        width: 100%;
+      }
+
+      @media (min-width: 40em) {
+        .container {
+          max-width: 40em;
+        }
+      }
+
+      @media (min-width: 48em) {
+        .container {
+          max-width: 48em;
+        }
+      }
+
+      @media (min-width: 30px) {
+        .container {
+          max-width: 30px;
+        }
+      }
+
+      @media (min-width: 1600px) {
+        .container {
+          max-width: 1600px;
+        }
+      }
+
+      @media (min-width: 64rem) {
+        .container {
+          max-width: 64rem;
+        }
+      }
+
+      @media (min-width: 80rem) {
+        .container {
+          max-width: 80rem;
+        }
+      }
+
+      @media (min-width: 96rem) {
+        .container {
+          max-width: 96rem;
+        }
+      }
+      
+<<<>>>
 # flex
 @config run
 flex-1 flex-1/2 flex-99 flex-[123] flex-auto flex-initial flex-none
@@ -22253,4 +22369,93 @@ ring-offset-0 ring-offset-1 ring-offset-2 ring-offset-4 ring-offset-[#0088cc] ri
 -@container -@container-normal -@container-normal/sidebar -@container-size -@container-size/sidebar -@container/sidebar
 ---
 
+<<<>>>
+# `--spacing: initial` disables the spacing multiplier
+@config theme
+@theme-var spacing initial
+@theme-var spacing-4 1rem
+px-1 px-4
+---
+
+      :root, :host {
+        --spacing-4: 1rem;
+      }
+
+      .px-4 {
+        padding-inline: var(--spacing-4);
+      }
+      
+<<<>>>
+# `--spacing-*: initial` disables the spacing multiplier
+@config theme
+@theme-var spacing-4 1rem
+px-1 px-4
+---
+
+      :root, :host {
+        --spacing-4: 1rem;
+      }
+
+      .px-4 {
+        padding-inline: var(--spacing-4);
+      }
+      
+<<<>>>
+# only multiples of 0.25 with no trailing zeroes are supported with the spacing multiplier
+@config theme
+@theme-var spacing 4px
+px-.75 px-0.25 px-0.375 px-1.5 px-2.50 px-2.75
+---
+
+      :root, :host {
+        --spacing: 4px;
+      }
+
+      .px-0\.25 {
+        padding-inline: calc(var(--spacing) * .25);
+      }
+
+      .px-1\.5 {
+        padding-inline: calc(var(--spacing) * 1.5);
+      }
+
+      .px-2\.75 {
+        padding-inline: calc(var(--spacing) * 2.75);
+      }
+      
+<<<>>>
+# spacing utilities must have a value
+@config theme-reference
+@theme-var spacing 4px
+px
+---
+
+<<<>>>
+# --spacing-* variables take precedence over --container-* variables
+@config theme
+@theme-var spacing-sm 8px
+@theme-var container-sm 256px
+basis-sm max-w-sm min-w-sm w-sm
+---
+
+      :root, :host {
+        --spacing-sm: 8px;
+      }
+
+      .w-sm {
+        width: var(--spacing-sm);
+      }
+
+      .max-w-sm {
+        max-width: var(--spacing-sm);
+      }
+
+      .min-w-sm {
+        min-width: var(--spacing-sm);
+      }
+
+      .basis-sm {
+        flex-basis: var(--spacing-sm);
+      }
+      
 <<<>>>


### PR DESCRIPTION
The extractor matched `test(` only at column 0 with a single-quoted name, so every block Prettier indents inside a `describe(` was dropped whole and silently.

This lands red on purpose. Five of the recovered cases diverge and all five are real: tw's `container` ignores test-declared `--breakpoint-*` tokens, and the runner filters `--spacing` / `--spacing-*` overrides out of the scheme, so `--spacing: initial`, a custom `--spacing` and `--spacing-sm` beating `--container-sm` all fail. Each is its own follow-up.

Blocks defining their own `@utility` stay out, since the extractor carries a candidate list and not the CSS around it, so their snapshots are not reproducible from a fixture.

Stacked on #339.