### PR TITLE
color: stop a theme colour crashing the opacity path

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -225,8 +225,7 @@ module Handler = struct
   let to_class (t : t) =
     match t with
     | Bg (color, shade) ->
-        if Color.is_base_color color || Color.is_custom_color color then
-          "bg-" ^ Color.pp color
+        if Color.is_shadeless color then "bg-" ^ Color.pp color
         else "bg-" ^ Color.pp color ^ "-" ^ string_of_int shade
     | Bg_gradient_to dir -> (
         match dir with
@@ -245,13 +244,11 @@ module Handler = struct
         in
         let color_class = function
           | Color_source.Named (color, shade) ->
-              if Color.is_base_color color || Color.is_custom_color color then
-                Color.pp color
+              if Color.is_shadeless color then Color.pp color
               else Color.pp color ^ "-" ^ string_of_int shade
           | Color_source.Named_opacity (color, shade, opacity) ->
               let base =
-                if Color.is_base_color color || Color.is_custom_color color then
-                  Color.pp color
+                if Color.is_shadeless color then Color.pp color
                 else Color.pp color ^ "-" ^ string_of_int shade
               in
               base ^ opacity_suffix opacity
@@ -346,8 +343,7 @@ module Handler = struct
     | Bg_transparent -> "bg-transparent"
     | Bg_opacity (color, shade, opacity) ->
         let base =
-          if Color.is_base_color color || Color.is_custom_color color then
-            "bg-" ^ Color.pp color
+          if Color.is_shadeless color then "bg-" ^ Color.pp color
           else "bg-" ^ Color.pp color ^ "-" ^ string_of_int shade
         in
         base ^ opacity_suffix opacity
@@ -1105,9 +1101,27 @@ module Handler = struct
     in
 
     (* Without a scheme override the palette still has a hex for the colour, and
-       Tailwind emits the same fallback + [@supports] pair either way. *)
-    let hex_of_palette () =
-      Color.rgb_to_hex (Color.oklch_to_rgb (Color.to_oklch color shade))
+       Tailwind emits the same fallback + [@supports] pair either way. A project
+       token has no palette entry, so its value comes from the theme instead. *)
+    let hex_pair hex =
+      ( Css.hex hex,
+        Css.hex
+          (if Color.opacity_var_bare_of opacity <> None then hex
+           else Color.hex_with_alpha hex percent) )
+    in
+    let value_pair () =
+      match Scheme.hex_color scheme color_name with
+      | Some hex -> hex_pair hex
+      | None -> (
+          match Color.to_oklch_opt color shade with
+          | Some oklch -> hex_pair (Color.rgb_to_hex (Color.oklch_to_rgb oklch))
+          | None ->
+              let value = Color.to_css ?theme color shade in
+              ( value,
+                if Color.opacity_var_bare_of opacity <> None then value
+                else
+                  Css.color_mix ~in_space:Srgb value Css.Transparent
+                    ~percent1:percent ))
     in
     match Color.opacity_keyword color with
     | Some keyword ->
@@ -1120,72 +1134,47 @@ module Handler = struct
           | None -> [ d_var; d_stops ]
         in
         style ~property_rules declarations
-    | None -> (
-        match
-          match Scheme.hex_color scheme color_name with
-          | Some _ as h -> h
-          | None -> Some (hex_of_palette ())
-        with
-        | Some hex_value ->
-            (* Scheme color: generate fallback + @supports + stops (same as
-               Tailwind) Tailwind outputs: 1. .from-X/N { --tw-gradient-from:
-               #RRGGBBAA } 2. @supports { .from-X/N { --tw-gradient-from:
-               color-mix(...) } } 3. .from-X/N { --tw-gradient-stops: ... } To
-               match, we put fallback in props, @supports in rules, and stops as
-               separate rule in rules. *)
-            let hex_alpha =
-              if Color.opacity_var_bare_of opacity <> None then hex_value
-              else Color.hex_with_alpha hex_value percent
-            in
-            let d_fallback, _ = Var.binding set_var (Css.hex hex_alpha) in
+    | None ->
+        (* Tailwind outputs three rules: 1. .from-X/N { --tw-gradient-from:
+           <fallback> } 2. @supports { .from-X/N { --tw-gradient-from:
+           color-mix(...) } } 3. .from-X/N { --tw-gradient-stops: ... } To
+           match, we put fallback in props, @supports in rules, and stops as
+           separate rule in rules. *)
+        let color_value, fallback_value = value_pair () in
+        let d_fallback, _ = Var.binding set_var fallback_value in
 
