### PR TITLE
test: deduplicate rendering classes without a quadratic scan

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -310,13 +310,27 @@ let render_dir root test_name =
       dir)
     root [ "tmp"; "browser"; safe ]
 
+(* First occurrence wins and the order is kept. Through a table rather than a
+   scan of what has been seen: the list this runs on is quadratic in the number
+   of classes. *)
 let dedup l =
+  let seen = Hashtbl.create 256 in
   List.rev
-    (fst
-       (List.fold_left
-          (fun (acc, seen) x ->
-            if List.mem x seen then (acc, seen) else (x :: acc, x :: seen))
-          ([], []) l))
+    (List.fold_left
+       (fun acc x ->
+         if Hashtbl.mem seen x then acc
+         else (
+           Hashtbl.add seen x ();
+           x :: acc))
+       [] l)
+
+(* The elements the browser check builds: every class on its own, since a class
+   alone can still differ in value, and one carrying each interacting pair,
+   which is where an ordering difference shows. *)
+let render_elements classnames =
+  dedup
+    (classnames
+    @ List.map (fun (a, b) -> a ^ " " ^ b) (interacting_pairs classnames))
 
 let check_rendering_matches ?(forms = false) ~test_name utilities =
   let root =
@@ -324,13 +338,7 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
   in
   if not (browser_available root) then Alcotest.skip ();
   let classnames = List.map Tw.pp utilities in
-  (* A class on its own can only show a difference in value; an ordering
-     difference needs an element carrying two classes that write the same
-     property. *)
-  let pairs = interacting_pairs classnames in
-  let elements =
-    dedup (classnames @ List.map (fun (a, b) -> a ^ " " ^ b) pairs)
-  in
+  let elements = render_elements classnames in
   let tailwind = tailwind_css ~forms classnames in
   let dir = render_dir root test_name in
   let path name = Filename.concat dir name in

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -78,6 +78,11 @@ val check_class_order : ?forms:bool -> test_name:string -> string list -> unit
     positions back is what catches a reorder. Skips when the CLI is unavailable.
 *)
 
+val render_elements : string list -> string list
+(** [render_elements classnames] is the element list {!check_rendering_matches}
+    renders: each class on its own, then one element per {!interacting_pairs}
+    pair, duplicates dropped and first occurrence kept. *)
+
 val check_rendering_matches :
   ?forms:bool -> test_name:string -> Tw.t list -> unit
 (** [check_rendering_matches ?forms ~test_name utilities] renders both sheets in

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -115,6 +115,14 @@ let test_unrelated_classes_are_not_paired () =
     "text-left and italic do not share an element" false
     (paired "text-left" "italic")
 
+(* The list handed to the browser: singles first, then the pairs, with the
+   repeat of a class dropped rather than rendered twice. *)
+let test_render_elements_are_unique_and_ordered () =
+  Alcotest.(check (list string))
+    "m-2 twice renders once"
+    [ "m-2"; "ml-2"; "m-2 ml-2" ]
+    (Test_helpers.render_elements [ "m-2"; "ml-2"; "m-2" ])
+
 let tests =
   [
     Alcotest.test_case "class position: continuing selector" `Quick
@@ -137,6 +145,8 @@ let tests =
       test_pairs_composed_through_a_variable;
     Alcotest.test_case "unrelated classes are not paired" `Quick
       test_unrelated_classes_are_not_paired;
+    Alcotest.test_case "render elements are unique and ordered" `Quick
+      test_render_elements_are_unique_and_ordered;
   ]
 
 let suite = ("test_helpers", tests)


### PR DESCRIPTION
The helper scanned a growing list per element. Naming the rendered element list also makes what the browser receives testable.