### PR TITLE
lib: point the stale comments at the modules that hold the code

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1237,7 +1237,7 @@ let check_shade ~utility color shade =
 
 (** Background color utilities *)
 
-(* Theme layer color variable ordering map. See rules.mli for detailed layer
+(* Theme layer color variable ordering map. See build.mli for detailed layer
    ordering documentation. *)
 let theme_color_order_map =
   [
@@ -2613,7 +2613,7 @@ module Handler = struct
                 ~percent1:percent
             in
             (* Create @supports block with oklab version as top-level rule. Use
-               placeholder selector that rules.ml replaces with actual class. *)
+               placeholder selector that rule.ml replaces with actual class. *)
             let supports_block =
               Css.supports ~condition:color_mix_supports_condition
                 [
@@ -2743,7 +2743,7 @@ module Handler = struct
     in
     let oklab_decl = property oklab_color in
     (* Create @supports block with oklab version as top-level rule. Use
-       placeholder selector that rules.ml replaces with actual class. *)
+       placeholder selector that rule.ml replaces with actual class. *)
     let supports_block =
       Css.supports ~condition:color_mix_supports_condition
         [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -76,7 +76,7 @@ module Handler = struct
     let open Css in
     (* Use top-level media queries to match Tailwind's minified output.
        Container media queries should come AFTER the base .container rule.
-       rules.ml handles this ordering since container has only media rules and
+       sort.ml handles this ordering since container has only media rules and
        base props. *)
     let container_selector = Selector.class_ "container" in
     let spelling length = Css.Pp.to_string Css.pp_length length in

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -2,7 +2,7 @@ module Css = Cascade.Css
 (* Typed CSS custom properties (variables) - Simplified API
 
    This module provides the core extensible variable system for CSS custom
-   properties following the simplified design from todo/vars.md *)
+   properties following the simplified design documented in var.mli *)
 
 (* Layer classification for CSS variables *)
 type layer = Theme | Utility
@@ -147,7 +147,7 @@ module Registry = struct
     | None -> false
 end
 
-(* Get property order for a variable name (for external use in rules.ml) *)
+(* Get property order for a variable name (for external use in build.ml) *)
 let property_order = Registry.property_order
 let register_property_order = Registry.register_property_order
 let order = Registry.order

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -453,7 +453,7 @@ val property_default :
     initial value may be generated, breaking the CSS output.
 
     TODO: Fix this architecture limitation to automatically include property
-    rules for property_default variables in rules.ml without requiring explicit
+    rules for property_default variables in build.ml without requiring explicit
     inclusion. *)
 
 val channel :


### PR DESCRIPTION
Seven comments named paths that do not exist: `rules.ml` and `rules.mli` were split into Output, Rule, Sort and Build, and `todo/vars.md` was never committed. Each reference now names the module that does the work today, verified per site rather than substituted: property ordering and property-rule collection are `build.ml`, the `"_"` placeholder selector is resolved in `rule.ml`, container media ordering is `sort.ml`, and the variable design is documented in `var.mli`.

`dune build @runtest` could not be run: main is red because cascade main dropped APIs tw still uses, which is being fixed on `cascade-main-catchup`. The change is comment-only, `ocamlformat` runs with `comment-check = true`, merlint is clean on the four files, and the build error set is identical to the base branch.

Stacked on #362.