### PR TITLE
dom: coalesce the style rebuild onto a microtask

### DIFF
--- a/lib/dom/tw_dom.ml
+++ b/lib/dom/tw_dom.ml
@@ -32,6 +32,23 @@ let rebuild_css () =
   let css_str = Css.to_string ~minify:true css in
   set_text_content el css_str
 
+(* Every rebuild compiles and serialises the whole accumulated sheet, so
+   rebuilding inside [use] costs one full compilation per component that
+   introduces a class: 1 + 2 + ... + n over a mount pass. The rebuild is instead
+   coalesced onto a microtask, which the browser drains at the end of the
+   current task and before it paints, so a mount pass compiles once. *)
+let pending : bool ref = ref false
+
+let flush () =
+  if !pending then (
+    pending := false;
+    rebuild_css ())
+
+let schedule_rebuild () =
+  if not !pending then (
+    pending := true;
+    Fut.await (Fut.return ()) flush)
+
 let init ?(base = true) () =
   include_base := base;
   ignore (ensure_style_el ())
@@ -46,7 +63,7 @@ let use styles =
         all_styles := s :: !all_styles;
         new_found := true))
     styles;
-  if !new_found then rebuild_css ();
+  if !new_found then schedule_rebuild ();
   Tw.to_classes styles
 
 let use_str s =

--- a/lib/dom/tw_dom.mli
+++ b/lib/dom/tw_dom.mli
@@ -23,8 +23,18 @@ val init : ?base:bool -> unit -> unit
 
 val use : Tw.t list -> string
 (** [use styles] registers the given utilities and returns a space-separated
-    class name string. New CSS rules are injected into the DOM immediately.
-    Already-registered utilities are not re-injected. *)
+    class name string. Already-registered utilities are not re-injected.
+
+    Injecting the new rules is deferred to a microtask, so a pass of component
+    mounts that each call [use] compiles the sheet once rather than once per
+    mount. The browser drains microtasks before it paints, so the rules are in
+    the document by the time anything is rendered; call {!flush} to inject them
+    at once. *)
+
+val flush : unit -> unit
+(** [flush ()] injects any rules {!use} has registered but not yet written to
+    the document, and does nothing when there are none. Only needed to read the
+    style element back within the task that registered the utilities. *)
 
 val use_str : string -> string
 (** [use_str s] parses a space-separated Tailwind class string, registers the

--- a/test/dom/test_tw_dom.ml
+++ b/test/dom/test_tw_dom.ml
@@ -68,6 +68,27 @@ let dom_dedup () =
   check bool "grows with new utility" true
     (String.length css3 > String.length css1)
 
+let style_el_text () =
+  match Brr.El.find_first_by_selector (Jstr.v "style[data-tw=\"runtime\"]") with
+  | Some el -> Jstr.to_string (Brr.El.text_content el)
+  | None -> ""
+
+let dom_batching () =
+  (* [use] coalesces its rebuild onto a microtask, so the sheet in the document
+     is only refreshed once the current task drains - or on demand. *)
+  Tw_dom.init ~base:false ();
+  Tw_dom.flush ();
+  let before = style_el_text () in
+  ignore (Tw_dom.use Tw.[ underline ]);
+  check string "sheet untouched within the task" before (style_el_text ());
+  Tw_dom.flush ();
+  check bool "sheet refreshed on flush" true
+    (Astring.String.is_infix ~affix:"underline" (style_el_text ()));
+  let flushed = style_el_text () in
+  Tw_dom.flush ();
+  check string "flush with nothing pending is a no-op" flushed
+    (style_el_text ())
+
 let has_dom =
   (* Check if document.createElement exists — absent in Node.js *)
   try
@@ -89,6 +110,7 @@ let dom_cases =
       test_case "use" `Quick dom_use;
       test_case "use_str" `Quick dom_use_str;
       test_case "dedup" `Quick dom_dedup;
+      test_case "batching" `Quick dom_batching;
     ]
   else []
 


### PR DESCRIPTION
Every newly seen class recompiled and reserialised the whole sheet, so registering n classes cost n rebuilds. Appending only new rules was rejected because it would land them after existing ones in the utilities layer and change the cascade.