### PR TITLE
effects, typography: check the palette defines the colour shade

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2654,13 +2654,10 @@ module Handler = struct
             | Ok (c, s) -> Ok (Shadow_color_opacity (c, s, op))
             | Error _ -> err_not_utility))
     | [ "shadow"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
-        match (Color.of_string color, Parse.int_any shade_str) with
-        | Ok c, Ok s -> (
-            match opacity with
-            | Color.No_opacity -> Ok (Shadow_color (c, s))
-            | _ -> Ok (Shadow_color_opacity (c, s, opacity)))
-        | _ -> err_not_utility)
+        match Color.shade_and_opacity_of_strings ~theme [ color; shade ] with
+        | Ok (c, s, Color.No_opacity) -> Ok (Shadow_color (c, s))
+        | Ok (c, s, opacity) -> Ok (Shadow_color_opacity (c, s, opacity))
+        | Error _ -> err_not_utility)
     (* A shadeless colour has no shade segment: shadow-white, shadow-black. *)
     | [ "shadow"; color ] -> (
         match Color.shade_of_strings [ color ] with
@@ -2704,13 +2701,10 @@ module Handler = struct
             | Ok (c, s) -> Ok (Inset_shadow_color_opacity (c, s, op))
             | Error _ -> err_not_utility))
     | [ "inset"; "shadow"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
-        match (Color.of_string color, Parse.int_any shade_str) with
-        | Ok c, Ok s -> (
-            match opacity with
-            | Color.No_opacity -> Ok (Inset_shadow_color (c, s))
-            | _ -> Ok (Inset_shadow_color_opacity (c, s, opacity)))
-        | _ -> err_not_utility)
+        match Color.shade_and_opacity_of_strings ~theme [ color; shade ] with
+        | Ok (c, s, Color.No_opacity) -> Ok (Inset_shadow_color (c, s))
+        | Ok (c, s, opacity) -> Ok (Inset_shadow_color_opacity (c, s, opacity))
+        | Error _ -> err_not_utility)
     | [ "inset"; "shadow"; color ] -> (
         match Color.shade_of_strings [ color ] with
         | Ok (c, s) -> Ok (Inset_shadow_color (c, s))
@@ -2808,23 +2802,15 @@ module Handler = struct
         | Ok width -> Ok (Ring_offset_width width)
         | Error _ -> err_not_utility)
     | [ "ring"; color; shade ] -> (
-        (* Check for opacity modifier in shade (e.g., "500/50" or
-           "500/[0.5]") *)
-        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
-        match (Color.of_string color, Parse.int_any shade_str) with
-        | Ok c, Ok s -> (
-            match opacity with
-            | Color.No_opacity -> Ok (Ring_color (c, s))
-            | _ -> Ok (Ring_color_opacity (c, s, opacity)))
-        | _ -> err_not_utility)
+        match Color.shade_and_opacity_of_strings ~theme [ color; shade ] with
+        | Ok (c, s, Color.No_opacity) -> Ok (Ring_color (c, s))
+        | Ok (c, s, opacity) -> Ok (Ring_color_opacity (c, s, opacity))
+        | Error _ -> err_not_utility)
     | [ "ring"; "offset"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
-        match (Color.of_string color, Parse.int_any shade_str) with
-        | Ok c, Ok s -> (
-            match opacity with
-            | Color.No_opacity -> Ok (Ring_offset_color (c, s))
-            | _ -> Ok (Ring_offset_color_opacity (c, s, opacity)))
-        | _ -> err_not_utility)
+        match Color.shade_and_opacity_of_strings ~theme [ color; shade ] with
+        | Ok (c, s, Color.No_opacity) -> Ok (Ring_offset_color (c, s))
+        | Ok (c, s, opacity) -> Ok (Ring_offset_color_opacity (c, s, opacity))
+        | Error _ -> err_not_utility)
     | [ "inset"; "ring" ] -> Ok Inset_ring_default
     | [ "inset"; "ring"; "transparent" ] -> Ok Inset_ring_transparent
     | [ "inset"; "ring"; "inherit" ] -> Ok Inset_ring_inherit
