### PR TITLE
html: drop repeated utilities before the page compiles them

### DIFF
--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -426,6 +426,23 @@ type tw_css = Link of string | Inline
 (* Type for page generation result *)
 type page = { html : string; css : Tw.Css.t; tw_css : tw_css }
 
+(* A page carries one [Tw.t] per class occurrence, and a page repeats its
+   utilities across every element that wears them. [Tw.to_css] does drop the
+   repeats, but only once each has been compiled to rules, so they are dropped
+   here first. Utilities with the same class name compile to the same rules, and
+   the first occurrence is the one kept on both paths, so the sheet is
+   unchanged. *)
+let dedup_by_class utilities =
+  let seen = Hashtbl.create 256 in
+  List.filter
+    (fun u ->
+      let cls = Tw.pp u in
+      if Hashtbl.mem seen cls then false
+      else (
+        Hashtbl.add seen cls ();
+        true))
+    utilities
+
 let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css ?forms head_content
     body_content =
   (* Build HTML tree with placeholder for CSS link *)
@@ -443,7 +460,7 @@ let page_impl ~lang ~meta_list ?title_text ~charset ~tw_css ?forms head_content
   let all_tw = to_tw body_element in
 
   (* Add styles from head content *)
-  let all_tw = all_tw @ List.concat_map to_tw head_content in
+  let all_tw = dedup_by_class (all_tw @ List.concat_map to_tw head_content) in
 
   (* The forms plugin base layer follows Tailwind's [\@plugin] model: it is
      emitted only when the plugin is explicitly enabled ([~forms:true]), since a

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -298,6 +298,36 @@ let test_class_attribute_whitespace () =
   check string "rendered on one line"
     "<div class=\"flex items-center gap-4\"></div>" (to_string elem)
 
+let sheet p = Tw.Css.to_string ~minify:true (snd (css p))
+
+let test_repeated_utilities_emit_one_sheet () =
+  (* Repeating a utility across a page must not change the sheet: that is what
+     lets the repeats be dropped before they are compiled. *)
+  let markup children = page ~tw_css:Inline [] children in
+  let once =
+    markup
+      [
+        div
+          ~at:[ At.v "class" "underline" ]
+          ~tw:Tw.[ p 4; flex; hover [ bg white ] ]
+          [ span ~tw:Tw.[ m 2 ] [ txt "a" ] ];
+      ]
+  in
+  let repeated =
+    markup
+      [
+        div
+          ~at:[ At.v "class" "underline" ]
+          ~tw:Tw.[ p 4; flex; hover [ bg white ] ]
+          (List.init 20 (fun _ ->
+               span
+                 ~at:[ At.v "class" "underline" ]
+                 ~tw:Tw.[ p 4; m 2; flex; hover [ bg white ] ]
+                 [ txt "a" ]));
+      ]
+  in
+  check string "sheet is the same" (sheet once) (sheet repeated)
+
 let suite =
   ( "tw_html",
     [
@@ -318,4 +348,6 @@ let suite =
       test_case "void elements" `Quick test_void_elements;
       test_case "class attribute whitespace" `Quick
         test_class_attribute_whitespace;
+      test_case "repeated utilities emit one sheet" `Quick
+        test_repeated_utilities_emit_one_sheet;
     ] )


### PR DESCRIPTION
A page returned one value per class occurrence and deduplicated only after every one had been compiled end to end.