### PR TITLE
modifiers: emit the @supports test the author wrote

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1126,42 +1126,6 @@ let try_bracket_at_rule s =
     else None
   else None
 
-(* Whether every [(] in [s] closes: a compound condition keeps its own parens,
-   so unwrapping one pair only makes sense when what is left is balanced. *)
-let is_balanced s =
-  let rec go i depth =
-    if i >= String.length s then depth = 0
-    else
-      match s.[i] with
-      | '(' -> go (i + 1) (depth + 1)
-      | ')' when depth = 0 -> false
-      | ')' -> go (i + 1) (depth - 1)
-      | _ -> go (i + 1) depth
-  in
-  go 0 0
-
-(* Properties whose [@supports] test Tailwind also runs against the prefixed
-   spelling, so a browser that only ships the prefix still matches. The set is
-   its browser-support data; these are the entries observed against v4.3.3.
-   [text-size-adjust] additionally carries the [-moz-] spelling. *)
-let supports_vendor_prefixes = function
-  | "backdrop-filter" | "background-clip" | "box-decoration-break" | "hyphens"
-  | "mask" | "mask-image" | "mask-origin" | "mask-size" | "print-color-adjust"
-  | "text-decoration-skip-ink" | "user-select" ->
-      [ "-webkit-" ]
-  | "text-size-adjust" -> [ "-webkit-"; "-moz-" ]
-  | _ -> []
-
-(* [(prop: value)] as Tailwind writes it: one test per prefixed spelling, the
-   unprefixed one last, joined with [or]. *)
-let supports_property_test prop value =
-  let one p = String.concat "" [ "("; p; prop; ":"; value; ")" ] in
-  match supports_vendor_prefixes prop with
-  | [] -> one ""
-  | prefixes ->
-      String.concat ""
-        [ "("; String.concat " or " (List.map one prefixes @ [ one "" ]); ")" ]
-
 let normalize_supports_condition condition_str =
   (* Convert underscores to spaces (Tailwind bracket notation) *)
   let cond = String.map (fun c -> if c = '_' then ' ' else c) condition_str in
@@ -1175,23 +1139,16 @@ let normalize_supports_condition condition_str =
     "(" ^ cond ^ ": var(--tw))"
   else if cond <> "" && cond.[0] = '(' && cond.[String.length cond - 1] = ')'
   then
-    (* Already wrapped. A single [(prop: value)] still has to go through the
-       prefix expansion, so unwrap it and rebuild; anything else (a compound
-       condition, a [not]) is left as written. *)
-    let inner = String.sub cond 1 (String.length cond - 2) in
-    if is_balanced inner && String.contains inner ':' then
-      let i = String.index inner ':' in
-      supports_property_test
-        (String.trim (String.sub inner 0 i))
-        (String.trim (String.sub inner (i + 1) (String.length inner - i - 1)))
-    else cond
+    (* Already parenthesised, so it is the condition the author wrote. *)
+    cond
   else if String.contains cond ':' then
+    (* [prop: value] -> [(prop:value)], the property test Tailwind emits. *)
     let i = String.index cond ':' in
     let prop = String.trim (String.sub cond 0 i) in
     let value =
       String.trim (String.sub cond (i + 1) (String.length cond - i - 1))
     in
-    supports_property_test prop value
+    String.concat "" [ "("; prop; ":"; value; ")" ]
   else if String.contains cond '(' then
     (* Function call like font-format(opentype) or var(--test) *)
     cond

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -851,6 +851,35 @@ let test_valid_bracket_modifiers () =
   emits ":nth-of-type(odd)" "nth-of-type-[odd]:flex";
   emits "@supports (display: grid)" "supports-[display:grid]:flex"
 
+(* A [supports-<property>] test names the property the author wrote, even for a
+   property browsers once shipped behind a vendor prefix: Tailwind emits
+   [@supports (hyphens: var(--tw))], so the shorthand and the bracket spelling
+   of one property give the same condition. *)
+let test_supports_property_is_unprefixed () =
+  let condition cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    check bool cls true (Astring.String.is_infix ~affix (condition cls))
+  in
+  let unprefixed cls =
+    let css = condition cls in
+    check bool cls false (Astring.String.is_infix ~affix:"-webkit-" css);
+    check bool cls false (Astring.String.is_infix ~affix:"-moz-" css)
+  in
+  emits "@supports (hyphens: var(--tw))" "supports-hyphens:flex";
+  emits "@supports (user-select: var(--tw))" "supports-user-select:flex";
+  emits "@supports (user-select: var(--tw))" "supports-[user-select]:flex";
+  emits "@supports (text-size-adjust: var(--tw))"
+    "supports-text-size-adjust:flex";
+  emits "@supports (backdrop-filter: var(--tw))" "supports-backdrop-filter:flex";
+  unprefixed "supports-hyphens:flex";
+  unprefixed "supports-user-select:flex";
+  unprefixed "supports-text-size-adjust:flex";
+  unprefixed "supports-backdrop-filter:flex"
+
 (* Extend the suite with new tests *)
 let tests =
   tests
@@ -858,6 +887,8 @@ let tests =
       test_case "invalid bracket modifiers" `Quick
         test_invalid_bracket_modifiers;
       test_case "valid bracket modifiers" `Quick test_valid_bracket_modifiers;
+      test_case "supports property is unprefixed" `Quick
+        test_supports_property_is_unprefixed;
       test_case "empty attribute brackets" `Quick test_empty_attribute_brackets;
       test_case "padded attribute brackets" `Quick
         test_padded_attribute_brackets;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -278,8 +278,8 @@ let test_opacity_supports_under_variant () =
 
 (* An at-rule written in brackets wraps the utility rather than selecting it,
    and keeps its own spelling in the class name: reading it as the [supports-]
-   variant gave a class the HTML would not match. A property test also runs
-   against the prefixed spellings, as Tailwind's browser data has it. *)
+   variant gave a class the HTML would not match. Its condition is emitted as
+   written, prefixed property or not. *)
 let test_bracketed_at_rule_variant () =
   let css cls =
     match Tw.of_string cls with
@@ -295,8 +295,7 @@ let test_bracketed_at_rule_variant () =
   has "[@supports(display:grid)]:grid"
     ".\\[\\@supports\\(display\\:grid\\)\\]\\:grid";
   has "[@supports(backdrop-filter:blur(0))]:backdrop-blur"
-    "@supports(-webkit-backdrop-filter:blur(0))or (backdrop-filter:blur(0))";
-  (* an unprefixed property stays a single test *)
+    "@supports(backdrop-filter:blur(0))";
   has "supports-[display:grid]:flex" "@supports(display:grid)"
 
 (* [in-focus] scopes to an ancestor in that state, the same state names the

--- a/test/upstream/variants.txt
+++ b/test/upstream/variants.txt
@@ -1512,6 +1512,40 @@ supports-[(display:grid)_and_font-format(opentype)]:grid supports-[--test]:flex 
 <<<>>>
 # supports
 @config run
+supports-[user-select]:flex supports-backdrop-filter:flex supports-hyphens:flex supports-text-size-adjust:flex supports-user-select:flex
+---
+
+    @supports (backdrop-filter: var(--tw)) {
+      .supports-backdrop-filter\:flex {
+        display: flex;
+      }
+    }
+
+    @supports (hyphens: var(--tw)) {
+      .supports-hyphens\:flex {
+        display: flex;
+      }
+    }
+
+    @supports (text-size-adjust: var(--tw)) {
+      .supports-text-size-adjust\:flex {
+        display: flex;
+      }
+    }
+
+    @supports (user-select: var(--tw)) {
+      .supports-user-select\:flex {
+        display: flex;
+      }
+
+      .supports-\[user-select\]\:flex {
+        display: flex;
+      }
+    }
+    
+<<<>>>
+# supports
+@config run
 supports-[(display:grid)_and_font-format(opentype)]/foo:grid supports-[display:grid]/foo:flex supports-[font-format(opentype)]/foo:grid supports-[font-tech(color-COLRv1)]/foo:flex supports-[selector(A_>_B)]/foo:flex supports-[var(--test)]/foo:flex supports-gap/foo:grid
 ---
 


### PR DESCRIPTION
A `supports-*` condition was widened to `(-webkit-X: v) or (X: v)` on a comment's claim that Tailwind tests the prefixed spelling too. It does not: unminified Tailwind emits the bare property, and puts `supports-user-select` and `supports-[user-select]` in one block, so the two forms must produce the same condition. A `test/upstream/variants.txt` case now gates it, and `test/test_rule.ml` no longer pins the invented chain.