### PR TITLE
parse: split a class name once per parse, not once per handler

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -337,7 +337,7 @@ let bare_var_inner s =
 (** Split a class name on '-' but treat '[...]' as atomic. E.g.
     "m-[var(--value)]" → ["m"; "[var(--value)]"] E.g. "-m-[var(--value)]" →
     [""; "m"; "[var(--value)]"] *)
-let split_class class_name =
+let split_class_uncached class_name =
   let len = String.length class_name in
   let buf = Buffer.create 16 in
   let parts = ref [] in
@@ -376,3 +376,18 @@ let split_class class_name =
   done;
   parts := Buffer.contents buf :: !parts;
   List.rev !parts
+
+(* Utility.base_of_class offers one class name to every handler in turn until
+   one accepts it, and most handlers open by splitting that same name, so a
+   single class is split once per handler tried. The split is a pure function of
+   its argument, so remembering the last one collapses that run to one. *)
+let last_split : (string * string list) option ref = ref None
+
+let split_class class_name =
+  match !last_split with
+  | Some (key, parts) when key == class_name || String.equal key class_name ->
+      parts
+  | _ ->
+      let parts = split_class_uncached class_name in
+      last_split := Some (class_name, parts);
+      parts

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -132,14 +132,10 @@ let name_of_base u =
   try_handlers !handlers
 
 let class_of_base u =
-  let found = ref None in
   let visit (H (module M)) =
-    match (!found, u) with
-    | None, M.Self x -> found := Some (M.to_class x)
-    | _ -> ()
+    match u with M.Self x -> Some (M.to_class x) | _ -> None
   in
-  List.iter visit !handlers;
-  match !found with
+  match List.find_map visit !handlers with
   | Some class_name -> class_name
   | None -> failwith "name_of_base"
 

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -91,6 +91,22 @@ let test_decimal_class_suffixes_round_trip () =
 let test_redundant_zero_spellings_are_rejected () =
   List.iter unknown [ "p-04"; "p-4.0"; "p-1.50" ]
 
+(* [Parse.split_class] remembers the split of the last class name it was given,
+   because every handler in turn splits the same one. A parse must therefore not
+   depend on what was parsed before it, nor on whether two equal class names are
+   the same string. *)
+let test_parse_is_independent_of_history () =
+  let classes =
+    [ "p-4"; "px-4"; "m-[calc(1rem-2px)]"; "grid-cols-2"; "bg-blue-500" ]
+  in
+  List.iter round_trips classes;
+  List.iter round_trips (List.rev classes);
+  List.iter round_trips classes;
+  let built = String.concat "-" [ "grid"; "cols"; "2" ] in
+  round_trips "grid-cols-3";
+  round_trips built;
+  unknown "grid-cols-"
+
 let tests =
   Alcotest.
     [
@@ -106,6 +122,8 @@ let tests =
         test_decimal_class_suffixes_round_trip;
       test_case "redundant zero suffixes are rejected" `Quick
         test_redundant_zero_spellings_are_rejected;
+      test_case "parsing is independent of parse history" `Quick
+        test_parse_is_independent_of_history;
     ]
 
 let suite = ("parse", tests)


### PR DESCRIPTION
Forty-two of the handlers open by splitting the class again, so one class was split up to forty-two times. Threading the parts through every handler would touch thirty-eight files, so this memoises the split instead and leaves that structural change open.