### PR TITLE
color: accept a project theme colour with no opacity modifier

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1639,7 +1639,7 @@ module Handler = struct
         | Error e -> Error e)
     (* Named color *)
     | _ -> (
-        match Color.shade_of_strings rest with
+        match Color.shade_of_strings ?theme rest with
         | Ok (color, shade) -> gc (Color_source.Named (color, shade))
         | Error _ -> Error (`Msg "Invalid gradient color"))
 
@@ -1893,7 +1893,7 @@ module Handler = struct
         | Ok (color, shade, opacity) -> Ok (Bg_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "bg" :: rest -> (
-        match Color.shade_of_strings rest with
+        match Color.shade_of_strings ~theme rest with
         | Ok (color, shade) -> Ok (Bg (color, shade))
         | Error _ -> Error (`Msg "Invalid background color"))
     | "from" :: rest -> parse_gradient_color ~theme From rest

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1559,8 +1559,19 @@ let parse_opacity_modifier ?theme s =
       | Some opacity -> (base, opacity)
       | None -> (s, No_opacity))
 
-(* Parse color and shade from string list *)
-let shade_of_strings = function
+(* Parse color and shade from string list. A name the palette does not know is
+   still a colour when the [\@theme] block declared [--color-<name>]; such a
+   token carries no shade, and its name may span several segments. *)
+let shade_of_strings ?theme parts =
+  let theme_named () =
+    let name = String.concat "-" parts in
+    if
+      Parse.is_valid_theme_name name
+      && Scheme.theme_value theme ("color-" ^ name) <> None
+    then Ok (Theme_named name, 500)
+    else Error (`Msg ("Invalid color: " ^ name))
+  in
+  match parts with
   | [ color_str; shade_str ] -> (
       match of_string color_str with
       | Ok color -> (
@@ -1570,18 +1581,33 @@ let shade_of_strings = function
                  && (not (is_shadeless color))
                  && is_valid_shade color shade ->
               Ok (color, shade)
-          | _ -> Error (`Msg ("Invalid shade: " ^ shade_str)))
-      | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
+          | _ -> theme_named ())
+      | Error _ -> theme_named ())
   | [ color_str ] -> (
       match of_string color_str with
       | Ok color -> Ok (color, 500) (* Default shade *)
-      | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
+      | Error _ -> theme_named ())
   | [] -> Error (`Msg "No color specified")
-  | _ -> Error (`Msg "Too many color parts")
+  | _ -> theme_named ()
 
 (* Parse color, shade, and optional opacity modifier from string list. Handles
    formats like ["red"; "500/50"] or ["red"; "500/[0.5]"] *)
