### PR TITLE
var: drop the unused property collector and its second dedup loop

### DIFF
--- a/lib/property.mli
+++ b/lib/property.mli
@@ -6,8 +6,11 @@ val split : Css.statement list -> Css.statement list * Css.statement list
 (** [split stmts] partitions into ({i \@property} rules, other statements). *)
 
 val dedup : Css.statement list -> Css.statement list
-(** [dedup props] deduplicates {i \@property} rules by name, preserving first.
-*)
+(** [dedup props] deduplicates {i \@property} rules by name, keeping the first
+    of each name. CSS Properties and Values API 1 sec. 2 gives the last
+    registration for a name, which is what cascade's canonicaliser keeps;
+    nothing rides on the difference here because tw's duplicates all come from
+    one {!Var} and are identical. *)
 
 val initial_values : Css.statement list -> (string * string) list
 (** [initial_values stmts] extracts (name, initial-value) pairs from

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -349,7 +349,8 @@ let property_typed : type a.
   | Color, None -> property ~name Universal ~inherits ()
   | Color, Some v -> property ~name Color ~initial_value:v ~inherits ()
   | Percentage, None -> property ~name Percentage ~inherits ()
-  | Percentage, Some v -> property ~name Percentage ~initial_value:v ~inherits ()
+  | Percentage, Some v ->
+      property ~name Percentage ~initial_value:v ~inherits ()
   | Length_percentage, None -> property ~name Length_percentage ~inherits ()
   | Length_percentage, Some v ->
       property ~name Length_percentage ~initial_value:v ~inherits ()
@@ -531,31 +532,6 @@ let order_of_declaration decl =
       match info_of_meta meta with Some (Info t) -> t.order | None -> None)
 
 let property_initial_string = property_info_to_declaration_value
-
-(* Heterogeneous collections *)
-type any_var = Any : ('a, 'r) t -> any_var
-
-let properties vars =
-  (* Collect statements from property rules and deduplicate by name *)
-  let stmts =
-    vars
-    |> List.filter_map (fun (Any v) -> property_rule v)
-    |> List.concat_map Css.statements
-  in
-  let seen = Hashtbl.create 32 in
-  let filtered =
-    List.filter
-      (fun stmt ->
-        match Css.as_property stmt with
-        | Some (Css.Property_info info) ->
-            if Hashtbl.mem seen info.name then false
-            else (
-              Hashtbl.add seen info.name ();
-              true)
-        | None -> true)
-      stmts
-  in
-  Css.v filtered
 
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]
 

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -617,15 +617,6 @@ val property_rules : ('a, [< `Property_default ]) t -> Css.t
     Only use this for property_default variables where you expect a property
     rule. *)
 
-(** {1 Heterogeneous Collections} *)
-
-(** Existential type for heterogeneous collections of variables *)
-type any_var = Any : ('a, 'r) t -> any_var
-
-val properties : any_var list -> Css.t
-(** [properties vars] generates deduplicated [@property] rules for all variables
-    that need them, sorted deterministically by (name, kind). *)
-
 (** {1 Helper Types and Functions} *)
 
 val css_name : ('a, _) t -> string


### PR DESCRIPTION
Nothing called it, and it carried a copy of the dedup that `Property` already implements. The surviving implementation keeps the first `@property` per name where the spec keeps the last, which is noted where it lives.