### PR TITLE
color: carry the author's digits through an opacity modifier

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -99,7 +99,7 @@ module Handler = struct
             [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
         in
         style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-    | Color.Opacity_percent p ->
+    | Color.Opacity_percent { value = p; _ } ->
         let srgb_fallback =
           Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
         in
@@ -114,7 +114,7 @@ module Handler = struct
         in
         style ~rules:(Some [ supports_block ]) [ fallback_decl ]
     | Color.Opacity_arbitrary f ->
-        let p = f *. 100.0 in
+        let p = f.value *. 100.0 in
         let srgb_fallback =
           Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
         in
@@ -128,7 +128,7 @@ module Handler = struct
             [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
         in
         style ~rules:(Some [ supports_block ]) [ fallback_decl ]
-    | Color.Opacity_bracket_percent p ->
+    | Color.Opacity_bracket_percent { value = p; _ } ->
         let srgb_fallback =
           Css.color_mix ~in_space:Srgb ~percent1:p color Css.Transparent
         in
@@ -266,24 +266,12 @@ module Handler = struct
 
   let suborder _ = 0
 
-  let opacity_suffix = function
-    | Color.No_opacity -> ""
-    | Color.Opacity_percent p ->
-        if Float.is_integer p then "/" ^ Pp.int (int_of_float p)
-        else "/" ^ Pp.float p
-    | Color.Opacity_bracket_percent p ->
-        if Float.is_integer p then "/[" ^ Pp.int (int_of_float p) ^ "%]"
-        else "/[" ^ Pp.float p ^ "%]"
-    | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
-    | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/" ^ v
-
   let to_class = function
     | Color_opacity { property; value; alpha_fn; opacity } ->
         let written =
           match alpha_fn with Some { spelling; _ } -> spelling | None -> value
         in
-        "[" ^ property ^ ":" ^ written ^ "]" ^ opacity_suffix opacity
+        "[" ^ property ^ ":" ^ written ^ "]" ^ Color.opacity_suffix opacity
     | Parsed_decl { property; value } -> "[" ^ property ^ ":" ^ value ^ "]"
 
   let of_class theme class_name =

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -209,19 +209,6 @@ module Handler = struct
 
   type Utility.base += Self of t
 
-  (* Format opacity modifier for class names *)
-  let opacity_suffix = function
-    | Color.No_opacity -> ""
-    | Color.Opacity_percent p ->
-        if Float.is_integer p then "/" ^ Pp.int (int_of_float p)
-        else "/" ^ Pp.float p
-    | Color.Opacity_bracket_percent p ->
-        if Float.is_integer p then "/[" ^ Pp.int (int_of_float p) ^ "%]"
-        else "/[" ^ Pp.float p ^ "%]"
-    | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
-    | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/" ^ v
-
   let to_class (t : t) =
     match t with
     | Bg (color, shade) ->
@@ -251,24 +238,24 @@ module Handler = struct
                 if Color.is_shadeless color then Color.pp color
                 else Color.pp color ^ "-" ^ string_of_int shade
               in
-              base ^ opacity_suffix opacity
+              base ^ Color.opacity_suffix opacity
           | Color_source.Current -> "current"
           | Color_source.Current_opacity opacity ->
-              "current" ^ opacity_suffix opacity
+              "current" ^ Color.opacity_suffix opacity
           | Color_source.Inherit -> "inherit"
           | Color_source.Transparent -> "transparent"
           | Color_source.Bracket_hex h -> "[#" ^ h ^ "]"
           | Color_source.Bracket_hex_opacity (h, opacity) ->
-              "[#" ^ h ^ "]" ^ opacity_suffix opacity
+              "[#" ^ h ^ "]" ^ Color.opacity_suffix opacity
           | Color_source.Bracket_color_var v -> "[color:" ^ v ^ "]"
           | Color_source.Bracket_color_var_opacity (v, opacity) ->
-              "[color:" ^ v ^ "]" ^ opacity_suffix opacity
+              "[color:" ^ v ^ "]" ^ Color.opacity_suffix opacity
           | Color_source.Bracket_var v -> "[" ^ v ^ "]"
           | Color_source.Bracket_var_opacity (v, opacity) ->
-              "[" ^ v ^ "]" ^ opacity_suffix opacity
+              "[" ^ v ^ "]" ^ Color.opacity_suffix opacity
           | Color_source.Bracket_color v -> "[" ^ v ^ "]"
           | Color_source.Bracket_color_opacity (v, opacity) ->
-              "[" ^ v ^ "]" ^ opacity_suffix opacity
+              "[" ^ v ^ "]" ^ Color.opacity_suffix opacity
         in
         prefix ^ color_class src
     | Gradient_stop_position (target, src) -> (
@@ -332,21 +319,21 @@ module Handler = struct
     | Bg_bracket_url_var v -> "bg-[url:" ^ v ^ "]"
     | Bg_bracket_linear_gradient (v, _) -> "bg-[" ^ v ^ "]"
     | Bg_bracket_color_var_opacity (v, opacity) ->
-        "bg-[color:" ^ v ^ "]" ^ opacity_suffix opacity
+        "bg-[color:" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Bg_bracket_var_opacity (v, opacity) ->
-        "bg-[" ^ v ^ "]" ^ opacity_suffix opacity
+        "bg-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Bg_bracket_color (orig, _) -> "bg-[" ^ orig ^ "]"
     | Bg_bracket_color_opacity (orig, _, opacity) ->
-        "bg-[" ^ orig ^ "]" ^ opacity_suffix opacity
+        "bg-[" ^ orig ^ "]" ^ Color.opacity_suffix opacity
     | Bg_current -> "bg-current"
-    | Bg_current_opacity opacity -> "bg-current" ^ opacity_suffix opacity
+    | Bg_current_opacity opacity -> "bg-current" ^ Color.opacity_suffix opacity
     | Bg_transparent -> "bg-transparent"
     | Bg_opacity (color, shade, opacity) ->
         let base =
           if Color.is_shadeless color then "bg-" ^ Color.pp color
           else "bg-" ^ Color.pp color ^ "-" ^ string_of_int shade
         in
-        base ^ opacity_suffix opacity
+        base ^ Color.opacity_suffix opacity
     | Bg_linear_to dir -> (
         match dir with
         | Bottom -> "bg-linear-to-b"
@@ -1923,9 +1910,7 @@ let bg ?opacity ?(shade = 500) color =
   Color.check_shade ~utility:"bg" color shade;
   match opacity with
   | None -> utility (Bg (color, shade))
-  | Some pct ->
-      utility
-        (Bg_opacity (color, shade, Color.Opacity_percent (Float.of_int pct)))
+  | Some pct -> utility (Bg_opacity (color, shade, Color.opacity_of_int pct))
 
 let bg_gradient_to dir = utility (Bg_gradient_to dir)
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1495,16 +1495,36 @@ let color_to_string (c : color) : string =
 
 (** Color parsing utilities *)
 
+(* A number in an opacity modifier, with the digits the author wrote beside the
+   value they denote. The class name is a selector, so it has to repeat the
+   spelling: [/[25]] and [/[25.0]] are one alpha and two different classes, and
+   re-printing the float picks the wrong one. *)
+type opacity_number = { value : float; text : string }
+
 (** Opacity modifier type *)
 type opacity_modifier =
   | No_opacity
-  | Opacity_percent of float (* e.g., /50 means 50% *)
-  | Opacity_arbitrary of float (* e.g., /[0.5] means 0.5 *)
+  | Opacity_percent of opacity_number (* e.g., /50 means 50% *)
+  | Opacity_arbitrary of opacity_number (* e.g., /[0.5] means 0.5 *)
   | Opacity_bracket_percent of
-      float (* e.g., /[50%] means 50% but preserves bracket form *)
+      opacity_number (* e.g., /[50%] means 50% but preserves bracket form *)
   | Opacity_named of string (* e.g., /half, /custom - theme-defined names *)
   | Opacity_var of string
 (* the modifier as written: /[var(--x)] or the /(--x) shorthand *)
+
+let opacity_of_int pct =
+  Opacity_percent { value = Float.of_int pct; text = string_of_int pct }
+
+(* The class-name spelling of a modifier, without the leading [/]. *)
+let pp_opacity = function
+  | No_opacity -> ""
+  | Opacity_percent n -> n.text
+  | Opacity_bracket_percent n -> "[" ^ n.text ^ "%]"
+  | Opacity_arbitrary n -> "[" ^ n.text ^ "]"
+  | Opacity_named name -> name
+  | Opacity_var v -> v
+
+let opacity_suffix = function No_opacity -> "" | o -> "/" ^ pp_opacity o
 
 (** Parse the modifier that follows the [/] in a colour class. *)
 let opacity_of_string ?theme opacity_str =
@@ -1518,11 +1538,11 @@ let opacity_of_string ?theme opacity_str =
     if String.ends_with ~suffix:"%" inner then
       let num_str = String.sub inner 0 (String.length inner - 1) in
       match float_of_string_opt num_str with
-      | Some f -> Some (Opacity_bracket_percent f)
+      | Some f -> Some (Opacity_bracket_percent { value = f; text = num_str })
       | None -> None
     else
       match float_of_string_opt inner with
-      | Some f -> Some (Opacity_arbitrary f)
+      | Some f -> Some (Opacity_arbitrary { value = f; text = inner })
       | None ->
           if Parse.is_var inner then Some (Opacity_var opacity_str) else None
   else if
@@ -1538,7 +1558,8 @@ let opacity_of_string ?theme opacity_str =
   else
     (* Numeric value like 50 or 2.5, or named opacity like half/custom *)
     match float_of_string_opt opacity_str with
-    | Some f when f >= 0. -> Some (Opacity_percent f)
+    | Some f when f >= 0. ->
+        Some (Opacity_percent { value = f; text = opacity_str })
     | _ ->
         (* Not a number — check if it's a named opacity defined in the theme
            (e.g., /half when --opacity-half exists) *)
@@ -1902,8 +1923,6 @@ module Handler = struct
      Css *)
   let mk_color_hex s : color = Hex s
   let color_of_string = of_string
-  let pp_int = Pp.int
-  let pp_float = Pp.float
 
   open Style
   open Css
@@ -2536,9 +2555,9 @@ module Handler = struct
   (** Convert opacity modifier to a percentage value (0-100) *)
   let opacity_to_percent = function
     | No_opacity -> 100.0
-    | Opacity_percent p -> p (* Already a percentage like 50 *)
-    | Opacity_bracket_percent p -> p (* [50%] is also a percentage *)
-    | Opacity_arbitrary f -> f *. 100.0 (* e.g., 0.5 -> 50 *)
+    | Opacity_percent p -> p.value (* Already a percentage like 50 *)
+    | Opacity_bracket_percent p -> p.value (* [50%] is also a percentage *)
+    | Opacity_arbitrary f -> f.value *. 100.0 (* e.g., 0.5 -> 50 *)
     | Opacity_named _ | Opacity_var _ ->
         (* Named/var opacity requires variable lookup, default to 100% *)
         100.0
@@ -2825,16 +2844,7 @@ module Handler = struct
         (* Named bracket colors: unique per variant to prevent merging.
            Different opacity syntaxes (e.g. /50 vs /[0.5]) produce identical CSS
            but Tailwind keeps them separate. *)
-        let opacity_tag =
-          match opacity with
-          | No_opacity -> ""
-          | Opacity_percent p -> "/" ^ string_of_float p
-          | Opacity_arbitrary f -> "/[" ^ string_of_float f ^ "]"
-          | Opacity_bracket_percent p -> "/[" ^ string_of_float p ^ "%]"
-          | Opacity_named n -> "/" ^ n
-          | Opacity_var v -> "/" ^ v
-        in
-        "outline-[" ^ inner ^ "]" ^ opacity_tag
+        "outline-[" ^ inner ^ "]" ^ opacity_suffix opacity
     in
     color_with_opacity_style ~property:Css.outline_color ~merge_key c 500
       opacity
@@ -3185,19 +3195,6 @@ module Handler = struct
     | Placeholder_bracket_color _ -> 80000
     | Placeholder_bracket_color_opacity _ -> 80000
 
-  (* Format opacity modifier for class names *)
-  let opacity_suffix = function
-    | No_opacity -> ""
-    | Opacity_percent p ->
-        if Float.is_integer p then "/" ^ pp_int (int_of_float p)
-        else "/" ^ pp_float p
-    | Opacity_bracket_percent p ->
-        if Float.is_integer p then "/[" ^ pp_int (int_of_float p) ^ "%]"
-        else "/[" ^ pp_float p ^ "%]"
-    | Opacity_arbitrary f -> "/[" ^ pp_float f ^ "]"
-    | Opacity_named name -> "/" ^ name
-    | Opacity_var v -> "/" ^ v
-
   let to_class = function
     | Bg (c, shade) ->
         if is_shadeless c then "bg-" ^ color_to_string c
@@ -3376,23 +3373,6 @@ let property_color_value = Handler.property_color_value
 let opacity_to_percent = Handler.opacity_to_percent
 let opacity_var_bare = Handler.opacity_var_bare
 let opacity_var_bare_of = Handler.opacity_var_name
-
-let pp_opacity = function
-  | No_opacity -> ""
-  | Opacity_percent pct ->
-      (* Handle both integer and decimal values *)
-      let rounded = Float.round pct in
-      if Float.equal pct rounded then string_of_int (int_of_float pct)
-      else Pp.float pct
-  | Opacity_bracket_percent pct ->
-      let rounded = Float.round pct in
-      if Float.equal pct rounded then
-        "[" ^ string_of_int (int_of_float pct) ^ "%]"
-      else "[" ^ Pp.float pct ^ "%]"
-  | Opacity_arbitrary f -> "[" ^ string_of_float f ^ "]"
-  | Opacity_named name -> name
-  | Opacity_var v -> v
-
 let shorten_hex_str = shorten_hex_str
 let bracket_color_to_custom = Handler.bracket_color_to_custom
 let css_color_to_hex = Handler.css_color_to_hex
@@ -3745,23 +3725,19 @@ let bg ?opacity ?(shade = 500) color =
   check_shade ~utility:"bg" color shade;
   match opacity with
   | None -> utility (Bg (color, shade))
-  | Some pct ->
-      utility (Bg_opacity (color, shade, Opacity_percent (Float.of_int pct)))
+  | Some pct -> utility (Bg_opacity (color, shade, opacity_of_int pct))
 
 let text ?opacity ?(shade = 500) color =
   check_shade ~utility:"text" color shade;
   match opacity with
   | None -> utility (Text (color, shade))
-  | Some pct ->
-      utility (Text_opacity (color, shade, Opacity_percent (Float.of_int pct)))
+  | Some pct -> utility (Text_opacity (color, shade, opacity_of_int pct))
 
 let border_color ?opacity ?(shade = 500) color =
   check_shade ~utility:"border_color" color shade;
   match opacity with
   | None -> utility (Border (color, shade))
-  | Some pct ->
-      utility
-        (Border_opacity (color, shade, Opacity_percent (Float.of_int pct)))
+  | Some pct -> utility (Border_opacity (color, shade, opacity_of_int pct))
 
 let bg_transparent = utility Bg_transparent
 let bg_current = utility Bg_current
@@ -3775,9 +3751,7 @@ let accent ?opacity ?(shade = 500) color =
   check_shade ~utility:"accent" color shade;
   match opacity with
   | None -> utility (Accent (color, shade))
-  | Some pct ->
-      utility
-        (Accent_opacity (color, shade, Opacity_percent (Float.of_int pct)))
+  | Some pct -> utility (Accent_opacity (color, shade, opacity_of_int pct))
 
 let accent_current = utility Accent_current
 let accent_inherit = utility Accent_inherit
@@ -3786,8 +3760,7 @@ let caret ?opacity ?(shade = 500) color =
   check_shade ~utility:"caret" color shade;
   match opacity with
   | None -> utility (Caret (color, shade))
-  | Some pct ->
-      utility (Caret_opacity (color, shade, Opacity_percent (Float.of_int pct)))
+  | Some pct -> utility (Caret_opacity (color, shade, opacity_of_int pct))
 
 let caret_current = utility Caret_current
 let caret_inherit = utility Caret_inherit

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -340,15 +340,26 @@ val caret_transparent : t
 
 (** {1 Opacity Modifiers} *)
 
+type opacity_number = {
+  value : float;  (** the number the modifier denotes *)
+  text : string;  (** the digits the author wrote, for the class name *)
+}
+(** A number in an opacity modifier. The class name is a selector, so it repeats
+    [text] rather than re-printing [value]: [/[25]] and [/[25.0]] denote one
+    alpha and are two different classes. *)
+
 type opacity_modifier =
   | No_opacity
-  | Opacity_percent of float  (** e.g., /50 means 50% *)
-  | Opacity_arbitrary of float  (** e.g., /[0.5] means 0.5 *)
-  | Opacity_bracket_percent of float
+  | Opacity_percent of opacity_number  (** e.g., /50 means 50% *)
+  | Opacity_arbitrary of opacity_number  (** e.g., /[0.5] means 0.5 *)
+  | Opacity_bracket_percent of opacity_number
       (** e.g., /[50%] means 50% but preserves bracket form in class name *)
   | Opacity_named of string  (** e.g., /half, /custom - theme-defined names *)
   | Opacity_var of string
       (** e.g., /[var(--x)] - var ref used directly as percentage *)
+
+val opacity_of_int : int -> opacity_modifier
+(** [opacity_of_int pct] is the modifier a class spells [/pct]. *)
 
 val opacity_var_bare : string -> string
 (** [opacity_var_bare v] is the bare custom-property name inside an opacity
@@ -501,9 +512,13 @@ val opacity_to_percent : opacity_modifier -> float
 (** [opacity_to_percent modifier] returns the opacity as a float percentage. *)
 
 val pp_opacity : opacity_modifier -> string
-(** [pp_opacity modifier] returns a string representation of the opacity
-    modifier for use in class names. E.g., Opacity_percent 50. -> "50",
-    Opacity_arbitrary 0.5 -> "[0.5]". *)
+(** [pp_opacity modifier] is the class-name spelling of [modifier], without the
+    leading ["/"]: ["50"] for [/50], ["[0.5]"] for [/[0.5]], [""] for
+    {!No_opacity}. *)
+
+val opacity_suffix : opacity_modifier -> string
+(** [opacity_suffix modifier] is {!pp_opacity} behind the ["/"] that separates
+    it from the colour, and [""] for {!No_opacity}. *)
 
 val hex_alpha_color :
   ?theme:Scheme.t -> color -> int -> opacity_modifier -> string option

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -7,10 +7,6 @@ module Css = Cascade.Css
 
 module Handler = struct
   open Style
-
-  let pp_int = Pp.int
-  let pp_float = Pp.float
-
   open Css
 
   type t =
@@ -304,26 +300,13 @@ module Handler = struct
     let rule = Css.rule ~selector [ decl; Css.border_style bs ] in
     style ~rules:(Some [ rule ]) []
 
-  (* Format opacity modifier for class names *)
-  let opacity_suffix = function
-    | Color.No_opacity -> ""
-    | Color.Opacity_percent p ->
-        if Float.is_integer p then "/" ^ pp_int (int_of_float p)
-        else "/" ^ pp_float p
-    | Color.Opacity_bracket_percent p ->
-        if Float.is_integer p then "/[" ^ pp_int (int_of_float p) ^ "%]"
-        else "/[" ^ pp_float p ^ "%]"
-    | Color.Opacity_arbitrary f -> "/[" ^ pp_float f ^ "]"
-    | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/" ^ v
-
   (* Divide color with opacity using Color helpers *)
   let divide_color_opacity_style ?theme color shade opacity =
     let base_class_name =
       if Color.is_shadeless color then "divide-" ^ Color.color_to_string color
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
     in
-    let class_name = base_class_name ^ opacity_suffix opacity in
+    let class_name = base_class_name ^ Color.opacity_suffix opacity in
     let selector =
       Css.Selector.(
         where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
@@ -331,7 +314,7 @@ module Handler = struct
     Color.divide_with_opacity ?theme color shade opacity selector
 
   let divide_current_opacity_style opacity =
-    let class_name = "divide-current" ^ opacity_suffix opacity in
+    let class_name = "divide-current" ^ Color.opacity_suffix opacity in
     let selector =
       Css.Selector.(
         where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
@@ -353,17 +336,17 @@ module Handler = struct
         else "divide-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
     | Named_color_opacity (c, shade, opacity) ->
         if Color.is_shadeless c then
-          "divide-" ^ Color.color_to_string c ^ opacity_suffix opacity
+          "divide-" ^ Color.color_to_string c ^ Color.opacity_suffix opacity
         else
           "divide-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
-          ^ opacity_suffix opacity
+          ^ Color.opacity_suffix opacity
     | Transparent -> "divide-transparent"
     | Current -> "divide-current"
-    | Current_opacity opacity -> "divide-current" ^ opacity_suffix opacity
+    | Current_opacity opacity -> "divide-current" ^ Color.opacity_suffix opacity
     | Inherit -> "divide-inherit"
     | Bracket_color (v, _) -> "divide-[" ^ v ^ "]"
     | Bracket_color_opacity (v, _, opacity) ->
-        "divide-[" ^ v ^ "]" ^ opacity_suffix opacity
+        "divide-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Line_style bs -> "divide-" ^ border_style_to_string bs
 
   let to_style theme =
@@ -609,9 +592,7 @@ let divide_color ?opacity ?(shade = 500) color =
   match opacity with
   | None -> utility (Named_color (color, shade))
   | Some pct ->
-      utility
-        (Named_color_opacity
-           (color, shade, Color.Opacity_percent (float_of_int pct)))
+      utility (Named_color_opacity (color, shade, Color.opacity_of_int pct))
 
 let divide_transparent = utility Transparent
 let divide_current = utility Current

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -3299,8 +3299,7 @@ let ring_color ?opacity ?(shade = 500) color =
   match opacity with
   | None -> utility (Ring_color (color, shade))
   | Some pct ->
-      utility
-        (Ring_color_opacity (color, shade, Opacity_percent (Float.of_int pct)))
+      utility (Ring_color_opacity (color, shade, Color.opacity_of_int pct))
 
 let inset_ring = utility Inset_ring_default
 let opacity n = utility (Opacity n)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -857,14 +857,14 @@ module Handler = struct
   let drop_shadow_opacity ?theme opacity =
     let alpha_str =
       match opacity with
-      | Color.Opacity_percent p ->
+      | Color.Opacity_percent { value = p; _ } ->
           (* keep a fractional alpha (/12.5 -> 12.5%), do not truncate to 12% *)
           if Float.is_integer p then string_of_int (int_of_float p) ^ "%"
           else Css.Pp.string_of_float p ^ "%"
       | _ -> "100%"
     in
     let percent =
-      match opacity with Color.Opacity_percent p -> p | _ -> 100.
+      match opacity with Color.Opacity_percent p -> p.value | _ -> 100.
     in
     let fallback = Color.hex_to_oklab_alpha "#000000" (percent /. 100.) in
     (* The modifier recolours the shadow, so it applies to the size, which is
@@ -907,7 +907,7 @@ module Handler = struct
 
   let drop_shadow_size_opacity (v, blur) opacity =
     let percent =
-      match opacity with Color.Opacity_percent p -> p | _ -> 100.
+      match opacity with Color.Opacity_percent p -> p.value | _ -> 100.
     in
     let alpha_str =
       if Float.is_integer percent then

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -71,26 +71,14 @@ module Handler = struct
     in
     (group lsl 32) + detail
 
-  let opacity_suffix = function
-    | Color.No_opacity -> ""
-    | Color.Opacity_percent p ->
-        if Float.is_integer p then "/" ^ Pp.int (int_of_float p)
-        else "/" ^ Pp.float p
-    | Color.Opacity_bracket_percent p ->
-        if Float.is_integer p then "/[" ^ Pp.int (int_of_float p) ^ "%]"
-        else "/[" ^ Pp.float p ^ "%]"
-    | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
-    | Color.Opacity_named n -> "/" ^ n
-    | Color.Opacity_var v -> "/" ^ v
-
   let spec_class = function
     | Theme (color, shade, op) ->
         let base =
           if Color.is_shadeless color then Color.color_to_string color
           else Color.color_to_string color ^ "-" ^ string_of_int shade
         in
-        base ^ opacity_suffix op
-    | Bracket (raw, _, op) -> raw ^ opacity_suffix op
+        base ^ Color.opacity_suffix op
+    | Bracket (raw, _, op) -> raw ^ Color.opacity_suffix op
     | Current -> "current"
     | Inherit -> "inherit"
     | Transparent -> "transparent"

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -49,19 +49,6 @@ module Handler = struct
   let name = "svg"
   let priority _ = 22
 
-  (* Format opacity modifier for class names *)
-  let opacity_suffix = function
-    | Color.No_opacity -> ""
-    | Color.Opacity_percent p ->
-        if Float.is_integer p then "/" ^ Pp.int (int_of_float p)
-        else "/" ^ Pp.float p
-    | Color.Opacity_bracket_percent p ->
-        if Float.is_integer p then "/[" ^ Pp.int (int_of_float p) ^ "%]"
-        else "/[" ^ Pp.float p ^ "%]"
-    | Color.Opacity_arbitrary f -> "/[" ^ Pp.float f ^ "]"
-    | Color.Opacity_named name -> "/" ^ name
-    | Color.Opacity_var v -> "/" ^ v
-
   (* Fill color style with scheme support *)
   let fill_color_style ?theme color shade =
     if Color.is_custom_color color then
@@ -264,49 +251,50 @@ module Handler = struct
     | Fill_inherit -> "fill-inherit"
     | Fill_transparent -> "fill-transparent"
     | Fill_current -> "fill-current"
-    | Fill_current_opacity opacity -> "fill-current" ^ opacity_suffix opacity
+    | Fill_current_opacity opacity ->
+        "fill-current" ^ Color.opacity_suffix opacity
     | Fill_color (c, shade) ->
         if Color.is_shadeless c then "fill-" ^ Color.color_to_string c
         else "fill-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
     | Fill_color_opacity (c, shade, opacity) ->
         if Color.is_shadeless c then
-          "fill-" ^ Color.color_to_string c ^ opacity_suffix opacity
+          "fill-" ^ Color.color_to_string c ^ Color.opacity_suffix opacity
         else
           "fill-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
-          ^ opacity_suffix opacity
+          ^ Color.opacity_suffix opacity
     | Fill_bracket_color (v, _) -> "fill-[" ^ v ^ "]"
     | Fill_bracket_color_opacity (v, _, opacity) ->
-        "fill-[" ^ v ^ "]" ^ opacity_suffix opacity
+        "fill-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Fill_bracket_var v -> "fill-[" ^ v ^ "]"
     | Fill_bracket_var_opacity (v, opacity) ->
-        "fill-[" ^ v ^ "]" ^ opacity_suffix opacity
+        "fill-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Fill_bracket_typed_var v -> "fill-[color:" ^ v ^ "]"
     | Fill_bracket_typed_var_opacity (v, opacity) ->
-        "fill-[color:" ^ v ^ "]" ^ opacity_suffix opacity
+        "fill-[color:" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Stroke_none -> "stroke-none"
     | Stroke_inherit -> "stroke-inherit"
     | Stroke_transparent -> "stroke-transparent"
     | Stroke_current -> "stroke-current"
     | Stroke_current_opacity opacity ->
-        "stroke-current" ^ opacity_suffix opacity
+        "stroke-current" ^ Color.opacity_suffix opacity
     | Stroke_color (c, shade) ->
         if Color.is_shadeless c then "stroke-" ^ Color.color_to_string c
         else "stroke-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
     | Stroke_color_opacity (c, shade, opacity) ->
         if Color.is_shadeless c then
-          "stroke-" ^ Color.color_to_string c ^ opacity_suffix opacity
+          "stroke-" ^ Color.color_to_string c ^ Color.opacity_suffix opacity
         else
           "stroke-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
-          ^ opacity_suffix opacity
+          ^ Color.opacity_suffix opacity
     | Stroke_bracket_color (v, _) -> "stroke-[" ^ v ^ "]"
     | Stroke_bracket_color_opacity (v, _, opacity) ->
-        "stroke-[" ^ v ^ "]" ^ opacity_suffix opacity
+        "stroke-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Stroke_bracket_var v -> "stroke-[" ^ v ^ "]"
     | Stroke_bracket_var_opacity (v, opacity) ->
-        "stroke-[" ^ v ^ "]" ^ opacity_suffix opacity
+        "stroke-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Stroke_bracket_typed_var v -> "stroke-[color:" ^ v ^ "]"
     | Stroke_bracket_typed_var_opacity (v, opacity) ->
-        "stroke-[color:" ^ v ^ "]" ^ opacity_suffix opacity
+        "stroke-[color:" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Stroke_0 -> "stroke-0"
     | Stroke_1 -> "stroke-1"
     | Stroke_2 -> "stroke-2"

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -738,6 +738,63 @@ let test_invalid_bracket_hex () =
   emits "outline-[#abc]" "outline-color:#abc";
   emits "placeholder-[#abc]" "color:#abc"
 
+(* A class name is a selector, so it has to repeat the text the author wrote
+   rather than a re-print of the number it parsed to. [/[25]] and [/[25.0]]
+   denote one alpha and are two distinct classes; only the author's spelling
+   matches the markup. *)
+let test_opacity_modifier_class_roundtrip () =
+  let roundtrip cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.(check string) "class" cls (Tw.pp u)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  List.iter roundtrip
+    [
+      "bg-red-500/50";
+      "bg-red-500/2.5";
+      "bg-red-500/[25]";
+      "bg-red-500/[.5]";
+      "bg-red-500/[25%]";
+      "bg-red-500/[25.50%]";
+      "bg-red-500/[var(--o)]";
+      "bg-red-500/(--o)";
+      "text-red-500/[25]";
+      "border-red-500/[25]";
+      "shadow-lg/[25]";
+      "shadow-red-500/[25]";
+      "inset-shadow-sm/[25]";
+      "ring-red-500/[25]";
+      "ring-offset-red-500/[25]";
+      "inset-ring-red-500/[25]";
+      "drop-shadow-lg/[25]";
+      "drop-shadow/[25]";
+      "text-shadow-lg/[25]";
+      "decoration-red-500/[25]";
+      "divide-red-500/[25]";
+      "fill-red-500/[25]";
+      "accent-red-500/[25]";
+      "outline-red-500/[25]";
+      "placeholder-red-500/[25]";
+      "from-red-500/[25]";
+      "[color:red]/[25]";
+    ]
+
+(* The bracket modifier holds a number, so a non-numeric spelling is not a
+   utility at all rather than one with a surprising class name. *)
+let test_opacity_modifier_rejects_non_numeric () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u)
+      | Error (`Msg _) -> ())
+    [
+      "bg-red-500/[abc]";
+      "bg-red-500/[]";
+      "bg-red-500/[25px]";
+      "bg-red-500/[%]";
+      "shadow-lg/[25px]";
+    ]
+
 let tests =
   [
     ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
@@ -779,6 +836,12 @@ let tests =
     ("CSS modes with colors", `Quick, test_css_mode_with_colors);
     ("v4.3.3 colour families", `Quick, test_v433_color_families);
     ("Full opacity and important", `Quick, test_full_opacity_and_important);
+    ( "Opacity modifier class roundtrip",
+      `Quick,
+      test_opacity_modifier_class_roundtrip );
+    ( "Opacity modifier rejects non-numeric",
+      `Quick,
+      test_opacity_modifier_rejects_non_numeric );
     ("Shorthand hex with alpha", `Quick, test_shorthand_hex_alpha);
   ]
 


### PR DESCRIPTION
An opacity modifier was reprinted from the parsed float, so `shadow-lg/[25]` emitted the selector `.shadow-lg\/\[25\.\]` and could not match the class in the markup. Every colour family lost `/[.5]`, `/[25.50%]` and `/[1e2]` the same way, `ring-*` and `decoration-*` included. Six duplicate opacity formatters collapse into one.