### PR TITLE
ci: run the upstream parity suite without its tolerance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Test
         run: opam exec -- dune runtest
 
+      # dune runtest leaves the upstream parity runner's canonicalization
+      # tolerance in place. Running it again with the tolerance off means a
+      # case that starts leaning on it fails under its own name here, instead
+      # of passing quietly on the way through.
+      - name: Upstream parity without the canonicalization tolerance
+        env:
+          TW_UPSTREAM_STRICT: 1
+        run: opam exec -- dune exec test/upstream/test.exe
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
`dune runtest` leaves the upstream parity runner's canonicalization tolerance in place, so `TW_UPSTREAM_STRICT=1` has never run in CI. This PR adds a second step that runs the suite with the tolerance off, so a case that starts leaning on it fails under its own name.

The tolerance is unreached today (`--tw-prose-*` and `--font-mono` do not occur in the fixtures, `--font-sans` occurs twice and passes strict), so the step is green on `main` and on this branch.

Stacked on #336: both append to `ci.yml`, so they are chained rather than left to conflict on merge.