### PR TITLE
test: pair a shorthand with the longhands it overlaps

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -52,10 +52,62 @@ let properties_of_class cls =
              | _ -> acc)
            []
 
-(* Classes that write on each other, paired up. An ordering difference is only
-   observable on an element carrying two such classes; one class on its own can
-   only show a difference in value. *)
-let interacting_pairs classes =
+(* What a class writes on an element carrying it, as one rule. The theme
+   bindings it drags in are left out - every class reading the spacing scale
+   writes [--spacing], which says nothing about what two of them do to each
+   other - and so are the [*, ::before] property defaults: neither is a selector
+   holding a [.]. *)
+let class_rule cls =
+  let decls =
+    match Tw.of_string cls with
+    | Error _ -> []
+    | Ok u ->
+        Tw.to_css ~base:false [ u ]
+        |> Css.fold
+             (fun acc stmt ->
+               match Css.as_rule stmt with
+               | Some (sel, decls, _)
+                 when String.contains (Css.Selector.to_string sel) '.' ->
+                   decls @ acc
+               | _ -> acc)
+             []
+  in
+  Css.rule ~selector:(Css.Selector.class_ cls) decls
+
+(* Two classes whose relative order is cascade-significant. Canonicalisation
+   sorts statements that cannot observe each other into a content-keyed order
+   and leaves the order of the ones that can, so a pair whose two spellings
+   canonicalise apart is a pair writing a common slot - cascade's own footprint
+   model, shorthand expansion included. This is what pairing on the declared
+   property name cannot see: [inset-px] and [top-px] share no property name and
+   both decide [top]. *)
+let cascade_conflict a b =
+  let canon stmts =
+    Css.canonicalize_rule_order (Css.v stmts) |> Css.to_string ~minify:true
+  in
+  canon [ a; b ] <> canon [ b; a ]
+
+let overlapping_pairs classes =
+  let rules = List.map (fun cls -> (cls, class_rule cls)) classes in
+  let rec go acc = function
+    | [] | [ _ ] -> acc
+    | (a, ra) :: tl ->
+        let acc =
+          List.fold_left
+            (fun acc (b, rb) ->
+              if cascade_conflict ra rb then (a, b) :: acc else acc)
+            acc tl
+        in
+        go acc tl
+  in
+  go [] rules
+
+(* Classes that declare a property in common. Kept alongside the footprint
+   model, which is about order alone: two classes writing the same property with
+   the same value do not conflict, and still compose - [shadow-lg] reads the
+   colour [shadow-current] writes, and only an element carrying both shows what
+   the pair computes to. *)
+let same_property_pairs classes =
   let by_prop = Hashtbl.create 256 in
   List.iter
     (fun cls ->
@@ -86,6 +138,14 @@ let interacting_pairs classes =
       in
       pairs acc cs)
     by_prop []
+
+(* Classes that write on each other, paired up. An ordering difference is only
+   observable on an element carrying two such classes; one class on its own can
+   only show a difference in value. *)
+let interacting_pairs classes =
+  let key (a, b) = if a <= b then (a, b) else (b, a) in
+  same_property_pairs classes @ overlapping_pairs classes
+  |> List.map key |> List.sort_uniq compare
 
 (* The single ordering predicate. The fuzzer minimises with it and every suite
    asserts on it, so a minimal case it reports is a case the assertion also

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -52,10 +52,10 @@ let properties_of_class cls =
              | _ -> acc)
            []
 