-            (* Theme variable for @supports block *)
-            let color_var = Color.color_var color shade in
-            let theme_decl, color_ref =
-              Var.binding color_var (Css.hex hex_value)
-            in
-            let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
-            let d_oklab, _ = Var.binding set_var oklab_color in
+        (* Theme variable for @supports block *)
+        let color_var = Color.color_var color shade in
+        let theme_decl, color_ref = Var.binding color_var color_value in
+        let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
+        let d_oklab, _ = Var.binding set_var oklab_color in
 
-            (* Build @supports block with placeholder selector *)
-            let supports_rule =
-              Css.supports ~condition:Color.color_mix_supports_condition
-                [
-                  Css.rule ~selector:(Css.Selector.class_ "_")
-                    [ theme_decl; d_oklab ];
-                ]
-            in
+        (* Build @supports block with placeholder selector *)
+        let supports_rule =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [
+              Css.rule ~selector:(Css.Selector.class_ "_")
+                [ theme_decl; d_oklab ];
+            ]
+        in
 
-            (* Build stops rule with placeholder selector (will be replaced) *)
-            let stops_decls =
-              match d_via_stops_opt with
-              | Some d_via_stops -> [ d_via_stops; d_stops ]
-              | None -> [ d_stops ]
-            in
-            let stops_rule =
-              Css.rule ~selector:(Css.Selector.class_ "_") stops_decls
-            in
+        (* Build stops rule with placeholder selector (will be replaced) *)
+        let stops_decls =
+          match d_via_stops_opt with
+          | Some d_via_stops -> [ d_via_stops; d_stops ]
+          | None -> [ d_stops ]
+        in
+        let stops_rule =
+          Css.rule ~selector:(Css.Selector.class_ "_") stops_decls
+        in
 
-            (* Three separate rules: fallback, @supports, stops *)
-            let fallback_rule =
-              Css.rule ~selector:(Css.Selector.class_ "_") [ d_fallback ]
-            in
-            style ~property_rules
-              ~rules:(Some [ fallback_rule; supports_rule; stops_rule ])
-              []
-        | None ->
-            (* Non-scheme color: use color-mix directly *)
-            let oklch = Color.to_oklch color shade in
-            let color_value =
-              Color.mix_alpha opacity (Css.oklch oklch.l oklch.c oklch.h)
-            in
-            let d_var, _ = Var.binding set_var color_value in
-            let declarations =
-              match d_via_stops_opt with
-              | Some d_via_stops -> [ d_var; d_via_stops; d_stops ]
-              | None -> [ d_var; d_stops ]
-            in
-            style ~property_rules declarations)
+        (* Three separate rules: fallback, @supports, stops *)
+        let fallback_rule =
+          Css.rule ~selector:(Css.Selector.class_ "_") [ d_fallback ]
+        in
+        style ~property_rules
+          ~rules:(Some [ fallback_rule; supports_rule; stops_rule ])
+          []
 
   (** Build gradient stops declarations for a given prefix (from-/via-/to-).
       Returns (d_stops, d_via_stops_opt) *)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1125,8 +1125,7 @@ module Handler = struct
     | Border_hidden -> "border-hidden"
     | Border_none -> "border-none"
     | Border_color (c, shade) ->
-        if Color.is_base_color c || Color.is_custom_color c then
-          "border-" ^ Color.color_to_string c
+        if Color.is_shadeless c then "border-" ^ Color.color_to_string c
         else "border-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
     | Border_transparent -> "border-transparent"
     | Border_current -> "border-current"

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -879,23 +879,24 @@ let rgb r g b =
   Rgb { red = r; green = g; blue = b }
 
 (* Convert color to OKLCH data for a given shade *)
-let to_oklch color shade =
+let to_oklch_opt color shade =
   match color with
