### PR TITLE
backgrounds: read a gradient stop position as a length-percentage

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -80,7 +80,12 @@ module Handler = struct
   end
 
   (* Gradient position source *)
-  type gradient_position_source = Percent of float | Bracket of string
+  (* A bracket stop position carries the author's text alongside the value it
+     denotes, so the class name is spelled exactly as it was written. *)
+  type gradient_position_source =
+    | Percent of float
+    | Bracket of string * Css.length_percentage
+
   type gradient_target = From | Via | To
 
   type t =
@@ -280,7 +285,7 @@ module Handler = struct
               else string_of_float p
             in
             prefix ^ p_str ^ "%"
-        | Bracket v -> prefix ^ "[" ^ v ^ "]")
+        | Bracket (spelling, _) -> prefix ^ "[" ^ spelling ^ "]")
     | Bg_origin_border -> "bg-origin-border"
     | Bg_origin_padding -> "bg-origin-padding"
     | Bg_origin_content -> "bg-origin-content"
@@ -1315,34 +1320,34 @@ module Handler = struct
     let d_var, _ = Var.binding pos_var value in
     style ~property_rules:(gradient_position_property_rules ()) [ d_var ]
 
-  (* Parse bracket inner to a length_percentage value *)
-  let parse_bracket_position_value (inner : string) : Css.length_percentage =
-    if String.ends_with ~suffix:"%" inner then
-      let num_s = String.sub inner 0 (String.length inner - 1) in
-      match float_of_string_opt num_s with
-      | Some p -> Pct p
-      | None -> Pct 0. (* fallback *)
-    else if String.ends_with ~suffix:"px" inner then
-      let num_s = String.sub inner 0 (String.length inner - 2) in
-      match float_of_string_opt num_s with
-      | Some p -> Length (Px p)
-      | None -> Pct 0. (* fallback *)
-    else if Parse.is_var inner then
+  (* The one reader for a bracket stop position, used both to decide that a
+     bracket is a position and to convert it, so the two cannot disagree. A stop
+     takes a [<length-percentage>]; Tailwind reads any other bracket - a
+     keyword, a unitless number, the docs' [<value>] placeholder - as a colour,
+     and a colour spelled that way has no typed rendering here, so it is
+     refused. *)
+  let parse_bracket_position_value (inner : string) :
+      Css.length_percentage option =
+    let typed_var prefix =
+      let n = String.length prefix in
+      if String.length inner > n && String.sub inner 0 n = prefix then
+        let var_str = String.sub inner n (String.length inner - n) in
+        let bare = Parse.extract_var_name var_str in
+        let vr : Css.length_percentage Css.var = Var.bracket bare in
+        Some (Css.Var vr : Css.length_percentage)
+      else None
+    in
+    if Parse.is_var inner then
       let bare = Parse.extract_var_name inner in
       let vr : Css.length_percentage Css.var = Var.bracket bare in
-      Var vr
-    else if String.length inner > 11 && String.sub inner 0 11 = "percentage:"
-    then
-      let var_str = String.sub inner 11 (String.length inner - 11) in
-      let bare = Parse.extract_var_name var_str in
-      let vr : Css.length_percentage Css.var = Var.bracket bare in
-      Var vr
-    else if String.length inner > 7 && String.sub inner 0 7 = "length:" then
-      let var_str = String.sub inner 7 (String.length inner - 7) in
-      let bare = Parse.extract_var_name var_str in
-      let vr : Css.length_percentage Css.var = Var.bracket bare in
-      Var vr
-    else Pct 0. (* fallback *)
+      Some (Css.Var vr : Css.length_percentage)
+    else
+      match typed_var "percentage:" with
+      | Some v -> Some v
+      | None -> (
+          match typed_var "length:" with
+          | Some v -> Some v
+          | None -> Parse.arbitrary_length_percentage inner)
 
   (** Convert a var string to a typed CSS color value *)
   let color_var_ref v : Css.color =
@@ -1415,8 +1420,7 @@ module Handler = struct
         let _prefix, _set_var, pos_var = gradient_target_info target in
         match src with
         | Percent p -> gradient_position_style pos_var (Pct p)
-        | Bracket v ->
-            gradient_position_style pos_var (parse_bracket_position_value v))
+        | Bracket (_, value) -> gradient_position_style pos_var value)
     | Via_none ->
         let property_rules =
           match Var.property_rule gradient_via_stops_var with
@@ -1553,21 +1557,6 @@ module Handler = struct
         (String.sub s 0 i, Some (String.sub s (i + 1) (String.length s - i - 1)))
     | None -> (s, None)
 
