### PR TITLE
html: render every void element without an end tag

### DIFF
--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -13,11 +13,16 @@ let str = String.concat ""
 module El = struct
   type html =
     | Element of string * (string * string) list * html list
+    | Void_element of string * (string * string) list
+        (** An HTML void element: no children, no end tag. Only {!void_v} builds
+            one, so the elements rendered without an end tag are exactly the
+            constructors that call it. *)
     | Text of string
     | Void
     | Raw of string
 
   let v ~at name children = Element (name, at, children)
+  let void_v ~at name = Void_element (name, at)
   let txt s = Text s
   let void = Void
   let unsafe_raw s = Raw s
@@ -35,35 +40,36 @@ module El = struct
       s;
     Buffer.contents b
 
+  let add_open_tag b name attrs =
+    Buffer.add_char b '<';
+    Buffer.add_string b name;
+    List.iter
+      (fun (k, v) ->
+        Buffer.add_char b ' ';
+        Buffer.add_string b k;
+        Buffer.add_string b "=\"";
+        Buffer.add_string b (escape_html v);
+        Buffer.add_char b '"')
+      attrs
+
   let rec to_string ?(doctype = false) = function
     | Text s -> escape_html s
     | Raw s -> s
     | Void -> ""
+    | Void_element (name, attrs) ->
+        let b = Buffer.create 64 in
+        add_open_tag b name attrs;
+        Buffer.add_string b " />";
+        Buffer.contents b
     | Element (name, attrs, children) ->
         let b = Buffer.create 256 in
         if doctype && name = "html" then Buffer.add_string b "<!DOCTYPE html>\n";
-        Buffer.add_char b '<';
+        add_open_tag b name attrs;
+        Buffer.add_char b '>';
+        List.iter (fun child -> Buffer.add_string b (to_string child)) children;
+        Buffer.add_string b "</";
         Buffer.add_string b name;
-        List.iter
-          (fun (k, v) ->
-            Buffer.add_char b ' ';
-            Buffer.add_string b k;
-            Buffer.add_string b "=\"";
-            Buffer.add_string b (escape_html v);
-            Buffer.add_char b '"')
-          attrs;
-        if
-          children = []
-          && List.mem name [ "img"; "br"; "hr"; "input"; "meta"; "link" ]
-        then Buffer.add_string b " />"
-        else (
-          Buffer.add_char b '>';
-          List.iter
-            (fun child -> Buffer.add_string b (to_string child))
-            children;
-          Buffer.add_string b "</";
-          Buffer.add_string b name;
-          Buffer.add_char b '>');
+        Buffer.add_char b '>';
         Buffer.contents b
 end
 
@@ -324,7 +330,7 @@ let void_el ?(forms = false) name ?at ?(tw = []) () =
   let tw_from_at, raw_classes, other_atts = extract_class_attrs atts in
   let all_tw = tw @ tw_from_at in
   let atts_with_tw = class_atts all_tw raw_classes other_atts in
-  { el = El.v ~at:atts_with_tw name []; tw = all_tw; forms }
+  { el = El.void_v ~at:atts_with_tw name; tw = all_tw; forms }
 
 let img ?at ?tw () = void_el "img" ?at ?tw ()
 let meta ?at ?tw () = void_el "meta" ?at ?tw ()

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -268,6 +268,27 @@ let test_no_class_without_tw () =
   check bool "no class attribute" false
     (Astring.String.is_infix ~affix:"class=" html_str)
 
+let test_void_elements () =
+  (* A void element carries no end tag, whichever constructor built it. *)
+  let s = to_string (picture [ source ~at:[ At.src "a.webp" ] () ]) in
+  check bool "source self-closed" true
+    (Astring.String.is_infix ~affix:"<source src=\"a.webp\" />" s);
+  check bool "no source end tag" false
+    (Astring.String.is_infix ~affix:"</source>" s);
+  let img_str = to_string (img ~at:[ At.src "a.png" ] ()) in
+  check bool "img self-closed" true
+    (Astring.String.is_infix ~affix:"<img src=\"a.png\" />" img_str);
+  let br_str = to_string (br ()) in
+  check string "br self-closed" "<br />" br_str;
+  let hr_str = to_string (hr ()) in
+  check string "hr self-closed" "<hr />" hr_str;
+  let meta_str = to_string (meta ~at:[ At.charset "utf-8" ] ()) in
+  check string "meta self-closed" "<meta charset=\"utf-8\" />" meta_str;
+  let link_str = to_string (link ~at:[ At.rel "icon" ] ()) in
+  check string "link self-closed" "<link rel=\"icon\" />" link_str;
+  let input_str = to_string (input ~at:[ At.name "q" ] ()) in
+  check string "input self-closed" "<input name=\"q\" />" input_str
+
 let suite =
   ( "tw_html",
     [
@@ -285,4 +306,5 @@ let suite =
       test_case "cache busting consistency" `Quick
         test_page_cache_busting_consistency;
       test_case "inline css" `Quick test_inline_css;
+      test_case "void elements" `Quick test_void_elements;
     ] )


### PR DESCRIPTION
`source` was built with `void_el` but missing from the printer's separate name list, so it rendered a stray `</source>` inside `<picture>` and `<video>`. The printer now keys off a constructor only `void_el` builds, so the two sets cannot drift apart.