### PR TITLE
color: mix a colour keyword against its opacity modifier

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2539,12 +2539,11 @@ module Handler = struct
         Css.color_mix ~in_space color Css.Transparent
           ~percent1:(opacity_to_percent opacity)
 
-  (* Multiplying a fully transparent colour by another alpha is still fully
-     transparent. Keep that identity explicit: older cascade releases folded
-     [color-mix(transparent N%, transparent)] to an opaque-alpha black. *)
-  let apply_alpha ?(in_space : Css.color_space = Oklab) opacity = function
-    | Css.Transparent -> Css.Transparent
-    | color -> mix_alpha ~in_space opacity color
+  (* A colour keyword takes the modifier's alpha through the same mix as any
+     other colour. At full opacity the mix is a no-op and Tailwind writes the
+     keyword itself. *)
+  let apply_alpha ?(in_space : Css.color_space = Oklab) opacity color =
+    if is_fully_opaque opacity then color else mix_alpha ~in_space opacity color
 
   (** Condition for progressive enhancement with color-mix in oklab *)
   let color_mix_supports_condition =

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -461,6 +461,30 @@ let test_keyword_opacity_families () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "text-shadow-inherit/50 should be rejected"
 
+(* A colour keyword carries its opacity modifier into a mix like any other
+   colour. Only a fully opaque modifier collapses back to the bare keyword. *)
+let test_keyword_opacity_mixes () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "bg-transparent/50"
+    "background-color: color-mix(in oklab, transparent 50%, transparent)";
+  has "text-transparent/25"
+    "color: color-mix(in oklab, transparent 25%, transparent)";
+  has "border-transparent/[0.25]"
+    "border-color: color-mix(in oklab, transparent 25%, transparent)";
+  has "decoration-transparent/50"
+    "text-decoration-color: color-mix(in oklab, transparent 50%, transparent)";
+  has "bg-inherit/50"
+    "background-color: color-mix(in oklab, inherit 50%, transparent)";
+  has "bg-transparent/100" "background-color: transparent";
+  has "border-inherit/100" "border-color: inherit"
+
 (* A palette colour with no shade segment must not absorb one and rename the
    class. Tailwind rejects the candidate instead. *)
 let test_shadeless_colour_rejects_shade_segment () =
@@ -621,6 +645,7 @@ let tests =
     ("Alpha from a var", `Quick, test_alpha_from_a_var);
     ("Invalid shades", `Quick, test_invalid_shade);
     ("Keyword opacity families", `Quick, test_keyword_opacity_families);
+    ("Keyword opacity mixes", `Quick, test_keyword_opacity_mixes);
     ( "Shadeless colour rejects a shade segment",
       `Quick,
       test_shadeless_colour_rejects_shade_segment );


### PR DESCRIPTION
`bg-transparent/50` emitted a bare `transparent` because a short-circuit worked around a cascade fold that no longer exists, so the modifier was silently dropped. Removing it also required moving the fully-opaque check ahead of the keyword branch, since `border-inherit/100` was mixing where Tailwind writes the bare keyword.