### PR TITLE
html: render a document through a single buffer

### DIFF
--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -27,8 +27,7 @@ module El = struct
   let void = Void
   let unsafe_raw s = Raw s
 
-  let escape_html s =
-    let b = Buffer.create (String.length s) in
+  let add_escaped b s =
     String.iter
       (function
         | '<' -> Buffer.add_string b "&lt;"
@@ -37,8 +36,7 @@ module El = struct
         | '"' -> Buffer.add_string b "&quot;"
         | '\'' -> Buffer.add_string b "&#x27;"
         | c -> Buffer.add_char b c)
-      s;
-    Buffer.contents b
+      s
 
   let add_open_tag b name attrs =
     Buffer.add_char b '<';
@@ -48,29 +46,33 @@ module El = struct
         Buffer.add_char b ' ';
         Buffer.add_string b k;
         Buffer.add_string b "=\"";
-        Buffer.add_string b (escape_html v);
+        add_escaped b v;
         Buffer.add_char b '"')
       attrs
 
-  let rec to_string ?(doctype = false) = function
-    | Text s -> escape_html s
-    | Raw s -> s
-    | Void -> ""
+  (* One buffer serves the whole document. Rendering each element to its own
+     string and copying that into its parent's buffer would copy every byte once
+     per level of nesting. *)
+  let rec add_html b ~doctype = function
+    | Text s -> add_escaped b s
+    | Raw s -> Buffer.add_string b s
+    | Void -> ()
     | Void_element (name, attrs) ->
-        let b = Buffer.create 64 in
         add_open_tag b name attrs;
-        Buffer.add_string b " />";
-        Buffer.contents b
+        Buffer.add_string b " />"
     | Element (name, attrs, children) ->
-        let b = Buffer.create 256 in
         if doctype && name = "html" then Buffer.add_string b "<!DOCTYPE html>\n";
         add_open_tag b name attrs;
         Buffer.add_char b '>';
-        List.iter (fun child -> Buffer.add_string b (to_string child)) children;
+        List.iter (add_html b ~doctype:false) children;
         Buffer.add_string b "</";
         Buffer.add_string b name;
-        Buffer.add_char b '>';
-        Buffer.contents b
+        Buffer.add_char b '>'
+
+  let to_string ?(doctype = false) html =
+    let b = Buffer.create 1024 in
+    add_html b ~doctype html;
+    Buffer.contents b
 end
 
 module At = struct

--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -174,8 +174,16 @@ end
 
 type tw = Tw.t
 
+(* The utilities of a node and of everything below it. Concatenating a subtree's
+   utilities into its parent copies that list once per level above it, so a
+   document costs O(nodes x depth) to collect. The children are held unflattened
+   instead and walked once, when the utilities are asked for. *)
+type tw_tree = { own : tw list; kids : tw_tree list }
+
+let no_tw = { own = []; kids = [] }
+
 (* Type that combines HTML element with its Tailwind classes *)
