### PR TITLE
test: read the upstream fixtures through one reader

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -11,5 +11,6 @@
   tw_tools
   cascade
   cascade.diff
-  test_helpers)
+  test_helpers
+  upstream_fixture)
  (deps upstream/utilities.txt upstream/variants.txt))

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -19,24 +19,7 @@ let canonical_stylesheet_css css = String.trim css
 let is_allowed_canonicalization_diff diff =
   let allowed_custom_property = function
     | "--font-sans" | "--font-mono" -> true
-    | name
-      when String.starts_with ~prefix:"--text-" name
-           && String.ends_with ~suffix:"--line-height" name ->
-        true
     | name when String.starts_with ~prefix:"--tw-prose-" name -> true
-    | _ -> false
-  in
-  let known_selector_permutation expected actual =
-    match (expected, actual) with
-    | ( ".prose :where(ul ul, ul ol, ol ul, ol \
-         ol):not(:where([class~=\"not-prose\"], [class~=\"not-prose\"] *))",
-        ".prose :where(ol ol, ol ul, ul ol, ul \
-         ul):not(:where([class~=\"not-prose\"], [class~=\"not-prose\"] *))" )
-    | ( ".prose :where(th, td):not(:where([class~=\"not-prose\"], \
-         [class~=\"not-prose\"] *))",
-        ".prose :where(td, th):not(:where([class~=\"not-prose\"], \
-         [class~=\"not-prose\"] *))" ) ->
-        true
     | _ -> false
   in
   let allowed_rule_change = function
@@ -48,9 +31,6 @@ let is_allowed_canonicalization_diff diff =
              (fun (change : Tree_diff.declaration) ->
                allowed_custom_property change.property_name)
              property_changes
-    | Tree_diff.Selector_changed { old_selector; new_selector; declarations } ->
-        declarations <> []
-        && known_selector_permutation old_selector new_selector
     | _ -> false
   in
   let allowed_container = function
@@ -237,145 +217,6 @@ let check_list tw_styles = check_exact_match tw_styles
 
 (* ===== UPSTREAM PARSE PARITY ============================================= *)
 
