### PR TITLE
html: split a class attribute on every HTML whitespace

### DIFF
--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -222,9 +222,7 @@ let class_atts tw_styles raw_classes other_atts =
 
 (* Parse a class string, returning (recognized_tw, raw_strings) *)
 let parse_class_value value =
-  let classes =
-    String.split_on_char ' ' value |> List.filter (fun s -> s <> "")
-  in
+  let classes = Tw.split_whitespace value in
   List.fold_left
     (fun (tw_acc, raw_acc) cls ->
       match Tw.of_string cls with

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3703,9 +3703,21 @@ val of_string : ?theme:Scheme.t -> string -> (t, [ `Msg of string ]) result
 
     Returns [Error (`Msg reason)] if the class string is not recognized. *)
 
+val split_whitespace : string -> string list
+(** [split_whitespace s] splits a [class] attribute into its class names on any
+    HTML whitespace - space, tab, newline, carriage return or form feed - and
+    drops empty runs. This is the split {!str} performs, exposed so that a
+    consumer parsing each name itself, such as {!Tw_html}, agrees with it on
+    what a class name is.
+
+    Example:
+    {[
+    let names = split_whitespace "flex\n  items-center"
+    ]} *)
+
 val str : string -> t list
-(** [str s] parses a space-separated string of Tailwind class names into a list
-    of styles. Raises [Invalid_argument] if any class is not recognized.
+(** [str s] parses a whitespace-separated string of Tailwind class names into a
+    list of styles. Raises [Invalid_argument] if any class is not recognized.
 
     Example:
     {[

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -289,6 +289,15 @@ let test_void_elements () =
   let input_str = to_string (input ~at:[ At.name "q" ] ()) in
   check string "input self-closed" "<input name=\"q\" />" input_str
 
+let test_class_attribute_whitespace () =
+  (* A class attribute written across lines is still a list of classes. *)
+  let elem = div ~at:[ At.v "class" "flex\n  items-center\tgap-4" ] [] in
+  check (list string) "every class recognised"
+    [ "flex"; "items-center"; "gap-4" ]
+    (List.map Tw.pp (to_tw elem));
+  check string "rendered on one line"
+    "<div class=\"flex items-center gap-4\"></div>" (to_string elem)
+
 let suite =
   ( "tw_html",
     [
@@ -307,4 +316,6 @@ let suite =
         test_page_cache_busting_consistency;
       test_case "inline css" `Quick test_inline_css;
       test_case "void elements" `Quick test_void_elements;
+      test_case "class attribute whitespace" `Quick
+        test_class_attribute_whitespace;
     ] )


### PR DESCRIPTION
A class attribute written across lines yielded tokens containing newlines, every one of which failed to parse and fell silently into the raw bucket with no CSS generated. It now uses the same whitespace split as the class parser.