### PR TITLE
masks: order the mask utilities by Tailwind's property table

### DIFF
--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -821,65 +821,67 @@ module Handler = struct
     | Mask_stop_keyword (dir, pos_end, value, _) ->
         build_color_value_style dir pos_end value
 
+  (* Tailwind sorts a layer's rules by the properties they set, walking the
+     fixed table its property-order list gives: mask-image, then a block per
+     side (--tw-mask-top, then its from-color, from-position, to-color and
+     to-position stops, then the same for right, bottom and left), then the
+     --tw-mask-linear, --tw-mask-radial and --tw-mask-conic blocks, then
+     mask-composite. Two rules sort on the first table index that separates
+     them, and one that runs out of properties sorts after one that keeps going.
+     These suborders are those indices, spread four apart to leave room for the
+     two tie-breaks below. *)
+  let property_suborder index = 4 * index
+
+  (* mask-x-* and mask-y-* write the opposite side too, so they lead the
+     mask-r-* and mask-t-* they share a first property with. Tailwind breaks the
+     remaining ties on the class name, where the (--var) spellings lead the
+     lengths and percentages. *)
+  let stop_suborder dir pos_end ~color ~var =
+    let block =
+      match dir with
+      | Top | Y -> 210
+      | Right | X -> 215
+      | Bottom -> 220
+      | Left -> 225
+      | Linear -> 231
+      | Radial -> 239
+      | Conic -> 245
+    in
+    let stop =
+      match (pos_end, color) with
+      | From, true -> 1
+      | From, false -> 2
+      | To, true -> 3
+      | To, false -> 4
+    in
+    let sides = match dir with X | Y -> 0 | _ -> 2 in
+    property_suborder (block + stop) + sides + if var then 0 else 1
+
   let suborder = function
     | Mask_stop_keyword (dir, pos_end, _, _)
-    | Mask_stop_color (dir, pos_end, _, _)
+    | Mask_stop_color (dir, pos_end, _, _) ->
+        stop_suborder dir pos_end ~color:true ~var:false
     | Mask_color_ref (dir, pos_end, _) ->
-        let dir_offset =
-          match dir with
-          | Top -> 0
-          | Right -> 100
-          | Bottom -> 200
-          | Left -> 300
-          | X -> 400
-          | Y -> 500
-          | Linear -> 600
-          | Radial -> 700
-          | Conic -> 800
-        in
-        let pos_offset = match pos_end with From -> 0 | To -> 50 in
-        dir_offset + pos_offset
+        stop_suborder dir pos_end ~color:true ~var:true
     | Mask_var_ref (dir, pos_end, _, _) ->
-        let dir_offset =
-          match dir with
-          | Top -> 0
-          | Right -> 100
-          | Bottom -> 200
-          | Left -> 300
-          | X -> 400
-          | Y -> 500
-          | Linear -> 600
-          | Radial -> 700
-          | Conic -> 800
-        in
-        let pos_offset = match pos_end with From -> 0 | To -> 50 in
-        dir_offset + pos_offset + 1
+        stop_suborder dir pos_end ~color:false ~var:true
     | Mask_position (dir, pos_end, _) ->
-        let dir_offset =
-          match dir with
-          | Top -> 0
-          | Right -> 100
-          | Bottom -> 200
-          | Left -> 300
-          | X -> 400
-          | Y -> 500
-          | Linear -> 600
-          | Radial -> 700
-          | Conic -> 800
-        in
-        let pos_offset = match pos_end with From -> 0 | To -> 50 in
-        dir_offset + pos_offset + 10
-    | Mask_linear_angle _ -> 650
-    | Mask_conic_angle _ -> 850
-    | Mask_radial -> 750
-    | Mask_radial_size (Arbitrary_size _) -> 755
-    | Mask_radial_at _ -> 760
-    | Mask_radial_shape Circle -> 770
-    | Mask_radial_shape Ellipse -> 771
-    | Mask_radial_size Closest_corner -> 780
-    | Mask_radial_size Closest_side -> 781
-    | Mask_radial_size Farthest_corner -> 782
-    | Mask_radial_size Farthest_side -> 783
+        stop_suborder dir pos_end ~color:false ~var:false
+    | Mask_linear_angle _ -> property_suborder 231
+    | Mask_radial -> property_suborder 236
+    | Mask_radial_size (Arbitrary_size _) -> property_suborder 238
+    | Mask_conic_angle _ -> property_suborder 245
+    (* mask-circle, the radial size keywords and mask-radial-at-* set a
+       --tw-mask-radial-* variable and no mask-image, so they trail every
+       mask-image utility, [Masks]'s mask-none and mask-[<image>] forms at 10100
+       included, and still lead its mask-composite band at 10200. *)
+    | Mask_radial_shape Circle -> 10150
+    | Mask_radial_shape Ellipse -> 10151
+    | Mask_radial_size Closest_corner -> 10160
+    | Mask_radial_size Closest_side -> 10161
+    | Mask_radial_size Farthest_corner -> 10162
+    | Mask_radial_size Farthest_side -> 10163
+    | Mask_radial_at _ -> 10170
 
   (* Check if a float is a valid Tailwind spacing multiplier: non-negative,
      either an integer or ending in .5 *)

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -422,66 +422,35 @@ module Handler = struct
             Css.mask_size (Var var_ref);
           ]
 