-(* Classes that declare a property in common, paired up. An ordering difference
-   is only observable on an element carrying two such classes; one class on its
-   own can only show a difference in value. *)
-let same_property_pairs classes =
+(* Classes that write on each other, paired up. An ordering difference is only
+   observable on an element carrying two such classes; one class on its own can
+   only show a difference in value. *)
+let interacting_pairs classes =
   let by_prop = Hashtbl.create 256 in
   List.iter
     (fun cls ->
@@ -267,7 +267,7 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
   (* A class on its own can only show a difference in value; an ordering
      difference needs an element carrying two classes that write the same
      property. *)
-  let pairs = same_property_pairs classnames in
+  let pairs = interacting_pairs classnames in
   let elements =
     dedup (classnames @ List.map (fun (a, b) -> a ^ " " ^ b) pairs)
   in

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -25,10 +25,10 @@ val properties_of_class : string -> Css.Declaration.prop_key list
 (** [properties_of_class cls] is every property [cls] declares, custom
     properties included: two utilities can conflict on a [--tw-*] alone. *)
 
-val same_property_pairs : string list -> (string * string) list
-(** [same_property_pairs classes] pairs up the classes that declare a property
-    in common. An element carrying such a pair is where an ordering difference
-    becomes observable; a class on its own can only differ in value. *)
+val interacting_pairs : string list -> (string * string) list
+(** [interacting_pairs classes] pairs up the classes that write on each other.
+    An element carrying such a pair is where an ordering difference becomes
+    observable; a class on its own can only differ in value. *)
 
 val ordering_diff : ?forms:bool -> Tw.t list -> Cascade_diff.Css_compare.t
 (** [ordering_diff ?forms utilities] compares tw's sheet for [utilities] against
@@ -82,11 +82,11 @@ val check_rendering_matches :
   ?forms:bool -> test_name:string -> Tw.t list -> unit
 (** [check_rendering_matches ?forms ~test_name utilities] renders both sheets in
     headless Chromium and fails on any computed style that differs. Each class
-    gets an element of its own, plus one per {!same_property_pairs} pair, which
-    is where an ordering difference shows. Fails too when an element does not
-    carry the classes it was given, since then the comparison is vacuous. Skips
-    when node or Playwright is absent; [TW_BROWSER_TESTS=0] opts out where they
-    are present. *)
+    gets an element of its own, plus one per {!interacting_pairs} pair, which is
+    where an ordering difference shows. Fails too when an element does not carry
+    the classes it was given, since then the comparison is vacuous. Skips when
+    node or Playwright is absent; [TW_BROWSER_TESTS=0] opts out where they are
+    present. *)
 
 (** {1 CSS Test Helpers} *)
 

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -80,6 +80,41 @@ let test_no_var_when_none_referenced () =
     "text-left references no variable" false
     (references_var "text-left")
 
+(* Where an ordering difference becomes observable: an element carrying two
+   classes that write on each other. *)
+let paired a b =
+  let pairs = Test_helpers.interacting_pairs [ a; b ] in
+  List.exists (fun p -> p = (a, b) || p = (b, a)) pairs
+
+(* [inset] and [top] are one property after shorthand expansion, so which of the
+   two rules comes last decides where the element sits. They share no property
+   name, so pairing on the name alone never puts them on one element. The [px]
+   step rather than a scale step: [inset-4] and [top-4] each write [--spacing]
+   too, which pairs them for a reason that says nothing about the two
+   properties. *)
+let test_pairs_shorthand_with_longhand () =
+  Alcotest.(check bool)
+    "inset-px and top-px share an element" true
+    (paired "inset-px" "top-px")
+
+(* The same relation one family over: [flex] writes [flex-grow]. *)
+let test_pairs_shorthand_with_its_own_longhand () =
+  Alcotest.(check bool)
+    "flex-1 and grow share an element" true (paired "flex-1" "grow")
+
+(* A pair that interacts through a variable rather than a slot: shadow-current
+   feeds the colour the size utility's shadow reads, which neither class shows
+   on its own. *)
+let test_pairs_composed_through_a_variable () =
+  Alcotest.(check bool)
+    "shadow-lg and shadow-current share an element" true
+    (paired "shadow-lg" "shadow-current")
+
+let test_unrelated_classes_are_not_paired () =
+  Alcotest.(check bool)
+    "text-left and italic do not share an element" false
+    (paired "text-left" "italic")
+
 let tests =
   [
     Alcotest.test_case "class position: continuing selector" `Quick
@@ -94,6 +129,14 @@ let tests =
     Alcotest.test_case "var under color-mix" `Quick test_var_under_color_mix;
     Alcotest.test_case "no var referenced" `Quick
       test_no_var_when_none_referenced;
+    Alcotest.test_case "pairs shorthand with longhand" `Quick
+      test_pairs_shorthand_with_longhand;
+    Alcotest.test_case "pairs shorthand with its own longhand" `Quick
+      test_pairs_shorthand_with_its_own_longhand;
+    Alcotest.test_case "pairs classes composed through a variable" `Quick
+      test_pairs_composed_through_a_variable;
+    Alcotest.test_case "unrelated classes are not paired" `Quick
+      test_unrelated_classes_are_not_paired;
   ]
 
 let suite = ("test_helpers", tests)


### PR DESCRIPTION
The rendering harness paired classes by declared property name, so a shorthand and its longhand never shared an element and were never compared in the browser. Pairing now also uses cascade's canonical rule order, which exposes the overlap after expansion.