### PR TITLE
test: see a var() anywhere in a declaration value

### DIFF
--- a/test/helpers/dune
+++ b/test/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name test_helpers)
- (libraries tw tw_tools alcotest fmt cascade cascade.diff))
+ (libraries tw tw_tools alcotest astring fmt cascade cascade.diff))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -490,10 +490,13 @@ let inline_has_property prop_name inline_style =
 
 (** Check if declarations contain any var() references *)
 let has_var_in_declarations ?(inline = false) decls =
+  (* Anywhere in the value, not only at its head: [calc(var(--spacing)*4)] and
+     [color-mix(in oklab, var(--c) 50%, #0000)] reference a variable as much as
+     a bare [var(--c)] does, and an assertion that a sheet holds none is vacuous
+     on them otherwise. *)
   List.exists
     (fun decl ->
-      let value = Css.declaration_value ~inline decl in
-      String.length value >= 4 && String.sub value 0 4 = "var(")
+      Astring.String.is_infix ~affix:"var(" (Css.declaration_value ~inline decl))
     decls
 
 (** {1 Utility Generators} *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -427,16 +427,18 @@ let test_inline_style_no_vars () =
 let test_inline_vs_variables_diff () =
   (* Same utility under Variables vs Inline should differ: Inline has no var().
      Generate sheets in their respective modes to avoid carrying layer content
-     that may still contain var() in declarations. *)
+     that may still contain var() in declarations. p-4 spells its reference as
+     calc(var(--spacing) * 4), so the variables sheet only counts as referencing
+     one if the reference is read past the head of the value. *)
   let sheet_vars =
     Tw.Build.to_css
       ~config:{ Tw.Build.base = false; forms = None; layers = true }
-      [ Tw.Borders.rounded_sm ]
+      [ p 4 ]
   in
   let sheet_inline =
     Tw.Build.to_css
       ~config:{ Tw.Build.base = false; forms = None; layers = true }
-      [ Tw.Borders.rounded_sm ]
+      [ p 4 ]
     |> Css.inline_vars
   in
   (* Extract all declarations using fold *)

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -46,6 +46,40 @@ let test_position_absent_class () =
   Alcotest.(check (option int))
     "flex is not in the sheet" None (position "flex")
 
+(* Every declaration a class emits, theme bindings included. *)
+let declarations_of cls =
+  match Tw.of_string cls with
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  | Ok u ->
+      Tw.to_css ~base:false [ u ]
+      |> Cascade.Css.fold
+           (fun acc stmt ->
+             match Cascade.Css.as_rule stmt with
+             | Some (_, decls, _) -> decls @ acc
+             | None -> acc)
+           []
+
+let references_var cls =
+  Test_helpers.has_var_in_declarations (declarations_of cls)
+
+(* A [var()] under calc() is still a variable reference. A predicate that only
+   reads the head of the value calls the spacing scale no reference at all, and
+   every assertion that a sheet holds none passes on it by accident. *)
+let test_var_under_calc () =
+  Alcotest.(check bool)
+    "p-4 references the spacing variable" true (references_var "p-4")
+
+(* Same shape one function further in: the colour sits inside color-mix. *)
+let test_var_under_color_mix () =
+  Alcotest.(check bool)
+    "bg-black/50 references the palette variable" true
+    (references_var "bg-black/50")
+
+let test_no_var_when_none_referenced () =
+  Alcotest.(check bool)
+    "text-left references no variable" false
+    (references_var "text-left")
+
 let tests =
   [
     Alcotest.test_case "class position: continuing selector" `Quick
@@ -56,6 +90,10 @@ let tests =
       test_position_ignores_longer_class;
     Alcotest.test_case "class position: absent class" `Quick
       test_position_absent_class;
+    Alcotest.test_case "var under calc" `Quick test_var_under_calc;
+    Alcotest.test_case "var under color-mix" `Quick test_var_under_color_mix;
+    Alcotest.test_case "no var referenced" `Quick
+      test_no_var_when_none_referenced;
   ]
 
 let suite = ("test_helpers", tests)


### PR DESCRIPTION
The predicate tested only the first four characters, so `calc(var(--spacing)*4)` and every colour mix read as holding no variable. The absence assertions that relied on it were passing because inline rendering resolves variables, so the blindness was latent rather than masking a failure.