+  (* Tailwind sorts by the property a utility sets, in the order of its property
+     table: mask-image, mask-composite, mask-mode, mask-type, mask-size,
+     mask-clip, mask-position, mask-repeat, mask-origin. Utilities that set the
+     same property share a slot, where the class name breaks the tie. *)
   let suborder_in_family = function
-    | Bracket_image_var _ -> 100
-    | Bracket_image _ -> 101
-    | Bracket_url _ -> 102
-    | Bracket_url_var _ -> 103
-    | Bracket_var _ -> 104
-    | No_mask -> 105
-    | Add -> 200
-    | Exclude -> 201
-    | Intersect -> 202
-    | Subtract -> 203
-    | Alpha -> 300
-    | Luminance -> 301
-    | Match -> 302
-    | Type_alpha -> 303
-    | Type_luminance -> 304
-    | Bracket_contain -> 400
-    | Bracket_cover -> 401
-    | Bracket_length _ -> 402
-    | Bracket_size _ -> 403
-    | Auto -> 404
-    | Contain -> 405
-    | Cover -> 406
-    | Bracket_position _ -> 500
-    | Bracket_typed_position _ -> 501
-    | Position Keyword.Bottom -> 502
-    | Position Keyword.Bottom_left -> 503
-    | Position Keyword.Bottom_right -> 504
-    | Position Keyword.Center -> 505
-    | Position Keyword.Left -> 506
-    | Position Keyword.Right -> 507
-    | Position Keyword.Top -> 508
-    | Position Keyword.Top_left -> 509
-    | Position Keyword.Top_right -> 510
-    | No_repeat -> 600
-    | Repeat -> 601
-    | Repeat_round -> 602
-    | Repeat_space -> 603
-    | Repeat_x -> 604
-    | Repeat_y -> 605
-    | Clip_border -> 700
-    | Clip_content -> 701
-    | Clip_fill -> 702
-    | Clip_padding -> 703
-    | Clip_stroke -> 704
-    | Clip_view -> 705
-    | No_clip -> 706
-    | Origin_border -> 800
-    | Origin_content -> 801
-    | Origin_fill -> 802
-    | Origin_padding -> 803
-    | Origin_stroke -> 804
-    | Origin_view -> 805
-    | Position_bracket _ -> 511
-    | Position_bracket_var _ -> 512
-    | Size_bracket _ -> 407
-    | Size_bracket_var _ -> 408
+    | Bracket_image_var _ | Bracket_image _ | Bracket_url _ | Bracket_url_var _
+    | Bracket_var _ | No_mask ->
+        100
+    | Add | Exclude | Intersect | Subtract -> 200
+    | Alpha | Luminance | Match -> 300
+    | Type_alpha | Type_luminance -> 400
+    | Bracket_contain | Bracket_cover | Bracket_length _ | Bracket_size _ | Auto
+    | Contain | Cover | Size_bracket _ | Size_bracket_var _ ->
+        500
+    | Clip_border | Clip_content | Clip_fill | Clip_padding | Clip_stroke
+    | Clip_view | No_clip ->
+        600
+    | Bracket_position _ | Bracket_typed_position _ | Position _
+    | Position_bracket _ | Position_bracket_var _ ->
+        700
+    | No_repeat | Repeat | Repeat_round | Repeat_space | Repeat_x | Repeat_y ->
+        800
+    | Origin_border | Origin_content | Origin_fill | Origin_padding
+    | Origin_stroke | Origin_view ->
+        900
 
-  (* These share a priority with the mask-gradient utilities and sort after
-     them, so the two families occupy disjoint suborder bands. *)
+  (* These share a priority with the mask-gradient utilities. The gradient stops
+     all set mask-image, so they sort below this band; the mask-radial keywords
+     set only a variable and land between mask-none and mask-add. *)
   let suborder t = 10000 + suborder_in_family t
 
   (* [mask-[<image>]] takes any background-image value, so what makes one is


### PR DESCRIPTION
The mask suborders were numbered per constructor rather than by the property each utility sets, so `mask-x-*` sorted behind `mask-r-*` and the `mask-radial` keywords ahead of `mask-none`. cascade 1.2.0 reports the resulting reorder against Tailwind, so `masks / order matches Tailwind` fails from #349 upward without this.

Tailwind interleaves `background-size` through `background-origin` between the mask gradient variables and `mask-composite`, which one priority per family cannot express; that gap stays.