-type upstream_case = {
-  source : string;
-  name : string;
-  config : upstream_config;
-  variants : string list;
-  theme_vars : (string * string) list;
-      (** [@theme-var name value] token declarations captured from the fixture;
-          they must be threaded into the per-case scheme so custom tokens (e.g.
-          a themed [--inset-shadow]) validate. *)
-  classes : string list;
-  expected : string;
-}
-
-and upstream_config =
-  | Theme
-  | Theme_inline
-  | Theme_reference
-  | Theme_inline_reference
-  | No_theme
-  | Run
-
-let upstream_config_of_string = function
-  | "theme" -> Theme
-  | "theme-inline" -> Theme_inline
-  | "theme-reference" -> Theme_reference
-  | "theme-inline-reference" -> Theme_inline_reference
-  | "none" -> No_theme
-  | "run" -> Run
-  | _ -> No_theme
-
-let split_classes line =
-  let len = String.length line in
-  let buf = Buffer.create 64 in
-  let acc = ref [] in
-  let depth = ref 0 in
-  for i = 0 to len - 1 do
-    let c = line.[i] in
-    if c = '[' then (
-      incr depth;
-      Buffer.add_char buf c)
-    else if c = ']' then (
-      decr depth;
-      Buffer.add_char buf c)
-    else if c = ' ' && !depth = 0 then (
-      let s = Buffer.contents buf in
-      if s <> "" then acc := s :: !acc;
-      Buffer.clear buf)
-    else Buffer.add_char buf c
-  done;
-  let s = Buffer.contents buf in
-  if s <> "" then acc := s :: !acc;
-  List.rev !acc
-
-let fixture_path filename =
-  (* Found at [upstream/<f>] under the dune sandbox (see the test/dune deps), or
-     [test/upstream/<f>] when run from the repo root. *)
-  [
-    filename;
-    Filename.concat "upstream" filename;
-    Filename.concat "test/upstream" filename;
-  ]
-  |> List.find_opt Sys.file_exists
-  |> Option.value ~default:filename
-
-let separator lines =
-  let rec go before = function
-    | [] -> None
-    | line :: rest ->
-        if String.trim line = "---" then Some (List.rev before, rest)
-        else go (line :: before) rest
-  in
-  go [] lines
-
-let parse_upstream_block source block =
-  let lines = String.split_on_char '\n' block in
-  match separator lines with
-  | None -> None
-  | Some (before, after) ->
-      let before = List.map String.trim before in
-      let name =
-        before
-        |> List.find_opt (String.starts_with ~prefix:"# ")
-        |> Option.map (fun s -> String.sub s 2 (String.length s - 2))
-        |> Option.value ~default:"<unnamed>"
-      in
-      let variants =
-        before
-        |> List.filter_map (fun s ->
-            if String.starts_with ~prefix:"@variant " s then
-              Some (String.sub s 9 (String.length s - 9))
-            else None)
-      in
-      let theme_vars =
-        before
-        |> List.filter_map (fun s ->
-            if String.starts_with ~prefix:"@theme-var " s then
-              (* "@theme-var <name> <value>": split on the first space. *)
-              let rest = String.sub s 11 (String.length s - 11) in
-              match String.index_opt rest ' ' with
-              | Some i ->
-                  let n = String.sub rest 0 i in
-                  let v =
-                    String.sub rest (i + 1) (String.length rest - i - 1)
-                  in
-                  Some (n, v)
-              | None -> None
-            else None)
-      in
-      let config =
-        before
-        |> List.find_opt (String.starts_with ~prefix:"@config ")
-        |> Option.map (fun s ->
-            String.sub s 8 (String.length s - 8) |> upstream_config_of_string)
-        |> Option.value ~default:No_theme
-      in
-      let class_line =
-        before
-        |> List.filter (fun s ->
-            s <> ""
-            && (not (String.starts_with ~prefix:"# " s))
-            && (not (String.starts_with ~prefix:"@config " s))
-            && (not (String.starts_with ~prefix:"@variant " s))
-            && not (String.starts_with ~prefix:"@theme-var " s))
-        |> List.rev
-        |> List.find_opt (fun _ -> true)
-      in
-      let classes = Option.value ~default:"" class_line |> split_classes in
-      let expected = after |> String.concat "\n" |> String.trim in
-      Some { source; name; config; variants; theme_vars; classes; expected }
-
-let read_upstream_cases filename =
-  let path = fixture_path filename in
-  let ic = open_in path in
-  let content = really_input_string ic (in_channel_length ic) in
-  close_in ic;
-  content
-  |> Astring.String.cuts ~sep:"<<<>>>"
-  |> List.filter_map (parse_upstream_block filename)
-
 let register_upstream_variant_directives directives =
   let parse_variant_directive d =
     match String.split_on_char ' ' d with
@@ -417,50 +258,28 @@ let register_upstream_variant_directives directives =
   Tw.Modifiers.register_container_variants
     (List.filter_map parse_container_directive directives)
 
-let upstream_positive_cases filename =
-  read_upstream_cases filename
-  |> List.filter (fun c -> c.expected <> "" && c.classes <> [])
-
-let extract_root_vars expected =
-  let pattern = Re.Pcre.regexp {|--([a-zA-Z0-9_-]+):\s*([^;}]+)|} in
-  Re.all pattern expected
-  |> List.filter_map (fun m ->
-      try
-        let name = Re.Group.get m 1 in
-        let value = String.trim (Re.Group.get m 2) in
-        Some (name, value)
-      with Not_found | Failure _ -> None)
-
-let extract_var_fallbacks expected =
-  let pattern =
-    Re.Pcre.regexp
-      {|var\(--([a-zA-Z0-9_-]+),\s*(var\(--[a-zA-Z0-9_-]+\)|[^)]+)\)|}
-  in
-  Re.all pattern expected
-  |> List.filter_map (fun m ->
-      try
-        let name = Re.Group.get m 1 in
-        let fallback = String.trim (Re.Group.get m 2) in
-        Some (name, fallback)
-      with Not_found | Failure _ -> None)
-
-(* The [--tw-*] vars a utility emits at runtime are tw's own output rather than
-   theme tokens a test declares; they must not become token overrides. *)
-let is_runtime_var name = String.length name > 3 && String.sub name 0 3 = "tw-"
+let upstream_positive_cases basename =
+  match Upstream_fixture.path basename with
+  | None -> Alcotest.failf "%s not found. Run extract_tests.exe first." basename
+  | Some p ->
+      Upstream_fixture.read p
+      |> List.filter (fun (c : Upstream_fixture.case) ->
+          c.expected <> "" && c.classes <> [])
 
 (* Build the per-test scheme from the @theme tokens in the expected CSS, so
    of_string validates custom tokens against the threaded theme. *)
