### PR TITLE
tw: say what an unrecognised bracket class got wrong

### DIFF
--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -211,6 +211,23 @@ let resolve_theme_functions s =
   done;
   Buffer.contents buf
 
+(* The rejection a class gets once no handler has claimed it. A bracket class
+   that looks like an arbitrary property but that nothing accepted is malformed
+   rather than unsupported: the bracket has no property name or does not end the
+   class, or the modifier after it is not an opacity on a colour. *)
+let unknown_class_error ~base_class class_str =
+  if
+    String.length base_class > 2
+    && base_class.[0] = '['
+    && String.contains base_class ':'
+  then
+    Error
+      (`Msg
+         ("Invalid arbitrary property '" ^ class_str
+        ^ "': expected [property:value], optionally followed by an /opacity \
+           modifier on a colour value (e.g. [color:var(--x)]/50)"))
+  else Error (`Msg ("Unknown class: " ^ class_str))
+
 (* Parse a single class string into a Tw.t *)
 let of_string ?(theme = Scheme.default) class_str =
   let modifiers, base_class = modifiers_of_string class_str in
@@ -258,23 +275,7 @@ let of_string ?(theme = Scheme.default) class_str =
           match Utility.base_of_class theme normalized with
           | Ok base_utility -> finish ~alias:base_class base_utility
           | Error _ -> Error (`Msg ("Unknown class: " ^ class_str)))
-      | None ->
-          (* An arbitrary-property class ([prop:value]) that no handler accepted
-             gets actionable feedback: only colour properties with an /opacity
-             modifier are emitted today. *)
-          if
-            String.length base_class > 2
-            && base_class.[0] = '['
-            && String.contains base_class ':'
-          then
-            Error
-              (`Msg
-                 ("Unsupported arbitrary property '" ^ class_str
-                ^ "': only colour properties with an /opacity modifier are \
-                   emitted (e.g. [color:var(--x)]/50); plain [--name:value] \
-                   declarations and non-colour properties are not yet \
-                   supported"))
-          else Error (`Msg ("Unknown class: " ^ class_str)))
+      | None -> unknown_class_error ~base_class class_str)
 
 let str s =
   let classes = split_whitespace s in

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -1153,6 +1153,34 @@ let unterminated_theme_call () =
            (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string))
   | Error (`Msg m) -> Alcotest.failf "bg-[theme(colors.red.500)]: %s" m
 
+(* The rejection an unrecognised [prop:value] candidate gets has to describe the
+   shape one must have. Plain [--name:value] declarations and non-colour
+   properties are emitted, so the message must not point the reader at those. *)
+let arbitrary_property_rejection_message () =
+  let message cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error (`Msg m) -> m
+  in
+  List.iter
+    (fun cls ->
+      let m = message cls in
+      Alcotest.(check bool)
+        (cls ^ " does not call the supported forms unsupported")
+        false
+        (Astring.String.is_infix ~affix:"not yet supported" m);
+      Alcotest.(check bool)
+        (cls ^ " names the shape a candidate must have")
+        true
+        (Astring.String.is_infix ~affix:"[property:value]" m))
+    [ "[color:red]xyz"; "[--foo:bar]xyz"; "[:red]"; "[color:red]/notanopacity" ];
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok _ -> ()
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m)
+    [ "[--foo:bar]"; "[mask-type:luminance]" ]
+
 let all_colors_grays () =
   check_list
     (bg_shades slate shades @ bg_shades gray shades @ bg_shades zinc shades
@@ -1380,6 +1408,8 @@ let core_tests =
     test_case "style combination" `Slow style_combination;
     test_case "paren var shorthand" `Quick paren_var_shorthand;
     test_case "unterminated theme() call" `Quick unterminated_theme_call;
+    test_case "arbitrary property rejection message" `Quick
+      arbitrary_property_rejection_message;
     test_case "responsive classes" `Slow responsive_classes;
     test_case "multiple classes" `Slow multiple_classes;
     test_case "all colors same shade" `Slow all_colors_same_shade;


### PR DESCRIPTION
The message told authors that plain declarations and non-colour properties were unsupported, but both work; the classes that actually reach it are malformed. It now names the shape it expected.