### PR TITLE
test: read a @theme namespace reset out of an upstream test

### DIFF
--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -11,7 +11,7 @@
 
 ; Pins the [@theme] scanner on the declaration shapes Prettier produces:
 ; values wrapped over several lines, a [;] or [}] inside a string or a
-; comment, and brackets that span lines.
+; comment, brackets that span lines, and a [--namespace-*] reset.
 
 (rule
  (action

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -191,7 +191,10 @@ let theme_scanner () =
     pending_space = false;
   }
 
-let theme_decl_re = Re.Pcre.regexp {|^--([A-Za-z0-9-]+)\s*:\s*(.*)$|}
+(* [--spacing-*: initial] resets a whole namespace, so [*] belongs in a token
+   name: without it the reset reads as no declaration at all and the test that
+   sets it silently loses its theme. *)
+let theme_decl_re = Re.Pcre.regexp {|^--([A-Za-z0-9*-]+)\s*:\s*(.*)$|}
 
 let scanner_add s c =
   if s.pending_space && Buffer.length s.decl > 0 then Buffer.add_char s.decl ' ';

--- a/test/upstream/theme_scanner_expected.txt
+++ b/test/upstream/theme_scanner_expected.txt
@@ -1,5 +1,6 @@
 # multiline-theme
 @config theme
+@theme-var spacing-* initial
 @theme-var font-sans ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'
 @theme-var single-line 1rem
 @theme-var quoted 'a;b}c'

--- a/test/upstream/theme_scanner_input.ts
+++ b/test/upstream/theme_scanner_input.ts
@@ -7,6 +7,7 @@ test('multiline-theme', async () => {
       ['font-sans', 'shadow-wrapped'],
       css`
         @theme {
+          --spacing-*: initial;
           --font-sans:
             ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
             'Segoe UI Symbol', 'Noto Color Emoji';

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -22388,6 +22388,7 @@ px-1 px-4
 <<<>>>
 # `--spacing-*: initial` disables the spacing multiplier
 @config theme
+@theme-var spacing-* initial
 @theme-var spacing-4 1rem
 px-1 px-4
 ---


### PR DESCRIPTION
The extractor's token-name pattern had no `*`, so `--spacing-*: initial` read as no declaration at all and the test that sets it ran against a theme it never wrote. `utilities.txt` gains that line in place rather than being regenerated, because the local Tailwind checkout has moved on since the corpus was built.

Stacked on #357.