### PR TITLE
containers: build .container from the breakpoint scale

### DIFF
--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -33,27 +33,62 @@ module Handler = struct
     | Container_size -> "@container-size"
     | Container_named name -> "@container/" ^ name
 
-  let layout_container_style =
+  (* The unit a breakpoint value carries: what is left once its digits and dots
+     are gone, or the head of a function call. *)
+  let breakpoint_unit value =
+    match String.index_opt value '(' with
+    | Some i -> String.sub value 0 i
+    | None ->
+        let unit = Buffer.create (String.length value) in
+        String.iter
+          (fun c ->
+            if not ((c >= '0' && c <= '9') || c = '.') then
+              Buffer.add_char unit c)
+          value;
+        Buffer.contents unit
+
+  (* The integer a breakpoint value starts with, the way [parseInt] reads it. *)
+  let breakpoint_number value : int option =
+    let stop = ref 0 in
+    let len = String.length value in
+    if len > 0 && (value.[0] = '-' || value.[0] = '+') then incr stop;
+    let digits = !stop in
+    while !stop < len && value.[!stop] >= '0' && value.[!stop] <= '9' do
+      incr stop
+    done;
+    if !stop = digits then None
+    else int_of_string_opt (String.sub value 0 !stop)
+
+  (* Tailwind sorts the scale by unit first and then by number, ascending, so an
+     [em] breakpoint precedes a [px] one whatever their widths. A value with no
+     leading number falls back to comparing the spellings. *)
+  let compare_breakpoints a b =
+    if String.equal a b then 0
+    else
+      match String.compare (breakpoint_unit a) (breakpoint_unit b) with
+      | 0 -> (
+          match (breakpoint_number a, breakpoint_number b) with
+          | Some x, Some y -> Int.compare x y
+          | _ -> String.compare a b)
+      | order -> order
+
+  let layout_container_style theme =
     let open Css in
     (* Use top-level media queries to match Tailwind's minified output.
        Container media queries should come AFTER the base .container rule.
        rules.ml handles this ordering since container has only media rules and
        base props. *)
     let container_selector = Selector.class_ "container" in
-    let min_width_rem rem = media_min_width_length (Rem rem) in
+    let spelling length = Css.Pp.to_string Css.pp_length length in
     let media_rules =
-      [
-        media ~condition:(min_width_rem 40.)
-          [ rule ~selector:container_selector [ max_width (Rem 40.) ] ];
-        media ~condition:(min_width_rem 48.)
-          [ rule ~selector:container_selector [ max_width (Rem 48.) ] ];
-        media ~condition:(min_width_rem 64.)
-          [ rule ~selector:container_selector [ max_width (Rem 64.) ] ];
-        media ~condition:(min_width_rem 80.)
-          [ rule ~selector:container_selector [ max_width (Rem 80.) ] ];
-        media ~condition:(min_width_rem 96.)
-          [ rule ~selector:container_selector [ max_width (Rem 96.) ] ];
-      ]
+      Scheme.all_breakpoints theme
+      |> List.map snd
+      |> List.stable_sort (fun a b ->
+          compare_breakpoints (spelling a) (spelling b))
+      |> List.map (fun length ->
+          media
+            ~condition:(media_min_width_length length)
+            [ rule ~selector:container_selector [ max_width length ] ])
     in
     style ~rules:(Some media_rules) [ width (Pct 100.) ]
 
@@ -66,8 +101,8 @@ module Handler = struct
   let container_named_style name =
     style [ Css.Declaration.container ~type_:Inline_size name ]
 
-  let to_style _theme = function
-    | Layout_container -> layout_container_style
+  let to_style theme = function
+    | Layout_container -> layout_container_style theme
     | Container -> container_query
     | Container_normal -> container_normal_style
     | Container_size -> container_size_style

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -217,6 +217,37 @@ let token scheme name =
   | Some _ as v -> v
   | None -> if is_removed scheme name then None else token_default name
 