-  | Black -> { l = 0.0; c = 0.0; h = 0.0 }
-  | White -> { l = 100.0; c = 0.0; h = 0.0 }
-  | Oklch oklch -> oklch
+  | Black -> Some { l = 0.0; c = 0.0; h = 0.0 }
+  | White -> Some { l = 100.0; c = 0.0; h = 0.0 }
+  | Oklch oklch -> Some oklch
   | Hex h -> (
       match hex_to_rgb h with
-      | Some rgb -> rgb_to_oklch rgb
-      | None -> { l = 0.0; c = 0.0; h = 0.0 })
-  | Rgb { red; green; blue } -> rgb_to_oklch { r = red; g = green; b = blue }
+      | Some rgb -> Some (rgb_to_oklch rgb)
+      | None -> Some { l = 0.0; c = 0.0; h = 0.0 })
+  | Rgb { red; green; blue } ->
+      Some (rgb_to_oklch { r = red; g = green; b = blue })
   | Css c -> (
       (* Extract RGB channels from CSS color for oklch conversion *)
       match c with
       | Css.Hex { r; g; b; _ } | Css.Authored_hex { r; g; b; _ } -> (
           match hex_to_rgb (hex_string_of_rgb (r, g, b)) with
-          | Some rgb -> rgb_to_oklch rgb
-          | None -> { l = 0.0; c = 0.0; h = 0.0 })
+          | Some rgb -> Some (rgb_to_oklch rgb)
+          | None -> Some { l = 0.0; c = 0.0; h = 0.0 })
       | Css.Rgb (Channels { r; g; b })
       | Css.Rgba { rgb = Channels { r; g; b }; _ } ->
           let chan_to_int : Css.channel -> int = function
@@ -905,10 +906,11 @@ let to_oklch color shade =
             | Var _ -> 0
             | None -> 0
           in
-          rgb_to_oklch
-            { r = chan_to_int r; g = chan_to_int g; b = chan_to_int b }
-      | _ -> { l = 0.0; c = 0.0; h = 0.0 })
-  | _ -> (
+          Some
+            (rgb_to_oklch
+               { r = chan_to_int r; g = chan_to_int g; b = chan_to_int b })
+      | _ -> Some { l = 0.0; c = 0.0; h = 0.0 })
+  | _ ->
       (* For named colors, get OKLCH data directly from Tailwind *)
       let color_name =
         match color with
@@ -940,12 +942,15 @@ let to_oklch color shade =
         | Rose -> "rose"
         | _ -> ""
       in
-      match Tailwind.get_color_oklch color_name shade with
-      | Some oklch -> oklch
-      | None ->
-          failwith
-            ("No OKLCH data for color " ^ color_name ^ " shade "
-           ^ string_of_int shade))
+      Tailwind.get_color_oklch color_name shade
+
+(* A colour outside the palette has no OKLCH of its own; reading it as black
+   keeps the conversion total. Callers that can do better - the ones with a
+   theme to consult - go through [to_oklch_opt] instead. *)
+let to_oklch color shade =
+  match to_oklch_opt color shade with
+  | Some oklch -> oklch
+  | None -> { l = 0.0; c = 0.0; h = 0.0 }
 
 (* Convert color to OKLCH CSS string for a given shade *)
 let to_oklch_css color shade =
@@ -1003,6 +1008,14 @@ let oklch_node_of color shade =
   let oklch = to_oklch color shade in
   css_color_of_oklch oklch
 
+(* A project token declared in an [\@theme] block names a colour the palette
+   knows nothing about: [--color-brand] has no shades to convert, and its value
+   is whatever the block bound it to. *)
+let theme_named_color ?theme name =
+  match Scheme.theme_value theme ("color-" ^ name) with
+  | Some value -> Css.parse_color value
+  | None -> None
+
 (* The palette ([Red], [Blue], ...) is a fixed set of (colour, shade) pairs and
    its oklch nodes are immutable, so materialise each node once and share it
    across every utility and variant that uses the colour, instead of
@@ -1049,7 +1062,7 @@ let palette_nodes =
      table)
 
 (* Convert color to CSS color value *)
-let to_css color shade =
+let to_css ?theme color shade =
   match color with
   | Black -> Css.hex "#000"
   | White -> Css.hex "#fff"
