### PR TITLE
var: refuse a second, disagreeing property order for a name

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1512,3 +1512,4 @@ let outline_offset_1 = utility (Outline_offset 1)
 let outline_offset_2 = utility (Outline_offset 2)
 let outline_offset_4 = utility (Outline_offset 4)
 let outline_offset_8 = utility (Outline_offset 8)
+let border_style_var = Handler.border_style_var

--- a/lib/borders.mli
+++ b/lib/borders.mli
@@ -631,4 +631,10 @@ val outline_offset_4 : t
 val outline_offset_8 : t
 (** [outline_offset_8] sets outline offset to 8px. *)
 
+val border_style_var : Cascade.Css.border_style Var.property_default
+(** [border_style_var] is [--tw-border-style], the channel a border-width
+    utility reads its style from. Declared once here and shared, so the divide
+    utilities that read the same property cannot register a second, disagreeing
+    slot for it. *)
+
 module Handler : Utility.Handler

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -45,12 +45,10 @@ module Handler = struct
     Var.property_default Css.Number_percentage ~initial:(Num 0.0)
       ~universal:true ~property_order:5 ~family:`Border "tw-divide-y-reverse"
 
-  (* Reference to --tw-border-style (defined in borders.ml). Must use the same
-     property_order:6 as borders.ml to avoid overwriting the registry. *)
-  let border_style_var =
-    Var.property_default Css.Border_style
-      ~initial:(Solid : Css.border_style)
-      ~property_order:6 ~family:`Border "tw-border-style"
+  (* [--tw-border-style] is one custom property with one slot in the properties
+     layer. Borders declares it; reading its handle here is what keeps the two
+     families pointing at the same declaration. *)
+  let border_style_var = Borders.border_style_var
 
   (* {2 Divide Width Utilities} *)
 

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -352,9 +352,11 @@ module Handler = struct
         prop ~order:61 "top" "linear-gradient(#fff, #fff)";
       ]
 
-  (* @property rules for a specific direction's from/to vars. Order offset
-     varies by direction so that e.g. left endpoints sort before right endpoints
-     in the properties layer. *)
+  (* @property rules for a specific direction's from/to vars. The order offset
+     varies by axis so that e.g. right endpoints sort before left endpoints in
+     the properties layer. A direction keeps one slot whichever utility emits
+     it: [mask-l-*] and the left half of [mask-x-*] name the same four custom
+     properties, so both ask for 66. *)
   let direction_endpoint_rules ?(order_base = 62) dir_name =
     concat
       [
@@ -388,7 +390,7 @@ module Handler = struct
       [
         common_property_rules;
         directional_gradient_property_rules;
-        direction_endpoint_rules "bottom";
+        direction_endpoint_rules ~order_base:66 "bottom";
       ]
 
   let left_property_rules =
@@ -396,7 +398,7 @@ module Handler = struct
       [
         common_property_rules;
         directional_gradient_property_rules;
-        direction_endpoint_rules "left";
+        direction_endpoint_rules ~order_base:66 "left";
       ]
 
   let x_property_rules =

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -123,7 +123,8 @@ module Registry = struct
     | None -> Hashtbl.replace tbl name value
 
   let register_property_order ~name ~order =
-    Hashtbl.replace property_order_registry name order
+    register_once property_order_registry ~what:"property order" ~pp:Pp.int
+      ~name ~value:order
 
   let property_order name =
     (* Strip leading -- if present *)
@@ -578,7 +579,6 @@ let order_of_declaration decl =
       match info_of_meta meta with Some (Info t) -> t.order | None -> None)
 
 let property_initial_string = property_info_to_declaration_value
-
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]
 
 let bracket ?fallback name =

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -479,7 +479,10 @@ val register_property_order : name:string -> order:int -> unit
     variable name. Used by modules that create [\@property] rules directly
     (without using [Var.property_default]) and need to participate in the
     properties layer ordering. The [name] should be without the ["--"] prefix.
-*)
+
+    A name owns its slot: a second registration that agrees restates it, and one
+    that disagrees raises [Invalid_argument] rather than letting module
+    initialisation order decide the properties layer. *)
 
 val order : string -> (int * int) option
 (** [order name] returns the theme layer order for a variable name, with or

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -203,6 +203,23 @@ let family_registered_once () =
     (fun () ->
       ignore (Tw.Var.channel ~family:`Shadow Css.Length "test-family-owner"))
 
+(* A variable's slot in the properties layer is one fact about one custom
+   property, the same way its family is. A second registration that agrees
+   restates it; one that disagrees is a hand-copied constant that has drifted,
+   and it is refused rather than letting module initialisation order settle
+   it. *)
+let property_order_registered_once () =
+  Tw.Var.register_property_order ~name:"test-order-owner" ~order:6;
+  Tw.Var.register_property_order ~name:"test-order-owner" ~order:6;
+  check
+    (Alcotest.option Alcotest.int)
+    "established" (Some 6)
+    (Tw.Var.property_order "test-order-owner");
+  Alcotest.check_raises "a disagreeing property order is refused"
+    (Invalid_argument
+       "--test-order-owner: property order is 6, registered again as 7")
+    (fun () -> Tw.Var.register_property_order ~name:"test-order-owner" ~order:7)
+
 let tests =
   [
     test_case "var CSS output" `Quick var_css_output;
@@ -219,6 +236,8 @@ let tests =
       order_of_theme_renamed_weight;
     test_case "order of unknown name" `Quick order_of_unknown_name;
     test_case "family registered once" `Quick family_registered_once;
+    test_case "property order registered once" `Quick
+      property_order_registered_once;
   ]
 
 let suite = ("var", tests)


### PR DESCRIPTION
The properties-layer slot was last-write-wins, so a disagreeing second registration silently changed the emitted order according to module initialisation. `divide` now reads the border-style handle rather than redeclaring it, and the mask directions agree on one order, which is the one last-write-wins already settled on.