### PR TITLE
gitignore: match the node_modules symlink as well as the directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tmp/
 
 # Node.js
 node_modules/
+node_modules
 .npm/
 
 # Generated example files


### PR DESCRIPTION
The `node_modules/` pattern only matches a directory, and worktree setup links `node_modules` rather than creating it, so every worktree carried it as untracked noise. `_opam` already carries both spellings a few lines above.

`dune build @runtest` could not be run: main is red because cascade main dropped APIs tw still uses, which is being fixed on `cascade-main-catchup`. This change touches no code; it was verified with `git status` and `git check-ignore` before and after.