@@ -1065,7 +1078,13 @@ let to_css color shade =
       Css.hex ("#" ^ shorten_hex_str hex_value)
   | Oklch oklch -> css_color_of_oklch oklch
   | Css c -> c
-  | Rgb _ | Theme_named _ -> oklch_node_of color shade
+  | Theme_named name -> (
+      match theme_named_color ?theme name with
+      | Some c -> c
+      (* Only a token the theme declares parses into [Theme_named], so a class
+         never lands here; a colour built by hand out of thin air does. *)
+      | None -> Css.Transparent)
+  | Rgb _ -> oklch_node_of color shade
   | _ -> (
       match Hashtbl.find_opt (Lazy.force palette_nodes) (color, shade) with
       | Some node -> node
@@ -1729,7 +1748,7 @@ module Handler = struct
     let color_name = scheme_color_name c shade in
     match Scheme.hex_color (resolve_scheme theme) color_name with
     | Some hex -> Css.hex hex
-    | None -> to_css c (if is_base_color c then 500 else shade)
+    | None -> to_css ?theme c (if is_base_color c then 500 else shade)
 
   (* The theme-layer declaration for a palette colour together with the typed
      reference to it, so a utility outside this module can both emit the token
@@ -1855,7 +1874,7 @@ module Handler = struct
             let std_name = "color-" ^ color_name in
             match Scheme.theme_value theme std_name with
             | Some value -> parse_theme_color value
-            | None -> to_css c (if is_base_color c then 500 else shade)))
+            | None -> to_css ?theme c (if is_base_color c then 500 else shade)))
 
   (* Aliases for color constructors/functions that will be shadowed by open
      Css *)
@@ -2549,6 +2568,18 @@ module Handler = struct
   let color_mix_supports_condition =
     Css.Supports.property "color" "color-mix(in lab, red, red)"
 
+  (* What a browser without [color-mix()] reads. A palette colour converts to a
+     plain hex carrying the alpha. A project token has no such conversion - its
+     value is whatever the [\@theme] block bound it to, and that may be a colour
+     space no hex can spell - so it takes the sRGB mix Tailwind writes instead.
+     [value] is the colour already resolved against the theme. *)
+  let opacity_fallback ~percent c shade value =
+    match to_oklch_opt c shade with
+    | Some oklch ->
+        Css.hex (hex_with_alpha (rgb_to_hex (oklch_to_rgb oklch)) percent)
+    | None ->
+        Css.color_mix ~in_space:Srgb value Css.Transparent ~percent1:percent
+
   (* The same colour set on several properties at once: a per-side border colour
      on the [x]/[y] axes needs two. *)
 
@@ -2635,7 +2666,7 @@ module Handler = struct
               | Some prefix ->
                   property_color_value ?theme ~property_prefix:prefix c shade
               | Stdlib.Option.None ->
