### PR TITLE
theme: read `initial` in a @theme block as a removal

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -613,17 +613,18 @@ let extract_non_tw_custom_declarations selector_props =
    declarations. This is the threaded replacement for the override seam that
    used to live in [Var.binding]: a Theme-role variable whose token is
    overridden in [theme] emits the override value instead of its registered
-   default. [custom_declaration_name] returns the full [--name] form; the scheme
-   keys overrides by the bare name. *)
+   default. A token the block removed ([--spacing: initial]) has no declaration
+   left to emit. [custom_declaration_name] returns the full [--name] form; the
+   scheme keys overrides by the bare name. *)
 let apply_token_override theme decl =
   match Css.custom_declaration_name decl with
   | Some full_name
     when String.length full_name > 2 && String.sub full_name 0 2 = "--" -> (
       let bare = String.sub full_name 2 (String.length full_name - 2) in
       match Scheme.token_override theme bare with
-      | Some css -> Css.custom_property ~layer:"theme" full_name css
-      | None -> decl)
-  | _ -> decl
+      | Some css -> Some (Css.custom_property ~layer:"theme" full_name css)
+      | None -> if Scheme.is_removed theme bare then None else Some decl)
+  | _ -> Some decl
 
 (* Check if declaration name is a default font family indirection *)
 let is_default_family_name = function
@@ -809,7 +810,7 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
     ?(default_decls = []) selector_props =
   let extracted =
     extract_non_tw_custom_declarations selector_props
-    |> List.map (apply_token_override theme)
+    |> List.filter_map (apply_token_override theme)
   in
   let extracted =
     extracted
@@ -852,7 +853,7 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
   (* A project [@theme] override wins wherever the declaration came from: the
      built-in defaults carry the same token names as the extracted ones. *)
   pre @ extracted @ post
-  |> List.map (apply_token_override theme)
+  |> List.filter_map (apply_token_override theme)
   |> List.map (inline_default_family theme)
   |> sort_by_var_order |> theme_layer_rule ~layers
 

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -433,7 +433,7 @@ module Handler = struct
                 Ok (Space_arb { axis = `X; value = len; raw = value })
             | _ -> (
                 match Parse.spacing_value ~name:"space-x" value with
-                | Ok n ->
+                | Ok n when Theme.has_spacing_step ~theme n ->
                     Ok
                       (Space
                          {
@@ -441,7 +441,7 @@ module Handler = struct
                            axis = `X;
                            value = `Rem (n *. 0.25);
                          })
-                | Error _ -> err_not_utility))
+                | Ok _ | Error _ -> err_not_utility))
       | [ "space"; "y"; value ] -> (
           if value = "reverse" then Ok Space_y_reverse
           else if value = "px" then
@@ -452,7 +452,7 @@ module Handler = struct
                 Ok (Space_arb { axis = `Y; value = len; raw = value })
             | _ -> (
                 match Parse.spacing_value ~name:"space-y" value with
-                | Ok n ->
+                | Ok n when Theme.has_spacing_step ~theme n ->
                     Ok
                       (Space
                          {
@@ -460,27 +460,27 @@ module Handler = struct
                            axis = `Y;
                            value = `Rem (n *. 0.25);
                          })
-                | Error _ -> err_not_utility))
+                | Ok _ | Error _ -> err_not_utility))
       | [ ""; "space"; "x"; value ] -> (
           if value = "px" then
             Ok (Space { negative = true; axis = `X; value = `Px })
           else
             match Parse.spacing_value ~name:"space-x" value with
-            | Ok n ->
+            | Ok n when Theme.has_spacing_step ~theme n ->
                 Ok
                   (Space
                      { negative = true; axis = `X; value = `Rem (n *. 0.25) })
-            | Error _ -> err_not_utility)
+            | Ok _ | Error _ -> err_not_utility)
       | [ ""; "space"; "y"; value ] -> (
           if value = "px" then
             Ok (Space { negative = true; axis = `Y; value = `Px })
           else
             match Parse.spacing_value ~name:"space-y" value with
-            | Ok n ->
+            | Ok n when Theme.has_spacing_step ~theme n ->
                 Ok
                   (Space
                      { negative = true; axis = `Y; value = `Rem (n *. 0.25) })
-            | Error _ -> err_not_utility)
+            | Ok _ | Error _ -> err_not_utility)
       | _ -> err_not_utility
     in
     parse_class parts

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -701,6 +701,21 @@ module Handler = struct
     || Scheme.theme_value (Some theme) ("spacing-" ^ n) <> None
 
   let of_class theme class_name =
