### PR TITLE
transitions: read an arbitrary ease with cascade's grammar

### DIFF
--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -37,7 +37,9 @@ module Handler = struct
     | Ease_out
     | Ease_in_out
     | Ease_initial
-    | Ease_arbitrary of string
+    (* The author's bracket text travels with the timing function it denotes, so
+       the class name is spelled exactly as it was written. *)
+    | Ease_arbitrary of string * Css.timing_function
 
   type Utility.base += Self of t
 
@@ -416,64 +418,27 @@ module Handler = struct
         Css.transition_timing_function (Css.Var ease_in_out_ref);
       ]
 
-  let parse_cubic_bezier raw =
-    let prefix = "cubic-bezier(" in
-    if
-      String.length raw > String.length prefix + 1
-      && String.sub raw 0 (String.length prefix) = prefix
-      && raw.[String.length raw - 1] = ')'
-    then
-      let inner =
-        String.sub raw (String.length prefix)
-          (String.length raw - String.length prefix - 1)
-      in
-      match String.split_on_char ',' inner |> List.map String.trim with
-      | [ a; b; c; d ] -> (
-          match
-            ( float_of_string_opt a,
-              float_of_string_opt b,
-              float_of_string_opt c,
-              float_of_string_opt d )
-          with
-          | Some a, Some b, Some c, Some d ->
-              Some (Css.Cubic_bezier (a, b, c, d))
-          | _ -> None)
-      | _ -> None
-    else None
-
-  let parse_raw_timing_function raw : Css.timing_function =
-    match parse_cubic_bezier raw with
-    | Some tf -> tf
-    | None -> (
-        match raw with
-        | "linear" -> Linear
-        | "ease" -> Ease
-        | "ease-in" -> Ease_in
-        | "ease-out" -> Ease_out
-        | "ease-in-out" -> Ease_in_out
-        | _ -> invalid_arg ("Unsupported timing function: " ^ raw))
-
-  let ease_arbitrary s =
+  (* The timing function an [ease-[...]] bracket denotes, read with cascade's
+     own grammar. [None] is a bracket no timing function reads from, and
+     [of_class] refuses the utility rather than leaving [to_style] to raise. *)
+  let arbitrary_timing_function s : Css.timing_function option =
     if Parse.is_var s then
-      let bare_name = Parse.extract_var_name s in
-      let ref_ : Css.timing_function Css.var = Var.bracket bare_name in
-      let tw_ease_decl, _ = Var.binding tw_ease_var (Css.Var ref_) in
-      let prop_rule = Var.property_rule tw_ease_var in
-      let property_rules =
-        match prop_rule with Some r -> r | None -> Css.empty
-      in
-      style ~property_rules
-        [ tw_ease_decl; Css.transition_timing_function (Css.Var ref_) ]
+      Some (Css.Var (Var.bracket (Parse.extract_var_name s)))
     else
-      (* Raw timing function like "cubic-bezier(0.4,0,0.2,1)" *)
-      let raw = String.map (fun c -> if c = '_' then ' ' else c) s in
-      let tf = parse_raw_timing_function raw in
-      let tw_ease_decl, _ = Var.binding tw_ease_var tf in
-      let prop_rule = Var.property_rule tw_ease_var in
-      let property_rules =
-        match prop_rule with Some r -> r | None -> Css.empty
-      in
-      style ~property_rules [ tw_ease_decl; Css.transition_timing_function tf ]
+      let cursor = Cascade.Cursor.of_string (Parse.decode_underscores s) in
+      match
+        Cascade.Cursor.try_parse_full_err Css.Properties.read_timing_function
+          cursor
+      with
+      | Ok tf -> Some tf
+      | Error _ -> None
+
+  let ease_arbitrary tf =
+    let tw_ease_decl, _ = Var.binding tw_ease_var tf in
+    let property_rules =
+      match Var.property_rule tw_ease_var with Some r -> r | None -> Css.empty
+    in
+    style ~property_rules [ tw_ease_decl; Css.transition_timing_function tf ]
 
   let delay n = style [ Css.transition_delay (Css.Ms (float_of_int n)) ]
   let delay_arbitrary d = style [ Css.transition_delay d ]
@@ -516,7 +481,7 @@ module Handler = struct
     | Ease_out -> ease_out
     | Ease_in_out -> ease_in_out
     | Ease_initial -> ease_initial
-    | Ease_arbitrary s -> ease_arbitrary s
+    | Ease_arbitrary (_, tf) -> ease_arbitrary tf
 
   let suborder = function
     | Transition -> 0
@@ -626,8 +591,11 @@ module Handler = struct
     | [ "ease"; "out" ] -> Ok Ease_out
     | [ "ease"; "in"; "out" ] -> Ok Ease_in_out
     | [ "ease"; "initial" ] -> Ok Ease_initial
-    | [ "ease"; value ] when Parse.is_bracket_value value ->
-        Ok (Ease_arbitrary (Parse.bracket_inner value))
+    | [ "ease"; value ] when Parse.is_bracket_value value -> (
+        let inner = Parse.bracket_inner value in
+        match arbitrary_timing_function inner with
+        | Some tf -> Ok (Ease_arbitrary (inner, tf))
+        | None -> Error (`Msg "Invalid ease value"))
     | _ -> Error (`Msg "Not a transition utility")
 
   let to_class = function
@@ -651,7 +619,7 @@ module Handler = struct
     | Ease_out -> "ease-out"
     | Ease_in_out -> "ease-in-out"
     | Ease_initial -> "ease-initial"
-    | Ease_arbitrary s -> "ease-[" ^ s ^ "]"
+    | Ease_arbitrary (s, _) -> "ease-[" ^ s ^ "]"
 
   let examples = [ Transition; Duration 150; Delay 150; Ease_linear ]
 end

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -62,12 +62,37 @@ let test_invalid_arbitrary_property () =
   accepted "transition-[opacity,transform]";
   accepted "transition-[var(--x)]"
 
+(* [ease-[...]] takes a timing function. A bracket the timing-function grammar
+   cannot read used to be accepted and then raise out of [to_css], which is a
+   pure conversion. *)
+let test_invalid_arbitrary_ease () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let renders cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "ease-[foo]";
+  rejected "ease-[1]";
+  rejected "ease-[50%]";
+  rejected "ease-[]";
+  renders "ease-[linear]";
+  renders "ease-[cubic-bezier(0.4,0,0.2,1)]";
+  renders "ease-[steps(4,end)]";
+  renders "ease-[var(--my-ease)]"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "initial resets" `Quick test_initial_resets;
       Alcotest.test_case "invalid arbitrary property" `Quick
         test_invalid_arbitrary_property;
+      Alcotest.test_case "invalid arbitrary ease" `Quick
+        test_invalid_arbitrary_ease;
     ]
 
 let suite = ("transitions", tests)


### PR DESCRIPTION
`ease-[foo]` was accepted by the parser and then raised out of `to_css`, which is a pure conversion. Reading the timing function with the shared grammar rejects it at parse time and admits `steps()`, `linear()` and the step keywords that the hand-rolled reader did not.