### PR TITLE
backgrounds: sort the sizing utilities among the masks

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -430,7 +430,74 @@ module Handler = struct
   open Css
 
   let name = "backgrounds"
-  let priority _ = 20
+
+  (* Tailwind sorts a layer by the rank its property table gives the property
+     each rule writes. The background utilities take two stretches of that
+     table: background-color (198) and background-image (199) with the gradient
+     variables (202-208), then background-size (251) through background-origin
+     (256). The second stretch falls between the mask-image utilities and
+     mask-composite, so it sorts with the masks. *)
+  let property_rank = function
+    | Bg _ | Bg_opacity _ | Bg_inherit | Bg_current | Bg_current_opacity _
+    | Bg_transparent | Bg_bracket_color _ | Bg_bracket_color_opacity _
+    | Bg_bracket_color_var _ | Bg_bracket_color_var_opacity _ | Bg_bracket_var _
+    | Bg_bracket_var_opacity _ ->
+        198
+    | Bg_gradient_to _ | Bg_linear_to _ | Bg_linear_to_interp _
+    | Bg_linear_angle _ | Bg_linear_angle_neg _ | Bg_linear_angle_interp _
+    | Bg_linear_angle_neg_interp _ | Bg_linear_bracket _
+    | Bg_linear_bracket_neg _ | Bg_conic | Bg_conic_angle _
+    | Bg_conic_angle_neg _ | Bg_conic_interp _ | Bg_conic_angle_interp _
+    | Bg_conic_angle_neg_interp _ | Bg_radial | Bg_radial_interp _
+    | Bg_radial_bracket _ | Bg_bracket_image_var _ | Bg_bracket_image _
+    | Bg_bracket_linear_gradient _ | Bg_bracket_url _ | Bg_bracket_image_url _
+    | Bg_bracket_url_var _ | Bg_none ->
+        199
+    | Via_none -> 202
+    | Gradient_color (From, _) -> 203
+    | Gradient_stop_position (From, _) -> 204
+    | Gradient_color (Via, _) -> 205
+    | Gradient_stop_position (Via, _) -> 206
+    | Gradient_color (To, _) -> 207
+    | Gradient_stop_position (To, _) -> 208
+    | Bg_auto | Bg_cover | Bg_contain | Bg_bracket_contain | Bg_bracket_cover
+    | Bg_bracket_size _ | Bg_bracket_length _ | Bg_size_bracket _ ->
+        251
+    | Bg_fixed | Bg_local | Bg_scroll -> 252
+    | Bg_clip_border | Bg_clip_padding | Bg_clip_content | Bg_clip_text -> 253
+    | Bg_position _ | Bg_bracket_position _ | Bg_bracket_typed_position _
+    | Bg_position_bracket _ ->
+        254
+    | Bg_repeat | Bg_no_repeat | Bg_repeat_x | Bg_repeat_y | Bg_repeat_round
+    | Bg_repeat_space ->
+        255
+    | Bg_origin_border | Bg_origin_padding | Bg_origin_content -> 256
+
+  (* The masks open their band at mask-image; every rank past it belongs to
+     them, and the background properties in that stretch interleave. *)
+  let mask_image_rank = 209
+  let background_image_rank = 199
+  let priority t = if property_rank t > mask_image_rank then 21 else 20
+
+  (* Rules sharing a slot sort by declaration count, most first, then by class
+     name. In background-image's slot the linear directions and angles carry an
+     @supports fallback the other gradient functions do not, and the plain
+     images write nothing past background-image, so they close it. *)
+  let suborder t =
+    let rank = property_rank t in
+    if rank <> background_image_rank then Utility.Property_order.last rank
+    else
+      match t with
+      | Bg_gradient_to _ | Bg_linear_to _ | Bg_linear_to_interp _
+      | Bg_linear_angle _ | Bg_linear_angle_neg _ | Bg_linear_angle_interp _
+      | Bg_linear_angle_neg_interp _ ->
+          Utility.Property_order.slot rank
+      | Bg_linear_bracket _ | Bg_linear_bracket_neg _ | Bg_conic
+      | Bg_conic_angle _ | Bg_conic_angle_neg _ | Bg_conic_interp _
+      | Bg_conic_angle_interp _ | Bg_conic_angle_neg_interp _ | Bg_radial
+      | Bg_radial_interp _ | Bg_radial_bracket _ ->
+          Utility.Property_order.slot rank + 1
+      | _ -> Utility.Property_order.last rank
 
   (* Gradient variables with proper @property definitions matching Tailwind v4.
      Order in @layer properties: translate (0-2), scale (3-5), border-style (6),
@@ -1477,78 +1544,6 @@ module Handler = struct
             let ref : Css.background_size Css.var = Var.bracket var_name in
             style [ Css.background_size (Var ref) ]
         | None -> style [ Css.background_size Auto ])
