### PR TITLE
grid_item: refuse an arbitrary grid line at parse time

### DIFF
--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -55,7 +55,10 @@ module Handler = struct
     (* Column *)
     | Col of int
     | Neg_col of int (* -col-12 = calc(12 * -1) *)
-    | Col_arbitrary of string (* col-[span_123/span_123] *)
+    (* The author's bracket text travels with the grid line it denotes, so the
+       class name is spelled exactly as it was written. *)
+    | Col_arbitrary of string * (Css.grid_line * Css.grid_line)
+      (* col-[span_123/span_123] *)
     | Col_auto
     | Col_span of int
     | Col_span_arbitrary of string (* col-span-[var(--my-variable)] *)
@@ -63,17 +66,17 @@ module Handler = struct
     | Col_start of int
     | Neg_col_start of int
     | Col_start_auto
-    | Col_start_arbitrary of string
+    | Col_start_arbitrary of string * Css.grid_line
     | Col_start_named of string (* col-start-custom *)
     | Col_end of int
     | Neg_col_end of int
     | Col_end_auto
-    | Col_end_arbitrary of string
+    | Col_end_arbitrary of string * Css.grid_line
     | Col_end_named of string (* col-end-custom *)
     (* Row *)
     | Row of int
     | Neg_row of int
-    | Row_arbitrary of string
+    | Row_arbitrary of string * (Css.grid_line * Css.grid_line)
     | Row_auto
     | Row_span of int
     | Row_span_arbitrary of string (* row-span-[var(--my-variable)] *)
@@ -81,12 +84,12 @@ module Handler = struct
     | Row_start of int
     | Neg_row_start of int
     | Row_start_auto
-    | Row_start_arbitrary of string
+    | Row_start_arbitrary of string * Css.grid_line
     | Row_start_named of string (* row-start-custom *)
     | Row_end of int
     | Neg_row_end of int
     | Row_end_auto
-    | Row_end_arbitrary of string
+    | Row_end_arbitrary of string * Css.grid_line
     | Row_end_named of string (* row-end-custom *)
 
   type Utility.base += Self of t
@@ -98,18 +101,31 @@ module Handler = struct
 
   let col n = style [ grid_column (Num n, Auto) ]
   let neg_col n = style [ grid_column (Num (-n), Auto) ]
-  let read_gl s = Css.Properties.read_grid_line (Cascade.Cursor.of_string s)
 
-  let read_grid_line_pair s =
+  (* The grid line a bracket denotes. [None] is a bracket the grid-line grammar
+     cannot read, and [of_class] refuses the utility rather than leaving
+     [to_style] to raise. *)
+  let read_gl s : Css.grid_line option =
+    let cursor = Cascade.Cursor.of_string s in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Properties.read_grid_line cursor
+    with
+    | Ok gl -> Some gl
+    | Error _ -> None
+
+  (* [col-[a/b]] takes both lines of the shorthand; a bracket that is one line
+     leaves the end line [auto]. *)
+  let read_grid_line_pair s : (Css.grid_line * Css.grid_line) option =
     let cursor = Cascade.Cursor.of_string s in
     match
       Cascade.Cursor.try_parse_full_err Css.Properties.read_grid_line_pair
         cursor
     with
-    | Ok (Lines (start, end_)) -> (start, end_)
-    | Ok (Var _) | Error _ -> (read_gl s, Auto)
+    | Ok (Lines (start, end_)) -> Some (start, end_)
+    | Ok (Var _) | Error _ ->
+        Option.map (fun gl -> (gl, (Auto : Css.grid_line))) (read_gl s)
 
-  let col_arbitrary s = style [ grid_column (read_grid_line_pair s) ]
+  let col_arbitrary pair = style [ grid_column pair ]
 
   let col_auto ?theme () =
     match Scheme.theme_value theme "grid-column-auto" with
@@ -149,7 +165,7 @@ module Handler = struct
   let col_span_full = style [ grid_column (Num 1, Num (-1)) ]
   let col_start n = style [ grid_column_start (Num n) ]
   let neg_col_start n = style [ grid_column_start (Num (-n)) ]