-let upstream_scheme config theme_vars expected =
+let upstream_scheme (config : Upstream_fixture.config) theme_vars expected =
   let overrides =
     match config with
     | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
         let base =
-          extract_root_vars expected
-          |> List.filter (fun (name, _) -> not (is_runtime_var name))
+          Upstream_fixture.extract_root_vars expected
+          |> List.filter (fun (name, _) ->
+              not (Upstream_fixture.is_runtime_var name))
         in
         if config = Theme_reference || config = Theme_inline_reference then
           let extra =
-            extract_var_fallbacks expected
+            Upstream_fixture.extract_var_fallbacks expected
             |> List.filter (fun (name, _) -> not (List.mem_assoc name base))
           in
           base @ extra
@@ -474,7 +293,8 @@ let upstream_scheme config theme_vars expected =
     let extra =
       theme_vars
       |> List.filter (fun (name, _) ->
-          (not (is_runtime_var name)) && not (List.mem_assoc name overrides))
+          (not (Upstream_fixture.is_runtime_var name))
+          && not (List.mem_assoc name overrides))
     in
     overrides @ extra
   in
@@ -492,7 +312,7 @@ let check_upstream_positive_fixture_parse filename () =
     [ ("xs", 320.); ("10xl", 1600.); ("lg-sm-potato", 1600.) ];
   let rejected =
     cases