-
-  let suborder = function
-    (* All bg-color utilities share the same suborder (10000) to allow
-       alphabetical selector sorting within the optimizer. This matches
-       Tailwind's output ordering. *)
-    | Bg _ | Bg_inherit | Bg_bracket_color_var _ | Bg_bracket_var _
-    | Bg_bracket_color_var_opacity _ | Bg_bracket_var_opacity _
-    | Bg_bracket_color _ | Bg_bracket_color_opacity _ | Bg_current
-    | Bg_current_opacity _ | Bg_transparent | Bg_opacity _ ->
-        10000
-    (* Gradient direction utilities - same suborder for alphabetical sorting *)
-    | Bg_gradient_to _ | Bg_linear_to _ | Bg_linear_to_interp _
-    | Bg_linear_angle _ | Bg_linear_angle_neg _ | Bg_linear_angle_interp _
-    | Bg_linear_angle_neg_interp _ ->
-        100000
-    (* Conic/radial/bracket gradients - same suborder for alphabetical *)
-    | Bg_linear_bracket _ | Bg_linear_bracket_neg _ | Bg_conic
-    | Bg_conic_angle _ | Bg_conic_angle_neg _ | Bg_conic_interp _
-    | Bg_conic_angle_interp _ | Bg_conic_angle_neg_interp _ | Bg_radial
-    | Bg_radial_interp _ | Bg_radial_bracket _ ->
-        200000
-    (* Gradient color utilities *)
-    | Gradient_color (From, _) -> 110000
-    | Gradient_color (Via, _) -> 120000
-    | Via_none -> 120002
-    | Gradient_color (To, _) -> 130000
-    (* Gradient position utilities *)
-    | Gradient_stop_position (From, _) -> 110001
-    | Gradient_stop_position (Via, _) -> 120001
-    | Gradient_stop_position (To, _) -> 130001
-    (* bg-origin utilities *)
-    | Bg_origin_border -> 140000
-    | Bg_origin_content -> 140001
-    | Bg_origin_padding -> 140002
-    (* bg-clip utilities *)
-    | Bg_clip_border -> 150000
-    | Bg_clip_content -> 150001
-    | Bg_clip_padding -> 150002
-    | Bg_clip_text -> 150003
-    (* Bracket image variants — before bg-none *)
-    | Bg_bracket_image_var _ -> 210010
-    | Bg_bracket_image _ -> 210011
-    | Bg_bracket_linear_gradient _ -> 210011
-    | Bg_bracket_url _ -> 210012
-    | Bg_bracket_image_url _ -> 210012
-    | Bg_bracket_url_var _ -> 210013
-    | Bg_none -> 210020
-    (* bg-size: bracket before named; length before size for merge order *)
-    | Bg_bracket_contain -> 299990
-    | Bg_bracket_cover -> 299991
-    | Bg_bracket_length _ -> 299992
-    | Bg_bracket_size _ -> 299993
-    | Bg_size_bracket _ -> 299994
-    | Bg_auto -> 300000
-    | Bg_contain -> 300001
-    | Bg_cover -> 300002
-    (* bg-attachment utilities *)
-    | Bg_fixed -> 400000
-    | Bg_local -> 400001
-    | Bg_scroll -> 400002
-    (* bg-position: bracket before named *)
-    | Bg_bracket_position _ -> 499980
-    | Bg_bracket_typed_position _ -> 499981
-    | Bg_position_bracket _ -> 499982
-    | Bg_position _ -> 500000
-    (* bg-repeat utilities *)
-    | Bg_no_repeat -> 600000
-    | Bg_repeat -> 600001
-    | Bg_repeat_round -> 600002
-    | Bg_repeat_space -> 600003
-    | Bg_repeat_x -> 600004
-    | Bg_repeat_y -> 600005
 
   (** Split a string on the first '/' into (base, modifier_opt). E.g. "r/oklab"
       → ("r", Some "oklab"), "45" → ("45", None) *)

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -828,9 +828,14 @@ module Handler = struct
      --tw-mask-linear, --tw-mask-radial and --tw-mask-conic blocks, then
      mask-composite. Two rules sort on the first table index that separates
      them, and one that runs out of properties sorts after one that keeps going.
-     These suborders are those indices, spread four apart to leave room for the
-     two tie-breaks below. *)
-  let property_suborder index = 4 * index
+     Every utility here writes mask-image and carries on, so they share its
+     slot; inside it they sort by the index that separates them, spread four
+     apart to leave room for the two tie-breaks below. *)
+  let mask_image_rank = 209
+  let first_stop_rank = 210
+
+  let property_suborder index =
+    Utility.Property_order.slot mask_image_rank + (4 * (index - first_stop_rank))
 
   (* mask-x-* and mask-y-* write the opposite side too, so they lead the
      mask-r-* and mask-t-* they share a first property with. Tailwind breaks the
@@ -871,17 +876,14 @@ module Handler = struct
     | Mask_radial -> property_suborder 236
     | Mask_radial_size (Arbitrary_size _) -> property_suborder 238
     | Mask_conic_angle _ -> property_suborder 245
-    (* mask-circle, the radial size keywords and mask-radial-at-* set a
-       --tw-mask-radial-* variable and no mask-image, so they trail every
-       mask-image utility, [Masks]'s mask-none and mask-[<image>] forms at 10100
-       included, and still lead its mask-composite band at 10200. *)
-    | Mask_radial_shape Circle -> 10150
-    | Mask_radial_shape Ellipse -> 10151
-    | Mask_radial_size Closest_corner -> 10160
-    | Mask_radial_size Closest_side -> 10161
-    | Mask_radial_size Farthest_corner -> 10162
-    | Mask_radial_size Farthest_side -> 10163
-    | Mask_radial_at _ -> 10170
+    (* mask-circle, the radial size keywords and mask-radial-at-* write a
+       --tw-mask-radial-* variable and no mask-image, so each closes the slot of
+       the variable it names: --tw-mask-radial-shape (237),
+       --tw-mask-radial-size (238) and --tw-mask-radial-position (239). The
+       class name orders the ones sharing a slot. *)
+    | Mask_radial_shape _ -> Utility.Property_order.last 237
+    | Mask_radial_size _ -> Utility.Property_order.last 238
+    | Mask_radial_at _ -> Utility.Property_order.last 239
 
   (* Check if a float is a valid Tailwind spacing multiplier: non-negative,
      either an integer or ending in .5 *)

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -422,36 +422,37 @@ module Handler = struct
             Css.mask_size (Var var_ref);
           ]
 