-  let col_start_arbitrary s = style [ grid_column_start (read_gl s) ]
+  let col_start_arbitrary gl = style [ grid_column_start gl ]
 
   let col_start_auto ?theme () =
     match Scheme.theme_value theme "grid-column-start-auto" with
@@ -161,7 +177,7 @@ module Handler = struct
 
   let col_end n = style [ grid_column_end (Num n) ]
   let neg_col_end n = style [ grid_column_end (Num (-n)) ]
-  let col_end_arbitrary s = style [ grid_column_end (read_gl s) ]
+  let col_end_arbitrary gl = style [ grid_column_end gl ]
 
   let col_end_auto ?theme () =
     match Scheme.theme_value theme "grid-column-end-auto" with
@@ -173,7 +189,7 @@ module Handler = struct
 
   let row n = style [ grid_row (Num n, Auto) ]
   let neg_row n = style [ grid_row (Num (-n), Auto) ]
-  let row_arbitrary s = style [ grid_row (read_grid_line_pair s) ]
+  let row_arbitrary pair = style [ grid_row pair ]
 
   let row_auto ?theme () =
     match Scheme.theme_value theme "grid-row-auto" with
@@ -186,7 +202,7 @@ module Handler = struct
   let row_span_full = style [ grid_row (Num 1, Num (-1)) ]
   let row_start n = style [ grid_row_start (Num n) ]
   let neg_row_start n = style [ grid_row_start (Num (-n)) ]
-  let row_start_arbitrary s = style [ grid_row_start (read_gl s) ]
+  let row_start_arbitrary gl = style [ grid_row_start gl ]
 
   let row_start_auto ?theme () =
     match Scheme.theme_value theme "grid-row-start-auto" with
@@ -198,7 +214,7 @@ module Handler = struct
 
   let row_end n = style [ grid_row_end (Num n) ]
   let neg_row_end n = style [ grid_row_end (Num (-n)) ]
-  let row_end_arbitrary s = style [ grid_row_end (read_gl s) ]
+  let row_end_arbitrary gl = style [ grid_row_end gl ]
 
   let row_end_auto ?theme () =
     match Scheme.theme_value theme "grid-row-end-auto" with
@@ -222,36 +238,36 @@ module Handler = struct
     function
     | Col n -> col n
     | Neg_col n -> neg_col n
-    | Col_arbitrary s -> col_arbitrary s
+    | Col_arbitrary (_, pair) -> col_arbitrary pair
     | Col_auto -> col_auto ()
     | Col_span n -> col_span n
     | Col_span_arbitrary s -> col_span_arbitrary s
     | Col_span_full -> col_span_full
     | Col_start n -> col_start n
     | Neg_col_start n -> neg_col_start n
-    | Col_start_arbitrary s -> col_start_arbitrary s
+    | Col_start_arbitrary (_, gl) -> col_start_arbitrary gl
     | Col_start_auto -> col_start_auto ()
     | Col_start_named s -> col_start_named s
     | Col_end n -> col_end n
     | Neg_col_end n -> neg_col_end n
-    | Col_end_arbitrary s -> col_end_arbitrary s
+    | Col_end_arbitrary (_, gl) -> col_end_arbitrary gl
     | Col_end_auto -> col_end_auto ()
     | Col_end_named s -> col_end_named s
     | Row n -> row n
     | Neg_row n -> neg_row n
-    | Row_arbitrary s -> row_arbitrary s
+    | Row_arbitrary (_, pair) -> row_arbitrary pair
     | Row_auto -> row_auto ()
     | Row_span n -> row_span n
     | Row_span_arbitrary s -> row_span_arbitrary s
     | Row_span_full -> row_span_full
     | Row_start n -> row_start n
     | Neg_row_start n -> neg_row_start n
-    | Row_start_arbitrary s -> row_start_arbitrary s
+    | Row_start_arbitrary (_, gl) -> row_start_arbitrary gl
     | Row_start_auto -> row_start_auto ()
     | Row_start_named s -> row_start_named s
     | Row_end n -> row_end n
     | Neg_row_end n -> neg_row_end n
-    | Row_end_arbitrary s -> row_end_arbitrary s
+    | Row_end_arbitrary (_, gl) -> row_end_arbitrary gl
     | Row_end_auto -> row_end_auto ()
     | Row_end_named s -> row_end_named s
 
