### PR TITLE
tw: follow cascade's current main

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -49,43 +49,19 @@ type color =
   | Css of Css.color
   | Theme_named of string
 
+(* The colour-space primitives are cascade's, so a value tw converts one way and
+   cascade serialises back the other survives the round trip. tw used to carry
+   its own copies, and its forward matrix went straight to LMS while its inverse
+   went via XYZ: the two were not exact inverses, and [#0088cc] came back as
+   [#0288cc]. *)
 let linearize_channel c =
-  let c' = float_of_int c /. 255.0 in
-  if c' <= 0.04045 then c' /. 12.92 else ((c' +. 0.055) /. 1.055) ** 2.4
+  Cascade.Color_space.linear_of_srgb (float_of_int c /. 255.0)
 
 let gamma_correct c =
-  let c' =
-    if c <= 0.0031308 then c *. 12.92
-    else (1.055 *. (c ** (1.0 /. 2.4))) -. 0.055
-  in
-  int_of_float ((c' *. 255.0) +. 0.5)
-
-let cbrt_signed x =
-  if x < 0.0 then -.(-.x ** (1.0 /. 3.0)) else x ** (1.0 /. 3.0)
+  int_of_float ((Cascade.Color_space.srgb_of_linear c *. 255.0) +. 0.5)
 
 let linear_rgb_to_oklab r_lin g_lin b_lin =
-  let l =
-    (0.4122214708 *. r_lin) +. (0.5363325363 *. g_lin) +. (0.0514459929 *. b_lin)
-  in
-  let m =
-    (0.2119034982 *. r_lin) +. (0.6806995451 *. g_lin) +. (0.1073969566 *. b_lin)
-  in
-  let s =
-    (0.0883024619 *. r_lin) +. (0.2817188376 *. g_lin) +. (0.6299787005 *. b_lin)
-  in
-  let l' = cbrt_signed l in
-  let m' = cbrt_signed m in
-  let s' = cbrt_signed s in
-  let ok_l =
-    (0.2104542553 *. l') +. (0.7936177850 *. m') -. (0.0040720468 *. s')
-  in
-  let ok_a =
-    (1.9779984951 *. l') -. (2.4285922050 *. m') +. (0.4505937099 *. s')
-  in
-  let ok_b =
-    (0.0259040371 *. l') +. (0.7827717662 *. m') -. (0.8086757660 *. s')
-  in
-  (ok_l, ok_a, ok_b)
+  Cascade.Color_space.oklab_of_linear_srgb (r_lin, g_lin, b_lin)
 
 let rgb_to_oklch rgb =
   let r_lin = linearize_channel rgb.r in
@@ -110,91 +86,12 @@ let rgb_to_oklab rgb =
   let ok_l, ok_a, ok_b = linear_rgb_to_oklab r_lin g_lin b_lin in
   (ok_l *. 100.0, ok_a, ok_b)
 
-(* Convert OKLab to linear sRGB via XYZ intermediate, matching the CSS Color
-   Level 4 / lightningcss conversion path. *)
 let oklab_to_linear_srgb ok_l ok_a ok_b =
-  (* OKLab to LMS (cube root space) *)
-  let l' = ok_l +. (0.3963377774 *. ok_a) +. (0.2158037573 *. ok_b) in
-  let m' = ok_l -. (0.1055613458 *. ok_a) -. (0.0638541728 *. ok_b) in
-  let s' = ok_l -. (0.0894841775 *. ok_a) -. (1.2914855480 *. ok_b) in
-  (* Cube to get LMS *)
-  let l = l' *. l' *. l' in
-  let m = m' *. m' *. m' in
-  let s = s' *. s' *. s' in
-  (* LMS to XYZ (D65) *)
-  let x =
-    (1.2268798733741557 *. l) -. (0.5578149965554813 *. m)
-    +. (0.28139105017721583 *. s)
-  in
-  let y =
-    (-0.04057576262431372 *. l)
-    +. (1.1122868293970594 *. m) -. (0.07171106666151701 *. s)
-  in
-  let z =
-    (-0.07637294974672142 *. l)
-    -. (0.4214933239627914 *. m) +. (1.5869240244272418 *. s)
-  in
-  (* XYZ to linear sRGB *)
-  let r_lin =
-    (3.2409699419045226 *. x) -. (1.5373831775700939 *. y)
-    -. (0.4986107602930034 *. z)
-  in
-  let g_lin =
-    (-0.9692436362808796 *. x) +. (1.8759675015077202 *. y)
-    +. (0.04155505740717559 *. z)
-  in
-  let b_lin =
-    (0.05563007969699366 *. x) -. (0.20397696064091520 *. y)
-    +. (1.0569715142428786 *. z)
-  in
-  (r_lin, g_lin, b_lin)
+  Cascade.Color_space.linear_srgb_of_oklab (ok_l, ok_a, ok_b)
 
-(* Convert linear sRGB to OKLab via XYZ intermediate *)
 let linear_srgb_to_oklab r_lin g_lin b_lin =
-  (* linear sRGB to XYZ *)
-  let x =
-    (0.4123907992659595 *. r_lin)
-    +. (0.357584339383878 *. g_lin)
-    +. (0.1804807884018343 *. b_lin)
-  in
-  let y =
-    (0.21263900587151027 *. r_lin)
-    +. (0.715168678767756 *. g_lin)
-    +. (0.07219231536073371 *. b_lin)
-  in
-  let z =
-    (0.01933081871559182 *. r_lin)
-    +. (0.11919477979462598 *. g_lin)
-    +. (0.9505321522496607 *. b_lin)
-  in
-  (* XYZ to LMS *)
-  let l = (0.8189330101 *. x) +. (0.3618667424 *. y) -. (0.1288597137 *. z) in
-  let m = (0.0329845436 *. x) +. (0.9293118715 *. y) +. (0.0361456387 *. z) in
-  let s = (0.0482003018 *. x) +. (0.2643662691 *. y) +. (0.6338517070 *. z) in
-  (* Cube root *)
-  let cbrt x =
-    if x < 0.0 then -.(Float.abs x ** (1.0 /. 3.0))
-    else if x = 0.0 then 0.0
-    else x ** (1.0 /. 3.0)
-  in
-  let l' = cbrt l in
-  let m' = cbrt m in
-  let s' = cbrt s in
-  (* LMS' to OKLab *)
-  let ok_l =
-    (0.2104542553 *. l') +. (0.7936177850 *. m') -. (0.0040720468 *. s')
-  in
-  let ok_a =
-    (1.9779984951 *. l') -. (2.4285922050 *. m') +. (0.4505937099 *. s')
-  in
-  let ok_b =
-    (0.0259040371 *. l') +. (0.7827717662 *. m') -. (0.8086757660 *. s')
-  in
-  (ok_l, ok_a, ok_b)
+  Cascade.Color_space.oklab_of_linear_srgb (r_lin, g_lin, b_lin)
 
-(* CSS Color Level 4 gamut mapping algorithm, matching lightningcss. Uses binary
-   search on OKLCh chroma to find the closest in-gamut sRGB color. Reference:
-   https://www.w3.org/TR/css-color-4/#css-gamut-mapping *)
 let clip_val x = Float.max 0.0 (Float.min 1.0 x)
 let clip (r, g, b) = (clip_val r, clip_val g, clip_val b)
 

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -826,14 +826,19 @@ module Handler = struct
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
-    let with_alpha =
+    (* Tailwind writes the plain fallback as a hex carrying the alpha byte and
+       keeps the oklab spelling for the [color-mix] the [@supports] block
+       guards, so the two are built separately. Folding the fallback through
+       oklab as well made it depend on a colour-space round trip. *)
+    let base_value, with_alpha =
       match c with
       | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
           let hex = "#" ^ rgba_hex_string r g b a in
-          Color.hex_to_oklab_alpha hex alpha
-      | _ -> c
+          ( Css.hex (Color.hex_with_alpha hex percent),
+            Color.hex_to_oklab_alpha hex alpha )
+      | _ -> (c, c)
     in
-    let base_decl, _ = Var.binding shadow_color_var with_alpha in
+    let base_decl, _ = Var.binding shadow_color_var base_value in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab ~var_name:"tw-shadow-alpha"
         with_alpha Css.Transparent
@@ -1436,14 +1441,17 @@ module Handler = struct
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
-    let with_alpha =
+    (* As for the outer shadow: the plain fallback is a hex carrying the alpha
+       byte, and the oklab spelling is kept for the guarded [color-mix]. *)
+    let base_value, with_alpha =
       match c with
       | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
           let hex = "#" ^ rgba_hex_string r g b a in
-          Color.hex_to_oklab_alpha hex alpha
-      | _ -> c
+          ( Css.hex (Color.hex_with_alpha hex percent),
+            Color.hex_to_oklab_alpha hex alpha )
+      | _ -> (c, c)
     in
-    let base_decl, _ = Var.binding inset_shadow_color_var with_alpha in
+    let base_decl, _ = Var.binding inset_shadow_color_var base_value in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab
         ~var_name:"tw-inset-shadow-alpha" with_alpha Css.Transparent

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -83,10 +83,14 @@ module Rules_selector = struct
           (List.map (replace_class_with ~old_class ~replacement) selectors)
     | Css.Selector.Cue selectors ->
         Css.Selector.Cue
-          (List.map (replace_class_with ~old_class ~replacement) selectors)
+          (Option.map
+             (List.map (replace_class_with ~old_class ~replacement))
+             selectors)
     | Css.Selector.Cue_region selectors ->
         Css.Selector.Cue_region
-          (List.map (replace_class_with ~old_class ~replacement) selectors)
+          (Option.map
+             (List.map (replace_class_with ~old_class ~replacement))
+             selectors)
     | Css.Selector.Nth_child (nth, of_) ->
         Css.Selector.Nth_child
           ( nth,

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -581,12 +581,14 @@ let is_outline_utility bc =
       | _ :: _, base -> String.starts_with ~prefix:"outline" base)
   | None -> false
 
+let is_digit c = c >= '0' && c <= '9'
+
 (* Natural sort comparison: treats consecutive digit sequences as integers.
    E.g., "2.5" < "2.25" because 5 < 25 when compared as numbers. This matches
    Tailwind v4's selector ordering for opacity modifiers like /2.5 vs /2.25. *)
 let natural_extract_number s i =
   let rec go j acc =
-    if j >= String.length s || not (Cascade.Reader.is_digit s.[j]) then (acc, j)
+    if j >= String.length s || not (is_digit s.[j]) then (acc, j)
     else go (j + 1) ((acc * 10) + Char.code s.[j] - Char.code '0')
   in
   go i 0
@@ -621,7 +623,7 @@ let natural_compare s1 s2 =
     | `Greater -> 1
     | `Continue ->
         let c1 = s1.[i1] and c2 = s2.[i2] in
-        if Cascade.Reader.is_digit c1 && Cascade.Reader.is_digit c2 then
+        if is_digit c1 && is_digit c2 then
           let n1, end1 = natural_extract_number s1 i1 in
           let n2, end2 = natural_extract_number s2 i2 in
           let num_cmp = Int.compare n1 n2 in

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -207,13 +207,14 @@ module Handler = struct
     | Stroke_bracket_typed_var_opacity (v, opacity) ->
         bracket_var_opacity_style ~property:Css.stroke ~merge_key:"stroke-" v
           opacity
-    | Stroke_0 -> style Css.[ stroke_width (Px 0.) ]
-    | Stroke_1 -> style Css.[ stroke_width (Px 1.) ]
-    | Stroke_2 -> style Css.[ stroke_width (Px 2.) ]
-    | Stroke_width n -> style Css.[ stroke_width (Px (float_of_int n)) ]
+    | Stroke_0 -> style Css.[ stroke_width (Length (Length (Px 0.))) ]
+    | Stroke_1 -> style Css.[ stroke_width (Length (Length (Px 1.))) ]
+    | Stroke_2 -> style Css.[ stroke_width (Length (Length (Px 2.))) ]
+    | Stroke_width n ->
+        style Css.[ stroke_width (Length (Length (Px (float_of_int n)))) ]
     | Stroke_width_bracket inner ->
         let w = parse_bracket_width inner in
-        style [ Css.stroke_width w ]
+        style [ Css.stroke_width (Length (Length w)) ]
     | Stroke_width_typed_var inner ->
         let var_part =
           match String.index_opt inner ':' with

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -323,10 +323,14 @@ let property_universal : type a.
   | None -> property ~name Universal ~inherits ()
   | Some v -> (
       match (kind, v) with
-      | Gradient_stop, List [] -> property ~name Universal ~inherits ()
-      | Percentage, Pct 0. -> property ~name Universal ~inherits ()
-      | Gradient_direction, To_bottom -> property ~name Universal ~inherits ()
-      | Gradient_position, Linear_position To_bottom ->
+      | Gradient_stop, (List [] : Css.gradient_stop) ->
+          property ~name Universal ~inherits ()
+      | Percentage, (Pct 0. : Css.percentage) ->
+          property ~name Universal ~inherits ()
+      | Gradient_direction, (To_bottom : Css.gradient_direction) ->
+          property ~name Universal ~inherits ()
+      | Gradient_position, (Linear_position To_bottom : Css.gradient_position)
+        ->
           property ~name Universal ~inherits ()
       | _ ->
           let initial_str = string_of_kind_value kind v in
@@ -347,7 +351,8 @@ let property_typed : type a.
   | Percentage, None -> property ~name Length_percentage ~inherits ()
   | Percentage, Some v ->
       property ~name Length_percentage
-        ~initial_value:(Pct (match v with Pct f -> f | _ -> 0.0))
+        ~initial_value:
+          (Pct (match (v : Css.percentage) with Pct f -> f | _ -> 0.0))
         ~inherits ()
   | Length_percentage, None -> property ~name Length_percentage ~inherits ()
   | Length_percentage, Some v ->
@@ -357,7 +362,8 @@ let property_typed : type a.
       let initial_str = string_of_kind_value kind v in
       property ~name Universal ~initial_value:initial_str ~inherits ()
   | Gradient_stop, None -> property ~name Universal ~inherits ()
-  | Gradient_stop, Some (List []) -> property ~name Universal ~inherits ()
+  | Gradient_stop, Some (List [] : Css.gradient_stop) ->
+      property ~name Universal ~inherits ()
   | Gradient_stop, Some v ->
       property ~name Universal
         ~initial_value:(string_of_kind_value kind v)

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -323,10 +323,9 @@ let property_universal : type a.
   | None -> property ~name Universal ~inherits ()
   | Some v -> (
       match (kind, v) with
-      | Gradient_stop, List []
-      | Percentage, Pct 0.
-      | Gradient_direction, To_bottom ->
-          property ~name Universal ~inherits ()
+      | Gradient_stop, List [] -> property ~name Universal ~inherits ()
+      | Percentage, Pct 0. -> property ~name Universal ~inherits ()
+      | Gradient_direction, To_bottom -> property ~name Universal ~inherits ()
       | Gradient_position, Linear_position To_bottom ->
           property ~name Universal ~inherits ()
       | _ ->

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -205,11 +205,13 @@ let properties_kind_of_kind : type a. a Css.kind -> a Css.Properties.kind =
   | Rotate -> Css.Properties.Rotate
   | Scale -> Css.Properties.Scale
   | Shadow -> Css.Properties.Shadow
-  | Box_shadow -> Css.Properties.Box_shadow
   | Content -> Css.Properties.Content
   | Gradient_stop -> Css.Properties.Gradient_stop
   | Gradient_direction -> Css.Properties.Gradient_direction
   | Gradient_position -> Css.Properties.Gradient_position
+  | Radial_shape -> Css.Properties.Radial_shape
+  | Radial_size -> Css.Properties.Radial_size
+  | Position_value -> Css.Properties.Position_value
   | Animation -> Css.Properties.Animation
   | Timing_function -> Css.Properties.Timing_function
   | Transform -> Css.Properties.Transform

--- a/test/test_clipping.ml
+++ b/test/test_clipping.ml
@@ -6,7 +6,7 @@ let test_clip_polygon () =
   let tri = Tw.clip_polygon [ (50., 0.); (0., 100.); (100., 100.) ] in
   check string "clip class" "clip-[polygon(50% 0%, 0% 100%, 100% 100%)]"
     (Tw.pp tri);
-  let css = to_css [ tri ] |> Css.pp ~minify:false in
+  let css = to_css [ tri ] |> Css.to_string ~minify:false in
   check bool "has clip-path property" true
     (Astring.String.is_infix ~affix:"clip-path:" css);
   (* Polygon points preserve percentage units and the API keeps compact

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -507,7 +507,7 @@ let test_achromatic_none_hue () =
 let test_v433_color_families () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   let has cls affix =
@@ -527,7 +527,7 @@ let test_v433_color_families () =
 let test_full_opacity_and_important () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   let has cls affix =

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -53,7 +53,7 @@ let test_drop_shadow_color () =
 let test_drop_shadow_opacity_keeps_both_layers () =
   let css =
     match Tw.of_string "drop-shadow/50" with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "drop-shadow/50: %s" m
   in
   let has affix = Astring.String.is_infix ~affix css in
@@ -68,7 +68,7 @@ let test_drop_shadow_opacity_keeps_both_layers () =
 let test_drop_shadow_fractional_alpha () =
   let css =
     match Tw.of_string "drop-shadow/12.5" with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "drop-shadow/12.5: %s" m
   in
   Alcotest.(check bool)
@@ -134,7 +134,9 @@ let suborder_matches_tailwind () =
 (* backdrop-blur-N must reference the unified v4 --blur-N token (not the dropped
    --backdrop-blur-N) and emit the shipped --blur-N decl. *)
 let test_backdrop_blur_token () =
-  let css = Tw.to_css [ Tw.backdrop_blur_sm ] |> Tw.Css.pp ~minify:true in
+  let css =
+    Tw.to_css [ Tw.backdrop_blur_sm ] |> Tw.Css.to_string ~minify:true
+  in
   Alcotest.(check bool)
     "references var(--blur-sm)" true
     (Astring.String.is_infix ~affix:"var(--blur-sm)" css);

--- a/test/test_gap.ml
+++ b/test/test_gap.ml
@@ -100,7 +100,7 @@ let test_space_px_values () =
     generate calc(var(--spacing)*64), not calc(var(--spacing)*16) *)
 let test_css_values () =
   let open Tw in
-  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.pp ~minify:true in
+  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.to_string ~minify:true in
   (* gap-64 => calc(var(--spacing)*64) *)
   Alcotest.check bool "gap-64 uses spacing*64" true
     (Astring.String.is_infix ~affix:"*64)" (css_for (gap 64)));

--- a/test/test_margin.ml
+++ b/test/test_margin.ml
@@ -133,7 +133,7 @@ let rendering_matches_tailwind () =
     generate calc(var(--spacing)*64), not calc(var(--spacing)*16) *)
 let test_css_values () =
   let open Tw in
-  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.pp ~minify:true in
+  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.to_string ~minify:true in
   (* m-64 => calc(var(--spacing)*64) *)
   Alcotest.check bool "m-64 uses spacing*64" true
     (Astring.String.is_infix ~affix:"*64)" (css_for (m 64)));

--- a/test/test_mask_gradient.ml
+++ b/test/test_mask_gradient.ml
@@ -28,7 +28,7 @@ let test_invalid () =
 let test_from_zero_keeps_unit () =
   let css =
     match Tw.of_string "mask-t-from-0" with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "mask-t-from-0: %s" m
   in
   Alcotest.(check bool)
@@ -41,7 +41,7 @@ let test_from_zero_keeps_unit () =
 let test_stop_colors () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   let has cls affix =
@@ -63,7 +63,7 @@ let test_stop_colors () =
 
 let pretty cls =
   match Tw.of_string cls with
-  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:false
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:false
   | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
 
 let has cls affix =

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -49,7 +49,7 @@ let test_typed () =
 let test_bracket_image () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   Alcotest.(check bool)
@@ -66,7 +66,7 @@ let test_bracket_image () =
 let test_bracket_layer_list () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   Alcotest.(check bool)
@@ -96,7 +96,7 @@ let test_invalid_bracket_value () =
 let test_bracket_position_grammar () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   let has cls affix =

--- a/test/test_padding.ml
+++ b/test/test_padding.ml
@@ -56,7 +56,7 @@ let suborder_matches_tailwind () =
     generate calc(var(--spacing)*64), not calc(var(--spacing)*16) *)
 let test_css_values () =
   let open Tw in
-  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.pp ~minify:true in
+  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.to_string ~minify:true in
   (* p-64 => calc(var(--spacing)*64) *)
   Alcotest.check bool "p-64 uses spacing*64" true
     (Astring.String.is_infix ~affix:"*64)" (css_for (p 64)));

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -167,7 +167,7 @@ let test_aspect_classes () =
 
 let test_aspect_css () =
   let open Tw in
-  let css = to_css [ aspect_ratio 16 9 ] |> Css.pp ~minify:true in
+  let css = to_css [ aspect_ratio 16 9 ] |> Css.to_string ~minify:true in
   Alcotest.check bool "has aspect-ratio" true
     (Astring.String.is_infix ~affix:"aspect-ratio" css);
   Alcotest.check bool "has 16/9" true
@@ -211,7 +211,7 @@ let test_logical_size_fractions () =
    var(--aspect-square) with a stray --aspect-square theme token that bare
    Tailwind does not define. *)
 let test_aspect_square_inlined () =
-  let css = Tw.(to_css [ aspect_square ]) |> Tw.Css.pp ~minify:true in
+  let css = Tw.(to_css [ aspect_square ]) |> Tw.Css.to_string ~minify:true in
   Alcotest.check bool "aspect-square inlines the ratio" true
     (Astring.String.is_infix ~affix:"aspect-ratio:1" css);
   Alcotest.check bool "aspect-square references no var" false
@@ -238,7 +238,7 @@ let test_class_generation () =
   (* Verify CSS values are correct. These use calc(var(--spacing)*N) format
      where N is the class number (NOT the rem value). Tailwind v4: w-64 =>
      calc(var(--spacing)*64), h-10 => calc(var(--spacing)*10) *)
-  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.pp ~minify:true in
+  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.to_string ~minify:true in
   (* w-64 => calc(var(--spacing)*64) *)
   Alcotest.check bool "w-64 uses spacing*64" true
     (Astring.String.is_infix ~affix:"*64)" (css_for (w 64)));

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -251,7 +251,7 @@ let test_named_font_family () =
   let css theme cls =
     match Tw.of_string ~theme cls with
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-    | Ok u -> Tw.Css.pp ~minify:true (Tw.to_css ~base:false ~theme [ u ])
+    | Ok u -> Tw.Css.to_string ~minify:true (Tw.to_css ~base:false ~theme [ u ])
   in
   let themed =
     Tw.Scheme.with_overrides Tw.Scheme.default
@@ -446,7 +446,7 @@ let rendering_matches_tailwind () =
 
 (* tracking-normal's token must keep the em unit (0em), not collapse to 0. *)
 let test_tracking_normal_unit () =
-  let css = Tw.to_css [ Tw.tracking_normal ] |> Tw.Css.pp ~minify:true in
+  let css = Tw.to_css [ Tw.tracking_normal ] |> Tw.Css.to_string ~minify:true in
   Alcotest.check bool "tracking-normal token keeps em unit" true
     (Astring.String.is_infix ~affix:"--tracking-normal:0em" css)
 
@@ -509,7 +509,7 @@ let test_text_line_height_override () =
 let test_text_bracket_functions () =
   let css cls =
     match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.pp ~minify:true
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   Alcotest.(check bool)

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -502,6 +502,28 @@ let color_mix_to_oklab s =
                   Fmt.str "oklab(%.6f%% %.6f %.6f / %.6f)" (l *. 100.) a b alpha
               | _ -> whole)))
 
+(* Tailwind writes the [color-mix] fallback percentage as a bare number:
+   [color-mix(in srgb, red .5, transparent)]. CSS Color 5 sec. 3.1 admits only a
+   [<percentage>] there, so a browser drops that declaration and cascade's
+   reader refuses it, which takes the whole declaration off the expected side
+   and reports tw's own (valid) [50%] as an addition. The two spell one value,
+   so the fixture's spelling is normalised to the percentage before either side
+   is parsed. Only a bare number directly before the closing paren or a comma
+   inside [color-mix(...)] is touched. *)
+let color_mix_percentage =
+  let mix = Re.Pcre.regexp {|\bcolor-mix\(([^()]*)\)|} in
+  let bare = Re.Pcre.regexp {|( )(\.\d+|0?\.\d+)(\s*[,)]|\s*$)|} in
+  fun s ->
+    Re.replace mix s ~f:(fun g ->
+        let args = Re.Group.get g 1 in
+        let args =
+          Re.replace bare args ~f:(fun d ->
+              let n = float_of_string (Re.Group.get d 2) in
+              Fmt.str "%s%g%%%s" (Re.Group.get d 1) (n *. 100.)
+                (Re.Group.get d 3))
+        in
+        "color-mix(" ^ args ^ ")")
+
 (* Reduce the precision of [oklab]/[oklch]/[lab]/[lch] coefficients to three
    decimals, mirroring Tailwind's own snapshot serialiser
    ([test-utils/custom-serializer.ts]): it truncates those axes because
@@ -903,7 +925,7 @@ let run_test_case test () =
     if our_css = "" && expected = "" then ()
     else
       let normalize_colors s =
-        truncate_color_precision (color_mix_to_oklab s)
+        truncate_color_precision (color_mix_to_oklab (color_mix_percentage s))
       in
       let result =
         Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
@@ -944,6 +966,25 @@ let run_test_case test () =
           (Fmt.str "CSS mismatch for: %s\n\n%s\n\nExpected:\n%s\n\nGot:\n%s%s"
              (String.concat " " test.classes)
              (Buffer.contents buf) expected got rejected_note)
+
+(* Guards [color_mix_percentage]: the bare-number mixing percentage Tailwind
+   writes in its [color-mix] fallback becomes the percentage CSS Color 5 sec.
+   3.1 requires, and nothing else in the function is touched. *)
+let test_color_mix_percentage () =
+  let check msg expected input =
+    Alcotest.(check string) msg expected (color_mix_percentage input)
+  in
+  check "bare fraction becomes a percentage"
+    "color-mix(in srgb, red 50%, transparent)"
+    "color-mix(in srgb, red .5, transparent)";
+  check "a percentage is left alone" "color-mix(in srgb, red 50%, transparent)"
+    "color-mix(in srgb, red 50%, transparent)";
+  (* The [var()] fallback spelling carries its own bare number and is a value,
+     not a mixing percentage, so it stays as written. *)
+  check "var fallback untouched"
+    "color-mix(in oklab, red var(--opacity-half, .5), transparent)"
+    "color-mix(in oklab, red var(--opacity-half, .5), transparent)";
+  check "text outside color-mix untouched" "opacity: .5" "opacity: .5"
 
 (* Guards [truncate_color_precision]: it truncates (never rounds) the
    oklab-family axes to three decimals like Tailwind's snapshot serialiser, so
@@ -1045,6 +1086,7 @@ let () =
   let tolerance_cases =
     [
       test_case "oklab precision truncation" `Quick test_color_tolerance;
+      test_case "color-mix percentage" `Quick test_color_mix_percentage;
       test_case "canonical tolerance rejects layer order" `Quick
         test_layer_order_not_tolerated;
       test_case "the theme echo is limited to declared tokens" `Quick


### PR DESCRIPTION
cascade's public API moved and tw stopped compiling, then stopped matching four upstream fixtures. This is the bottom of the stack, so everything above it inherits the fix.

- `tw`: follow cascade's current public API.
- `svg`: cascade now models `stroke-width` as `Number | Length of length_percentage | ...` rather than a bare length, per SVG 2 sec. 13.3.
- `color`: tw's private CSS Color 4 stack goes, in favour of `Cascade.Color_space`. tw converted sRGB to OKLab with a direct LMS matrix and back via XYZ, so the two were not inverses and `#0088cc` came back as `#0288cc`.
- `effects`: the shadow and inset-shadow colour fallbacks are written as a hex carrying the alpha byte, which is what Tailwind emits; the oklab spelling stays inside the `@supports` guarded `color-mix`.
- `test`: Tailwind writes the `color-mix` fallback percentage as a bare number (`red .5`), which CSS Color 5 sec. 3.1 does not admit, so cascade's reader refuses it and the declaration left the expected side. The harness normalises that spelling on both sides, as it already does for oklab precision. tw's `50%` is the valid one.