-  (* Tailwind sorts by the property a utility sets, in the order of its property
-     table: mask-image, mask-composite, mask-mode, mask-type, mask-size,
-     mask-clip, mask-position, mask-repeat, mask-origin. Utilities that set the
-     same property share a slot, where the class name breaks the tie. *)
-  let suborder_in_family = function
+  (* Tailwind sorts by the property a utility sets, at the rank its property
+     table gives it: mask-image (209), then mask-composite (257) through
+     mask-origin (264). Utilities that set the same property share a slot, where
+     the class name breaks the tie. *)
+  let property_rank = function
     | Bracket_image_var _ | Bracket_image _ | Bracket_url _ | Bracket_url_var _
     | Bracket_var _ | No_mask ->
-        100
-    | Add | Exclude | Intersect | Subtract -> 200
-    | Alpha | Luminance | Match -> 300
-    | Type_alpha | Type_luminance -> 400
+        209
+    | Add | Exclude | Intersect | Subtract -> 257
+    | Alpha | Luminance | Match -> 258
+    | Type_alpha | Type_luminance -> 259
     | Bracket_contain | Bracket_cover | Bracket_length _ | Bracket_size _ | Auto
     | Contain | Cover | Size_bracket _ | Size_bracket_var _ ->
-        500
+        260
     | Clip_border | Clip_content | Clip_fill | Clip_padding | Clip_stroke
     | Clip_view | No_clip ->
