### PR TITLE
sizing: read a named size off --spacing before --container

### DIFF
--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -108,19 +108,27 @@ module Handler = struct
     let pct_value = Float.round (raw *. 10000.0) /. 10000.0 in
     style [ flex_basis (Pct pct_value) ]
 
+  (* [basis] lists --flex-basis, then --spacing, then --container, so a named
+     size reads the first of those the theme defines. *)
   let basis_named_style ?theme name =
     let var_name = "container-" ^ name in
-    match Scheme.theme_value theme var_name with
-    | Some value_str ->
-        let decl =
-          Css.custom_property ~layer:"theme" ("--" ^ var_name) value_str
-        in
-        let ref : Css.flex_basis Css.var =
-          Var.theme_ref var_name
-            ~default:(Css.Zero : Css.flex_basis)
-            ~default_css:"0px"
-        in
-        style [ decl; flex_basis (Var ref) ]
+    let overridden namespace =
+      let token = namespace ^ "-" ^ name in
+      Option.map
+        (fun value_str ->
+          let decl =
+            Css.custom_property ~layer:"theme" ("--" ^ token) value_str
+          in
+          let ref : Css.flex_basis Css.var =
+            Var.theme_ref token
+              ~default:(Css.Zero : Css.flex_basis)
+              ~default_css:"0px"
+          in
+          style [ decl; flex_basis (Var ref) ])
+        (Scheme.theme_value theme token)
+    in
+    match List.find_map overridden [ "flex-basis"; "spacing"; "container" ] with
+    | Some styled -> styled
     (* Without an override the container scale still declares its own default,
        so the token the utility reads is in the sheet. *)
     | None -> (

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -622,22 +622,30 @@ module Handler = struct
 
   let aspect_ratio' w h = style [ Css.aspect_ratio (Ratio (w, h)) ]
 
-  (* v4 resolves w-<name> to --width-<name> when the theme defines it, and
-     otherwise to the --container-<name> scale (the default). Only w-* reads
-     --width-*. *)
-  let width_override theme prop spelling : Style.t option =
-    match prop with
-    | Width -> (
-        match Scheme.theme_value (Some theme) ("width-" ^ spelling) with
-        | None -> None
-        | Some v ->
+  (* v4 resolves a named size through the namespaces its family lists before the
+     container scale: [w-sm] reads [--width-sm], then [--spacing-sm], and only
+     then the [--container-sm] default. *)
+  let named_namespaces = function
+    | Width -> [ "width"; "spacing" ]
+    | Min_width -> [ "min-width"; "spacing" ]
+    | Max_width -> [ "max-width"; "spacing" ]
+    | Inline_size | Min_inline_size | Max_inline_size -> [ "spacing" ]
+    | _ -> []
+
+  let named_override theme prop spelling : Style.t option =
+    let f = family prop in
+    List.find_map
+      (fun namespace ->
+        let token = namespace ^ "-" ^ spelling in
+        Option.map
+          (fun value ->
             let decl =
-              Css.custom_property ~layer:"theme" ("--width-" ^ spelling) v
+              Css.custom_property ~layer:"theme" ("--" ^ token) value
             in
-            Some
-              (style
-                 [ decl; width (Var (Var.theme_ref ("width-" ^ spelling))) ]))
-    | _ -> None
+            let length : length = Var (Var.theme_ref token) in
+            style (decl :: List.map (fun decl -> decl length) f.decls))
+          (Scheme.theme_value (Some theme) token))
+      (named_namespaces prop)
 
   let sized_style theme prop v =
     let f = family prop in
@@ -666,7 +674,7 @@ module Handler = struct
         let decl, len = Theme.spacing_calc_float ~theme (n *. 4.) in
         style (decl :: List.map (fun d -> d len) f.decls)
     | Themed t -> (
-        match width_override theme prop t.spelling with
+        match named_override theme prop t.spelling with
         | Some s -> s
         | None -> style (t.decl :: List.map (fun d -> d t.value) f.decls))
 

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -97,8 +97,29 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"flex_props suborder matches Tailwind" shuffled
 
+(* [basis] lists --flex-basis, then --spacing, then --container, so a theme that
+   sets both --spacing-sm and --container-sm reads the spacing one. *)
+let test_basis_named_prefers_spacing () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("spacing-sm", "8px"); ("container-sm", "256px") ]
+  in
+  let css =
+    match Tw.of_string ~theme "basis-sm" with
+    | Ok u -> Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "basis-sm: %s" m
+  in
+  Alcotest.(check bool)
+    "basis-sm reads --spacing-sm" true
+    (Astring.String.is_infix ~affix:"var(--spacing-sm)" css);
+  Alcotest.(check bool)
+    "basis-sm declares --spacing-sm" true
+    (Astring.String.is_infix ~affix:"--spacing-sm: 8px" css)
+
 let tests =
   [
+    test_case "basis-* prefers --spacing-*" `Quick
+      test_basis_named_prefers_spacing;
     test_case "flex_props of_string - valid values" `Quick of_string_valid;
     test_case "flex_props of_string - invalid values" `Quick of_string_invalid;
     test_case "flex_props suborder matches Tailwind" `Quick

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -442,8 +442,35 @@ let test_logical_px_step () =
     "inline-px is 1px" true
     (Astring.String.is_infix ~affix:"inline-size: 1px" (css_of "inline-px"))
 
+(* v4 resolves a named size through the namespaces the family lists ahead of the
+   container scale, so a theme that sets both --spacing-sm and --container-sm
+   reads the spacing one. *)
+let test_named_size_prefers_spacing () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("spacing-sm", "8px"); ("container-sm", "256px") ]
+  in
+  List.iter
+    (fun cls ->
+      let css =
+        match Tw.of_string ~theme cls with
+        | Ok u -> Tw.to_css ~theme ~base:false [ u ] |> Css.to_string
+        | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      in
+      Alcotest.(check bool)
+        (cls ^ " reads --spacing-sm")
+        true
+        (Astring.String.is_infix ~affix:"var(--spacing-sm)" css);
+      Alcotest.(check bool)
+        (cls ^ " declares --spacing-sm")
+        true
+        (Astring.String.is_infix ~affix:"--spacing-sm: 8px" css))
+    [ "w-sm"; "min-w-sm"; "max-w-sm" ]
+
 let tests =
   [
+    test_case "named size prefers --spacing-*" `Quick
+      test_named_size_prefers_spacing;
     test_case "fractional spacing" `Quick test_fractional_spacing;
     test_case "logical px step" `Quick test_logical_px_step;
     test_case "bracket keeps its slash" `Quick test_bracket_keeps_its_slash;


### PR DESCRIPTION
`w-sm` and its neighbours read `--container-sm` directly, so a theme defining `--spacing-sm` was ignored. v4 walks each family's namespace list, and `w`, `min-w`, `max-w` and `basis` all reach `--spacing` before `--container`.

Stacked on #359.