### PR TITLE
modifiers: carry the bracket text of an arbitrary breakpoint

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -56,12 +56,8 @@ let breakpoint_name qual bp =
   match qual with "" -> base | q -> q ^ "-" ^ base
 
 (** Helper: arbitrary breakpoint class selector *)
-let arbitrary_breakpoint_class prefix px cls =
-  let px_str =
-    if Float.is_integer px then Int.to_string (Float.to_int px)
-    else Float.to_string px
-  in
-  Css.Selector.Class (prefix ^ "[" ^ px_str ^ "px]:" ^ cls)
+let arbitrary_breakpoint_class prefix (w : Style.arbitrary_px) cls =
+  Css.Selector.Class (prefix ^ "[" ^ w.text ^ "]:" ^ cls)
 
 (** Render a CSS length in compact form (no spaces in calc operators) for class
     names. *)
@@ -716,13 +712,17 @@ let max_xl2 styles =
   wrap (Max_responsive `Xl_2) styles
 
 (* Arbitrary breakpoint variants *)
+(* A caller with a bare number has written no bracket, so spell one the way
+   [min-[600px]] reads. *)
+let arbitrary_px px : Style.arbitrary_px = { px; text = Pp.float px ^ "px" }
+
 let min_arbitrary px styles =
   validate_no_nested_responsive styles;
-  wrap (Min_arbitrary px) styles
+  wrap (Min_arbitrary (arbitrary_px px)) styles
 
 let max_arbitrary px styles =
   validate_no_nested_responsive styles;
-  wrap (Max_arbitrary px) styles
+  wrap (Max_arbitrary (arbitrary_px px)) styles
 
 (* ARIA/Peer/Data variants *)
 let peer_checked styles = wrap Peer_checked styles
@@ -1077,13 +1077,16 @@ let parse_css_length s : Css.length option =
      spec-valid [calc(1000px + 12em)] the length reader accepts. *)
   Css.parse_length (Parse.decode_arbitrary_value s)
 
-(* Parse a pixel value from a string like "600px" or "600" *)
+(* Parse a pixel value from a string like "600px" or "600", keeping the
+   spelling: it is what the variant's own class is named after. *)
 let parse_px_value s =
-  let s =
+  let digits =
     if String.ends_with ~suffix:"px" s then String.sub s 0 (String.length s - 2)
     else s
   in
-  try Some (float_of_string s) with Failure _ -> None
+  match float_of_string_opt digits with
+  | Some px -> Some ({ px; text = s } : Style.arbitrary_px)
+  | None -> None
 
 (* Preprocess a has-selector string: & → * and ensure combinator spacing. *)
 let preprocess_has_selector s =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -299,18 +299,9 @@ let responsive_modifier_condition ?theme = function
         | `Xl_2 -> "max-2xl"
       in
       (breakpoint_not_condition ?theme bp, prefix)
-  | Style.Min_arbitrary px ->
-      let px_str =
-        if Float.is_integer px then Int.to_string (Float.to_int px)
-        else Float.to_string px
-      in
-      (media_min_width_px px, "min-[" ^ px_str ^ "px]")
-  | Style.Max_arbitrary px ->
-      let px_str =
-        if Float.is_integer px then Int.to_string (Float.to_int px)
-        else Float.to_string px
-      in
-      (media_not_min_width_px px, "max-[" ^ px_str ^ "px]")
+  | Style.Min_arbitrary w -> (media_min_width_px w.px, "min-[" ^ w.text ^ "]")
+  | Style.Max_arbitrary w ->
+      (media_not_min_width_px w.px, "max-[" ^ w.text ^ "]")
   | Style.Min_arbitrary_length l ->
       let len_str = Modifiers.compact_length l in
       (Css.media_min_width_length l, "min-[" ^ len_str ^ "]")
@@ -398,19 +389,17 @@ let max_responsive_rule ?theme ?inner_has_hover breakpoint base_class selector
     (breakpoint_not_condition ?theme breakpoint)
     base_class selector props
 
-let arbitrary_px_string px =
-  if Float.is_integer px then Int.to_string (Float.to_int px)
-  else Float.to_string px
-
-let min_arbitrary_rule ?inner_has_hover px base_class selector props =
-  let prefix = "min-[" ^ arbitrary_px_string px ^ "px]" in
-  media_rule_with_prefix ?inner_has_hover prefix (media_min_width_px px)
+let min_arbitrary_rule ?inner_has_hover (w : Style.arbitrary_px) base_class
+    selector props =
+  let prefix = "min-[" ^ w.text ^ "]" in
+  media_rule_with_prefix ?inner_has_hover prefix (media_min_width_px w.px)
     base_class selector props
 
-let max_arbitrary_rule ?inner_has_hover px base_class selector props =
-  let prefix = "max-[" ^ arbitrary_px_string px ^ "px]" in
+let max_arbitrary_rule ?inner_has_hover (w : Style.arbitrary_px) base_class
+    selector props =
+  let prefix = "max-[" ^ w.text ^ "]" in
   media_rule_with_prefix ?inner_has_hover prefix
-    (media_not_min_width_px px)
+    (media_not_min_width_px w.px)
     base_class selector props
 
 let arbitrary_length_rule ?inner_has_hover prefix condition l base_class
@@ -1245,12 +1234,12 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
       not_media_rule ~nvo
         ~condition:(breakpoint_condition ?theme bp)
         modified_class props
-  | Style.Min_arbitrary px ->
+  | Style.Min_arbitrary w ->
       not_media_rule ~nvo
-        ~condition:(media_not_min_width_px px)
+        ~condition:(media_not_min_width_px w.px)
         modified_class props
-  | Style.Max_arbitrary px ->
-      not_media_rule ~nvo ~condition:(media_min_width_px px) modified_class
+  | Style.Max_arbitrary w ->
+      not_media_rule ~nvo ~condition:(media_min_width_px w.px) modified_class
         props
   | Style.Min_arbitrary_length l ->
       not_media_rule ~nvo
@@ -1770,10 +1759,10 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
   | Style.Max_responsive breakpoint ->
       max_responsive_rule ?theme ~inner_has_hover breakpoint base_class selector
         props
-  | Style.Min_arbitrary px ->
-      min_arbitrary_rule ~inner_has_hover px base_class selector props
-  | Style.Max_arbitrary px ->
-      max_arbitrary_rule ~inner_has_hover px base_class selector props
+  | Style.Min_arbitrary w ->
+      min_arbitrary_rule ~inner_has_hover w base_class selector props
+  | Style.Max_arbitrary w ->
+      max_arbitrary_rule ~inner_has_hover w base_class selector props
   | Style.Min_arbitrary_length l ->
       min_arbitrary_length_rule ~inner_has_hover l base_class selector props
   | Style.Max_arbitrary_length l ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -25,6 +25,12 @@ type container_query =
   | Container_len_cmp of container_cmp * string * Css.length
   | Container_scoped of string * container_query
 
+(* The pixel width of a [min-[<w>]] or [max-[<w>]] breakpoint, carrying the
+   bracket as the author wrote it: the variant names its own class, and
+   re-printing the number drops a trailing zero, a leading zero or an
+   exponent. *)
+type arbitrary_px = { px : float; text : string }
+
 type modifier =
   | Hover
   | Focus
@@ -36,8 +42,8 @@ type modifier =
   | Responsive of breakpoint
   | Min_responsive of breakpoint
   | Max_responsive of breakpoint
-  | Min_arbitrary of float
-  | Max_arbitrary of float
+  | Min_arbitrary of arbitrary_px
+  | Max_arbitrary of arbitrary_px
   | Min_arbitrary_length of Css.length
   | Max_arbitrary_length of Css.length
   | Peer_hover
@@ -451,18 +457,8 @@ let rec pp_modifier = function
   | Max_responsive `Lg -> "max-lg"
   | Max_responsive `Xl -> "max-xl"
   | Max_responsive `Xl_2 -> "max-2xl"
-  | Min_arbitrary px ->
-      let px_str =
-        if Float.is_integer px then Int.to_string (Float.to_int px)
-        else Float.to_string px
-      in
-      String.concat "" [ "min-["; px_str; "px]" ]
-  | Max_arbitrary px ->
-      let px_str =
-        if Float.is_integer px then Int.to_string (Float.to_int px)
-        else Float.to_string px
-      in
-      String.concat "" [ "max-["; px_str; "px]" ]
+  | Min_arbitrary w -> String.concat "" [ "min-["; w.text; "]" ]
+  | Max_arbitrary w -> String.concat "" [ "max-["; w.text; "]" ]
   | Min_arbitrary_length l ->
       "min-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
   | Max_arbitrary_length l ->

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -34,6 +34,15 @@ type container_query =
   | Container_scoped of string * container_query
       (** [@sm/main]: a size query aimed at the container named [main]. *)
 
+type arbitrary_px = {
+  px : float;  (** the width the bracket denotes, in pixels *)
+  text : string;  (** the bracket as the author wrote it, e.g. ["600.50px"] *)
+}
+(** The pixel width of a [min-[<w>]] or [max-[<w>]] breakpoint. The variant
+    names its own class, so the bracket has to come back out spelled as it went
+    in: re-printing [px] drops a trailing zero, a leading zero or an exponent
+    and leaves a selector the markup does not carry. *)
+
 type modifier =
   | Hover
   | Focus
@@ -45,8 +54,8 @@ type modifier =
   | Responsive of breakpoint
   | Min_responsive of breakpoint
   | Max_responsive of breakpoint
-  | Min_arbitrary of float
-  | Max_arbitrary of float
+  | Min_arbitrary of arbitrary_px
+  | Max_arbitrary of arbitrary_px
   | Min_arbitrary_length of Css.length
   | Max_arbitrary_length of Css.length
   | Peer_hover

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -330,6 +330,36 @@ let test_modifier_class_roundtrip () =
       "marker:text-gray-500";
     ]
 
+(* [min-[<px>]] and [max-[<px>]] name themselves after the bracket, so the
+   bracket has to come back out spelled as the author wrote it. Re-printing the
+   parsed number drops a trailing zero, a leading zero and an exponent, and the
+   selector then matches nothing in the markup. *)
+let test_arbitrary_breakpoint_spelling () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u -> Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u))
+    [
+      "min-[320px]:flex";
+      "min-[600.50px]:flex";
+      "min-[0600px]:flex";
+      "min-[1e3px]:flex";
+      "min-[600]:flex";
+      "min-[.5rem]:flex";
+      "max-[48rem]:flex";
+      "max-[37.50px]:flex";
+    ]
+
+(* The bracket holds a length, so a word is not a breakpoint at all. *)
+let test_arbitrary_breakpoint_rejects_non_length () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u)
+      | Error (`Msg _) -> ())
+    [ "min-[abc]:flex"; "max-[abc]:flex"; "min-[]:flex" ]
+
 (* Test suite *)
 (* The [!] prefix marks the utility's own declarations !important, leaves theme
    tokens (--spacing) normal, preserves the class name, and nests under a
@@ -942,6 +972,10 @@ let tests =
         test_nested_modifier_css_generation;
       test_case "not-has shorthand selector" `Quick
         test_not_has_shorthand_selector;
+      test_case "arbitrary breakpoint spelling" `Quick
+        test_arbitrary_breakpoint_spelling;
+      test_case "arbitrary breakpoint rejects non-length" `Quick
+        test_arbitrary_breakpoint_rejects_non_length;
     ]
 
 let suite = ("modifiers", tests)


### PR DESCRIPTION
Five copies of a class-token float formatter reprinted the parsed value, so an arbitrary breakpoint's spelling was not the one the author wrote.