-let shade_and_opacity_of_strings ?theme = function
+let shade_and_opacity_of_strings ?theme parts =
+  (* The modifier rides on the last segment however long the name: a project
+     token spelled [brand-primary/50] splits into ["brand"; "primary/50"]. *)
+  let theme_named () =
+    match List.rev parts with
+    | [] -> Error (`Msg "No color specified")
+    | last :: front ->
+        let base, opacity = parse_opacity_modifier ?theme last in
+        let name = String.concat "-" (List.rev (base :: front)) in
+        if
+          Parse.is_valid_theme_name name
+          && Scheme.theme_value theme ("color-" ^ name) <> None
+        then Ok (Theme_named name, 500, opacity)
+        else Error (`Msg ("Invalid color: " ^ name))
+  in
+  match parts with
   | [ color_str; shade_opacity_str ] -> (
       let shade_str, opacity =
         parse_opacity_modifier ?theme shade_opacity_str
@@ -1594,8 +1620,8 @@ let shade_and_opacity_of_strings ?theme = function
                  && (not (is_shadeless color))
                  && is_valid_shade color shade ->
               Ok (color, shade, opacity)
-          | _ -> Error (`Msg ("Invalid shade: " ^ shade_str)))
-      | Error _ -> Error (`Msg ("Invalid color: " ^ color_str)))
+          | _ -> theme_named ())
+      | Error _ -> theme_named ())
   | [ color_str ] -> (
       (* Could be "current/50" or just "black" *)
       let base_str, opacity = parse_opacity_modifier ?theme color_str in
@@ -1616,13 +1642,9 @@ let shade_and_opacity_of_strings ?theme = function
       | None -> (
           match of_string base_str with
           | Ok color -> Ok (color, 500, opacity)
-          | Error _
-            when Parse.is_valid_theme_name base_str
-                 && Scheme.theme_value theme ("color-" ^ base_str) <> None ->
-              Ok (Theme_named base_str, 500, opacity)
-          | Error _ -> Error (`Msg ("Invalid color: " ^ color_str))))
+          | Error _ -> theme_named ()))
   | [] -> Error (`Msg "No color specified")
-  | _ -> Error (`Msg "Too many color parts")
+  | _ -> theme_named ()
 
 (** {1 Parsing Functions} *)
 
@@ -2009,7 +2031,7 @@ module Handler = struct
         | Ok (color, shade, opacity) -> Ok (Bg_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "bg" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Bg (color, shade))
         | Error e -> Error e)
     | [ "text"; "transparent" ] -> Ok Text_transparent
@@ -2059,7 +2081,7 @@ module Handler = struct
             Ok (Text_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "text" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Text (color, shade))
         | Error e -> Error e)
     | [ "border"; "transparent" ] -> Ok Border_transparent
@@ -2126,7 +2148,7 @@ module Handler = struct
                      (bs, Side_color.Named_opacity (color, shade, opacity)))
             | Error e -> Error e)
         | color_parts -> (
-            match shade_of_strings color_parts with
+            match shade_of_strings ~theme color_parts with
             | Ok (color, shade) ->
                 Ok (Border_side_color (bs, Side_color.Named (color, shade)))
             | Error e -> Error e))
@@ -2136,7 +2158,7 @@ module Handler = struct
             Ok (Border_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "border" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Border (color, shade))
         | Error e -> Error e)
     | [ "accent"; "transparent" ] -> Ok Accent_transparent
@@ -2170,7 +2192,7 @@ module Handler = struct
             Ok (Accent_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "accent" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Accent (color, shade))
         | Error e -> Error e)
     | [ "caret"; "inherit" ] -> Ok Caret_inherit
@@ -2204,7 +2226,7 @@ module Handler = struct
             Ok (Caret_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "caret" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Caret (color, shade))
         | Error e -> Error e)
     | [ "outline"; "transparent" ] -> Ok Outline_transparent
@@ -2255,7 +2277,7 @@ module Handler = struct
             Ok (Outline_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "outline" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Outline (color, shade))
         | Error e -> Error e)
     | [ "placeholder"; "transparent" ] -> Ok Placeholder_transparent
@@ -2291,7 +2313,7 @@ module Handler = struct
             Ok (Placeholder_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "placeholder" :: color_parts -> (
-        match shade_of_strings color_parts with
+        match shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Placeholder (color, shade))
         | Error e -> Error e)
     | _ -> Error (`Msg "Not a color utility")

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -381,9 +381,12 @@ val parse_opacity_modifier :
     ("500", Opacity_percent 50.0). Named opacities are validated at parse time
     against the [@theme] tokens in [theme]. *)
 
-val shade_of_strings : string list -> (color * int, [ `Msg of string ]) result
-(** [shade_of_strings parts] parses a color and shade from a list of strings.
-    Example: ["blue"; "500"] -> Ok (Blue, 500). *)
+val shade_of_strings :
+  ?theme:Scheme.t -> string list -> (color * int, [ `Msg of string ]) result
+(** [shade_of_strings ?theme parts] parses a color and shade from a list of
+    strings. Example: ["blue"; "500"] -> Ok (Blue, 500). A name the palette does
+    not know resolves against [theme]: a [--color-<name>] token the project
+    declared is a shadeless colour of its own. *)
 
 val shade_and_opacity_of_strings :
   ?theme:Scheme.t ->

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -239,7 +239,7 @@ module Handler = struct
         | Ok (c, shade, op) -> Ok (mk (Theme (c, shade, op)))
         | Error e -> Error e)
     | parts -> (
-        match Color.shade_of_strings parts with
+        match Color.shade_of_strings ?theme parts with
         | Ok (c, shade) -> Ok (mk (Theme (c, shade, Color.No_opacity)))
         | Error e -> Error e)
 

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -409,7 +409,7 @@ module Handler = struct
             Ok (Fill_color_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "fill" :: color_parts -> (
-        match Color.shade_of_strings color_parts with
+        match Color.shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Fill_color (color, shade))
         | Error e -> Error e)
     | [ "stroke"; "none" ] -> Ok Stroke_none