-                  to_css c (if is_base_color c then 500 else shade)
+                  to_css ?theme c (if is_base_color c then 500 else shade)
             in
             let theme_decl, color_ref = Var.binding color_var color_value in
             (* An opacity read from a var has no percentage to fold into a hex
@@ -2644,10 +2675,7 @@ module Handler = struct
               match opacity_var_name opacity with
               | Some _ -> property_decls (Css.Var color_ref)
               | None ->
-                  let oklch = to_oklch c shade in
-                  let rgb = oklch_to_rgb oklch in
-                  let hex_value = rgb_to_hex rgb in
-                  property_decls (Css.hex (hex_with_alpha hex_value percent))
+                  property_decls (opacity_fallback ~percent c shade color_value)
             in
             let oklab_color =
               match opacity_var_name opacity with
@@ -3150,10 +3178,10 @@ module Handler = struct
 
   let to_class = function
     | Bg (c, shade) ->
-        if is_base_color c || is_custom_color c then "bg-" ^ color_to_string c
+        if is_shadeless c then "bg-" ^ color_to_string c
         else "bg-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Bg_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "bg-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "bg-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3162,10 +3190,10 @@ module Handler = struct
     | Bg_current -> "bg-current"
     | Bg_current_opacity opacity -> "bg-current" ^ opacity_suffix opacity
     | Text (c, shade) ->
-        if is_base_color c || is_custom_color c then "text-" ^ color_to_string c
+        if is_shadeless c then "text-" ^ color_to_string c
         else "text-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Text_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "text-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "text-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3184,11 +3212,10 @@ module Handler = struct
     | Text_bracket_typed_var_opacity (v, opacity) ->
         "text-[color:" ^ v ^ "]" ^ opacity_suffix opacity
     | Border (c, shade) ->
-        if is_base_color c || is_custom_color c then
-          "border-" ^ color_to_string c
+        if is_shadeless c then "border-" ^ color_to_string c
         else "border-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Border_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "border-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "border-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3215,10 +3242,10 @@ module Handler = struct
         let v =
           match value with
           | Side_color.Named (c, shade) ->
-              if is_base_color c || is_custom_color c then color_to_string c
+              if is_shadeless c then color_to_string c
               else color_to_string c ^ "-" ^ string_of_int shade
           | Side_color.Named_opacity (c, shade, opacity) ->
-              (if is_base_color c || is_custom_color c then color_to_string c
+              (if is_shadeless c then color_to_string c
                else color_to_string c ^ "-" ^ string_of_int shade)
               ^ opacity_suffix opacity
           | Side_color.Bracket (orig, _) -> "[" ^ orig ^ "]"
@@ -3229,11 +3256,10 @@ module Handler = struct
     | Border_bracket_color_opacity (v, _, opacity) ->
         "border-[" ^ v ^ "]" ^ opacity_suffix opacity
     | Accent (c, shade) ->
-        if is_base_color c || is_custom_color c then
-          "accent-" ^ color_to_string c
+        if is_shadeless c then "accent-" ^ color_to_string c
         else "accent-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Accent_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "accent-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "accent-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3247,11 +3273,10 @@ module Handler = struct
     | Accent_bracket_color_opacity (v, _, opacity) ->
         "accent-[" ^ v ^ "]" ^ opacity_suffix opacity
     | Caret (c, shade) ->
-        if is_base_color c || is_custom_color c then
-          "caret-" ^ color_to_string c
+        if is_shadeless c then "caret-" ^ color_to_string c
         else "caret-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Caret_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "caret-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "caret-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3264,11 +3289,10 @@ module Handler = struct
     | Caret_bracket_color_opacity (v, _, opacity) ->
         "caret-[" ^ v ^ "]" ^ opacity_suffix opacity
     | Outline (c, shade) ->
-        if is_base_color c || is_custom_color c then
-          "outline-" ^ color_to_string c
+        if is_shadeless c then "outline-" ^ color_to_string c
         else "outline-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Outline_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "outline-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "outline-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3288,11 +3312,10 @@ module Handler = struct
     | Outline_bracket_typed_var_opacity (v, opacity) ->
         "outline-[color:" ^ v ^ "]" ^ opacity_suffix opacity
     | Placeholder (c, shade) ->
-        if is_base_color c || is_custom_color c then
-          "placeholder-" ^ color_to_string c
+        if is_shadeless c then "placeholder-" ^ color_to_string c
         else "placeholder-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Placeholder_opacity (c, shade, opacity) ->
-        if is_base_color c || is_custom_color c then
+        if is_shadeless c then
           "placeholder-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "placeholder-" ^ color_to_string c ^ "-" ^ string_of_int shade
@@ -3399,9 +3422,9 @@ let color_mix_supports_stmts ~stmts =
 let mix_alpha = Handler.mix_alpha
 let apply_alpha = Handler.apply_alpha
 
-let oklab_with_supports ~property ~fallback_decl c shade opacity =
+let oklab_with_supports ?theme ~property ~fallback_decl c shade opacity =
   let cvar = color_var c shade in
-  let color_value = to_css c (if is_base_color c then 500 else shade) in
+  let color_value = to_css ?theme c (if is_base_color c then 500 else shade) in
   let theme_decl, color_ref = Var.binding cvar color_value in
   let oklab_color = mix_alpha opacity (Css.Var color_ref) in
   let oklab_decl = property oklab_color in
@@ -3417,7 +3440,7 @@ let generic_color_with_opacity ?theme ~property c shade opacity =
   | None when is_fully_opaque opacity && not (is_custom_color c) ->
       (* At 100% the mix is a no-op, so Tailwind writes the colour itself. *)
       let theme_decl, color_ref =
-        Var.binding (color_var c shade) (to_css c shade)
+        Var.binding (color_var c shade) (to_css ?theme c shade)
       in
       let value : Css.color = Var color_ref in
       Style.style [ theme_decl; property value ]
@@ -3436,17 +3459,19 @@ let generic_color_with_opacity ?theme ~property c shade opacity =
             if alpha_var then property (Css.hex hex_value)
             else property (Css.hex (hex_with_alpha hex_value percent))
           in
-          oklab_with_supports ~property ~fallback_decl c shade opacity
+          oklab_with_supports ?theme ~property ~fallback_decl c shade opacity
       | None ->
-          let oklch = to_oklch c shade in
+          (* A palette colour renders as its oklch node; a project token as
+             whatever the theme bound it to. *)
+          let base = to_css ?theme c shade in
           let fallback_color =
-            if alpha_var then css_color_of_oklch oklch
+            if alpha_var then base
             else
-              Css.color_mix ~in_space:Srgb (css_color_of_oklch oklch)
-                Css.Transparent ~percent1:percent
+              Css.color_mix ~in_space:Srgb base Css.Transparent
+                ~percent1:percent
           in
-          oklab_with_supports ~property ~fallback_decl:(property fallback_color)
-            c shade opacity)
+          oklab_with_supports ?theme ~property
+            ~fallback_decl:(property fallback_color) c shade opacity)
 
 let generic_current_with_opacity ?merge_key ~fallback_decl ~property opacity =
   let oklab_color = mix_alpha opacity Css.Current in
