### PR TITLE
tools: quote the temp directory in the tailwindcss command

### DIFF
--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -286,7 +286,7 @@ let generate ?(minify = false) ?(optimize = true) ?forms ?input_css classnames =
       Fmt.str
         "cd %s && %s -i input.css -o output.css --content input.html%s%s \
          2>/dev/null"
-        dir tailwind_cmd minify_flag optimize_flag
+        (Filename.quote dir) tailwind_cmd minify_flag optimize_flag
     in
 
     let exit_code = Sys.command cmd in


### PR DESCRIPTION
The generation directory is interpolated into the shell command unquoted, while the cleanup call beside it quotes the same value. The name is generated so nothing breaks today, but the command should not rely on that.

This branch was also to move `lib/tools` out from under `lib/`, since it uses Fmt against the no-Fmt-under-lib rule. That is dropped: merlint E912 rejects a new top-level `dev-tools/` ("lib/ for libraries"), and `tw_tools` is linked into the public `tw` executable via `bin/dune`, so it is neither dev-only nor test-only and `test/` is wrong for it too. `lib/tools/merlint.toml` already records the Fmt exemption for the one file that needs it.

`tw_tools` depends only on `fmt`, `unix` and `uutf`, so `dune build @@lib/tools/check` passes despite main being red on the cascade catch-up; merlint is clean on the file. Stacked on #363.