-        600
+        261
     | Bracket_position _ | Bracket_typed_position _ | Position _
     | Position_bracket _ | Position_bracket_var _ ->
-        700
+        262
     | No_repeat | Repeat | Repeat_round | Repeat_space | Repeat_x | Repeat_y ->
-        800
+        263
     | Origin_border | Origin_content | Origin_fill | Origin_padding
     | Origin_stroke | Origin_view ->
-        900
+        264
 
-  (* These share a priority with the mask-gradient utilities. The gradient stops
-     all set mask-image, so they sort below this band; the mask-radial keywords
-     set only a variable and land between mask-none and mask-add. *)
-  let suborder t = 10000 + suborder_in_family t
+  (* Each of these writes one property and stops there, so it closes that
+     property's slot: the mask-gradient utilities that write mask-image and
+     carry on sort inside mask-image's, and the background sizing utilities that
+     share this priority take the slots between the two families. *)
+  let suborder t = Utility.Property_order.last (property_rank t)
 
   (* [mask-[<image>]] takes any background-image value, so what makes one is
      whether the value parser accepts it, not which gradient function it

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -17,6 +17,13 @@ let base x = Base x
 let important ?(suffix = false) x = Important (suffix, x)
 let alias class_name u = Aliased (class_name, u)
 
+(* See the .mli. *)
+module Property_order = struct
+  let width = 1000
+  let slot rank = width * rank
+  let last rank = slot rank + (width - 1)
+end
+
 module type Handler = sig
   type t
   type base += Self of t

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -89,6 +89,24 @@ val important : ?suffix:bool -> t -> t
 val pp : t -> string
 (** [pp u] is a human-readable representation of [u] for debugging. *)
 
+(** Tailwind's property table, read as a suborder scale.
+
+    Tailwind sorts a layer by the ranks its property table gives the properties
+    each rule writes: two rules are separated by the first rank they do not
+    share, and one whose ranks run out there sorts after one that keeps going. A
+    {!Handler.suborder} is a single integer, so each rank takes a slot a
+    thousand values wide. *)
+module Property_order : sig
+  val slot : int -> int
+  (** [slot rank] is the suborder of a utility whose sort key reaches [rank] and
+      writes a further property. Add what separates it from the others sharing
+      [rank], keeping the total below [slot (rank + 1)]. *)
+
+  val last : int -> int
+  (** [last rank] is the suborder of a utility whose sort key ends at [rank]. It
+      sorts after every utility in [rank]'s slot. *)
+end
+
 (** Handler module type for utility registration *)
 module type Handler = sig
   type t

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -311,6 +311,47 @@ let check_ordering_matches ?forms ~test_name utilities =
       Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
       Alcotest.failf "%s\n%s" test_name (Buffer.contents buf)
 
+(* Where a class's rule starts in a sheet. The selector is matched up to its
+   closing delimiter so [.bg-top] does not report [.bg-top-left]. *)
+let class_position sheet cls =
+  let sel = Css.Selector.to_string (Css.Selector.class_ cls) in
+  let n = String.length sel and len = String.length sheet in
+  let rec scan i =
+    if i + n > len then None
+    else if
+      String.sub sheet i n = sel
+      && i + n < len
+      && (sheet.[i + n] = '{' || sheet.[i + n] = ',')
+    then Some i
+    else scan (i + 1)
+  in
+  scan 0
+
+let check_class_order ?forms ~test_name classes =
+  let utilities =
+    List.map
+      (fun c ->
+        match Tw.of_string c with
+        | Ok u -> u
+        | Error (`Msg m) -> Alcotest.failf "%s: %s" c m)
+      classes
+  in
+  let order label sheet =
+    List.map
+      (fun cls ->
+        match class_position sheet cls with
+        | Some i -> (i, cls)
+        | None ->
+            Alcotest.failf "%s: %s missing from the %s sheet" test_name cls
+              label)
+      classes
+    |> List.sort compare |> List.map snd
+  in
+  let expected = order "Tailwind" (tailwind_css ?forms classes) in
+  Alcotest.(check (list string))
+    test_name expected
+    (order "tw" (our_css utilities))
+
 (** CSS Test Helpers *)
 
 (** Check if a layer exists in the stylesheet *)

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -62,6 +62,14 @@ val check_ordering_matches :
     of utilities between our implementation and Tailwind CSS, failing the test
     if they differ. *)
 
+val check_class_order : ?forms:bool -> test_name:string -> string list -> unit
+(** [check_class_order ?forms ~test_name classes] compares where each of
+    [classes] lands in tw's sheet against where the pinned Tailwind CLI puts it.
+    {!check_ordering_matches} pairs rules up by key, so a layer holding every
+    expected rule in the wrong places still compares equal; reading the
+    positions back is what catches a reorder. Skips when the CLI is unavailable.
+*)
+
 val check_rendering_matches :
   ?forms:bool -> test_name:string -> Tw.t list -> unit
 (** [check_rendering_matches ?forms ~test_name utilities] renders both sheets in

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -230,6 +230,41 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"backgrounds suborder matches Tailwind" shuffled
 
+(* Tailwind's property table runs the background properties in two stretches:
+   background-color and background-image with the gradient variables come first,
+   then background-size through background-origin, which sit between the
+   mask-image utilities and mask-composite. The masks have to interleave with
+   that second stretch. *)
+let order_matches_tailwind () =
+  let classes =
+    [
+      "bg-red-500";
+      "bg-linear-to-r";
+      "bg-conic";
+      "bg-none";
+      "via-none";
+      "from-red-500";
+      "to-90%";
+      "mask-t-from-50%";
+      "mask-circle";
+      "mask-none";
+      "bg-cover";
+      "bg-fixed";
+      "bg-clip-text";
+      "bg-center";
+      "bg-repeat-x";
+      "bg-origin-border";
+      "mask-add";
+      "mask-alpha";
+      "mask-cover";
+      "mask-top";
+      "mask-repeat-x";
+      "mask-origin-border";
+    ]
+  in
+  Test_helpers.check_class_order
+    ~test_name:"background and mask order matches Tailwind" classes
+
 (* A gradient and a background colour both end up in background-image and
    background-color, and the gradient stops share the --tw-gradient-* slots.
    Palette colours are left out: tw declares the theme token as a hex where
@@ -416,6 +451,8 @@ let tests =
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "backgrounds suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "background and mask order matches Tailwind" `Slow
+      order_matches_tailwind;
     test_case "backgrounds render like Tailwind" `Slow
       rendering_matches_tailwind;
   ]


### PR DESCRIPTION
Tailwind's property table runs background-size through background-origin between the mask-image utilities and mask-composite, so the two families interleave; tw put every background rule ahead of every mask rule. A background utility's priority now follows the property it writes.