### PR TITLE
var: refuse a second, disagreeing family registration

### DIFF
--- a/lib/var.ml
+++ b/lib/var.ml
@@ -99,6 +99,29 @@ module Registry = struct
         Hashtbl.replace name_registry name order;
         order
 
+  (* A name owns its family and its [@property] need: each is a fact about one
+     custom property, not a slot several families share. A second registration
+     that agrees restates the fact; one that disagrees is a constant copied by
+     hand that has drifted, so it is refused rather than letting module
+     initialisation order decide the properties layer. *)
+  let register_once tbl ~what ~pp ~name ~value =
+    match Hashtbl.find_opt tbl name with
+    | Some established when established <> value ->
+        invalid_arg
+          (Pp.str
+             [
+               "--";
+               name;
+               ": ";
+               what;
+               " is ";
+               pp established;
+               ", registered again as ";
+               pp value;
+             ])
+    | Some _ -> ()
+    | None -> Hashtbl.replace tbl name value
+
   let register_property_order ~name ~order =
     Hashtbl.replace property_order_registry name order
 
@@ -120,8 +143,30 @@ module Registry = struct
     in
     Hashtbl.find_opt name_registry name
 
+  let family_name : family -> string = function
+    | `Border -> "Border"
+    | `Rotate -> "Rotate"
+    | `Skew -> "Skew"
+    | `Scale -> "Scale"
+    | `Translate -> "Translate"
+    | `Gradient -> "Gradient"
+    | `Shadow -> "Shadow"
+    | `Inset_shadow -> "Inset_shadow"
+    | `Ring -> "Ring"
+    | `Inset_ring -> "Inset_ring"
+    | `Leading -> "Leading"
+    | `Font_weight -> "Font_weight"
+    | `Duration -> "Duration"
+    | `Tracking -> "Tracking"
+    | `Content -> "Content"
+    | `Text_shadow -> "Text_shadow"
+    | `Filter -> "Filter"
+    | `Drop_shadow -> "Drop_shadow"
+    | `Backdrop_filter -> "Backdrop_filter"
+
   let register_family ~name ~family =
-    Hashtbl.replace family_registry name family
+    register_once family_registry ~what:"family" ~pp:family_name ~name
+      ~value:family
 
   let family name =
     (* Strip leading -- if present *)
@@ -133,7 +178,8 @@ module Registry = struct
     Hashtbl.find_opt family_registry name
 
   let register_needs_property ~name ~needs =
-    Hashtbl.replace needs_property_registry name needs
+    register_once needs_property_registry ~what:"@property need" ~pp:Pp.bool
+      ~name ~value:needs
 
   let needs_property name =
     (* Strip leading -- if present *)

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -179,6 +179,30 @@ let order_of_unknown_name () =
   check order "unknown" None (Tw.Var.order "test-never-defined");
   check order "leading -- stripped" (Some (6, 8)) (Tw.Var.order "--text-xl")
 
+(* A name owns its family and its [@property] need: each is a fact about one
+   custom property, not a slot several families share. A second registration
+   that agrees restates the fact; one that disagrees is a constant copied by
+   hand that has drifted, and it is refused rather than letting module
+   initialisation order decide the properties layer. *)
+let family_registered_once () =
+  let (_ : Css.length Tw.Var.channel) =
+    Tw.Var.channel ~family:`Ring Css.Length "test-family-owner"
+  in
+  let (_ : Css.length Tw.Var.channel) =
+    Tw.Var.channel ~family:`Ring Css.Length "test-family-owner"
+  in
+  check
+    (Alcotest.option Alcotest.string)
+    "established" (Some "Ring")
+    (Option.map
+       (function `Ring -> "Ring" | _ -> "other")
+       (Tw.Var.family "test-family-owner"));
+  Alcotest.check_raises "a disagreeing family is refused"
+    (Invalid_argument
+       "--test-family-owner: family is Ring, registered again as Shadow")
+    (fun () ->
+      ignore (Tw.Var.channel ~family:`Shadow Css.Length "test-family-owner"))
+
 let tests =
   [
     test_case "var CSS output" `Quick var_css_output;
@@ -194,6 +218,7 @@ let tests =
     test_case "order of theme-renamed weight" `Quick
       order_of_theme_renamed_weight;
     test_case "order of unknown name" `Quick order_of_unknown_name;
+    test_case "family registered once" `Quick family_registered_once;
   ]
 
 let suite = ("var", tests)


### PR DESCRIPTION
A variable's family and its need for an `@property` were last-write-wins, so a disagreeing second registration changed the emitted layer silently. Registration order is now checked the way a duplicate variable already was.