### PR TITLE
var: read a variable's name off its handle

### DIFF
--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -90,13 +90,15 @@ module Handler = struct
      This allows combining multiple contain utilities - each sets its variable,
      and the contain property references all of them. *)
   let composable_contain_value =
-    let v name : Css.contain = Css.Var (Var.bracket ~fallback:Css.Empty name) in
+    let v var : Css.contain =
+      Css.Var (Var.bracket ~fallback:Css.Empty (Var.name var))
+    in
     Css.List
       [
-        v "tw-contain-size";
-        v "tw-contain-layout";
-        v "tw-contain-paint";
-        v "tw-contain-style";
+        v tw_contain_size_var;
+        v tw_contain_layout_var;
+        v tw_contain_paint_var;
+        v tw_contain_style_var;
       ]
 
   (* Create a composable contain style that sets one variable *)

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -460,7 +460,7 @@ module Handler = struct
     fst (Var.binding drop_shadow_color_var value)
 
   let drop_shadow_size_ref : Css.filter =
-    Css.Var (Var.bracket "tw-drop-shadow-size")
+    Css.Var (Var.bracket (Var.name drop_shadow_size_var))
 
   let drop_shadow_theme_ref name : Css.filter =
     Css.Drop_shadow (Css.Var (Var.bracket name) : Css.shadow)

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -94,9 +94,10 @@ module Handler = struct
      literal [100%]. *)
   let basis_spacing n =
     let spacing_decl, _ = Var.binding Theme.spacing_var Theme.spacing_base in
+    let spacing = Var.name Theme.spacing_var in
     let value : Css.flex_basis =
-      if n = 1 then Var (Var.theme_ref "spacing")
-      else Calc Css.Calc.(mul (var "spacing") (float (float_of_int n)))
+      if n = 1 then Var (Var.theme_ref spacing)
+      else Calc Css.Calc.(mul (var spacing) (float (float_of_int n)))
     in
     style [ spacing_decl; flex_basis value ]
 

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -108,15 +108,16 @@ module Handler = struct
 
   (* Return (declarations placed on the rule, optional @supports rules) that set
      [set_var] to the resolved colour. *)
-  let value_decls ?theme ~set_var ~prop_name spec :
+  let value_decls ?theme ~set_var spec :
       Css.declaration list * Css.statement list =
+    let keyword k =
+      Css.custom_property ~layer:"utilities" (Var.css_name set_var) k
+    in
     match spec with
     (* Tailwind keeps these keywords literal in the custom property, where
        cascade's typed pp would fold them ([#0000] / [currentColor]). *)
-    | Transparent ->
-        ([ Css.custom_property ~layer:"utilities" prop_name "transparent" ], [])
-    | Current ->
-        ([ Css.custom_property ~layer:"utilities" prop_name "currentcolor" ], [])
+    | Transparent -> ([ keyword "transparent" ], [])
+    | Current -> ([ keyword "currentcolor" ], [])
     | Inherit -> ([ fst (Var.binding set_var (Css.Inherit : Css.color)) ], [])
     | Theme (color, shade, Color.No_opacity) ->
         let color_decl, color_ref =
@@ -162,15 +163,12 @@ module Handler = struct
         in
         ([ fst (Var.binding set_var oklab) ], [])
 
-  let compose ?theme ~set_var ~prop_name spec =
-    let main_decls, supports_rules =
-      value_decls ?theme ~set_var ~prop_name spec
-    in
+  let compose ?theme ~set_var spec =
+    let main_decls, supports_rules = value_decls ?theme ~set_var spec in
     let scrollbar_color_decl =
       Css.scrollbar_color
         (Colors
-           ( Css.Var (Var.bracket "tw-scrollbar-thumb"),
-             Css.Var (Var.bracket "tw-scrollbar-track") ))
+           (Css.Var (Var.reference thumb_var), Css.Var (Var.reference track_var)))
     in
     let property_rules =
       [ Var.property_rule thumb_var; Var.property_rule track_var ]
@@ -192,7 +190,7 @@ module Handler = struct
         style ~property_rules ~rules:(Some ordered) []
 
   let to_style theme =
-    let compose ~set_var ~prop_name s = compose ~theme ~set_var ~prop_name s in
+    let compose ~set_var s = compose ~theme ~set_var s in
     function
     | Width_auto -> style [ Css.scrollbar_width Auto ]
     | Width_none -> style [ Css.scrollbar_width None ]
@@ -200,8 +198,8 @@ module Handler = struct
     | Gutter_auto -> style [ Css.scrollbar_gutter Auto ]
     | Gutter_stable -> style [ Css.scrollbar_gutter Stable ]
     | Gutter_both -> style [ Css.scrollbar_gutter Stable_both_edges ]
-    | Thumb s -> compose ~set_var:thumb_var ~prop_name:"--tw-scrollbar-thumb" s
-    | Track s -> compose ~set_var:track_var ~prop_name:"--tw-scrollbar-track" s
+    | Thumb s -> compose ~set_var:thumb_var s
+    | Track s -> compose ~set_var:track_var s
 
   let has_opacity s = String.contains s '/'
 

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -26,7 +26,7 @@ let spacing_base : Css.length = Rem 0.25
    publishes the breakpoints, so [theme()] in a project's CSS resolves against
    the same value the utilities use. *)
 let () =
