### PR TITLE
modifiers: validate the not-has shorthand's pseudo-class

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1532,8 +1532,11 @@ let try_not_shorthand inner =
     Some (Not (Data_custom (attr, "")))
     (* has-X shorthand — :has(:X) pseudo-class *)
   else if String.length inner > 4 && String.sub inner 0 4 = "has-" then
-    let pseudo = String.sub inner 4 (String.length inner - 4) in
-    Some (Not (Has (":" ^ pseudo))) (* nth-X shorthand — :nth-child(X) *)
+    (* The shorthand names a pseudo-class, so it has to read as one; the bracket
+       form validates its selector the same way. *)
+    let sel = ":" ^ String.sub inner 4 (String.length inner - 4) in
+    if is_valid_has_selector sel then Some (Not (Has sel)) else None
+    (* nth-X shorthand — :nth-child(X) *)
   else if String.length inner > 4 && String.sub inner 0 4 = "nth-" then
     let expr = String.sub inner 4 (String.length inner - 4) in
     Some (Not (Nth expr))

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -362,6 +362,24 @@ let test_important_prefix () =
     "!p-4 leaves the --spacing theme token normal" false
     (Astring.String.is_infix ~affix:"--spacing:.25rem!important" (css "!p-4"))
 
+(* [not-has-<X>] reads X as a pseudo-class. The shorthand accepted any text and
+   left the selector reader to raise out of [to_css], a pure conversion, while
+   the bracket form [has-[...]] validated its selector. *)
+let test_not_has_shorthand_selector () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  let renders cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "not-has-a\\:flex";
+  renders "not-has-checked:flex";
+  renders "not-has-hover:flex"
+
 let tests =
   [
     test_case "important prefix" `Quick test_important_prefix;
@@ -922,6 +940,8 @@ let tests =
         test_nested_modifier_class_names;
       test_case "nested modifier CSS generation" `Quick
         test_nested_modifier_css_generation;
+      test_case "not-has shorthand selector" `Quick
+        test_not_has_shorthand_selector;
     ]
 
 let suite = ("modifiers", tests)


### PR DESCRIPTION
`has-[...]` validated its argument while the `not-has-*` shorthand accepted anything and raised later.