### PR TITLE
opam: bound cascade to the 1.1 series

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (depends
   (ocaml (>= 5.2))
   dune
-  (cascade (>= 1.1.0))
+  (cascade (and (>= 1.1.0) (< 1.2.0)))
   cmdliner
   dune-build-info
   fmt

--- a/tw.opam
+++ b/tw.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/samoht/tw/issues"
 depends: [
   "ocaml" {>= "5.2"}
   "dune" {>= "3.21"}
-  "cascade" {>= "1.1.0"}
+  "cascade" {>= "1.1.0" & < "1.2.0"}
   "cmdliner"
   "dune-build-info"
   "fmt"


### PR DESCRIPTION
cascade breaks tw across minor releases, so an open-ended `cascade >= 1.1.0` lets the next cascade release break every installed tw. The published `tw.1.0.0` already carries a `cascade < 1.1.0` bound that had to be added after the fact, and cascade's development branch has since removed `Css.statement_declarations` and widened `Css.Stylesheet.layer_name` from `string` to `string list`.

Raising the bound is the step that pairs with a future cascade release; this only stops 1.1.0 from being broken by one.