@@ -449,7 +449,7 @@ module Handler = struct
             Ok (Stroke_color_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "stroke" :: color_parts -> (
-        match Color.shade_of_strings color_parts with
+        match Color.shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Stroke_color (color, shade))
         | Error e -> Error e)
     | _ -> err_not_utility

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -545,6 +545,62 @@ let test_theme_colour_opacity_families () =
       "from-brand/50";
     ]
 
+(* A project token is a colour in its own right, with or without a modifier: at
+   full opacity the utility simply references it. *)
+let test_theme_colour_without_opacity () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-brand", "oklch(55% 0.2 250)") ]
+  in
+  let css cls =
+    match Tw.of_string ~theme cls with
+    | Ok u ->
+        Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u);
+        Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  List.iter
+    (fun cls ->
+      Alcotest.(check bool)
+        (cls ^ " references the token")
+        true
+        (Astring.String.is_infix ~affix:"var(--color-brand)" (css cls)))
+    [
+      "bg-brand";
+      "text-brand";
+      "border-brand";
+      "divide-brand";
+      "fill-brand";
+      "stroke-brand";
+      "accent-brand";
+      "caret-brand";
+      "outline-brand";
+      "from-brand";
+    ]
+
+(* A token name is not limited to one segment, and the modifier still rides on
+   the last one. *)
+let test_multi_segment_theme_colour () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-brand-primary", "#123456") ]
+  in
+  let css cls =
+    match Tw.of_string ~theme cls with
+    | Ok u ->
+        Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u);
+        Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "bg-brand-primary references the token" true
+    (Astring.String.is_infix ~affix:"var(--color-brand-primary)"
+       (css "bg-brand-primary"));
+  Alcotest.(check bool)
+    "bg-brand-primary/50 keeps the alpha" true
+    (Astring.String.is_infix ~affix:"color-mix(in srgb,#123456 50%,transparent)"
+       (css "bg-brand-primary/50"))
+
 (* A name no [@theme] block declared is not a colour, whatever it looks like. *)
 let test_undeclared_theme_colour_rejected () =
   List.iter
@@ -552,7 +608,15 @@ let test_undeclared_theme_colour_rejected () =
       match Tw.of_string cls with
       | Error _ -> ()
       | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u))
-    [ "bg-brand/50"; "text-brand/50"; "border-brand/50" ]
+    [
+      "bg-brand/50";
+      "text-brand/50";
+      "border-brand/50";
+      "bg-brand";
+      "text-brand";
+      "border-brand";
+      "bg-brand-primary";
+    ]
 
 (* Test suite *)
 (* An achromatic palette colour must keep a [none] hue. A numeric hue renders
@@ -701,6 +765,8 @@ let tests =
     ( "Theme colour opacity across families",
       `Quick,
       test_theme_colour_opacity_families );
+    ("Theme colour without opacity", `Quick, test_theme_colour_without_opacity);
+    ("Multi-segment theme colour", `Quick, test_multi_segment_theme_colour);
     ( "Undeclared theme colour rejected",
       `Quick,
       test_undeclared_theme_colour_rejected );


### PR DESCRIPTION
Only the parser that handles a modifier consulted the theme, so `bg-brand` was rejected as unknown while `bg-brand/50` was not. Multi-segment token names are accepted on the same path.