@@ -3485,17 +3510,16 @@ let divide_opacity_via_property ?theme ~selector c shade opacity =
     property_color_var ?theme ~property_prefix:"border-color" c shade
   in
   let color_value =
-    property_color_value ~property_prefix:"border-color" c shade
+    property_color_value ?theme ~property_prefix:"border-color" c shade
   in
-  let hex_alpha =
-    let oklch = to_oklch c shade in
-    let hex = rgb_to_hex (oklch_to_rgb oklch) in
-    if Handler.opacity_var_name opacity <> None then hex
-    else hex_with_alpha hex (Handler.opacity_to_percent opacity)
+  let fallback_color =
+    if Handler.opacity_var_name opacity <> None then color_value
+    else
+      Handler.opacity_fallback
+        ~percent:(Handler.opacity_to_percent opacity)
+        c shade color_value
   in
-  let fallback_rule =
-    Css.rule ~selector [ Css.border_color (Css.hex hex_alpha) ]
-  in
+  let fallback_rule = Css.rule ~selector [ Css.border_color fallback_color ] in
   let theme_decl, color_ref = Var.binding cvar color_value in
   let oklab_color = mix_alpha opacity (Css.Var color_ref) in
   let supports_rule =
@@ -3504,9 +3528,9 @@ let divide_opacity_via_property ?theme ~selector c shade opacity =
   let supports_block = color_mix_supports_stmts ~stmts:[ supports_rule ] in
   Style.style ~rules:(Some [ fallback_rule; supports_block ]) []
 
-let bg_opacity_via_property c shade opacity =
+let bg_opacity_via_property ?theme c shade opacity =
   let cvar = color_var c shade in
-  let color_value = to_css c (if is_base_color c then 500 else shade) in
+  let color_value = to_css ?theme c (if is_base_color c then 500 else shade) in
   let theme_decl, color_ref = Var.binding cvar color_value in
   (* An opacity read from a var has no percentage to fold into the fallback, so
      that is the colour at full opacity, as Tailwind emits. *)
@@ -3514,10 +3538,10 @@ let bg_opacity_via_property c shade opacity =
     match Handler.opacity_var_name opacity with
     | Some _ -> Css.background_color (Css.Var color_ref)
     | None ->
-        let oklch = to_oklch c shade in
-        let hex = rgb_to_hex (oklch_to_rgb oklch) in
         Css.background_color