+    (* Every numeric inset step reads the spacing scale, so both readers below
+       answer for the whole family once the theme removes it. *)
+    let int_of_string_with_sign n =
+      match int_of_string_with_sign n with
+      | Ok x when Theme.has_spacing_step ~theme (Float.abs (float_of_int x)) ->
+          Ok x
+      | Ok _ -> Error (`Msg "the spacing scale has no such step")
+      | Error _ as error -> error
+    in
+    let parse_pos_spacing n : Style.spacing option =
+      match parse_pos_spacing n with
+      | Some (`Rem f) when not (Theme.has_spacing_step ~theme (f /. 0.25)) ->
+          None
+      | parsed -> parsed
+    in
     let parts = Parse.split_class class_name in
     match parts with
     | [ "static" ] -> Ok Position_static

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -151,8 +151,58 @@ let breakpoint_names scheme =
   List.sort_uniq String.compare (List.map fst scheme.breakpoints @ from_tokens)
   |> List.filter (fun name -> Option.is_some (breakpoint_length scheme name))
 
+(* Tailwind reads [--name: initial] in a [@theme] block as "remove this token",
+   and [--namespace-*: initial] as "remove the whole namespace", so a candidate
+   that needed the token stops resolving. *)
+let removed_value = "initial"
+
+(* Scales whose names begin with another scale's name and are not part of it:
+   [--font-*: initial] resets the font families, not the weights or the sizes.
+   Mirrors Tailwind's own [ignoredThemeKeyMap]. *)
+let nested_scales =
+  [
+    ("font", [ "font-weight"; "font-size" ]);
+    ("inset", [ "inset-shadow"; "inset-ring" ]);
+    ( "text",
+      [
+        "text-color";
+        "text-decoration-color";
+        "text-decoration-thickness";
+        "text-indent";
+        "text-shadow";
+        "text-underline-offset";
+      ] );
+    ("grid-column", [ "grid-column-start"; "grid-column-end" ]);
+    ("grid-row", [ "grid-row-start"; "grid-row-end" ]);
+  ]
+
+let in_nested_scale namespace name =
+  List.exists
+    (fun nested ->
+      String.equal name nested || String.starts_with ~prefix:(nested ^ "-") name)
+    (Option.value ~default:[] (List.assoc_opt namespace nested_scales))
+
+let clears_namespace name (key, value) =
+  String.equal value removed_value
+  && String.length key > 2
+  && String.equal (String.sub key (String.length key - 2) 2) "-*"
+  &&
+  let namespace = String.sub key 0 (String.length key - 2) in
+  String.starts_with ~prefix:namespace name
+  && not (in_nested_scale namespace name)
+
+(** Whether a [@theme] block removed [name], either outright or by resetting the
+    namespace it belongs to. A token the block goes on to declare survives its
+    own namespace reset. *)
+let is_removed scheme name =
+  match List.assoc_opt name scheme.token_overrides with
+  | Some value -> String.equal value removed_value
+  | None -> List.exists (clears_namespace name) scheme.token_overrides
+
 (** Lookup a per-render theme token override (from a [@theme] block). *)
-let token_override scheme name = List.assoc_opt name scheme.token_overrides
+let token_override scheme name =
+  if is_removed scheme name then None
+  else List.assoc_opt name scheme.token_overrides
 
 (** [theme_value theme name] looks up a per-render token override from the
     optionally-threaded [theme] ([None] when no theme is threaded). Threaded
@@ -160,11 +210,12 @@ let token_override scheme name = List.assoc_opt name scheme.token_overrides
 let theme_value theme name =
   match theme with Some s -> token_override s name | None -> None
 
-(** Resolve a theme token: override (if any) else the registered default. *)
+(** Resolve a theme token: override (if any) else the registered default. A
+    token the [@theme] block removed resolves to nothing, default or not. *)
 let token scheme name =
   match token_override scheme name with
   | Some _ as v -> v
-  | None -> token_default name
+  | None -> if is_removed scheme name then None else token_default name
 
 (** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
     on top of any existing token overrides (new entries win). *)

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -73,9 +73,17 @@ val all_default_tokens : unit -> (string * string) list
 val token_default : string -> string option
 (** [token_default name] returns the registered baseline default for [name]. *)
 
+val is_removed : t -> string -> bool
+(** [is_removed t name] is whether the [\@theme] block removed [name]. Tailwind
+    reads [--name: initial] as "remove this token" and [--namespace-*: initial]
+    as "remove the whole namespace", and a candidate that needed the token stops
+    resolving. A token the block declares in its own right survives a reset of
+    its namespace, and so does a nested scale that merely shares the prefix:
+    [--font-*: initial] leaves [--font-weight-*] alone. *)
+
 val token_override : t -> string -> string option
 (** [token_override t name] returns the per-render override for [name], if any.
-*)
+    A removed token has none. *)
 
 val theme_value : t option -> string -> string option
 (** [theme_value theme name] looks up a per-render token override from the
@@ -83,7 +91,8 @@ val theme_value : t option -> string -> string option
     replacement for the global [Var.theme_value]. *)
 
 val token : t -> string -> string option
-(** [token t name] resolves a theme token: override (if any) else default. *)
+(** [token t name] resolves a theme token: override (if any) else default, or
+    nothing at all when the [\@theme] block removed it. *)
 
 val with_overrides : ?inline:string list -> t -> (string * string) list -> t
 (** [with_overrides ?inline t overrides] applies [overrides] on top of [t]'s

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -182,7 +182,7 @@ module Handler = struct
     | "be" -> Some Be
     | _ -> None
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* scroll-m-4, scroll-p-4, scroll-mx-4, scroll-py-4, etc. *)
@@ -208,8 +208,9 @@ module Handler = struct
         | Some kind, Some axis -> (
             (* Try as spacing value (integer or fractional like 0.5, 2.5) *)
             match Parse.spacing_value ~name:"scroll" value with
-            | Ok n -> Ok { kind; negative; axis; value = Spacing n }
-            | Error _ -> (
+            | Ok n when Theme.has_spacing_step ~theme n ->
+                Ok { kind; negative; axis; value = Spacing n }
+            | Ok _ | Error _ -> (
                 (* Try as arbitrary value *)
                 match parse_arbitrary value with
                 | Some value -> Ok { kind; negative; axis; value }

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -706,7 +706,7 @@ module Handler = struct
 
   (* One parser for all thirteen sizing families: the family's own keyword
      table, then the fraction, bracket and spacing tails they share. *)
-  let parse_sized prop v =
+  let parse_sized ~theme prop v =
     let f = family prop in
     match lookup f v with
     | Some value -> Ok (Sized (prop, value))
@@ -720,7 +720,8 @@ module Handler = struct
           | None -> err_invalid_value f.css_name v
         else
           match Parse.decimal_float v with
-          | Some n when n >= 0. -> Ok (Sized (prop, Spacing (n *. 0.25)))
+          | Some n when n >= 0. && Theme.has_spacing_step ~theme n ->
+              Ok (Sized (prop, Spacing (n *. 0.25)))
           | _ -> err_invalid_value f.css_name v)
 
   let parse_max_w_screen s =
@@ -742,7 +743,8 @@ module Handler = struct
         | _ -> err_not_utility)
     | _ -> err_not_utility
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
+    let parse_sized prop v = parse_sized ~theme prop v in
     match Parse.split_class class_name with
     | [ "w"; value ] -> parse_sized Width value
     | [ "h"; value ] -> parse_sized Height value

--- a/lib/spacing.ml
+++ b/lib/spacing.ml
@@ -145,8 +145,8 @@ let parse_value_string ?theme ~allow_auto value : margin option =
   else if allow_auto && value = "auto" then Some `Auto
   else
     match Parse.spacing_value ~name:"spacing" value with
-    | Ok f -> Some (`Rem (f *. 0.25))
-    | Error _ ->
+    | Ok f when Theme.has_spacing_step ?theme f -> Some (`Rem (f *. 0.25))
+    | Ok _ | Error _ ->
         (* A named spacing (mx-big) is valid only when the theme defines the
            [--spacing-<name>] token; without that gate a stray source token like
            [my-form] would parse as a utility. *)

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -202,7 +202,7 @@ module Handler = struct
     | Border_spacing_y n -> 2032 + int_of_float (n *. 10.)
     | Border_spacing_y_arb _ -> 3000
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     | [ "border"; "collapse" ] -> Ok Border_collapse
@@ -217,8 +217,8 @@ module Handler = struct
         else err_not_utility
     | [ "border"; "spacing"; n ] -> (
         match Parse.spacing_value ~name:"border-spacing" n with
-        | Ok f -> Ok (Border_spacing f)
-        | Error _ -> err_not_utility)
+        | Ok f when Theme.has_spacing_step ~theme f -> Ok (Border_spacing f)
+        | Ok _ | Error _ -> err_not_utility)
     | [ "border"; "spacing"; "x"; n ] when Parse.is_bracket_value n ->
         let inner = Parse.bracket_inner n in
         if String.ends_with ~suffix:"px" inner then
@@ -229,8 +229,8 @@ module Handler = struct
         else err_not_utility
     | [ "border"; "spacing"; "x"; n ] -> (
         match Parse.spacing_value ~name:"border-spacing-x" n with
-        | Ok f -> Ok (Border_spacing_x f)
-        | Error _ -> err_not_utility)
+        | Ok f when Theme.has_spacing_step ~theme f -> Ok (Border_spacing_x f)
+        | Ok _ | Error _ -> err_not_utility)
     | [ "border"; "spacing"; "y"; n ] when Parse.is_bracket_value n ->
         let inner = Parse.bracket_inner n in
         if String.ends_with ~suffix:"px" inner then
@@ -241,8 +241,8 @@ module Handler = struct
         else err_not_utility
     | [ "border"; "spacing"; "y"; n ] -> (
         match Parse.spacing_value ~name:"border-spacing-y" n with
-        | Ok f -> Ok (Border_spacing_y f)
-        | Error _ -> err_not_utility)
+        | Ok f when Theme.has_spacing_step ~theme f -> Ok (Border_spacing_y f)
+        | Ok _ | Error _ -> err_not_utility)
     | [ "table"; "auto" ] -> Ok Table_auto
     | [ "table"; "fixed" ] -> Ok Table_fixed
     | [ "caption"; "top" ] -> Ok Caption_top

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -42,6 +42,26 @@ let spacing_times n =
 (* Create a spacing variable for explicit spacing values (e.g., --spacing-4) *)
 let spacing_n_var n = Var.theme Css.Length ("spacing-" ^ Pp.int n) ~order:(3, n)
 
+(* The length the theme binds to step [n] outright, as [--spacing-<n>]. Tailwind
+   reads a bare step off that binding first and off the [--spacing] multiplier
+   only when there is none. *)
+let explicit_spacing scheme n =
+  match Scheme.spacing scheme n with
+  | Some _ as length -> length
+  | None ->
+      Option.bind
+        (Scheme.token scheme ("spacing-" ^ Pp.int n))
+        (fun css -> Css.parse_length (String.trim css))
+
+(* Whether the bare step [n] of the spacing scale still resolves: [@theme {
+   --spacing: initial }] removes the multiplier, and every step that relied on
+   it stops being a utility. *)
+let has_spacing_step ?theme n =
+  let scheme = resolve_scheme theme in
+  Float.is_integer n
+  && explicit_spacing scheme (int_of_float (Float.abs n)) <> None
+  || Scheme.token scheme "spacing" <> None
+
 (* Create a spacing length value. When scheme has explicit spacing for |n|,
    returns var(--spacing-|n|) or calc(var(--spacing-|n|) * -1) for negatives.
    Otherwise returns calc(var(--spacing) * n). Returns the theme declaration and
@@ -49,7 +69,7 @@ let spacing_n_var n = Var.theme Css.Length ("spacing-" ^ Pp.int n) ~order:(3, n)
 let spacing_calc ?theme n : Css.declaration * Css.length =
   let abs_n = abs n in
   let is_negative = n < 0 in
-  match Scheme.spacing (resolve_scheme theme) abs_n with
+  match explicit_spacing (resolve_scheme theme) abs_n with
   | Some explicit_length ->
       (* Scheme has explicit spacing: use var(--spacing-|n|) *)
       let spacing_n = spacing_n_var abs_n in

--- a/lib/theme.mli
+++ b/lib/theme.mli
@@ -19,6 +19,13 @@ val spacing_n_var : int -> Css.length Var.theme
 (** [spacing_n_var n] creates the [--spacing-n] variable for explicit spacing
     values. *)
 
+val has_spacing_step : ?theme:Scheme.t -> float -> bool
+(** [has_spacing_step ?theme n] is whether step [n] of the spacing scale still
+    resolves. Tailwind reads a bare step off [--spacing-<n>] when the theme
+    binds one and off the [--spacing] multiplier otherwise, so
+    [\@theme \{ --spacing: initial \}] leaves the multiplied steps with nothing
+    to read and they stop being utilities. *)
+
 val spacing_calc : ?theme:Scheme.t -> int -> Css.declaration * Css.length
 (** [spacing_calc ?theme n] returns the theme declaration and a length for [n].
 

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1844,12 +1844,12 @@ module Typography_late = struct
         else Ok (Indent_neg_arbitrary inner)
     | [ "indent"; n ] -> (
         match Parse.spacing_value ~name:"indent" n with
-        | Ok f -> Ok (Indent f)
-        | Error _ -> err_not_utility)
+        | Ok f when Theme.has_spacing_step ~theme f -> Ok (Indent f)
+        | Ok _ | Error _ -> err_not_utility)
     | [ ""; "indent"; n ] -> (
         match Parse.spacing_value ~name:"indent" n with
-        | Ok f -> Ok (Indent_neg f)
-        | Error _ -> err_not_utility)
+        | Ok f when Theme.has_spacing_step ~theme f -> Ok (Indent_neg f)
+        | Ok _ | Error _ -> err_not_utility)
     | [ "line"; "clamp"; "none" ] -> Ok Line_clamp_none
     | [ "line"; "clamp"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in

--- a/test/test_scheme.ml
+++ b/test/test_scheme.ml
@@ -23,10 +23,26 @@ let test_breakpoint_override () =
     "breakpoint token populates the typed theme" (Some 1600.)
     (Tw.Scheme.breakpoint s "10xl")
 
+(* A namespace reset spares the scales Tailwind lists as separate even though
+   they share the prefix, so [--text-*: initial] drops the font sizes and leaves
+   [--text-shadow-*] standing. *)
+let test_namespace_reset_spares_nested_scales () =
+  let s =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("text-*", "initial") ]
+  in
+  Alcotest.(check bool)
+    "the font sizes go" true
+    (Tw.Scheme.token s "text-sm" = None);
+  Alcotest.(check bool)
+    "the text shadows stay" true
+    (Tw.Scheme.token s "text-shadow-2xs" <> None)
+
 let tests =
   Alcotest.
     [
       test_case "default scheme" `Quick test_default;
+      test_case "namespace reset spares nested scales" `Quick
+        test_namespace_reset_spares_nested_scales;
       test_case "find color" `Quick test_find_color;
       test_case "breakpoint override" `Quick test_breakpoint_override;
     ]

--- a/test/test_spacing.ml
+++ b/test/test_spacing.ml
@@ -63,6 +63,60 @@ let test_named_spacing_declares_token () =
               cls)
     [ "m-form"; "-m-form"; "p-form"; "px-form"; "gap-form"; "gap-x-form" ]
 
+(* Tailwind reads [--spacing: initial] as "remove the multiplier", so a bare
+   step has nothing to compute from and stops being a utility across every
+   family that offers the scale. A step the theme binds outright survives, and
+   the removed token itself never reaches the theme layer. *)
+let test_removed_spacing_multiplier () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("spacing", "initial"); ("spacing-4", "1rem") ]
+  in
+  List.iter
+    (fun cls ->
+      match Tw.of_string ~theme cls with
+      | Ok _ -> Alcotest.failf "%s is a utility with no --spacing to read" cls
+      | Error _ -> ())
+    [
+      "px-1";
+      "-m-2";
+      "gap-3";
+      "space-x-1";
+      "w-1";
+      "top-1";
+      "indent-1";
+      "scroll-m-1";
+      "border-spacing-1";
+    ];
+  match Tw.of_string ~theme "px-4" with
+  | Error (`Msg m) -> Alcotest.failf "px-4 rejected: %s" m
+  | Ok u ->
+      let css = Tw.to_css ~theme ~base:false [ u ] in
+      Alcotest.(check bool)
+        "the step the theme binds is declared" true
+        (Test_helpers.has_var_in_layer "--spacing-4" "theme" css);
+      Alcotest.(check bool)
+        "the removed multiplier is not declared" false
+        (Test_helpers.has_var_in_layer "--spacing" "theme" css)
+
+(* [--spacing-*: initial] resets the whole namespace, the multiplier included,
+   and only the steps the block goes on to declare survive it. *)
+let test_reset_spacing_namespace () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("spacing-*", "initial"); ("spacing-4", "1rem") ]
+  in
+  (match Tw.of_string ~theme "px-1" with
+  | Ok _ -> Alcotest.fail "px-1 is a utility after the namespace reset"
+  | Error _ -> ());
+  match Tw.of_string ~theme "px-4" with
+  | Error (`Msg m) -> Alcotest.failf "px-4 rejected: %s" m
+  | Ok u ->
+      let css = Tw.to_css ~theme ~base:false [ u ] in
+      Alcotest.(check bool)
+        "the step declared after the reset survives" true
+        (Test_helpers.has_var_in_layer "--spacing-4" "theme" css)
+
 let tests =
   [
     test_case "pp_spacing_suffix" `Quick test_pp_spacing_suffix;
@@ -70,6 +124,10 @@ let tests =
     test_case "int constructor" `Quick test_int_constructor;
     test_case "named spacing declares its token" `Quick
       test_named_spacing_declares_token;
+    test_case "--spacing: initial removes the multiplier" `Quick
+      test_removed_spacing_multiplier;
+    test_case "--spacing-*: initial resets the namespace" `Quick
+      test_reset_spacing_namespace;
   ]
 
 let suite = ("spacing", tests)


### PR DESCRIPTION
A token set to `initial` stored the keyword instead of deleting the key, so `px-1` stayed a utility under `@theme { --spacing: initial }` and the keyword reached the sheet. Tailwind deletes the key, and reads `--<namespace>-*: initial` as a reset of the whole namespace.

Stacked on #356.