### PR TITLE
parse: a bracket value is one bracket

### DIFF
--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -936,9 +936,8 @@ module Handler = struct
   let parse_value suffix =
     if String.length suffix > 0 && suffix.[0] = '[' then
       (* Arbitrary value - reject negative values *)
-      let len = String.length suffix in
-      if len > 2 && suffix.[len - 1] = ']' then
-        let inner = String.sub suffix 1 (len - 2) in
+      if Parse.is_bracket_value suffix then
+        let inner = Parse.bracket_inner suffix in
         if String.length inner > 0 && inner.[0] = '-' then Option.none
         else Option.some (Arbitrary inner)
       else Option.none
@@ -1051,9 +1050,8 @@ module Handler = struct
         parse_directional Linear To rest
     (* mask-linear-N (angle), mask-linear-[arb] *)
     | [ "mask"; "linear"; n ] -> (
-        if String.length n > 2 && n.[0] = '[' && n.[String.length n - 1] = ']'
-        then
-          let inner = String.sub n 1 (String.length n - 2) in
+        if Parse.is_bracket_value n then
+          let inner = Parse.bracket_inner n in
           Ok (Mask_linear_angle (Angle_arb inner))
         else
           match int_of_string_opt n with
@@ -1061,9 +1059,8 @@ module Handler = struct
           | None -> Error (`Msg "Invalid mask-linear angle value"))
     (* -mask-linear-N (negative angle), -mask-linear-[arb] *)
     | [ ""; "mask"; "linear"; n ] -> (
-        if String.length n > 2 && n.[0] = '[' && n.[String.length n - 1] = ']'
-        then
-          let inner = String.sub n 1 (String.length n - 2) in
+        if Parse.is_bracket_value n then
+          let inner = Parse.bracket_inner n in
           Ok (Mask_linear_angle (Angle_arb_neg inner))
         else
           match int_of_string_opt n with
@@ -1075,12 +1072,8 @@ module Handler = struct
     | "mask" :: "radial" :: "at" :: rest when rest <> [] ->
         let position = String.concat " " rest in
         (* Handle arbitrary values - strip brackets *)
-        if
-          String.length position > 2
-          && position.[0] = '['
-          && position.[String.length position - 1] = ']'
-        then
-          let inner = String.sub position 1 (String.length position - 2) in
+        if Parse.is_bracket_value position then
+          let inner = Parse.bracket_inner position in
           if radial_at_position inner = None then
             Error (`Msg ("Invalid mask-radial-at position: " ^ position))
           else Ok (Mask_radial_at (At_arbitrary inner))
@@ -1107,9 +1100,8 @@ module Handler = struct
         parse_directional Conic To rest
     (* mask-conic-N (angle), mask-conic-[arb] *)
     | [ "mask"; "conic"; n ] -> (
-        if String.length n > 2 && n.[0] = '[' && n.[String.length n - 1] = ']'
-        then
-          let inner = String.sub n 1 (String.length n - 2) in
+        if Parse.is_bracket_value n then
+          let inner = Parse.bracket_inner n in
           Ok (Mask_conic_angle (Angle_arb inner))
         else
           match int_of_string_opt n with
@@ -1117,9 +1109,8 @@ module Handler = struct
           | None -> Error (`Msg "Invalid mask-conic angle value"))
     (* -mask-conic-N (negative angle), -mask-conic-[arb] *)
     | [ ""; "mask"; "conic"; n ] -> (
-        if String.length n > 2 && n.[0] = '[' && n.[String.length n - 1] = ']'
-        then
-          let inner = String.sub n 1 (String.length n - 2) in
+        if Parse.is_bracket_value n then
+          let inner = Parse.bracket_inner n in
           Ok (Mask_conic_angle (Angle_arb_neg inner))
         else
           match int_of_string_opt n with
@@ -1138,11 +1129,8 @@ module Handler = struct
     | [ "mask"; "radial"; "farthest"; "side" ] ->
         Ok (Mask_radial_size Farthest_side)
     (* mask-radial-[size] - arbitrary size *)
-    | [ "mask"; "radial"; arb ]
-      when String.length arb > 2
-           && arb.[0] = '['
-           && arb.[String.length arb - 1] = ']' ->
-        let size_value = String.sub arb 1 (String.length arb - 2) in
+    | [ "mask"; "radial"; arb ] when Parse.is_bracket_value arb ->
+        let size_value = Parse.bracket_inner arb in
         (* Replace underscores with spaces *)
         let size_value =
           String.map (fun c -> if c = '_' then ' ' else c) size_value

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -98,11 +98,10 @@ let extract_var_name s =
     String.trim (String.sub s 6 (len - 7))
   else s
 
-(** Check if a string is a bracket-wrapped value like "[...]" *)
-(* One bracket, not two: the [\]] that closes the opening [\[] has to be the
-   last character. [[a]/[b]] is a bracket carrying a modifier and [[a]-[b]] is
-   two brackets; reading either as one leaves the inner text with its brackets
-   unbalanced, which no declaration value takes. *)
+(* One bracket, not two: the closing bracket has to be the last character. A
+   suffix carrying a second bracket - one bracket with a bracket modifier, or
+   two brackets in a row - would otherwise read as one bracket whose inner text
+   has a stray bracket in it, which no declaration value takes. *)
 let is_bracket_value s =
   let len = String.length s in
   let rec close i depth =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -99,8 +99,21 @@ let extract_var_name s =
   else s
 
 (** Check if a string is a bracket-wrapped value like "[...]" *)
+(* One bracket, not two: the [\]] that closes the opening [\[] has to be the
+   last character. [[a]/[b]] is a bracket carrying a modifier and [[a]-[b]] is
+   two brackets; reading either as one leaves the inner text with its brackets
+   unbalanced, which no declaration value takes. *)
 let is_bracket_value s =
-  String.length s > 2 && s.[0] = '[' && s.[String.length s - 1] = ']'
+  let len = String.length s in
+  let rec close i depth =
+    if i >= len then false
+    else
+      match s.[i] with
+      | '[' -> close (i + 1) (depth + 1)
+      | ']' -> if depth = 0 then i = len - 1 else close (i + 1) (depth - 1)
+      | _ -> close (i + 1) depth
+  in
+  len > 2 && s.[0] = '[' && close 1 0
 
 (** Extract the inner content from a bracket value "[foo]" → "foo" *)
 let bracket_inner s =

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -56,8 +56,10 @@ val extract_var_name : string -> string
 *)
 
 val is_bracket_value : string -> bool
-(** [is_bracket_value s] returns [true] if [s] is a bracket-wrapped value like
-    ["[...]"]. *)
+(** [is_bracket_value s] returns [true] if [s] is one bracket-wrapped value like
+    ["[...]"]. The ["]"] closing the opening ["["] has to be the last character,
+    so ["[a]/[b]"] (a bracket with a modifier) and ["[a]-[b]"] (two brackets)
+    are not one bracket value. *)
 
 val bracket_inner : string -> string
 (** [bracket_inner s] extracts the inner content from ["[foo]"], returning

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -56,10 +56,10 @@ val extract_var_name : string -> string
 *)
 
 val is_bracket_value : string -> bool
-(** [is_bracket_value s] returns [true] if [s] is one bracket-wrapped value like
-    ["[...]"]. The ["]"] closing the opening ["["] has to be the last character,
-    so ["[a]/[b]"] (a bracket with a modifier) and ["[a]-[b]"] (two brackets)
-    are not one bracket value. *)
+(** [is_bracket_value s] returns [true] if [s] is one bracket-wrapped value. The
+    closing bracket has to be the last character, so a suffix carrying a second
+    bracket - one bracket with a bracket modifier, or two brackets in a row - is
+    not one bracket value. *)
 
 val bracket_inner : string -> string
 (** [bracket_inner s] extracts the inner content from ["[foo]"], returning

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -107,11 +107,47 @@ let test_parse_is_independent_of_history () =
   round_trips built;
   unknown "grid-cols-"
 
+(* The utilities that swallowed a second bracket refuse the class instead of
+   raising out of [to_css]. Tailwind emits nothing for any of them. *)
+let test_double_bracket_class_rejected () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u ->
+        Alcotest.failf "expected %s to be rejected, got %s" cls
+          (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
+    | Error _ -> ()
+  in
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok _ -> ()
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  rejected "mask-b-from-[foo]/[bar]";
+  rejected "mask-linear-from-[foo]-[bar]";
+  rejected "bg-linear-[foo]/[bar]";
+  rejected "bg-radial-[foo]/[bar]";
+  rejected "scale-z-[foo]/[bar]";
+  rejected "mask-radial-[foo]/[bar]";
+  rejected "-mask-linear-[foo]/[bar]";
+  rejected "-mask-conic-[foo]/[bar]";
+  rejected "mask-radial-at-[foo]/[bar]";
+  accepted "mask-b-from-[10%]";
+  accepted "bg-linear-[45deg]";
+  accepted "scale-z-[2]";
+  accepted "mask-radial-[50%_50%]";
+  accepted "-mask-linear-[45deg]";
+  accepted "mask-radial-at-[50%_50%]";
+  (* A bracket modifier on a utility that takes one still reads. *)
+  accepted "text-[10px]/[1.5]";
+  accepted "bg-red-500/[0.5]"
+
 let tests =
   Alcotest.
     [
       test_case "parse backslash escape in selector" `Quick
         test_escape_in_selector;
+      test_case "double bracket class rejected" `Quick
+        test_double_bracket_class_rejected;
       test_case "int suffixes reject non-decimal spellings" `Quick
         test_int_rejects_non_decimal_spellings;
       test_case "negative int suffixes reject non-decimal spellings" `Quick


### PR DESCRIPTION
A class carrying two brackets, as in `[a]/[b]` or `[a]-[b]`, was read as a single bracket and handed unbalanced text to a custom property. Six inline copies of the loose check are replaced by the shared one.