+(** Every breakpoint the theme defines, keyed by name: the registered defaults,
+    the [--breakpoint-*] tokens a [@theme] block set, and the legacy px-only
+    field. *)
+let all_breakpoints scheme =
+  let prefix = "breakpoint-" in
+  let suffix (key, _) =
+    if String.starts_with ~prefix key then
+      Some
+        (String.sub key (String.length prefix)
+           (String.length key - String.length prefix))
+    else None
+  in
+  let names =
+    List.filter_map suffix (all_default_tokens ())
+    @ List.filter_map suffix scheme.token_overrides
+    @ List.map fst scheme.breakpoints
+  in
+  List.sort_uniq String.compare names
+  |> List.filter_map (fun name ->
+      if is_removed scheme (prefix ^ name) then None
+      else
+        let length =
+          match breakpoint_length scheme name with
+          | Some _ as length -> length
+          | None ->
+              Option.bind
+                (token_default (prefix ^ name))
+                (fun css -> Css.parse_length (String.trim css))
+        in
+        Option.map (fun length -> (name, length)) length)
+
 (** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
     on top of any existing token overrides (new entries win). *)
 let with_overrides ?(inline = []) scheme overrides =

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -133,6 +133,12 @@ val breakpoint_length : t -> string -> Css.length option
     [breakpoint-NAME] token override takes precedence over the legacy px-only
     {!breakpoint} field. *)
 
+val all_breakpoints : t -> (string * Css.length) list
+(** [all_breakpoints t] is every breakpoint [t] defines, keyed by name and
+    sorted by name: the registered defaults, the [--breakpoint-*] tokens a
+    [\@theme] block set, and the legacy px-only {!breakpoints} field. A
+    breakpoint the block removed is left out. *)
+
 val breakpoint_names : t -> string list
 (** [breakpoint_names t] returns the custom breakpoint names available while
     parsing variants. *)

--- a/test/test_containers.ml
+++ b/test/test_containers.ml
@@ -176,9 +176,47 @@ let test_variant_width_order () =
     (List.sort Int.compare positions)
     positions
 
+(* Tailwind builds the .container media queries out of the --breakpoint-* tokens
+   themselves, sorted by unit and then ascending, so a theme that re-units or
+   extends the scale moves them. *)
+let test_container_reads_the_breakpoint_scale () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [
+        ("breakpoint-lg", "64rem");
+        ("breakpoint-xl", "80rem");
+        ("breakpoint-3xl", "1600px");
+        ("breakpoint-sm", "40em");
+        ("breakpoint-2xl", "96rem");
+        ("breakpoint-xs", "30px");
+        ("breakpoint-md", "48em");
+      ]
+  in
+  let css =
+    match Tw.of_string ~theme "container" with
+    | Ok u ->
+        Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "container: %s" m
+  in
+  let position width =
+    match Astring.String.find_sub ~sub:("max-width:" ^ width) css with
+    | Some i -> i
+    | None -> Alcotest.failf "no %s in %s" width css
+  in
+  let positions =
+    List.map position
+      [ "40em"; "48em"; "30px"; "1600px"; "64rem"; "80rem"; "96rem" ]
+  in
+  Alcotest.(check (list int))
+    "the scale sorts by unit and then ascending"
+    (List.sort Int.compare positions)
+    positions
+
 let tests =
   [
     test_case "types" `Quick test_container_types;
+    test_case "container reads the breakpoint scale" `Quick
+      test_container_reads_the_breakpoint_scale;
     test_case "variant width order" `Quick test_variant_width_order;
     test_case "variant composition" `Quick test_container_variant_composition;
     test_case "name" `Quick test_container_name;


### PR DESCRIPTION
`.container` emitted a fixed rem ladder, so a theme that re-units or extends `--breakpoint-*` was ignored. Tailwind emits one media query per breakpoint token, sorted by unit and then ascending.

Stacked on #358.