### PR TITLE
typography: keep the modifier's alpha in the decoration fallback

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -3442,6 +3442,7 @@ let color_mix_supports_stmts ~stmts =
   Css.supports ~condition:color_mix_supports_condition stmts
 
 let mix_alpha = Handler.mix_alpha
+let opacity_fallback = Handler.opacity_fallback
 let apply_alpha = Handler.apply_alpha
 
 let oklab_with_supports ?theme ~property ~fallback_decl c shade opacity =

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -369,6 +369,13 @@ val apply_alpha :
 (** [apply_alpha ?in_space opacity color] applies the modifier while preserving
     the identity that every alpha of [transparent] is still [transparent]. *)
 
+val opacity_fallback : percent:float -> color -> int -> Css.color -> Css.color
+(** [opacity_fallback ~percent c shade value] is what a browser without
+    [color-mix()] reads for [c] at [percent] opacity. A palette colour folds the
+    alpha into a plain hex; a project token, whose [value] the theme supplies
+    and which may name a colour space no hex can spell, takes an sRGB mix
+    instead. *)
+
 val opacity_of_string : ?theme:Scheme.t -> string -> opacity_modifier option
 (** [opacity_of_string ?theme s] parses the modifier that follows the [/] in a
     colour class: a percentage, a bracket value, the [(--x)] shorthand, or a

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2335,10 +2335,7 @@ module Typography_late = struct
             let theme_decl, color_ref =
               Var.binding color_var (Css.hex hex_value)
             in
-            let oklab_color =
-              Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-                ~percent1:percent
-            in
+            let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
             let webkit_decl = webkit_text_decoration_color oklab_color in
             let oklab_decl = text_decoration_color oklab_color in
             let supports_block =
@@ -2360,13 +2357,17 @@ module Typography_late = struct
                 ~property_prefix:"text-decoration-color" color shade
             in
             (* A project token may be any CSS colour, not necessarily a palette
-               colour that can be converted to a compile-time hex fallback. *)
-            let fallback_decl = text_decoration_color color_value in
-            let theme_decl, color_ref = Var.binding color_var color_value in
-            let oklab_color =
-              Css.color_mix ~in_space:Oklab (Css.Var color_ref) Css.Transparent
-                ~percent1:percent
+               colour that can be converted to a compile-time hex fallback, so
+               the modifier's alpha rides on an sRGB mix of the value itself. An
+               alpha read from a var has no percentage to mix in, leaving the
+               colour at full opacity. *)
+            let fallback_color =
+              if Color.opacity_var_bare_of opacity <> None then color_value
+              else Color.opacity_fallback ~percent color shade color_value
             in
+            let fallback_decl = text_decoration_color fallback_color in
+            let theme_decl, color_ref = Var.binding color_var color_value in
+            let oklab_color = Color.mix_alpha opacity (Css.Var color_ref) in
             let webkit_decl = webkit_text_decoration_color oklab_color in
             let oklab_decl = text_decoration_color oklab_color in
             let supports_block =

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -698,6 +698,35 @@ let test_decoration_shadeless_opacity () =
   rejected "decoration-nosuchcolor/50";
   rejected "decoration-white/"
 
+(* The pre-color-mix fallback has to carry the modifier's alpha, or a browser
+   without [color-mix()] paints the decoration fully opaque. A palette colour
+   folds the alpha into a hex; a project token, whose value the theme supplies,
+   takes the sRGB mix instead. *)
+let test_decoration_opacity_fallback () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-brand", "oklch(55% 0.2 250)") ]
+  in
+  let css cls =
+    match Tw.of_string ~theme cls with
+    | Ok u ->
+        Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "text-decoration-color:#fb2c3680" "decoration-red-500/50";
+  emits "text-decoration-color:#ffffff80" "decoration-white/50";
+  emits
+    "text-decoration-color:color-mix(in srgb,oklch(55%.2 250) 50%,transparent)"
+    "decoration-brand/50";
+  (* An alpha read from a var has no percentage to fold in, so the fallback is
+     the colour itself and the enhanced value reads the var. *)
+  emits "text-decoration-color:oklch(55%.2 250)" "decoration-brand/(--a)";
+  emits "color-mix(in oklab,var(--color-brand) var(--a),transparent)"
+    "decoration-brand/(--a)"
+
 (* A [#] bracket is only a decoration colour when what follows is a hex
    spelling. The decoration reader handed everything after the [#] to the
    raising constructor from inside [of_class], so a malformed hex escaped the
@@ -775,6 +804,8 @@ let tests =
       suborder_matches_tailwind;
     test_case "line-clamp sorts with box-sizing" `Quick
       line_clamp_sorts_with_box_sizing;
+    test_case "decoration opacity fallback" `Quick
+      test_decoration_opacity_fallback;
     test_case "typography renders like Tailwind" `Slow
       rendering_matches_tailwind;
   ]


### PR DESCRIPTION
The sRGB fallback dropped the opacity, so a browser without `color-mix(in lab)` painted the decoration fully opaque. A variable alpha was pinned at 100% in the guarded value for the same reason.