-          (Css.hex (hex_with_alpha hex (Handler.opacity_to_percent opacity)))
+          (Handler.opacity_fallback
+             ~percent:(Handler.opacity_to_percent opacity)
+             c shade color_value)
   in
   let oklab_decl =
     Css.background_color (mix_alpha opacity (Css.Var color_ref))
@@ -3538,7 +3562,7 @@ let divide_with_opacity_selector ?theme ~selector c shade opacity =
       Style.style ~rules:(Some [ rule ]) []
   | None when is_fully_opaque opacity && not (is_custom_color c) ->
       let theme_decl, color_ref =
-        Var.binding (color_var c shade) (to_css c shade)
+        Var.binding (color_var c shade) (to_css ?theme c shade)
       in
       let value : Css.color = Var color_ref in
       let rule = Css.rule ~selector [ Css.border_color value ] in
@@ -3606,7 +3630,9 @@ let bg_with_opacity ?theme c shade opacity =
       (* 100% opacity = no transparency. Tailwind outputs the plain color var
          reference, identical to the no-opacity case. *)
       let cvar = color_var c shade in
-      let color_value = to_css c (if is_base_color c then 500 else shade) in
+      let color_value =
+        to_css ?theme c (if is_base_color c then 500 else shade)
+      in
       let _d, color_ref = Var.binding cvar color_value in
       Style.style [ Css.background_color (Var color_ref) ]
   | None when is_custom_color c ->
@@ -3636,7 +3662,7 @@ let bg_with_opacity ?theme c shade opacity =
           let supports_block = color_mix_supports ~decls:[ oklab_decl ] in
           Style.style ~rules:(Some [ supports_block ])
             [ theme_decl; fallback_decl ]