-    |> List.concat_map (fun c ->
+    |> List.concat_map (fun (c : Upstream_fixture.case) ->
         register_upstream_variant_directives c.variants;
         let theme = upstream_scheme c.config c.theme_vars c.expected in
         c.classes
@@ -512,7 +332,7 @@ let check_upstream_positive_fixture_parse filename () =
       in
       let sample =
         rejected |> take 30
-        |> List.map (fun (c, cls, msg) ->
+        |> List.map (fun ((c : Upstream_fixture.case), cls, msg) ->
             Fmt.str "%s / %s / %s: %s" c.source c.name cls msg)
         |> String.concat "\n"
       in

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -1,3 +1,8 @@
+(library
+ (name upstream_fixture)
+ (modules upstream_fixture)
+ (libraries re))
+
 (executable
  (name extract_tests)
  (modules extract_tests)
@@ -6,7 +11,7 @@
 (test
  (name test)
  (modules test)
- (libraries alcotest tw cascade cascade.diff fmt re)
+ (libraries alcotest tw cascade cascade.diff fmt re upstream_fixture)
  (deps utilities.txt variants.txt))
 
 ; Pins the [@theme] scanner on the declaration shapes Prettier produces:

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -30,6 +30,7 @@
 module Css = Cascade.Css
 open Cascade_diff
 open Alcotest
+open Upstream_fixture
 
 (* Colour comparison is normalised the way Tailwind normalises its own
    snapshots: [color_mix_to_oklab] then [truncate_color_precision] run on both
@@ -47,184 +48,6 @@ open Alcotest
    gained typed calc + the custom-property prune, and the colour normalisation
    above replaced the allowlist.) *)
 let strict = Sys.getenv_opt "TW_UPSTREAM_STRICT" <> None
-
-type theme_config =
-  | Theme
-  | Theme_inline
-  | Theme_reference
-  | Theme_inline_reference
-  | No_theme
-  | Run
-
-let config_of_string = function
-  | "theme" -> Theme
-  | "theme-inline" -> Theme_inline
-  | "theme-reference" -> Theme_reference
-  | "theme-inline-reference" -> Theme_inline_reference
-  | "none" -> No_theme
-  | "run" -> Run
-  | _ -> No_theme
-
-type case = {
-  name : string;
-  config : theme_config;
-  classes : string list;
-  expected : string;
-  variants : string list;  (** [matchVariant] directive lines for this test. *)
-  theme_vars : (string * string) list;
-      (** [@theme] token overrides (name, value) captured from the test's CSS
-          template by the extractor (e.g. text-shadow sizes Tailwind inlines).
-      *)
-}
-
-(** Split a class line by spaces, but don't split inside brackets. *)
-let split_classes line =
-  let len = String.length line in
-  let buf = Buffer.create 64 in
-  let acc = ref [] in
-  let depth = ref 0 in
-  for i = 0 to len - 1 do
-    let c = line.[i] in
-    if c = '[' then (
-      incr depth;
-      Buffer.add_char buf c)
-    else if c = ']' then (
-      decr depth;
-      Buffer.add_char buf c)
-    else if c = ' ' && !depth = 0 then (
-      let s = Buffer.contents buf in
-      if s <> "" then acc := s :: !acc;
-      Buffer.clear buf)
-    else Buffer.add_char buf c
-  done;
-  let s = Buffer.contents buf in
-  if s <> "" then acc := s :: !acc;
-  List.rev !acc
-
-let read_test_cases filename =
-  if not (Sys.file_exists filename) then []
-  else
-    let ic = open_in filename in
-    let content = really_input_string ic (in_channel_length ic) in
-    close_in ic;
-    let tests = ref [] in
-    let current_variants = ref [] in
-    let current_theme_vars = ref [] in
-    let lines = String.split_on_char '\n' content in
-    let parse_config_line line =
-      let line = String.trim line in
-      if String.length line > 8 && String.sub line 0 8 = "@config " then
-        Some (config_of_string (String.sub line 8 (String.length line - 8)))
-      else None
-    in
-    let rec parse lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let line = String.trim line in
-          if String.length line > 2 && line.[0] = '#' && line.[1] = ' ' then (
-            let name = String.sub line 2 (String.length line - 2) in
-            current_variants := [];
-            current_theme_vars := [];
-            parse_config name No_theme rest)
-          else parse rest
-    and parse_config name default_config lines =
-      match lines with
-      | [] -> ()
-      | line :: rest -> (
-          match parse_config_line line with
-          | Some config -> parse_variants name config rest
-          | None -> parse_variants name default_config (line :: rest))
-    and parse_variants name config lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let tl = String.trim line in
-          if String.length tl >= 9 && String.sub tl 0 9 = "@variant " then (
-            current_variants :=
-              String.sub tl 9 (String.length tl - 9) :: !current_variants;
-            parse_variants name config rest)
-          else if String.length tl >= 11 && String.sub tl 0 11 = "@theme-var "
-          then (
-            (* "@theme-var <name> <value>" -- split on the first space. *)
-            let rest_str = String.sub tl 11 (String.length tl - 11) in
-            (match String.index_opt rest_str ' ' with
-            | Some i ->
-                let n = String.sub rest_str 0 i in
-                let v =
-                  String.sub rest_str (i + 1) (String.length rest_str - i - 1)
-                in
-                current_theme_vars := (n, v) :: !current_theme_vars
-            | None -> ());
-            parse_variants name config rest)
-          else parse_classes name config (line :: rest)
-    and parse_classes name config lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let line = String.trim line in
-          if line = "<<<>>>" then parse rest
-          else if line = "---" then
-            (* No classes line before ---, skip *)
-            parse_expected name config [] (Buffer.create 256) rest
-          else if String.length line > 2 && line.[0] = '#' && line.[1] = ' '
-          then (
-            (* New test without classes *)
-            let new_name = String.sub line 2 (String.length line - 2) in
-            current_variants := [];
-            current_theme_vars := [];
-            parse_config new_name No_theme rest)
-          else
-            let classes = split_classes line in
-            parse_after_classes name config classes rest
-    and parse_after_classes name config classes lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let line = String.trim line in
-          if line = "---" then
-            parse_expected name config classes (Buffer.create 256) rest
-          else if line = "<<<>>>" then
-            (* No expected CSS, skip this test *)
-            parse rest
-          else parse rest
-    and parse_expected name config classes buf lines =
-      match lines with
-      | [] ->
-          let expected = Buffer.contents buf |> String.trim in
-          if classes <> [] then
-            tests :=
-              {
-                name;
-                config;
-                classes;
-                expected;
-                variants = List.rev !current_variants;
-                theme_vars = List.rev !current_theme_vars;
-              }
-              :: !tests
-      | line :: rest ->
-          if String.trim line = "<<<>>>" then (
-            let expected = Buffer.contents buf |> String.trim in
-            if classes <> [] then
-              tests :=
-                {
-                  name;
-                  config;
-                  classes;
-                  expected;
-                  variants = List.rev !current_variants;
-                  theme_vars = List.rev !current_theme_vars;
-                }
-                :: !tests;
-            parse rest)
-          else (
-            if Buffer.length buf > 0 then Buffer.add_char buf '\n';
-            Buffer.add_string buf line;
-            parse_expected name config classes buf rest)
-    in
-    parse lines;
-    List.rev !tests
 
 (** Extract spacing values from expected CSS. *)
 let extract_spacing_from_css css : (int * Css.length) list =
@@ -383,21 +206,6 @@ let extract_var_names expected =
   in
   scan 0;
   !vars
-
-(** Extract all CSS custom property definitions from :root, :host block. Returns
-    (name, value) pairs where name is without the -- prefix. E.g.,
-    "--spacing-big: 100rem" → ("spacing-big", "100rem") *)
-let extract_root_vars expected =
-  let pattern = Re.Pcre.regexp {|--([a-zA-Z0-9_-]+):\s*([^;}]+)|} in
-  let matches = Re.all pattern expected in
-  List.filter_map
-    (fun m ->
-      try
-        let name = Re.Group.get m 1 in
-        let value = String.trim (Re.Group.get m 2) in
-        Some (name, value)
-      with Not_found | Failure _ -> None)
-    matches
 
 (* The expected CSS is Tailwind's own output, so a token read back out of it and
    handed to tw is compared against itself: on that token the runner is blind.
@@ -598,36 +406,12 @@ let test_layer_order_not_tolerated () =
     "a tolerated declaration cannot hide a layer-order change" false
     (is_allowed_canonicalization_diff diff)
 
-(** Extract var(--name, fallback) patterns from expected CSS. Returns (name,
-    fallback) pairs where name is without the -- prefix. Handles both concrete
-    fallbacks (e.g., var(--opacity-half, .5)) and nested var fallbacks (e.g.,
-    var(--opacity-custom, var(--custom-opacity))). *)
-let extract_var_fallbacks expected =
-  let pattern =
-    Re.Pcre.regexp
-      {|var\(--([a-zA-Z0-9_-]+),\s*(var\(--[a-zA-Z0-9_-]+\)|[^)]+)\)|}
-  in
-  let matches = Re.all pattern expected in
-  List.filter_map
-    (fun m ->
-      try
-        let name = Re.Group.get m 1 in
-        let fallback = String.trim (Re.Group.get m 2) in
-        Some (name, fallback)
-      with Not_found | Failure _ -> None)
-    matches
-
-(* The [--tw-*] vars a utility emits at runtime are tw's own output, not theme
-   tokens a test declares, so they must not become token overrides. Everything
-   the test's own [@theme] block sets goes through, the spacing scale included:
-   no [Scheme.t] field owns the bare [--spacing] multiplier, and filtering the
-   scale out only hid the tests that set it. *)
-
 (** Set theme value overrides for root vars from expected CSS. This enables
     utilities like z-auto and order-first to produce custom declarations in the
-    :root, :host block when [@config] theme is used. *)
-let is_runtime_var name = String.length name > 3 && String.sub name 0 3 = "tw-"
-
+    :root, :host block when [@config] theme is used. Everything the test's own
+    [@theme] block sets goes through, the spacing scale included: no [Scheme.t]
+    field owns the bare [--spacing] multiplier, and filtering the scale out only
+    hid the tests that set it. *)
 let theme_overrides_of ~declared config expected =
   match config with
   | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
@@ -1037,10 +821,6 @@ let print_parity_report () =
      breaks parity fails the CSS diff and names the rejected classes)@.";
   Fmt.epr "==============================@."
 
-let file basename =
-  let paths = [ basename; "test/upstream/" ^ basename ] in
-  List.find_opt Sys.file_exists paths
-
 (* Both fixtures are checked in and declared as dune deps, so a missing one is a
    broken checkout rather than an optional extra. A floor on the parsed cases
    catches the other way this gate can go quiet: a fixture whose format drifts
@@ -1051,15 +831,15 @@ let utilities_floor = 300
 let variants_floor = 80
 
 let load basename floor =
-  match file basename with
+  match path basename with
   | None ->
       Fmt.epr "%s not found. Run extract_tests.exe first.@." basename;
       exit 1
-  | Some path ->
-      let cases = read_test_cases path in
+  | Some p ->
+      let cases = read p in
       let n = List.length cases in
       if n < floor then (
-        Fmt.epr "%s yielded %d test cases, fewer than the floor of %d.@." path n
+        Fmt.epr "%s yielded %d test cases, fewer than the floor of %d.@." p n
           floor;
         exit 1);
       cases

--- a/test/upstream/upstream_fixture.ml
+++ b/test/upstream/upstream_fixture.ml
@@ -1,0 +1,247 @@
+(** Reader for the generated upstream fixtures ([utilities.txt],
+    [variants.txt]).
+
+    The fixtures are one block per upstream test, separated by [<<<>>>]:
+
+    {v
+    # <test name>
+    @config <theme config>
+    @variant <matchVariant directive>     (optional, repeatable)
+    @theme-var <name> <value>             (optional, repeatable)
+    <space-separated class list>
+    ---
+    <expected CSS>
+    v}
+
+    Both the fixture replay in [test/upstream/test.ml] and the parse-parity gate
+    in [test/test_tw.ml] read the same corpus, so they read it here: two readers
+    drifting apart is two different corpora behind one set of fixtures. See
+    [extract_tests.ml] for how the fixtures are generated. *)
+
+type config =
+  | Theme
+  | Theme_inline
+  | Theme_reference
+  | Theme_inline_reference
+  | No_theme
+  | Run
+
+let config_of_string = function
+  | "theme" -> Theme
+  | "theme-inline" -> Theme_inline
+  | "theme-reference" -> Theme_reference
+  | "theme-inline-reference" -> Theme_inline_reference
+  | "none" -> No_theme
+  | "run" -> Run
+  | _ -> No_theme
+
+type case = {
+  source : string;  (** Fixture the case was read from. *)
+  name : string;
+  config : config;
+  classes : string list;
+  expected : string;
+  variants : string list;  (** [matchVariant] directive lines for this test. *)
+  theme_vars : (string * string) list;
+      (** [@theme] token overrides (name, value) captured from the test's CSS
+          template by the extractor (e.g. text-shadow sizes Tailwind inlines).
+      *)
+}
+
+(** Split a class line by spaces, but don't split inside brackets. *)
+let split_classes line =
+  let len = String.length line in
+  let buf = Buffer.create 64 in
+  let acc = ref [] in
+  let depth = ref 0 in
+  for i = 0 to len - 1 do
+    let c = line.[i] in
+    if c = '[' then (
+      incr depth;
+      Buffer.add_char buf c)
+    else if c = ']' then (
+      decr depth;
+      Buffer.add_char buf c)
+    else if c = ' ' && !depth = 0 then (
+      let s = Buffer.contents buf in
+      if s <> "" then acc := s :: !acc;
+      Buffer.clear buf)
+    else Buffer.add_char buf c
+  done;
+  let s = Buffer.contents buf in
+  if s <> "" then acc := s :: !acc;
+  List.rev !acc
+
+let read filename =
+  if not (Sys.file_exists filename) then []
+  else
+    let ic = open_in filename in
+    let content = really_input_string ic (in_channel_length ic) in
+    close_in ic;
+    let tests = ref [] in
+    let current_variants = ref [] in
+    let current_theme_vars = ref [] in
+    let lines = String.split_on_char '\n' content in
+    let parse_config_line line =
+      let line = String.trim line in
+      if String.length line > 8 && String.sub line 0 8 = "@config " then
+        Some (config_of_string (String.sub line 8 (String.length line - 8)))
+      else None
+    in
+    let rec parse lines =
+      match lines with
+      | [] -> ()
+      | line :: rest ->
+          let line = String.trim line in
+          if String.length line > 2 && line.[0] = '#' && line.[1] = ' ' then (
+            let name = String.sub line 2 (String.length line - 2) in
+            current_variants := [];
+            current_theme_vars := [];
+            parse_config name No_theme rest)
+          else parse rest
+    and parse_config name default_config lines =
+      match lines with
+      | [] -> ()
+      | line :: rest -> (
+          match parse_config_line line with
+          | Some config -> parse_variants name config rest
+          | None -> parse_variants name default_config (line :: rest))
+    and parse_variants name config lines =
+      match lines with
+      | [] -> ()
+      | line :: rest ->
+          let tl = String.trim line in
+          if String.length tl >= 9 && String.sub tl 0 9 = "@variant " then (
+            current_variants :=
+              String.sub tl 9 (String.length tl - 9) :: !current_variants;
+            parse_variants name config rest)
+          else if String.length tl >= 11 && String.sub tl 0 11 = "@theme-var "
+          then (
+            (* "@theme-var <name> <value>" -- split on the first space. *)
+            let rest_str = String.sub tl 11 (String.length tl - 11) in
+            (match String.index_opt rest_str ' ' with
+            | Some i ->
+                let n = String.sub rest_str 0 i in
+                let v =
+                  String.sub rest_str (i + 1) (String.length rest_str - i - 1)
+                in
+                current_theme_vars := (n, v) :: !current_theme_vars
+            | None -> ());
+            parse_variants name config rest)
+          else parse_classes name config (line :: rest)
+    and parse_classes name config lines =
+      match lines with
+      | [] -> ()
+      | line :: rest ->
+          let line = String.trim line in
+          if line = "<<<>>>" then parse rest
+          else if line = "---" then
+            (* No classes line before ---, skip *)
+            parse_expected name config [] (Buffer.create 256) rest
+          else if String.length line > 2 && line.[0] = '#' && line.[1] = ' '
+          then (
+            (* New test without classes *)
+            let new_name = String.sub line 2 (String.length line - 2) in
+            current_variants := [];
+            current_theme_vars := [];
+            parse_config new_name No_theme rest)
+          else
+            let classes = split_classes line in
+            parse_after_classes name config classes rest
+    and parse_after_classes name config classes lines =
+      match lines with
+      | [] -> ()
+      | line :: rest ->
+          let line = String.trim line in
+          if line = "---" then
+            parse_expected name config classes (Buffer.create 256) rest
+          else if line = "<<<>>>" then
+            (* No expected CSS, skip this test *)
+            parse rest
+          else parse rest
+    and parse_expected name config classes buf lines =
+      match lines with
+      | [] ->
+          let expected = Buffer.contents buf |> String.trim in
+          if classes <> [] then
+            tests :=
+              {
+                source = filename;
+                name;
+                config;
+                classes;
+                expected;
+                variants = List.rev !current_variants;
+                theme_vars = List.rev !current_theme_vars;
+              }
+              :: !tests
+      | line :: rest ->
+          if String.trim line = "<<<>>>" then (
+            let expected = Buffer.contents buf |> String.trim in
+            if classes <> [] then
+              tests :=
+                {
+                  source = filename;
+                  name;
+                  config;
+                  classes;
+                  expected;
+                  variants = List.rev !current_variants;
+                  theme_vars = List.rev !current_theme_vars;
+                }
+                :: !tests;
+            parse rest)
+          else (
+            if Buffer.length buf > 0 then Buffer.add_char buf '\n';
+            Buffer.add_string buf line;
+            parse_expected name config classes buf rest)
+    in
+    parse lines;
+    List.rev !tests
+
+(* A fixture is found beside the executable under the dune sandbox, and under
+   [upstream/] or [test/upstream/] when the test runs from a parent
+   directory. *)
+let path basename =
+  List.find_opt Sys.file_exists
+    [
+      basename;
+      Filename.concat "upstream" basename;
+      Filename.concat "test/upstream" basename;
+    ]
+
+(* The [:root] custom properties a fixture's expected CSS declares, so a case's
+   theme tokens can be read back out of the output Tailwind produced for it. *)
+let extract_root_vars expected =
+  let pattern = Re.Pcre.regexp {|--([a-zA-Z0-9_-]+):\s*([^;}]+)|} in
+  let matches = Re.all pattern expected in
+  List.filter_map
+    (fun m ->
+      try
+        let name = Re.Group.get m 1 in
+        let value = String.trim (Re.Group.get m 2) in
+        Some (name, value)
+      with Not_found | Failure _ -> None)
+    matches
+
+(* The [var(--name, fallback)] pairs in a fixture's expected CSS. A [@theme
+   reference] block declares no [:root] value, so the fallback is the only place
+   its token appears. *)
+let extract_var_fallbacks expected =
+  let pattern =
+    Re.Pcre.regexp
+      {|var\(--([a-zA-Z0-9_-]+),\s*(var\(--[a-zA-Z0-9_-]+\)|[^)]+)\)|}
+  in
+  let matches = Re.all pattern expected in
+  List.filter_map
+    (fun m ->
+      try
+        let name = Re.Group.get m 1 in
+        let fallback = String.trim (Re.Group.get m 2) in
+        Some (name, fallback)
+      with Not_found | Failure _ -> None)
+    matches
+
+(* A [--tw-*] variable is a utility's own output rather than a theme token the
+   test declared, so it must not become a token override. *)
+let is_runtime_var name = String.length name > 3 && String.sub name 0 3 = "tw-"