@@ -319,8 +335,11 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "col"; "start"; "auto" ] -> Ok Col_start_auto
     | [ "col"; "start"; n ] when String.length n > 0 && n.[0] = '[' -> (
-        match parse_arbitrary n with
-        | Some v -> Ok (Col_start_arbitrary v)
+        match
+          Option.bind (parse_arbitrary n) (fun v ->
+              Option.map (fun x -> (v, x)) (read_gl v))
+        with
+        | Some (v, x) -> Ok (Col_start_arbitrary (v, x))
         | None -> err_not_utility)
     | [ "col"; "start"; n ] -> (
         match Parse.int_pos ~name:"col-start" n with
@@ -339,8 +358,11 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "col"; "end"; "auto" ] -> Ok Col_end_auto
     | [ "col"; "end"; n ] when String.length n > 0 && n.[0] = '[' -> (
-        match parse_arbitrary n with
-        | Some v -> Ok (Col_end_arbitrary v)
+        match
+          Option.bind (parse_arbitrary n) (fun v ->
+              Option.map (fun x -> (v, x)) (read_gl v))
+        with
+        | Some (v, x) -> Ok (Col_end_arbitrary (v, x))
         | None -> err_not_utility)
     | [ "col"; "end"; n ] -> (
         match Parse.int_pos ~name:"col-end" n with
@@ -359,8 +381,11 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "col"; n ] when String.length n > 0 && n.[0] = '[' -> (
         (* Calc col: col-[span_123/span_123] *)
-        match parse_arbitrary n with
-        | Some v -> Ok (Col_arbitrary v)
+        match
+          Option.bind (parse_arbitrary n) (fun v ->
+              Option.map (fun x -> (v, x)) (read_grid_line_pair v))
+        with
+        | Some (v, x) -> Ok (Col_arbitrary (v, x))
         | None -> err_not_utility)
     | [ "col"; n ] -> (
         match Parse.int_pos ~name:"col" n with
@@ -383,8 +408,11 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "row"; n ] when String.length n > 0 && n.[0] = '[' -> (
         (* Calc row: row-[span_123/span_123] *)
-        match parse_arbitrary n with
-        | Some v -> Ok (Row_arbitrary v)
+        match
+          Option.bind (parse_arbitrary n) (fun v ->
+              Option.map (fun x -> (v, x)) (read_grid_line_pair v))
+        with
+        | Some (v, x) -> Ok (Row_arbitrary (v, x))
         | None -> err_not_utility)
     | [ "row"; n ] -> (
         match Parse.int_pos ~name:"row" n with
@@ -397,8 +425,11 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "row"; "start"; "auto" ] -> Ok Row_start_auto
     | [ "row"; "start"; n ] when String.length n > 0 && n.[0] = '[' -> (
-        match parse_arbitrary n with
-        | Some v -> Ok (Row_start_arbitrary v)
+        match
+          Option.bind (parse_arbitrary n) (fun v ->
+              Option.map (fun x -> (v, x)) (read_gl v))
+        with
+        | Some (v, x) -> Ok (Row_start_arbitrary (v, x))
         | None -> err_not_utility)
     | [ "row"; "start"; n ] -> (
         match Parse.int_pos ~name:"row-start" n with
@@ -416,8 +447,11 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "row"; "end"; "auto" ] -> Ok Row_end_auto
     | [ "row"; "end"; n ] when String.length n > 0 && n.[0] = '[' -> (
-        match parse_arbitrary n with
-        | Some v -> Ok (Row_end_arbitrary v)
+        match
+          Option.bind (parse_arbitrary n) (fun v ->
+              Option.map (fun x -> (v, x)) (read_gl v))
+        with
+        | Some (v, x) -> Ok (Row_end_arbitrary (v, x))
         | None -> err_not_utility)
     | [ "row"; "end"; n ] -> (
         match Parse.int_pos ~name:"row-end" n with
@@ -443,37 +477,37 @@ module Handler = struct
     (* Column *)
     | Col n -> "col-" ^ string_of_int n
     | Neg_col n -> "-col-" ^ string_of_int n
-    | Col_arbitrary s -> "col-" ^ to_class_arbitrary s
+    | Col_arbitrary (s, _) -> "col-" ^ to_class_arbitrary s
     | Col_auto -> "col-auto"
     | Col_span n -> "col-span-" ^ string_of_int n
     | Col_span_arbitrary s -> "col-span-" ^ to_class_arbitrary s
     | Col_span_full -> "col-span-full"
     | Col_start n -> "col-start-" ^ string_of_int n
     | Neg_col_start n -> "-col-start-" ^ string_of_int n
-    | Col_start_arbitrary s -> "col-start-" ^ to_class_arbitrary s
+    | Col_start_arbitrary (s, _) -> "col-start-" ^ to_class_arbitrary s
     | Col_start_auto -> "col-start-auto"
     | Col_start_named s -> "col-start-" ^ s
     | Col_end n -> "col-end-" ^ string_of_int n
     | Neg_col_end n -> "-col-end-" ^ string_of_int n
-    | Col_end_arbitrary s -> "col-end-" ^ to_class_arbitrary s
+    | Col_end_arbitrary (s, _) -> "col-end-" ^ to_class_arbitrary s
     | Col_end_auto -> "col-end-auto"
     | Col_end_named s -> "col-end-" ^ s
     (* Row *)
     | Row n -> "row-" ^ string_of_int n
     | Neg_row n -> "-row-" ^ string_of_int n
-    | Row_arbitrary s -> "row-" ^ to_class_arbitrary s
+    | Row_arbitrary (s, _) -> "row-" ^ to_class_arbitrary s
     | Row_auto -> "row-auto"
     | Row_span n -> "row-span-" ^ string_of_int n
     | Row_span_arbitrary s -> "row-span-" ^ to_class_arbitrary s
     | Row_span_full -> "row-span-full"
     | Row_start n -> "row-start-" ^ string_of_int n
     | Neg_row_start n -> "-row-start-" ^ string_of_int n
-    | Row_start_arbitrary s -> "row-start-" ^ to_class_arbitrary s
+    | Row_start_arbitrary (s, _) -> "row-start-" ^ to_class_arbitrary s
     | Row_start_auto -> "row-start-auto"
     | Row_start_named s -> "row-start-" ^ s
     | Row_end n -> "row-end-" ^ string_of_int n
     | Neg_row_end n -> "-row-end-" ^ string_of_int n
-    | Row_end_arbitrary s -> "row-end-" ^ to_class_arbitrary s
+    | Row_end_arbitrary (s, _) -> "row-end-" ^ to_class_arbitrary s
     | Row_end_auto -> "row-end-auto"
     | Row_end_named s -> "row-end-" ^ s
 

--- a/test/test_grid_item.ml
+++ b/test/test_grid_item.ml
@@ -133,6 +133,30 @@ let test_arbitrary_span_var () =
   has "grid-row: span var(--my-variable) / span var(--my-variable)"
     "row-span-[var(--my-variable)]"
 
+(* [col-[...]] and [row-start-[...]] take grid lines. A bracket the grid-line
+   grammar cannot read is accepted and then raises out of [to_css], a pure
+   conversion, so the rejection belongs at parse time. *)
+let test_invalid_arbitrary_grid_line () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let renders cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "col-[50%]";
+  rejected "row-[1.5]";
+  rejected "col-start-[1fr]";
+  rejected "row-end-[50%]";
+  renders "col-[2]";
+  renders "col-[span_2/span_3]";
+  renders "col-[var(--x)]";
+  renders "col-start-[7]";
+  renders "row-end-[3]"
+
 let tests =
   [
     test_case "grid_item of_string - valid values" `Quick of_string_valid;
@@ -141,6 +165,8 @@ let tests =
     test_case "arbitrary span var()" `Quick test_arbitrary_span_var;
     test_case "grid_item suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "invalid arbitrary grid line" `Quick
+      test_invalid_arbitrary_grid_line;
   ]
 
 let suite = ("grid_item", tests)


### PR DESCRIPTION
`col-[50%]`, `row-[1.5]` and `col-start-[1fr]` parsed and then raised during rendering.