### PR TITLE
theme: bind the spacing step off its declared base

### DIFF
--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -44,7 +44,7 @@ module Handler = struct
   *)
   let spacing_to_decl_len ?theme ~negative n : Css.declaration * Css.length =
     if n = 0.0 then
-      let decl, _ = Var.binding Theme.spacing_var (Css.Rem 0.25) in
+      let decl, _ = Var.binding Theme.spacing_var Theme.spacing_base in
       (decl, Css.Px 0.)
     else
       let mult = if negative then -.n else n in

--- a/lib/spacing.ml
+++ b/lib/spacing.ml
@@ -66,11 +66,11 @@ let to_decl_len ?theme ?(negative = false) (s : spacing) :
   match s with
   | `Px ->
       let len : Css.length = if negative then Px (-1.) else Px 1. in
-      let decl, _ = Var.binding var (Css.Rem 0.25) in
+      let decl, _ = Var.binding var Theme.spacing_base in
       (Some decl, len)
   | `Full ->
       let len : Css.length = if negative then Pct (-100.) else Pct 100. in
-      let decl, _ = Var.binding var (Css.Rem 0.25) in
+      let decl, _ = Var.binding var Theme.spacing_base in
       (Some decl, len)
   | `Named name -> (
       match named_spacing_binding ?theme name with

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -435,7 +435,7 @@ module Handler = struct
 
   let translate_axis axis_var n =
     let spacing_decl, spacing_ref =
-      Var.binding Theme.spacing_var (Css.Rem 0.25)
+      Var.binding Theme.spacing_var Theme.spacing_base
     in
     (* [calc(var(--spacing) * 0)] is zero whatever the spacing is, and Tailwind
        writes that zero with a unit. The target is a [--tw-*] custom property,
@@ -462,7 +462,7 @@ module Handler = struct
      goes through the same path. *)
   let translate_axis_step axis_var f =
     let spacing_decl, spacing_ref =
-      Var.binding Theme.spacing_var (Css.Rem 0.25)
+      Var.binding Theme.spacing_var Theme.spacing_base
     in
     let spacing_value : Css.length =
       Css.Calc
@@ -639,7 +639,7 @@ module Handler = struct
      calc(var(--spacing) * n); a negative n renders the "* -n" multiplier. *)
   let translate_spacing n =
     let spacing_decl, spacing_ref =
-      Var.binding Theme.spacing_var (Css.Rem 0.25)
+      Var.binding Theme.spacing_var Theme.spacing_base
     in
     let spacing_value : Css.length =
       Css.Calc
@@ -830,7 +830,7 @@ module Handler = struct
 
   let translate_z n =
     let spacing_decl, spacing_ref =
-      Var.binding Theme.spacing_var (Css.Rem 0.25)
+      Var.binding Theme.spacing_var Theme.spacing_base
     in
     let spacing_value : Css.length =
       Css.Calc

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1160,7 +1160,7 @@ module Typography_early = struct
   let lh_modifier_to_css = function
     | Spacing n ->
         let spacing_decl, _spacing_ref =
-          Var.binding Theme.spacing_var (Css.Rem 0.25)
+          Var.binding Theme.spacing_var Theme.spacing_base
         in
         let lh_spacing_ref : Css.line_height Css.var = Var.bracket "spacing" in
         let lh : Css.line_height =
@@ -2618,7 +2618,9 @@ module Typography_late = struct
     text_indent (Indent { length; hanging = false; each_line = false })
 
   let indent n =
-    let spacing_decl, spacing_ref = Var.binding Theme.spacing_var (Rem 0.25) in
+    let spacing_decl, spacing_ref =
+      Var.binding Theme.spacing_var Theme.spacing_base
+    in
     let base : Css.length_percentage = Length (Css.Var spacing_ref) in
     let calc : Css.length_percentage Css.calc = Expr (Val base, Mul, Num n) in
     let length : Css.length_percentage = Calc calc in

--- a/test/test_theme.ml
+++ b/test/test_theme.ml
@@ -117,11 +117,63 @@ let priority_seven_namespace_order () =
   in
   check (list string) "Tailwind namespace order at shared slots" expected actual
 
+(* Utilities across ten modules bind [--spacing] as they emit, each supplying
+   the value the theme layer declares. Each has to bind it to
+   [Theme.spacing_base]: a hand-written copy of the step leaves whichever
+   utilities kept it declaring a stale [--spacing], and a sheet that mixes the
+   two keeps only one of the declarations. *)
+let one_spacing_declaration () =
+  let classes =
+    [
+      "p-4";
+      "gap-4";
+      "basis-4";
+      "grid-cols-[--spacing(4)]";
+      "mask-l-from-4";
+      "scroll-m-4";
+      "indent-4";
+      "leading-4";
+      "text-lg/4";
+      "translate-x-4";
+      "translate-x-0.5";
+      "translate-4";
+      "translate-z-4";
+      "p-px";
+      "p-full";
+    ]
+  in
+  let declared cls =
+    let style =
+      match Tw.of_string cls with
+      | Ok u -> u
+      | Error (`Msg m) -> failf "%s: %s" cls m
+    in
+    match Css.layer_block [ "theme" ] (Tw.to_css ~base:false [ style ]) with
+    | None -> failf "%s: expected @layer theme" cls
+    | Some statements ->
+        Css.rules_of_statements statements
+        |> List.concat_map snd
+        |> List.filter_map (fun d ->
+            match Css.custom_declaration_name d with
+            | Some "--spacing" -> Some (cls, Css.declaration_value d)
+            | _ -> None)
+  in
+  let base = Css.Pp.to_string Css.pp_length Tw.Theme.spacing_base in
+  let found = List.concat_map declared classes in
+  check int "every class declares --spacing" (List.length classes)
+    (List.length found);
+  check
+    (list (pair string string))
+    "every binding declares the same step"
+    (List.map (fun cls -> (cls, base)) classes)
+    found
+
 let tests =
   [
     test_case "theme layer stable order" `Quick theme_layer_stable_order;
     test_case "theme cross-module vars" `Quick theme_cross_module_vars;
     test_case "priority-7 namespace order" `Quick priority_seven_namespace_order;
+    test_case "one spacing declaration" `Quick one_spacing_declaration;
   ]
 
 let suite = ("theme", tests)


### PR DESCRIPTION
Nine sites hand-wrote the spacing step beside four that bound it, so editing the declared base would have split the theme layer into two disagreeing values with half the utilities keeping the old step.