--- a/test/upstream/upstream_fixture.mli
+++ b/test/upstream/upstream_fixture.mli
@@ -1,0 +1,72 @@
+(** Reader for the generated upstream fixtures ([utilities.txt],
+    [variants.txt]).
+
+    The fixtures are one block per upstream test, separated by [<<<>>>]:
+
+    {v
+    # <test name>
+    @config <theme config>
+    @variant <matchVariant directive>     (optional, repeatable)
+    @theme-var <name> <value>             (optional, repeatable)
+    <space-separated class list>
+    ---
+    <expected CSS>
+    v}
+
+    Both the fixture replay in [test/upstream/test.ml] and the parse-parity gate
+    in [test/test_tw.ml] read the same corpus, so they read it here: two readers
+    drifting apart is two different corpora behind one set of fixtures. See
+    [extract_tests.ml] for how the fixtures are generated. *)
+
+type config =
+  | Theme  (** [@theme { ... }] *)
+  | Theme_inline  (** [@theme inline { ... }] *)
+  | Theme_reference  (** [@theme reference { ... }] *)
+  | Theme_inline_reference  (** [@theme inline reference { ... }] *)
+  | No_theme  (** no [@theme] block *)
+  | Run  (** the [run()] helper rather than [compileCss()] *)
+
+val config_of_string : string -> config
+(** [config_of_string s] reads an [@config] line's argument. An unknown name
+    reads as {!constructor-No_theme}, the shape a fixture without a theme has.
+*)
+
+type case = {
+  source : string;  (** Fixture the case was read from. *)
+  name : string;
+  config : config;
+  classes : string list;
+  expected : string;
+  variants : string list;  (** [matchVariant] directive lines for this test. *)
+  theme_vars : (string * string) list;
+      (** [@theme] token overrides (name, value) captured from the test's CSS
+          template by the extractor (e.g. text-shadow sizes Tailwind inlines).
+      *)
+}
+
+val split_classes : string -> string list
+(** [split_classes line] splits a class list on spaces, keeping a bracket value
+    such as [data-[foo_=_bar]:flex] whole. *)
+
+val read : string -> case list
+(** [read path] reads every block of the fixture at [path]. A file that does not
+    exist reads as no cases, which the caller's floor turns into a failure. *)
+
+val path : string -> string option
+(** [path basename] is where [basename] sits relative to the running test:
+    beside the executable under the dune sandbox, or under [upstream/] or
+    [test/upstream/] when the test runs from a parent directory. *)
+
+val extract_root_vars : string -> (string * string) list
+(** [extract_root_vars expected] is the [--name: value] pairs a fixture's
+    expected CSS declares, so a case's theme tokens can be read back out of the
+    output Tailwind produced for it. *)
+
+val extract_var_fallbacks : string -> (string * string) list
+(** [extract_var_fallbacks expected] is the [var(--name, fallback)] pairs in a
+    fixture's expected CSS. A [@theme reference] block declares no [:root]
+    value, so the fallback is the only place its token appears. *)
+
+val is_runtime_var : string -> bool
+(** [is_runtime_var name] is whether [name] is a [tw-*] variable, i.e. a
+    utility's own output rather than a theme token the test declared. *)


### PR DESCRIPTION
The two upstream runners parsed the same fixtures with different readers, and the second carried tolerances over a different oracle that had rotted unnoticed. Both now share one reader; the removed allowances were dead, with the suite reporting no failures and no skips without them.