### PR TITLE
flex_props: refuse an arbitrary order at parse time

### DIFF
--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -45,8 +45,10 @@ module Handler = struct
     (* Order *)
     | Order of int
     | Neg_order of int (* -order-4 = calc(4 * -1) *)
-    | Neg_order_arbitrary of string (* -order-[var(--value)] *)
-    | Order_arbitrary of string (* order-[123] *)
+    (* The author's bracket text travels with the order it denotes, so the class
+       name is spelled exactly as it was written. *)
+    | Neg_order_arbitrary of string * Css.order (* -order-[var(--value)] *)
+    | Order_arbitrary of string * Css.order (* order-[123] *)
     | Order_first
     | Order_last
     | Order_none
@@ -197,11 +199,9 @@ module Handler = struct
     | Basis_arbitrary len -> style [ flex_basis len ]
     | Order n -> order_style n
     | Neg_order n -> style [ order (Int (-n)) ]
-    | Neg_order_arbitrary s ->
-        let o = Css.Properties.read_order (Cascade.Cursor.of_string s) in
+    | Neg_order_arbitrary (_, o) ->
         style [ order (Calc (Css.Calc.mul (Val o) (Css.Calc.float (-1.)))) ]
-    | Order_arbitrary s ->
-        style [ order (Css.Properties.read_order (Cascade.Cursor.of_string s)) ]
+    | Order_arbitrary (_, o) -> style [ order o ]
     | Order_first -> order_first ()
     | Order_last -> order_last ()
     | Order_none -> order_none
@@ -272,6 +272,17 @@ module Handler = struct
     | "5xl" | "6xl" | "7xl" ->
         true
     | _ -> false
+
+  (* The order an [order-[...]] bracket denotes. [None] is a bracket the order
+     grammar cannot read, and [of_class] refuses the utility rather than leaving
+     [to_style] to raise. *)
+  let arbitrary_order inner : Css.order option =
+    let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Properties.read_order cursor
+    with
+    | Ok o -> Some o
+    | Error _ -> None
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
@@ -345,7 +356,9 @@ module Handler = struct
           && value.[String.length value - 1] = ']'
         then
           let inner = String.sub value 1 (String.length value - 2) in
-          Ok (Order_arbitrary inner)
+          match arbitrary_order inner with
+          | Some o -> Ok (Order_arbitrary (inner, o))
+          | None -> err_not_utility
         else
           match Parse.decimal_int value with
           | Some n when n >= 0 -> Ok (Order n)
@@ -359,7 +372,9 @@ module Handler = struct
           && value.[String.length value - 1] = ']'
         then
           let inner = String.sub value 1 (String.length value - 2) in
-          Ok (Neg_order_arbitrary inner)
+          match arbitrary_order inner with
+          | Some o -> Ok (Neg_order_arbitrary (inner, o))
+          | None -> err_not_utility
         else
           match Parse.decimal_int value with
           | Some n when n >= 1 -> Ok (Neg_order n)
@@ -423,8 +438,8 @@ module Handler = struct
     (* Order *)
     | Order n -> "order-" ^ string_of_int n
     | Neg_order n -> "-order-" ^ string_of_int n
-    | Neg_order_arbitrary s -> "-order-[" ^ s ^ "]"
-    | Order_arbitrary s -> "order-[" ^ s ^ "]"
+    | Neg_order_arbitrary (s, _) -> "-order-[" ^ s ^ "]"
+    | Order_arbitrary (s, _) -> "order-[" ^ s ^ "]"
     | Order_first -> "order-first"
     | Order_last -> "order-last"
     | Order_none -> "order-none"

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -116,6 +116,29 @@ let test_basis_named_prefers_spacing () =
     "basis-sm declares --spacing-sm" true
     (Astring.String.is_infix ~affix:"--spacing-sm: 8px" css)
 
+(* [order-[...]] takes an order value. A bracket the order grammar cannot read
+   is accepted and then raises out of [to_css], a pure conversion, so the
+   rejection belongs at parse time. *)
+let test_invalid_arbitrary_order () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let renders cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "order-[foo]";
+  rejected "order-[1abc]";
+  rejected "order-[1.5]";
+  rejected "-order-[foo]";
+  renders "order-[13]";
+  renders "order-[var(--x)]";
+  renders "-order-[13]";
+  renders "-order-[var(--x)]"
+
 let tests =
   [
     test_case "basis-* prefers --spacing-*" `Quick
@@ -124,6 +147,7 @@ let tests =
     test_case "flex_props of_string - invalid values" `Quick of_string_invalid;
     test_case "flex_props suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "invalid arbitrary order" `Quick test_invalid_arbitrary_order;
   ]
 
 let suite = ("flex_props", tests)


### PR DESCRIPTION
`order-[foo]` and its negative form parsed and then raised during rendering.