-      | None -> bg_opacity_via_property c shade opacity)
+      | None -> bg_opacity_via_property ?theme c shade opacity)
 
 (** Determine the appropriate fallback for an opacity theme variable. If the
     theme defines a concrete value (e.g., "0.5"), use [Fallback (Num f)]. If the

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -72,8 +72,10 @@ val rgb_to_hex : rgb -> string
 val oklch_to_css : oklch -> string
 (** [oklch_to_css oklch] formats OKLCH for CSS. *)
 
-val to_css : color -> int -> Css.color
-(** [to_css color shade] converts a color to CSS color value. *)
+val to_css : ?theme:Scheme.t -> color -> int -> Css.color
+(** [to_css ?theme color shade] converts a color to CSS color value. A project
+    token declared in an [\@theme] block has no palette entry, so [theme]
+    supplies its value; without one such a colour reads as transparent. *)
 
 (** {1 Tailwind Colors} *)
 
@@ -180,7 +182,14 @@ val of_string : string -> (color, [ `Msg of string ]) result
 (** {1 Color Conversion} *)
 
 val to_oklch : color -> int -> oklch
-(** [to_oklch color shade] converts color to OKLCH data for a given shade. *)
+(** [to_oklch color shade] converts color to OKLCH data for a given shade. A
+    colour the palette does not define reads as black; use {!to_oklch_opt} to
+    tell that case apart. *)
+
+val to_oklch_opt : color -> int -> oklch option
+(** [to_oklch_opt color shade] is the OKLCH data for [color] at [shade], or
+    [None] for a colour the palette does not define - a project token, whose
+    value only the theme knows. *)
 
 val to_oklch_css : color -> int -> string
 (** [to_oklch_css color shade] converts color to OKLCH CSS string for a given

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -45,8 +45,7 @@ module Handler = struct
     !v
 
   let color_suffix color shade =
-    if Color.is_base_color color || Color.is_custom_color color then
-      Color.color_to_string color
+    if Color.is_shadeless color then Color.color_to_string color
     else Color.color_to_string color ^ "-" ^ string_of_int shade
 
   (* Bracket values sort first, then keywords/theme colours alphabetically (ties
@@ -87,8 +86,7 @@ module Handler = struct
   let spec_class = function
     | Theme (color, shade, op) ->
         let base =
-          if Color.is_base_color color || Color.is_custom_color color then
-            Color.color_to_string color
+          if Color.is_shadeless color then Color.color_to_string color
           else Color.color_to_string color ^ "-" ^ string_of_int shade
         in
         base ^ opacity_suffix op

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -219,8 +219,7 @@ module Handler = struct
     !v
 
   let color_suffix color shade =
-    if Color.is_base_color color || Color.is_custom_color color then
-      Color.color_to_string color
+    if Color.is_shadeless color then Color.color_to_string color
     else Color.color_to_string color ^ "-" ^ string_of_int shade
 
   (* Suborder: determines ordering within the svg priority group. Three groups:
@@ -267,11 +266,10 @@ module Handler = struct
     | Fill_current -> "fill-current"
     | Fill_current_opacity opacity -> "fill-current" ^ opacity_suffix opacity
     | Fill_color (c, shade) ->
-        if Color.is_base_color c || Color.is_custom_color c then
-          "fill-" ^ Color.color_to_string c
+        if Color.is_shadeless c then "fill-" ^ Color.color_to_string c
         else "fill-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
     | Fill_color_opacity (c, shade, opacity) ->
-        if Color.is_base_color c || Color.is_custom_color c then
+        if Color.is_shadeless c then
           "fill-" ^ Color.color_to_string c ^ opacity_suffix opacity
         else
           "fill-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
@@ -292,11 +290,10 @@ module Handler = struct
     | Stroke_current_opacity opacity ->
         "stroke-current" ^ opacity_suffix opacity
     | Stroke_color (c, shade) ->
-        if Color.is_base_color c || Color.is_custom_color c then
-          "stroke-" ^ Color.color_to_string c
+        if Color.is_shadeless c then "stroke-" ^ Color.color_to_string c
         else "stroke-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
     | Stroke_color_opacity (c, shade, opacity) ->
-        if Color.is_base_color c || Color.is_custom_color c then
+        if Color.is_shadeless c then
           "stroke-" ^ Color.color_to_string c ^ opacity_suffix opacity
         else
           "stroke-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -508,6 +508,52 @@ let test_decoration_theme_colour_opacity () =
       Alcotest.(check string)
         "custom theme colour round-trips" "decoration-brand/50" (Tw.pp u)
 
+(* A colour a project declared in an [@theme] block has no palette entry to
+   convert, so the opacity path has to read its value off the theme rather than
+   ask the palette for a shade it never had. *)
+let test_theme_colour_opacity_families () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-brand", "oklch(55% 0.2 250)") ]
+  in
+  let css cls =
+    match Tw.of_string ~theme cls with
+    | Ok u ->
+        Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u);
+        Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  List.iter
+    (fun cls ->
+      (* The pre-color-mix fallback keeps the modifier's alpha. *)
+      has cls "color-mix(in srgb,oklch(55%.2 250) 50%,transparent)";
+      (* The enhanced value reads the token rather than inlining it. *)
+      has cls "color-mix(in oklab,var(--color-brand) 50%,transparent)")
+    [
+      "bg-brand/50";
+      "text-brand/50";
+      "border-brand/50";
+      "divide-brand/50";
+      "fill-brand/50";
+      "accent-brand/50";
+      "from-brand/50";
+    ]
+
+(* A name no [@theme] block declared is not a colour, whatever it looks like. *)
+let test_undeclared_theme_colour_rejected () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error _ -> ()
+      | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u))
+    [ "bg-brand/50"; "text-brand/50"; "border-brand/50" ]
+
 (* Test suite *)
 (* An achromatic palette colour must keep a [none] hue. A numeric hue renders
    the same but folds to a plain hex, which pins the hue that interpolation is
@@ -652,6 +698,12 @@ let tests =
     ( "Decoration theme colour opacity",
       `Quick,
       test_decoration_theme_colour_opacity );
+    ( "Theme colour opacity across families",
+      `Quick,
+      test_theme_colour_opacity_families );
+    ( "Undeclared theme colour rejected",
+      `Quick,
+      test_undeclared_theme_colour_rejected );
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);
     ("RGB to hex", `Quick, test_rgb_to_hex);


### PR DESCRIPTION
A project `@theme` colour has no palette shade, so asking the palette for one raised out of a pure conversion and `bg-brand/50` aborted the CLI. It affected every colour family, and the absent shade was also leaking into the class name as `.bg-brand-500\/50`.