@@ -2867,13 +2853,10 @@ module Handler = struct
         | Ok width -> Ok (Inset_ring_width width)
         | Error _ -> err_not_utility)
     | [ "inset"; "ring"; color; shade ] -> (
-        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
-        match (Color.of_string color, Parse.int_any shade_str) with
-        | Ok c, Ok s -> (
-            match opacity with
-            | Color.No_opacity -> Ok (Inset_ring_color (c, s))
-            | _ -> Ok (Inset_ring_color_opacity (c, s, opacity)))
-        | _ -> err_not_utility)
+        match Color.shade_and_opacity_of_strings ~theme [ color; shade ] with
+        | Ok (c, s, Color.No_opacity) -> Ok (Inset_ring_color (c, s))
+        | Ok (c, s, opacity) -> Ok (Inset_ring_color_opacity (c, s, opacity))
+        | Error _ -> err_not_utility)
     | [ "mix"; "blend"; "normal" ] -> Ok Mix_blend_normal
     | [ "mix"; "blend"; "multiply" ] -> Ok Mix_blend_multiply
     | [ "mix"; "blend"; "screen" ] -> Ok Mix_blend_screen

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1717,15 +1717,10 @@ module Typography_late = struct
                       Ok (Decoration_color_opacity (c, shade, opacity))
                   | Error _ -> err_not_utility)))
     | [ "decoration"; color; shade ] -> (
-        (* Check for opacity modifier in shade (e.g., "500/50" or
-           "500/[0.5]") *)
-        let shade_str, opacity = Color.parse_opacity_modifier ~theme shade in
-        match (Color.of_string color, Parse.int_any shade_str) with
-        | Ok c, Ok s -> (
-            match opacity with
-            | Color.No_opacity -> Ok (Decoration_color (c, Some s))
-            | _ -> Ok (Decoration_color_opacity (c, s, opacity)))
-        | _ -> err_not_utility)
+        match Color.shade_and_opacity_of_strings ~theme [ color; shade ] with
+        | Ok (c, s, Color.No_opacity) -> Ok (Decoration_color (c, Some s))
+        | Ok (c, s, opacity) -> Ok (Decoration_color_opacity (c, s, opacity))
+        | Error _ -> err_not_utility)
     | [ "tracking"; v ] when Parse.is_bracket_value v -> (
         let inner = Parse.bracket_inner v in
         if Parse.is_var inner then Ok (Tracking_var inner)

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -408,6 +408,38 @@ let test_invalid_bracket_hex () =
   emits "inset-shadow-[0_1px_2px_#000]"
     "--tw-inset-shadow:inset 0 1px 2px var(--tw-inset-shadow-color,#000)"
 
+(* A shade the palette does not define is not a colour. These utilities read the
+   shade without checking it, so the class was accepted and then rendered a
+   fabricated black or a reference to a variable no theme declares. *)
+let test_undefined_shade () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u ->
+        Alcotest.failf "expected %s to be rejected, got %s" cls
+          (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "shadow-red-999";
+  rejected "inset-shadow-red-999";
+  rejected "ring-red-999";
+  rejected "ring-offset-red-999";
+  rejected "inset-ring-red-999";
+  rejected "shadow-red-0";
+  rejected "shadow-red-550";
+  rejected "ring-red-42";
+  rejected "shadow-red-999/50";
+  accepted "shadow-red-500";
+  accepted "inset-shadow-red-500";
+  accepted "ring-red-950";
+  accepted "ring-offset-red-50";
+  accepted "inset-ring-red-500";
+  accepted "shadow-red-500/50"
+
 (* [opacity-[<n>]] names its class after the bracket, so the number has to come
    back out spelled as the author wrote it rather than re-printed. *)
 let test_arbitrary_opacity_spelling () =
@@ -430,6 +462,7 @@ let test_arbitrary_opacity_rejects_non_number () =
 let tests =
   [
     test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+    test_case "undefined colour shade" `Quick test_undefined_shade;
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -411,6 +411,30 @@ let test_arbitrary_tracking_invalid () =
   renders "tracking-[var(--x)]";
   renders "-tracking-[.5em]"
 
+(* A shade the palette does not define is not a colour. [decoration-*] read the
+   shade without checking it, so the class was accepted and then referenced a
+   variable no theme declares. *)
+let test_decoration_undefined_shade () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u ->
+        Alcotest.failf "expected %s to be rejected, got %s" cls
+          (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "decoration-red-999";
+  rejected "decoration-red-0";
+  rejected "decoration-red-42";
+  rejected "decoration-red-999/50";
+  accepted "decoration-red-500";
+  accepted "decoration-red-950";
+  accepted "decoration-red-500/50"
+
 let of_string_invalid () =
   (* Invalid typography values *)
   let fail_maybe input =
@@ -832,6 +856,8 @@ let tests =
     test_case "text-[--spacing()/--alpha()] functions" `Quick
       test_text_bracket_functions;
     test_case "named font family from the theme" `Quick test_named_font_family;
+    test_case "decoration undefined colour shade" `Quick
+      test_decoration_undefined_shade;
     test_case "typography of_string - invalid values" `Quick of_string_invalid;
     test_case "typography suborder matches Tailwind" `Quick
       suborder_matches_tailwind;


### PR DESCRIPTION
`shadow-red-999` was accepted and rendered a fabricated black plus a reference to a variable no theme declares; `ring-*`, `inset-ring-*`, `ring-offset-*`, `inset-shadow-*` and `decoration-*` did the same. Tailwind rejects all of them. These six sites now use the validated shade reader the other families already share.