### PR TITLE
test: find a class whose selector continues past its name

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -311,8 +311,18 @@ let check_ordering_matches ?forms ~test_name utilities =
       Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
       Alcotest.failf "%s\n%s" test_name (Buffer.contents buf)
 
-(* Where a class's rule starts in a sheet. The selector is matched up to its
-   closing delimiter so [.bg-top] does not report [.bg-top-left]. *)
+(* Where a class's rule starts in a sheet. The match has to end where the class
+   name ends, so [.bg-top] does not report [.bg-top-left]; what follows it is
+   not constrained beyond that, so a selector that carries on past the class
+   ([.divide-x>*], [.group:hover .x]) is found rather than reported absent. *)
+let continues_class_name c =
+  match c with
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
+  (* A backslash starts an escape, which is part of the name it sits in; a byte
+     at or above 0x80 is part of a non-ASCII identifier. *)
+  | '\\' -> true
+  | c -> Char.code c >= 0x80
+
 let class_position sheet cls =
   let sel = Css.Selector.to_string (Css.Selector.class_ cls) in
   let n = String.length sel and len = String.length sheet in
@@ -320,8 +330,10 @@ let class_position sheet cls =
     if i + n > len then None
     else if
       String.sub sheet i n = sel
-      && i + n < len
-      && (sheet.[i + n] = '{' || sheet.[i + n] = ',')
+      (* An escaped dot belongs to the class name before it: [.w-1\.5] is one
+         class, not a [.5] inside another. *)
+      && (i = 0 || sheet.[i - 1] <> '\\')
+      && (i + n = len || not (continues_class_name sheet.[i + n]))
     then Some i
     else scan (i + 1)
   in

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -62,6 +62,14 @@ val check_ordering_matches :
     of utilities between our implementation and Tailwind CSS, failing the test
     if they differ. *)
 
+val class_position : string -> string -> int option
+(** [class_position sheet cls] is the byte offset in [sheet] where the rule for
+    class [cls] starts, or [None] when the sheet declares no such class. The
+    match ends where the class name ends, so [.bg-top] is not read off
+    [.bg-top-left]; what follows it is not constrained, so a selector that
+    continues past the class ([.divide-x>*], [.group:hover .x]) is found too.
+    The oracle behind {!check_class_order}. *)
+
 val check_class_order : ?forms:bool -> test_name:string -> string list -> unit
 (** [check_class_order ?forms ~test_name classes] compares where each of
     [classes] lands in tw's sheet against where the pinned Tailwind CLI puts it.

--- a/test/test.ml
+++ b/test/test.ml
@@ -28,6 +28,7 @@ let () =
     (* Return test suites *)
     [
       Test_tw.suite;
+      Test_test_helpers.suite;
       Test_source_scan.suite;
       Test_svg.suite;
       Test_tables.suite;

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -104,6 +104,17 @@ let order_matches_tailwind () =
   Test_helpers.check_ordering_matches ~test_name:"divide order matches Tailwind"
     (Test_helpers.shuffle (divide_utilities ()))
 
+(* divide's rules continue past the class name into a combinator, so where they
+   land in the sheet is a shape check_ordering_matches cannot see: it pairs
+   rules by key, and a layer holding each of them in the wrong place still
+   compares equal. *)
+let class_order_matches_tailwind () =
+  Test_helpers.check_class_order
+    ~test_name:"divide class order matches Tailwind"
+    (List.filter
+       (fun c -> Astring.String.is_prefix ~affix:"divide-" c)
+       divide_classes)
+
 (* divide-* and border-* write the same border properties, so what an element is
    actually bordered with is a rendering question, not only an ordering one. *)
 let rendering_matches_tailwind () =
@@ -142,6 +153,8 @@ let tests =
       Alcotest.test_case "typed arbitrary width" `Quick
         test_typed_arbitrary_width;
       Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
+      Alcotest.test_case "class order matches Tailwind" `Slow
+        class_order_matches_tailwind;
       Alcotest.test_case "renders like Tailwind" `Slow
         rendering_matches_tailwind;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -1,0 +1,61 @@
+(* The harness decides whether every other suite passes, so what its predicates
+   report is worth pinning on its own. Each case here feeds a predicate an input
+   whose answer is known by construction and checks the answer, rather than
+   checking anything the library emits. *)
+
+(* Two selector shapes a real utility has: divide's rule continues past the
+   class name into a combinator, and a longer class shares a shorter one's
+   prefix. Written the way a minified sheet spells them. *)
+let sheet =
+  ".divide-x>:not(:last-child){border-inline-width:1px}"
+  ^ ".bg-top{background-position:top}"
+  ^ ".divide-x-2>:not(:last-child){border-inline-width:2px}"
+  ^ ".bg-top-left{background-position:left top}"
+
+let position cls = Test_helpers.class_position sheet cls
+
+let index_of affix =
+  match Astring.String.find_sub ~sub:affix sheet with
+  | Some i -> i
+  | None -> Alcotest.failf "%s is not in the fixture sheet" affix
+
+(* [.divide-x] is followed by a combinator, not by [{] or [,]. A predicate that
+   only accepts those two delimiters reports the class as absent from a sheet
+   that declares it, and [check_class_order] then blames the generated CSS. *)
+let test_position_of_continuing_selector () =
+  Alcotest.(check (option int))
+    "divide-x is where its rule starts"
+    (Some (index_of ".divide-x>"))
+    (position "divide-x")
+
+(* The same shape one level down: the match has to end where the class name
+   ends, so [.divide-x] must not be read off [.divide-x-2]. *)
+let test_position_ignores_longer_class_with_combinator () =
+  Alcotest.(check (option int))
+    "divide-x-2 is its own rule"
+    (Some (index_of ".divide-x-2>"))
+    (position "divide-x-2")
+
+let test_position_ignores_longer_class () =
+  Alcotest.(check (option int))
+    "bg-top is not bg-top-left"
+    (Some (index_of ".bg-top{"))
+    (position "bg-top")
+
+let test_position_absent_class () =
+  Alcotest.(check (option int))
+    "flex is not in the sheet" None (position "flex")
+
+let tests =
+  [
+    Alcotest.test_case "class position: continuing selector" `Quick
+      test_position_of_continuing_selector;
+    Alcotest.test_case "class position: longer class with combinator" `Quick
+      test_position_ignores_longer_class_with_combinator;
+    Alcotest.test_case "class position: longer class" `Quick
+      test_position_ignores_longer_class;
+    Alcotest.test_case "class position: absent class" `Quick
+      test_position_absent_class;
+  ]
+
+let suite = ("test_helpers", tests)

--- a/test/test_test_helpers.mli
+++ b/test/test_test_helpers.mli
@@ -1,0 +1,4 @@
+(** Tests for the test harness's own predicates. *)
+
+val suite : string * unit Alcotest.test_case list
+(** [suite] is the test suite. *)


### PR DESCRIPTION
The ordering oracle looked for the class name followed by a brace or a comma, so it never found `divide-x`, `space-x-4` or any group variant, and then reported the class as missing from the sheet rather than as unsupported. It now matches on the end of the class name.