-type t = { el : El.html; tw : tw list; forms : bool }
+type t = { el : El.html; tw : tw_tree; forms : bool }
 
 (* Attribute type - abstract to prevent direct usage of class' *)
 type attr = At.t
@@ -193,17 +201,23 @@ end
 
 (* Internal helper to convert to El.html *)
 let to_htmlit t = t.el
-let to_tw t = t.tw
+
+let to_tw t =
+  let rec collect acc node =
+    List.fold_left collect (List.rev_append node.own acc) node.kids
+  in
+  List.rev (collect [] t.tw)
+
 let has_forms t = t.forms
 
 (* Text helpers *)
-let txt s = { el = El.txt s; tw = []; forms = false }
+let txt s = { el = El.txt s; tw = no_tw; forms = false }
 let txtf segments = txt (str segments)
-let raw s = { el = El.unsafe_raw s; tw = []; forms = false }
+let raw s = { el = El.unsafe_raw s; tw = no_tw; forms = false }
 let rawf segments = raw (str segments)
 
 (* Empty element *)
-let empty = { el = El.void; tw = []; forms = false }
+let empty = { el = El.void; tw = no_tw; forms = false }
 
 (* Build final attribute list from tw styles, raw class strings, and non-class
    attrs *)
@@ -250,7 +264,9 @@ let el_with_tw ?(forms = false) name ?at ?(tw = []) children =
   (* Convert children to Htmlit elements *)
   let child_els = List.map to_htmlit children in
   (* Collect all tw styles from this element and its children *)
-  let all_tw = all_tw_styles @ List.concat_map to_tw children in
+  let all_tw =
+    { own = all_tw_styles; kids = List.map (fun c -> c.tw) children }
+  in
   (* Propagate forms flag from children or this element *)
   let has_forms = forms || List.exists (fun c -> c.forms) children in
   { el = El.v ~at:atts_with_tw name child_els; tw = all_tw; forms = has_forms }
@@ -328,7 +344,11 @@ let void_el ?(forms = false) name ?at ?(tw = []) () =
   let tw_from_at, raw_classes, other_atts = extract_class_attrs atts in
   let all_tw = tw @ tw_from_at in
   let atts_with_tw = class_atts all_tw raw_classes other_atts in
-  { el = El.void_v ~at:atts_with_tw name; tw = all_tw; forms }
+  {
+    el = El.void_v ~at:atts_with_tw name;
+    tw = { own = all_tw; kids = [] };
+    forms;
+  }
 
 let img ?at ?tw () = void_el "img" ?at ?tw ()
 let meta ?at ?tw () = void_el "meta" ?at ?tw ()
@@ -344,7 +364,7 @@ let style ?at ?(tw = []) css =
   let atts_with_tw = class_atts all_tw raw_classes other_atts in
   {
     el = El.v ~at:atts_with_tw "style" [ El.unsafe_raw css ];
-    tw = all_tw;
+    tw = { own = all_tw; kids = [] };
     forms = false;
   }
 
@@ -516,7 +536,7 @@ let css page =
 
 (* Pretty printing *)
 let pp t =
-  let tw_classes = Tw.to_classes t.tw in
+  let tw_classes = Tw.to_classes (to_tw t) in
   let el_str = El.to_string ~doctype:false t.el in
   if tw_classes = "" then el_str
   else

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -298,6 +298,22 @@ let test_class_attribute_whitespace () =
   check string "rendered on one line"
     "<div class=\"flex items-center gap-4\"></div>" (to_string elem)
 
+let test_to_tw_document_order () =
+  (* A node reports its own utilities before its children's, and its children's
+     in document order, however deep the tree. *)
+  let leaf n = span ~tw:[ Tw.p n ] [] in
+  let tree =
+    div
+      ~tw:Tw.[ flex ]
+      [
+        section ~tw:Tw.[ m 1 ] [ leaf 1; div [ leaf 2 ] ];
+        section ~tw:Tw.[ m 2 ] [ leaf 3 ];
+      ]
+  in
+  check (list string) "pre-order, own before children"
+    [ "flex"; "m-1"; "p-1"; "p-2"; "m-2"; "p-3" ]
+    (List.map Tw.pp (to_tw tree))
+
 let sheet p = Tw.Css.to_string ~minify:true (snd (css p))
 
 let test_repeated_utilities_emit_one_sheet () =
@@ -340,6 +356,7 @@ let suite =
       test_case "boolean + aria/data attrs" `Quick test_boolean_and_data_attrs;
       test_case "nesting" `Quick test_nesting;
       test_case "to_tw" `Quick test_to_tw;
+      test_case "to_tw document order" `Quick test_to_tw_document_order;
       test_case "pretty printing" `Quick test_pp;
       test_case "page cache busting" `Quick test_page_cache_busting;
       test_case "cache busting consistency" `Quick

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -298,6 +298,18 @@ let test_class_attribute_whitespace () =
   check string "rendered on one line"
     "<div class=\"flex items-center gap-4\"></div>" (to_string elem)
 
+let test_document_rendering () =
+  (* The whole document is written into one buffer, so the doctype, the empty
+     node and raw text must each still land exactly once and in place. *)
+  let doc = root [ body [ txt "x" ] ] in
+  check string "doctype heads the document"
+    "<!DOCTYPE html>\n<html><body>x</body></html>"
+    (to_string ~doctype:true doc);
+  let nested = div [ doc; empty; raw "<b>&</b>" ] in
+  check string "no second doctype, empty writes nothing, raw is verbatim"
+    "<div><html><body>x</body></html><b>&</b></div>"
+    (to_string ~doctype:true nested)
+
 let test_to_tw_document_order () =
   (* A node reports its own utilities before its children's, and its children's
      in document order, however deep the tree. *)
@@ -355,6 +367,7 @@ let suite =
       test_case "html escaping" `Quick test_html_escaping;
       test_case "boolean + aria/data attrs" `Quick test_boolean_and_data_attrs;
       test_case "nesting" `Quick test_nesting;
+      test_case "document rendering" `Quick test_document_rendering;
       test_case "to_tw" `Quick test_to_tw;
       test_case "to_tw document order" `Quick test_to_tw_document_order;
       test_case "pretty printing" `Quick test_pp;


### PR DESCRIPTION
Subtree utilities were rebuilt per node and every element returned a fresh buffer its parent then copied, so both collection and printing cost a factor of the nesting depth.