-  Scheme.register_default_token "spacing"
+  Scheme.register_default_token (Var.name spacing_var)
     (Css.Pp.to_string Css.pp_length spacing_base)
 
 (* The spacing step times [n], rendered. Tailwind's v3 [spacing] and
@@ -60,7 +60,7 @@ let has_spacing_step ?theme n =
   let scheme = resolve_scheme theme in
   Float.is_integer n
   && explicit_spacing scheme (int_of_float (Float.abs n)) <> None
-  || Scheme.token scheme "spacing" <> None
+  || Scheme.token scheme (Var.name spacing_var) <> None
 
 (* Create a spacing length value. When scheme has explicit spacing for |n|,
    returns var(--spacing-|n|) or calc(var(--spacing-|n|) * -1) for negatives.

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1100,11 +1100,12 @@ module Typography_early = struct
         let spacing_decl, _ =
           Var.binding Theme.spacing_var Theme.spacing_base
         in
+        let spacing = Var.name Theme.spacing_var in
         let value : line_height =
-          if n = 1 then Css.Var (Var.theme_ref "spacing")
+          if n = 1 then Css.Var (Var.theme_ref spacing)
           else
             Css.Calc
-              (Css.Calc.mul (Css.Calc.var "spacing")
+              (Css.Calc.mul (Css.Calc.var spacing)
                  (Css.Calc.float (float_of_int n)))
         in
         let channel_decl, _ = Var.binding leading_var value in
@@ -1162,7 +1163,11 @@ module Typography_early = struct
         let spacing_decl, _spacing_ref =
           Var.binding Theme.spacing_var Theme.spacing_base
         in
-        let lh_spacing_ref : Css.line_height Css.var = Var.bracket "spacing" in
+        (* [--spacing] holds a length; here it is read as a line height, so the
+           reference is built at that kind off the same handle. *)
+        let lh_spacing_ref : Css.line_height Css.var =
+          Var.bracket (Var.name Theme.spacing_var)
+        in
         let lh : Css.line_height =
           Calc (Css.Calc.mul (Var lh_spacing_ref) (Num (float_of_int n)))
         in

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -559,6 +559,7 @@ let property_info_to_declaration_value (Css.Property_info info) =
               | Number -> Pp.float v ^ "%"
               | syntax -> Css.Pp.to_string (pp_value syntax) v)))
 
+let name var = var.name
 let css_name var = "--" ^ var.name
 
 let needs_property_rule v =

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -622,6 +622,11 @@ val property_rules : ('a, [< `Property_default ]) t -> Css.t
 
 (** {1 Helper Types and Functions} *)
 
+val name : ('a, _) t -> string
+(** [name var] is the custom property's name without the leading ["--"], the
+    spelling {!theme_ref} and {!bracket} take. Read it off the handle rather
+    than writing the name again beside it: the two cannot then drift apart. *)
+
 val css_name : ('a, _) t -> string
 (** [css_name var] returns the full CSS property name with [--] prefix. For
     example, [css_name gradient_from_var] returns ["--tw-gradient-from"]. Use

--- a/test/test_scrollbar.ml
+++ b/test/test_scrollbar.ml
@@ -24,7 +24,53 @@ let test_invalid () =
     (module Tw.Scrollbar.Handler)
     "scrollbar-gutter-foo"
 
+(* [scrollbar-color] reads the two custom properties the same utility declares.
+   Both names were written out three times over in one file, so a rename of
+   either handle would leave the property referenced but never set, and the
+   scrollbar would fall back to the browser's colours. *)
+let test_declares_what_it_references () =
+  let sheet =
+    let classes = [ "scrollbar-thumb-red-500"; "scrollbar-track-gray-200" ] in
+    let styles =
+      List.map
+        (fun cls ->
+          match Tw.of_string cls with
+          | Ok u -> u
+          | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m)
+        classes
+    in
+    Tw.to_css ~base:false styles |> Tw.Css.to_string ~minify:true
+  in
+  (* Every [--tw-scrollbar-*] name in the sheet, split by whether it is being
+     set or read. *)
+  let names ~read =
+    let prefix = "--tw-scrollbar-" in
+    let n = String.length prefix in
+    let len = String.length sheet in
+    let rec at i acc =
+      if i + n > len then List.sort_uniq String.compare acc
+      else if String.sub sheet i n <> prefix then at (i + 1) acc
+      else
+        let rec stop j =
+          if j >= len then j
+          else match sheet.[j] with 'a' .. 'z' | '-' -> stop (j + 1) | _ -> j
+        in
+        let e = stop i in
+        let is_read = i >= 4 && String.sub sheet (i - 4) 4 = "var(" in
+        let name = String.sub sheet i (e - i) in
+        at e (if is_read = read then name :: acc else acc)
+    in
+    at 0 []
+  in
+  Alcotest.(check (list string))
+    "the properties read are the properties set" (names ~read:false)
+    (names ~read:true)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "declares what it references" `Quick
+        test_declares_what_it_references;
+    ]
 
 let suite = ("scrollbar", tests)


### PR DESCRIPTION
Several files spelled a variable's name as a string beside the typed handle that defines it, so a rename would leave them referencing a property nothing declares.