### PR TITLE
cli: keep Tailwind's build-time at-rules out of the emitted CSS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@
   and make recursive content scans safe
   (#142, #144, #145, #208, #288, #318, #321).
 - Reject conflicting CLI backends instead of silently selecting one (#317).
+- Keep Tailwind's own at-rules out of the generated CSS: `@theme`, `@source`,
+  `@plugin`, `@config`, `@reference`, and `@tailwind` used to reach the
+  browser, which has no meaning for any of them (#361).
 
 ### Utility coverage
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -503,6 +503,58 @@ let take_custom_utilities css =
   let css, defs = take_named_defs "@utility" css in
   (css, List.filter (fun (n, _) -> not (String.contains n '*')) defs)
 
+(* The at-keywords Tailwind's dialect adds to CSS. They are input for the
+   generator, which reads each of them above -- for a definition, for an
+   expansion, or for the theme and the plugins the entrypoint asks for -- and
+   Tailwind emits none of them. This list is the whole of what makes an at-rule
+   one of Tailwind's; anything else is the author's CSS, and passes through
+   whether or not tw or a parser knows what it means. *)
+let tailwind_directives =
+  [
+    "@apply";
+    "@config";
+    "@custom-variant";
+    "@plugin";
+    "@reference";
+    "@slot";
+    "@source";
+    "@tailwind";
+    "@theme";
+    "@utility";
+    "@variant";
+  ]
+
+(* Drop them, so none reaches a browser that has no meaning for it. What is
+   still here declared nothing usable -- an [@utility] with no name, a variant
+   tw cannot expand -- or names something outside the stylesheet, so there is
+   nothing to salvage from the text either. *)
+let drop_directives css =
+  let scan = Scan.v css in
+  let len = String.length css in
+  let buf = Buffer.create len in
+  let directive_at i =
+    List.find_map
+      (fun name ->
+        match Scan.at_rule scan ~name i with
+        | Some { block = { next; _ }; _ } -> Some next
+        | None ->
+            Option.map
+              (fun ({ next; _ } : Scan.statement) -> next)
+              (Scan.at_statement scan ~name i))
+      tailwind_directives
+  in
+  let rec go i =
+    if i >= len then ()
+    else
+      match directive_at i with
+      | Some next -> go next
+      | None ->
+          Buffer.add_char buf css.[i];
+          go (i + 1)
+  in
+  go 0;
+  Buffer.contents buf
+
 let fill_slots template body =
   let scan = Scan.v template in
   let len = String.length template in
@@ -968,8 +1020,9 @@ let apply_variants ?(extra_defs = []) ?(udefs = []) ~theme css =
     let out = expand_apply ~theme ~defs ~udefs css in
     if depth >= 4 || String.equal out css then out else expand (depth + 1) out
   in
-  resolve_theme_fn ~theme
-    (expand_spacing_fn (expand_variants ~depth:0 defs (expand 0 css)))
+  drop_directives
+    (resolve_theme_fn ~theme
+       (expand_spacing_fn (expand_variants ~depth:0 defs (expand 0 css))))
 
 (* Preload every transitively-referenced stylesheet, keyed by the URL resolved
    against its importer, which is what the inliner looks up. Mirrors cascade's

--- a/test/cli/directives.t
+++ b/test/cli/directives.t
@@ -1,0 +1,117 @@
+Tailwind's at-rules are build-time input for the generator. Tailwind emits
+none of them, so none of them belongs in the CSS a browser gets. An at-rule
+that is not one of Tailwind's is the author's own and passes through.
+
+  $ cat > index.html <<EOF
+  > <div class="flex prose alpha theme-midnight:flex animate-wiggle"></div>
+  > EOF
+
+  $ cat > app.css <<EOF
+  > @import "tailwindcss";
+  > @tailwind utilities;
+  > @source "./src/**/*.html";
+  > @plugin "@tailwindcss/typography";
+  > @config "./tailwind.config.js";
+  > @reference "./ref.css";
+  > @theme { --animate-wiggle: wiggle 1s ease-in-out infinite; }
+  > @theme inline { --font-mine: Georgia, serif; }
+  > @utility alpha { padding: 1rem }
+  > @custom-variant theme-midnight (&:where([data-theme="midnight"] *));
+  > .page { @apply flex; }
+  > @variant sm { .wide { display: grid } }
+  > EOF
+
+  $ tw --minify --input-css app.css index.html > out.css
+
+  $ grep -c -- '@theme' out.css
+  0
+  [1]
+  $ grep -c -- '@source' out.css
+  0
+  [1]
+  $ grep -c -- '@plugin' out.css
+  0
+  [1]
+  $ grep -c -- '@config' out.css
+  0
+  [1]
+  $ grep -c -- '@reference' out.css
+  0
+  [1]
+  $ grep -c -- '@tailwind' out.css
+  0
+  [1]
+  $ grep -c -- '@utility' out.css
+  0
+  [1]
+  $ grep -c -- '@custom-variant' out.css
+  0
+  [1]
+  $ grep -c -- '@apply' out.css
+  0
+  [1]
+  $ grep -c -- '@variant' out.css
+  0
+  [1]
+  $ grep -c -- '@slot' out.css
+  0
+  [1]
+
+Removing the directive is not dropping what it declared: the theme token, the
+typography plugin, the declared utility, the declared variant, the applied
+rule and the built-in variant all reach the output they belong in.
+
+  $ grep -cF -- '--animate-wiggle:wiggle 1s ease-in-out infinite' out.css
+  1
+  $ grep -cF '.prose' out.css
+  1
+  $ grep -cF '.alpha{padding:1rem}' out.css
+  1
+  $ grep -cF '.theme-midnight\:flex:where([data-theme=midnight] *){display:flex}' out.css
+  1
+  $ grep -cF '.page{display:flex}' out.css
+  1
+  $ grep -cF '@media(min-width:40rem){.wide{display:grid}}' out.css
+  1
+
+A directive that declares nothing is still a directive. [@utility] with no
+name, [@custom-variant] with no selector, [@variant] naming a variant tw does
+not know and [@theme] with no block each leave the generator nothing to read,
+and a browser even less:
+
+  $ cat > degenerate.css <<EOF
+  > @import "tailwindcss";
+  > @utility { color: red }
+  > @custom-variant novariant;
+  > @variant not-a-variant { .q { color: blue } }
+  > @theme;
+  > EOF
+  $ tw --minify --input-css degenerate.css index.html > degenerate.out
+  $ grep -c -- '@utility' degenerate.out
+  0
+  [1]
+  $ grep -c -- '@custom-variant' degenerate.out
+  0
+  [1]
+  $ grep -c -- '@variant' degenerate.out
+  0
+  [1]
+  $ grep -c -- '@theme' degenerate.out
+  0
+  [1]
+
+An at-rule Tailwind never defined is the author's CSS. tw has no more claim on
+it than on any rule the project wrote, so it comes out the way it went in:
+
+  $ cat > third-party.css <<EOF
+  > @import "tailwindcss";
+  > @unknown-directive "keep me";
+  > @unknown-block { .kept { color: red } }
+  > EOF
+  $ tw --minify --input-css third-party.css index.html > third-party.out
+  $ grep -cF '@unknown-directive "keep me"' third-party.out
+  1
+  $ grep -cF '@unknown-block' third-party.out
+  1
+  $ grep -cF '.kept' third-party.out
+  1


### PR DESCRIPTION
`@theme`, `@source`, `@plugin`, `@config`, `@reference` and `@tailwind` reached the output, where a browser has no meaning for any of them; they are now removed along with the rest of Tailwind's dialect once tw has read them, while an at-rule tw does not recognise still passes through untouched.

This is inert below #349, where cascade 1.1.0 drops these at-rules along with every other one it cannot interpret, and turns the `test/cli/input-css.t` failure green from #349 up.