### PR TITLE
grid: keep span var() out of a custom-ident slot

### DIFF
--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -125,12 +125,27 @@ module Handler = struct
   let is_span_value s =
     int_of_string_opt s <> None || Parse.is_var s || Parse.is_ident s
 
-  let col_span_arbitrary s =
-    let gl =
-      match int_of_string_opt s with Some n -> Span n | None -> Span_name s
+  (* var() substitutes before the <grid-line> grammar applies, so the text in
+     [span var(--x)] is not a <custom-ident> and a printer that escapes it as
+     one corrupts the parentheses. The declaration parser keeps it raw. *)
+  let span_arbitrary property_name property s =
+    let raw =
+      if Parse.is_var s then
+        Css.parse_declaration property_name
+          (String.concat "" [ "span "; s; " / span "; s ])
+      else None
     in
-    style [ grid_column (gl, gl) ]
+    match raw with
+    | Some decl -> style [ decl ]
+    | None ->
+        let gl =
+          match int_of_string_opt s with
+          | Some n -> Span n
+          | None -> Span_name s
+        in
+        style [ property (gl, gl) ]
 
+  let col_span_arbitrary s = span_arbitrary "grid-column" grid_column s
   let col_span_full = style [ grid_column (Num 1, Num (-1)) ]
   let col_start n = style [ grid_column_start (Num n) ]
   let neg_col_start n = style [ grid_column_start (Num (-n)) ]
@@ -167,13 +182,7 @@ module Handler = struct
     | None -> style [ grid_row (Auto, Auto) ]
 
   let row_span n = style [ grid_row (Span n, Span n) ]
-
-  let row_span_arbitrary s =
-    let gl =
-      match int_of_string_opt s with Some n -> Span n | None -> Span_name s
-    in
-    style [ grid_row (gl, gl) ]
-
+  let row_span_arbitrary s = span_arbitrary "grid-row" grid_row s
   let row_span_full = style [ grid_row (Num 1, Num (-1)) ]
   let row_start n = style [ grid_row_start (Num n) ]
   let neg_row_start n = style [ grid_row_start (Num (-n)) ]

--- a/test/test_grid_item.ml
+++ b/test/test_grid_item.ml
@@ -113,11 +113,32 @@ let test_invalid_arbitrary_span () =
   accepted "col-span-[mycol]";
   accepted "col-span-[var(--my-variable)]"
 
+let css cls =
+  match Tw.of_string cls with
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+(* A var() reference is not a <custom-ident>: it substitutes before the
+   <grid-line> grammar applies, so its parentheses must reach the output
+   unescaped. *)
+let test_arbitrary_span_var () =
+  let has affix cls =
+    Alcotest.(check bool)
+      (Fmt.str "%s emits %s" cls affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "grid-column: span var(--my-variable) / span var(--my-variable)"
+    "col-span-[var(--my-variable)]";
+  has "grid-row: span var(--my-variable) / span var(--my-variable)"
+    "row-span-[var(--my-variable)]"
+
 let tests =
   [
     test_case "grid_item of_string - valid values" `Quick of_string_valid;
     test_case "grid_item of_string - invalid values" `Quick of_string_invalid;
     test_case "invalid arbitrary span" `Quick test_invalid_arbitrary_span;
+    test_case "arbitrary span var()" `Quick test_arbitrary_span_var;
     test_case "grid_item suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
   ]


### PR DESCRIPTION
`col-span-[var(--x)]` and `row-span-[var(--x)]` used to put the `var()` reference in the `<grid-line>` custom-ident slot, so cascade escaped its parentheses and the declaration emitted `span var\(--x\)`; the value now goes through the declaration parser and stays raw. Only cascade 1.2.0 escapes that slot, so the fix is latent against the 1.1 series pinned here and live from #349 upward, where the `utilities / col` and `utilities / row` parity cases need it.