-  (* A gradient stop bracket that is not a colour is a stop position: a
-     percentage, a length, or a var(). Anything else - the docs' [<value>]
-     placeholder included - is neither, and used to land as [0%]. *)
-
-  (** Parse gradient color/position from token list for a given target *)
-  let is_gradient_position inner =
-    Parse.is_var inner
-    || (String.length inner > 11 && String.sub inner 0 11 = "percentage:")
-    || (String.length inner > 7 && String.sub inner 0 7 = "length:")
-    ||
-    let n = String.length inner in
-    String.ends_with ~suffix:"%" inner
-    && float_of_string_opt (String.sub inner 0 (n - 1)) <> None
-    || Css.parse_length inner <> None
-
   (* A [#] stop only names a colour when what follows is a hex spelling. The
      stop keeps the text after the [#] and hands it to the raising [Css.hex]
      when the sheet is rendered, so the parser has to decide here. *)
@@ -1599,7 +1588,7 @@ module Handler = struct
           Color.parse_opacity_modifier ?theme bracket_opacity
         in
         match opacity_opt with
-        | Color.No_opacity when Parse.is_bracket_value bracket_opacity ->
+        | Color.No_opacity when Parse.is_bracket_value bracket_opacity -> (
             (* No valid opacity found — treat as plain bracket *)
             let inner = Parse.bracket_inner bracket_opacity in
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
@@ -1610,8 +1599,10 @@ module Handler = struct
                 (Color_source.Bracket_hex
                    (String.sub inner 1 (String.length inner - 1)))
             else if Parse.is_var inner then gc (Color_source.Bracket_var inner)
-            else if is_gradient_position inner then gp (Bracket inner)
-            else Error (`Msg "Invalid gradient stop value")
+            else
+              match parse_bracket_position_value inner with
+              | Some value -> gp (Bracket (inner, value))
+              | None -> Error (`Msg "Invalid gradient stop value"))
         | Color.No_opacity ->
             Error (`Msg "Invalid gradient bracket with opacity")
         | opacity when Parse.is_bracket_value base ->
@@ -1635,7 +1626,7 @@ module Handler = struct
                 gc (Color_source.Named_opacity (color, shade, opacity))
             | Error e -> Error e))
     (* Bracket notation without opacity *)
-    | [ bracket ] when Parse.is_bracket_value bracket ->
+    | [ bracket ] when Parse.is_bracket_value bracket -> (
         let inner = Parse.bracket_inner bracket in
         if String.length inner > 6 && String.sub inner 0 6 = "color:" then
           let var_str = String.sub inner 6 (String.length inner - 6) in
@@ -1647,8 +1638,10 @@ module Handler = struct
         else if Parse.is_var inner then gc (Color_source.Bracket_var inner)
         else if Color.parse_bracket_color inner <> None then
           gc (Color_source.Bracket_color inner)
-        else if is_gradient_position inner then gp (Bracket inner)
-        else Error (`Msg "Invalid gradient stop value")
+        else
+          match parse_bracket_position_value inner with
+          | Some value -> gp (Bracket (inner, value))
+          | None -> Error (`Msg "Invalid gradient stop value"))
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (
         match Color.shade_and_opacity_of_strings ?theme rest with

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -250,6 +250,41 @@ let decode_arbitrary_value s =
 
 let arbitrary_length s = Cascade.Css.parse_length (decode_arbitrary_value s)
 
+(* [<length-percentage>] is the length grammar minus the keywords the length
+   reader also admits ([auto], [none], [max-content], ...) and minus a unitless
+   number, which only reads as a length because [0] is one. The match is
+   exhaustive so a length constructor cascade adds later has to be classified
+   here rather than passing silently. *)
+let length_percentage_of_length (l : Cascade.Css.length) :
+    Cascade.Css.length_percentage option =
+  match l with
+  | Pct p -> Some (Pct p)
+  | Px _ | Cm _ | Mm _ | Q _ | In _ | Pt _ | Pc _ | Rem _ | Em _ | Ex _ | Cap _
+  | Ic _ | Ric _ | Rlh _ | Vw _ | Vh _ | Vmin _ | Vmax _ | Vi _ | Vb _ | Dvh _
+  | Dvw _ | Dvmin _ | Dvmax _ | Lvh _ | Lvw _ | Lvmin _ | Lvmax _ | Svh _
+  | Svw _ | Svmin _ | Svmax _ | Cqw _ | Cqh _ | Cqi _ | Cqb _ | Cqmin _
+  | Cqmax _ | Ch _ | Lh _ | Dimension _ ->
+      Some (Length l)
+  (* Math functions and references resolve to a length at used-value time. *)
+  | Clamp _ | Min _ | Max _ | Round _ | Mod _ | Rem_fn _ | Hypot _ | Abs _
+  | Sign _ | Env _ | Var _ | Calc _ ->
+      Some (Length l)
+  | Zero -> None
+  (* Keywords, and the functions that stand for an intrinsic size or an anchor
+     position rather than for a length. *)
+  | Size | Auto | None | Normal | Inherit | Initial | Unset | Revert
+  | Revert_layer | Fit_content | Fit_content_arg _ | Content | Contain
+  | Max_content | Min_content | Webkit_max_content | Webkit_min_content
+  | Webkit_fit_content | Moz_max_content | Moz_min_content | Moz_fit_content
+  | From_font | Hairline | Thin | Medium | Thick | Stretch | Minmax _
+  | Calc_size _ | Anchor_size _ | Anchor _ | Attr _ ->
+      None
+
+let arbitrary_length_percentage s =
+  match arbitrary_length s with
+  | Some l -> length_percentage_of_length l
+  | None -> None
+
 (* A CSS identifier, which is what a custom-ident or a property name written in
    an arbitrary value has to be. The docs pages carry [<value>] placeholders
    that are not CSS, and passing one through emits an invalid declaration. *)

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -84,6 +84,13 @@ val arbitrary_length : string -> Cascade.Css.length option
     and [--spacing()] all read; the whole CSS length grammar is accepted, not a
     hand-picked subset of units. Returns [None] when [s] is not a length. *)
 
+val arbitrary_length_percentage : string -> Cascade.Css.length_percentage option
+(** [arbitrary_length_percentage s] reads the inside of an arbitrary value as a
+    CSS [<length-percentage>]. It is {!arbitrary_length} narrowed to the values
+    that spelling admits: the keywords the length reader also accepts ([auto],
+    [none], [max-content], ...) and a unitless number are [None], because
+    neither is a length-percentage. *)
+
 val is_ident : string -> bool
 (** [is_ident s] is [true] when [s] is a CSS identifier, as a custom-ident or a
     property name written in an arbitrary value has to be. *)

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -426,8 +426,55 @@ let test_invalid_bracket_hex () =
   emits "via-[#abc]" "--tw-gradient-via:#abc";
   emits "to-[#123456]" "--tw-gradient-to:#123456"
 
+(* A bracket stop position is read with the CSS length-percentage grammar, so a
+   unit the reader does not name is not rendered as a zero position. *)
+let test_gradient_stop_position_units () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "from-[1rem]" "--tw-gradient-from-position:1rem";
+  emits "via-[10vw]" "--tw-gradient-via-position:10vw";
+  emits "to-[2em]" "--tw-gradient-to-position:2em";
+  emits "from-[calc(10%_+_2px)]" "--tw-gradient-from-position:calc(10% + 2px)";
+  (* the spellings the reader already named keep their value *)
+  emits "from-[50%]" "--tw-gradient-from-position:50%";
+  emits "from-[50px]" "--tw-gradient-from-position:50px";
+  emits "from-[length:var(--my-position)]"
+    "--tw-gradient-from-position:var(--my-position)";
+  (* the class name is spelled as it was written *)
+  Alcotest.(check string)
+    "from-[1rem] round-trips" "from-[1rem]"
+    (Tw.pp (Result.get_ok (Tw.of_string "from-[1rem]")))
+
+(* A bracket that is not a length-percentage is not a stop position. Tailwind
+   reads those as a colour, which has no typed spelling here, so the class is
+   refused rather than rendered as a zero position. *)
+let test_gradient_stop_position_not_a_length () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u ->
+        Alcotest.failf "expected %s to be rejected, got %s" cls
+          (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
+    | Error _ -> ()
+  in
+  rejected "from-[fit-content]";
+  rejected "from-[none]";
+  rejected "to-[max-content]";
+  rejected "from-[0]";
+  rejected "from-[1zz]";
+  rejected "via-[12px3]"
+
 let tests =
   [
+    test_case "gradient stop position units" `Quick
+      test_gradient_stop_position_units;
+    test_case "gradient stop position is a length-percentage" `Quick
+      test_gradient_stop_position_not_a_length;
     test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     test_case "bg colors" `Quick test_bg_colors;
     test_case "invalid gradient stop" `Quick test_invalid_gradient_stop;


### PR DESCRIPTION
`from-[1rem]`, `via-[10vw]` and `to-[2em]` emitted a `0%` position because the acceptor took any length while the reader handled only `%`, `px` and `var()`. Acceptor and reader are now one `<length-percentage>` reader, so a keyword or bare-number bracket is refused rather than silently zeroed.