### PR TITLE
columns: let the class name decide the order of column values

### DIFF
--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -101,49 +101,13 @@ module Handler = struct
         let ref : Css.columns_value Css.var = Var.bracket inner in
         style [ columns (Var ref) ]
 
-  (* Tailwind sorts column utilities lexicographically by their suffix. This
-     function computes a sort key that preserves lexicographic order: "1" < "10"
-     < "11" < "12" < "2" < "2xl" < "2xs" < "3" < ... < "auto" < "lg" < ... Uses
-     large weights so first character dominates the comparison. *)
-  let string_to_sortkey s =
-    let rec aux acc i =
-      if i >= String.length s || i >= 4 then acc
-      else
-        (* Each position uses 256x smaller weight than previous *)
-        let weight =
-          match i with
-          | 0 -> 256 * 256 * 256 (* 16777216 *)
-          | 1 -> 256 * 256 (* 65536 *)
-          | 2 -> 256
-          | _ -> 1
-        in
-        aux (acc + (Char.code s.[i] * weight)) (i + 1)
-    in
-    aux 0 0
-
-  let suborder t =
-    let suffix =
-      match t with
-      | Columns_auto -> "auto"
-      | Columns_count n -> string_of_int n
-      | Columns_3xs -> "3xs"
-      | Columns_2xs -> "2xs"
-      | Columns_xs -> "xs"
-      | Columns_sm -> "sm"
-      | Columns_md -> "md"
-      | Columns_lg -> "lg"
-      | Columns_xl -> "xl"
-      | Columns_2xl -> "2xl"
-      | Columns_3xl -> "3xl"
-      | Columns_4xl -> "4xl"
-      | Columns_5xl -> "5xl"
-      | Columns_6xl -> "6xl"
-      | Columns_7xl -> "7xl"
-      | Columns_arbitrary n -> "[" ^ string_of_int n ^ "]"
-      | Columns_arbitrary_len s -> "[" ^ s ^ "]"
-      | Columns_bracket_var _ -> "[z"
-    in
-    string_to_sortkey suffix
+  (* Every column utility shares one suborder. Tailwind orders the values of a
+     single utility by a natural, digit-aware compare of the candidate itself
+     (columns-9 before columns-10, columns-[100px] before columns-[100rem]),
+     which is what Sort falls back to once the suborders tie. A numeric key
+     built from a prefix of the suffix cannot express that order and, being
+     consulted first, would override it. *)
+  let suborder _ = 0
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in

--- a/test/test_columns.ml
+++ b/test/test_columns.ml
@@ -49,12 +49,49 @@ let test_typed () =
   Test_helpers.check_typed_class "columns-2xl" Tw.columns_2xl;
   Test_helpers.check_typed_class "columns-7xl" Tw.columns_7xl
 
+(* Tailwind orders the values of one utility by a natural (digit-aware) compare
+   of the class name, so [columns-9] precedes [columns-10] and the theme names
+   interleave with the counts. *)
+let test_numeric_order () =
+  Test_helpers.check_class_order ~test_name:"columns numeric order"
+    [
+      "columns-1";
+      "columns-2";
+      "columns-2xl";
+      "columns-2xs";
+      "columns-3";
+      "columns-3xs";
+      "columns-7xl";
+      "columns-10";
+      "columns-11";
+      "columns-12";
+      "columns-auto";
+      "columns-lg";
+    ]
+
+(* Arbitrary widths sort by the same natural compare: a four-character prefix is
+   not enough to separate [100px] from [100rem], and the counts still order
+   numerically. *)
+let test_arbitrary_order () =
+  Test_helpers.check_class_order ~test_name:"columns arbitrary order"
+    [
+      "columns-[9rem]";
+      "columns-[10rem]";
+      "columns-[100px]";
+      "columns-[100rem]";
+      "columns-[1000px]";
+      "columns-[var(--a)]";
+      "columns-[var(--b)]";
+    ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "columns arbitrary width" `Quick
         test_columns_arbitrary_width;
       Alcotest.test_case "typed constructors" `Quick test_typed;
+      Alcotest.test_case "numeric order" `Quick test_numeric_order;
+      Alcotest.test_case "arbitrary order" `Quick test_arbitrary_order;
     ]
 
 let suite = ("columns", tests)


### PR DESCRIPTION
A four-character sort key ordered column values lexicographically, so `columns-10`, `columns-11` and `columns-12` were emitted before `columns-2`. Dropping it lets the natural, digit-aware compare that already runs on ties decide, which is what Tailwind emits.