### PR TITLE
test: drop the unused re dependency

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -3,7 +3,6 @@
  (libraries
   tw
   alcotest
-  re
   astring
   fmt
   cmdliner


### PR DESCRIPTION
A dead dependency that merlint only reports once the build artefacts are fresh, which is why it blocked the hook intermittently rather than always.