### PR TITLE
layout: refuse an arbitrary z-index at parse time

### DIFF
--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -146,8 +146,11 @@ module Handler = struct
     | Z_auto
     | Z of int (* Dynamic z-index: z-5, z-100, etc. *)
     | Neg_z of int (* Negative z-index: -z-10, -z-50, etc. *)
-    | Z_arbitrary of string (* Arbitrary values: z-[123] *)
-    | Neg_z_arbitrary of string (* Negative arbitrary: -z-[var(--value)] *)
+    (* The author's bracket text travels with the z-index it denotes, so the
+       class name is spelled exactly as it was written. *)
+    | Z_arbitrary of string * Css.z_index (* Arbitrary values: z-[123] *)
+    | Neg_z_arbitrary of
+        string * Css.z_index (* Negative arbitrary: -z-[var(--value)] *)
     | (* Object fit *)
       Object_contain
     | Object_cover
@@ -390,8 +393,8 @@ module Handler = struct
     | Z_50 -> "z-50"
     | Z_auto -> "z-auto"
     | Neg_z n -> "-z-" ^ string_of_int n
-    | Z_arbitrary s -> "z-[" ^ s ^ "]"
-    | Neg_z_arbitrary s -> "-z-[" ^ s ^ "]"
+    | Z_arbitrary (s, _) -> "z-[" ^ s ^ "]"
+    | Neg_z_arbitrary (s, _) -> "-z-[" ^ s ^ "]"
     | Object_contain -> "object-contain"
     | Object_cover -> "object-cover"
     | Object_fill -> "object-fill"
@@ -481,11 +484,8 @@ module Handler = struct
     | Z_50 -> style [ z_index (Index 50) ]
     | Z_auto -> z_auto_style ()
     | Neg_z n -> style [ z_index (Index (-n)) ]
-    | Z_arbitrary s ->
-        style
-          [ z_index (Css.Properties.read_z_index (Cascade.Cursor.of_string s)) ]
-    | Neg_z_arbitrary s ->
-        let zi = Css.Properties.read_z_index (Cascade.Cursor.of_string s) in
+    | Z_arbitrary (_, zi) -> style [ z_index zi ]
+    | Neg_z_arbitrary (_, zi) ->
         style [ z_index (Calc (Css.Calc.mul (Val zi) (Css.Calc.float (-1.)))) ]
     | Object_contain -> style [ object_fit Contain ]
     | Object_cover -> style [ object_fit Cover ]
@@ -599,6 +599,17 @@ module Handler = struct
 
   (** {1 Parsing Functions} *)
 
+  (* The z-index a [z-[...]] bracket denotes. [None] is a bracket the z-index
+     grammar cannot read, and [of_class] refuses the utility rather than leaving
+     [to_style] to raise. *)
+  let arbitrary_z_index inner : Css.z_index option =
+    let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Properties.read_z_index cursor
+    with
+    | Ok zi -> Some zi
+    | Error _ -> None
+
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
@@ -635,7 +646,10 @@ module Handler = struct
         (* Arbitrary value: z-[123] *)
         let len = String.length n in
         if len > 2 && n.[len - 1] = ']' then
-          Ok (Z_arbitrary (String.sub n 1 (len - 2)))
+          let inner = String.sub n 1 (len - 2) in
+          match arbitrary_z_index inner with
+          | Some zi -> Ok (Z_arbitrary (inner, zi))
+          | None -> Error (`Msg ("Invalid z-index arbitrary value: " ^ n))
         else Error (`Msg ("Invalid z-index arbitrary value: " ^ n))
     | [ "z"; n ] -> (
         (* Dynamic z-index: z-5, z-100, etc. *)
@@ -651,7 +665,9 @@ module Handler = struct
           && value.[String.length value - 1] = ']'
         then
           let inner = String.sub value 1 (String.length value - 2) in
-          Ok (Neg_z_arbitrary inner)
+          match arbitrary_z_index inner with
+          | Some zi -> Ok (Neg_z_arbitrary (inner, zi))
+          | None -> Error (`Msg ("Invalid negative z-index value: " ^ value))
         else
           match Parse.decimal_int value with
           | Some i -> Ok (Neg_z i)

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -238,6 +238,30 @@ let test_object_and_z_values () =
   | Error _ -> ());
   has "z-auto" "z-index:auto"
 
+(* [z-[...]] takes a z-index. A bracket the z-index grammar cannot read is
+   accepted and then raises out of [to_css], a pure conversion, so the rejection
+   belongs at parse time. *)
+let test_invalid_arbitrary_z_index () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let renders cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "z-[foo]";
+  rejected "z-[1.5]";
+  rejected "z-[50%]";
+  rejected "-z-[foo]";
+  renders "z-[13]";
+  renders "z-[auto]";
+  renders "z-[var(--x)]";
+  renders "-z-[13]";
+  renders "-z-[var(--x)]"
+
 let tests =
   [
     test_case "display utilities" `Quick test_display_utilities;
@@ -259,6 +283,7 @@ let tests =
     test_case "isolation and float slots" `Quick isolation_and_float_slots;
     test_case "layout suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "invalid arbitrary z-index" `Quick test_invalid_arbitrary_z_index;
   ]
 
 let suite = ("layout", tests)


### PR DESCRIPTION
`z-[foo]` and `-z-[1.5]` parsed and then raised during rendering.