### PR TITLE
utilities: let the compiler check a handler's conversions

### DIFF
--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -209,150 +209,229 @@ module Handler = struct
   let place_self_center_safe = style [ place_self (Safe_center, Safe_center) ]
   let place_self_end_safe = style [ place_self (Safe_end, Safe_end) ]
 
-  (* Single source of truth: (handler, class_name, style, suborder) *)
-  let alignment_data =
+  (* Class name, style and cascade suborder of one utility. Written as a match
+     rather than a lookup table: a constructor added to [t] without an entry
+     here is a compile error, not a [Not_found] raised out of [to_class] partway
+     through rendering a sheet. *)
+  let data : t -> string * Style.t * int = function
+    (* Justify content *)
+    | Justify_start -> ("justify-start", justify_start, 58)
+    | Justify_end -> ("justify-end", justify_end, 54)
+    | Justify_center -> ("justify-center", justify_center, 52)
+    | Justify_between -> ("justify-between", justify_between, 51)
+    | Justify_around -> ("justify-around", justify_around, 50)
+    | Justify_evenly -> ("justify-evenly", justify_evenly, 56)
+    | Justify_normal -> ("justify-normal", justify_normal, 57)
+    | Justify_stretch -> ("justify-stretch", justify_stretch, 59)
+    | Justify_center_safe -> ("justify-center-safe", justify_center_safe, 53)
+    | Justify_end_safe -> ("justify-end-safe", justify_end_safe, 55)
+    (* Align items *)
+    | Items_start -> ("items-start", items_start, 36)
+    | Items_end -> ("items-end", items_end, 34)
+    | Items_center -> ("items-center", items_center, 32)
+    | Items_baseline -> ("items-baseline", items_baseline, 30)
+    | Items_stretch -> ("items-stretch", items_stretch, 38)
+    | Items_baseline_last -> ("items-baseline-last", items_baseline_last, 31)
+    | Items_center_safe -> ("items-center-safe", items_center_safe, 33)
+    | Items_end_safe -> ("items-end-safe", items_end_safe, 35)
+    | Items_start_safe -> ("items-start-safe", items_start_safe, 37)
+    (* Align content *)
+    | Content_start -> ("content-start", content_start, 29)
+    | Content_end -> ("content-end", content_end, 25)
+    | Content_center -> ("content-center", content_center, 23)
+    | Content_between -> ("content-between", content_between, 22)
+    | Content_around -> ("content-around", content_around, 20)
+    | Content_evenly -> ("content-evenly", content_evenly, 27)
+    | Content_stretch -> ("content-stretch", content_stretch, 31)
+    | Content_baseline -> ("content-baseline", content_baseline, 21)
+    | Content_normal -> ("content-normal", content_normal, 28)
+    | Content_center_safe -> ("content-center-safe", content_center_safe, 24)
+    | Content_end_safe -> ("content-end-safe", content_end_safe, 26)
+    | Content_start_safe -> ("content-start-safe", content_start_safe, 30)
+    (* Align self *)
+    | Self_auto -> ("self-auto", self_auto, 76010)
+    | Self_start -> ("self-start", self_start, 76017)
+    | Self_end -> ("self-end", self_end, 76015)
+    | Self_center -> ("self-center", self_center, 76013)
+    | Self_baseline -> ("self-baseline", self_baseline, 76011)
+    | Self_baseline_last -> ("self-baseline-last", self_baseline_last, 76012)
+    | Self_stretch -> ("self-stretch", self_stretch, 76019)
+    | Self_center_safe -> ("self-center-safe", self_center_safe, 76014)
+    | Self_end_safe -> ("self-end-safe", self_end_safe, 76016)
+    | Self_start_safe -> ("self-start-safe", self_start_safe, 76018)
+    (* Justify items *)
+    | Justify_items_start -> ("justify-items-start", justify_items_start, 74)
+    | Justify_items_end -> ("justify-items-end", justify_items_end, 72)
+    | Justify_items_center -> ("justify-items-center", justify_items_center, 70)
+    | Justify_items_stretch ->
+        ("justify-items-stretch", justify_items_stretch, 75)
+    | Justify_items_normal -> ("justify-items-normal", justify_items_normal, 73)
+    | Justify_items_center_safe ->
+        ("justify-items-center-safe", justify_items_center_safe, 71)
+    | Justify_items_end_safe ->
+        ("justify-items-end-safe", justify_items_end_safe, 73)
+    (* Justify self *)
+    | Justify_self_auto -> ("justify-self-auto", justify_self_auto, 76030)
+    | Justify_self_start -> ("justify-self-start", justify_self_start, 76035)
+    | Justify_self_end -> ("justify-self-end", justify_self_end, 76033)
+    | Justify_self_center -> ("justify-self-center", justify_self_center, 76031)
+    | Justify_self_stretch ->
+        ("justify-self-stretch", justify_self_stretch, 76037)
+    | Justify_self_center_safe ->
+        ("justify-self-center-safe", justify_self_center_safe, 76032)
+    | Justify_self_end_safe ->
+        ("justify-self-end-safe", justify_self_end_safe, 76034)
+    | Justify_self_start_safe ->
+        ("justify-self-start-safe", justify_self_start_safe, 76036)
+    (* Place content *)
+    | Place_content_start -> ("place-content-start", place_content_start, 8)
+    | Place_content_end -> ("place-content-end", place_content_end, 5)
+    | Place_content_center -> ("place-content-center", place_content_center, 3)
+    | Place_content_between ->
+        ("place-content-between", place_content_between, 2)
+    | Place_content_around -> ("place-content-around", place_content_around, 0)
+    | Place_content_evenly -> ("place-content-evenly", place_content_evenly, 7)
+    | Place_content_stretch ->
+        ("place-content-stretch", place_content_stretch, 10)
+    | Place_content_baseline ->
+        ("place-content-baseline", place_content_baseline, 1)
+    | Place_content_center_safe ->
+        ("place-content-center-safe", place_content_center_safe, 4)
+    | Place_content_end_safe ->
+        ("place-content-end-safe", place_content_end_safe, 6)
+    | Place_content_start_safe ->
+        ("place-content-start-safe", place_content_start_safe, 9)
+    (* Place items *)
+    | Place_items_start -> ("place-items-start", place_items_start, 15)
+    | Place_items_end -> ("place-items-end", place_items_end, 13)
+    | Place_items_center -> ("place-items-center", place_items_center, 11)
+    | Place_items_stretch -> ("place-items-stretch", place_items_stretch, 17)
+    | Place_items_baseline -> ("place-items-baseline", place_items_baseline, 10)
+    | Place_items_center_safe ->
+        ("place-items-center-safe", place_items_center_safe, 12)
+    | Place_items_end_safe -> ("place-items-end-safe", place_items_end_safe, 14)
+    | Place_items_start_safe ->
+        ("place-items-start-safe", place_items_start_safe, 16)
+    (* Place self *)
+    | Place_self_auto -> ("place-self-auto", place_self_auto, 76000)
+    | Place_self_start -> ("place-self-start", place_self_start, 76005)
+    | Place_self_end -> ("place-self-end", place_self_end, 76003)
+    | Place_self_center -> ("place-self-center", place_self_center, 76001)
+    | Place_self_stretch -> ("place-self-stretch", place_self_stretch, 76006)
+    | Place_self_center_safe ->
+        ("place-self-center-safe", place_self_center_safe, 76002)
+    | Place_self_end_safe -> ("place-self-end-safe", place_self_end_safe, 76004)
+
+  (* Every constructor, for the class-name lookup. A missing entry costs a class
+     that no longer parses, which the round-trip test reports. *)
+  let all =
     [
       (* Justify content *)
-      (Justify_start, "justify-start", justify_start, 58);
-      (Justify_end, "justify-end", justify_end, 54);
-      (Justify_center, "justify-center", justify_center, 52);
-      (Justify_between, "justify-between", justify_between, 51);
-      (Justify_around, "justify-around", justify_around, 50);
-      (Justify_evenly, "justify-evenly", justify_evenly, 56);
-      (Justify_normal, "justify-normal", justify_normal, 57);
-      (Justify_stretch, "justify-stretch", justify_stretch, 59);
-      (Justify_center_safe, "justify-center-safe", justify_center_safe, 53);
-      (Justify_end_safe, "justify-end-safe", justify_end_safe, 55);
+      Justify_start;
+      Justify_end;
+      Justify_center;
+      Justify_between;
+      Justify_around;
+      Justify_evenly;
+      Justify_normal;
+      Justify_stretch;
+      Justify_center_safe;
+      Justify_end_safe;
       (* Align items *)
-      (Items_start, "items-start", items_start, 36);
-      (Items_end, "items-end", items_end, 34);
-      (Items_center, "items-center", items_center, 32);
-      (Items_baseline, "items-baseline", items_baseline, 30);
-      (Items_stretch, "items-stretch", items_stretch, 38);
-      (Items_baseline_last, "items-baseline-last", items_baseline_last, 31);
-      (Items_center_safe, "items-center-safe", items_center_safe, 33);
-      (Items_end_safe, "items-end-safe", items_end_safe, 35);
-      (Items_start_safe, "items-start-safe", items_start_safe, 37);
+      Items_start;
+      Items_end;
+      Items_center;
+      Items_baseline;
+      Items_stretch;
+      Items_baseline_last;
+      Items_center_safe;
+      Items_end_safe;
+      Items_start_safe;
       (* Align content *)
-      (Content_start, "content-start", content_start, 29);
-      (Content_end, "content-end", content_end, 25);
-      (Content_center, "content-center", content_center, 23);
-      (Content_between, "content-between", content_between, 22);
-      (Content_around, "content-around", content_around, 20);
-      (Content_evenly, "content-evenly", content_evenly, 27);
-      (Content_stretch, "content-stretch", content_stretch, 31);
-      (Content_baseline, "content-baseline", content_baseline, 21);
-      (Content_normal, "content-normal", content_normal, 28);
-      (Content_center_safe, "content-center-safe", content_center_safe, 24);
-      (Content_end_safe, "content-end-safe", content_end_safe, 26);
-      (Content_start_safe, "content-start-safe", content_start_safe, 30);
+      Content_start;
+      Content_end;
+      Content_center;
+      Content_between;
+      Content_around;
+      Content_evenly;
+      Content_stretch;
+      Content_baseline;
+      Content_normal;
+      Content_center_safe;
+      Content_end_safe;
+      Content_start_safe;
       (* Align self *)
-      (Self_auto, "self-auto", self_auto, 76010);
-      (Self_start, "self-start", self_start, 76017);
-      (Self_end, "self-end", self_end, 76015);
-      (Self_center, "self-center", self_center, 76013);
-      (Self_baseline, "self-baseline", self_baseline, 76011);
-      (Self_baseline_last, "self-baseline-last", self_baseline_last, 76012);
-      (Self_stretch, "self-stretch", self_stretch, 76019);
-      (Self_center_safe, "self-center-safe", self_center_safe, 76014);
-      (Self_end_safe, "self-end-safe", self_end_safe, 76016);
-      (Self_start_safe, "self-start-safe", self_start_safe, 76018);
+      Self_auto;
+      Self_start;
+      Self_end;
+      Self_center;
+      Self_baseline;
+      Self_baseline_last;
+      Self_stretch;
+      Self_center_safe;
+      Self_end_safe;
+      Self_start_safe;
       (* Justify items *)
-      (Justify_items_start, "justify-items-start", justify_items_start, 74);
-      (Justify_items_end, "justify-items-end", justify_items_end, 72);
-      (Justify_items_center, "justify-items-center", justify_items_center, 70);
-      (Justify_items_stretch, "justify-items-stretch", justify_items_stretch, 75);
-      (Justify_items_normal, "justify-items-normal", justify_items_normal, 73);
-      ( Justify_items_center_safe,
-        "justify-items-center-safe",
-        justify_items_center_safe,
-        71 );
-      ( Justify_items_end_safe,
-        "justify-items-end-safe",
-        justify_items_end_safe,
-        73 );
+      Justify_items_start;
+      Justify_items_end;
+      Justify_items_center;
+      Justify_items_stretch;
+      Justify_items_normal;
+      Justify_items_center_safe;
+      Justify_items_end_safe;
       (* Justify self *)
-      (Justify_self_auto, "justify-self-auto", justify_self_auto, 76030);
-      (Justify_self_start, "justify-self-start", justify_self_start, 76035);
-      (Justify_self_end, "justify-self-end", justify_self_end, 76033);
-      (Justify_self_center, "justify-self-center", justify_self_center, 76031);
-      (Justify_self_stretch, "justify-self-stretch", justify_self_stretch, 76037);
-      ( Justify_self_center_safe,
-        "justify-self-center-safe",
-        justify_self_center_safe,
-        76032 );
-      ( Justify_self_end_safe,
-        "justify-self-end-safe",
-        justify_self_end_safe,
-        76034 );
-      ( Justify_self_start_safe,
-        "justify-self-start-safe",
-        justify_self_start_safe,
-        76036 );
+      Justify_self_auto;
+      Justify_self_start;
+      Justify_self_end;
+      Justify_self_center;
+      Justify_self_stretch;
+      Justify_self_center_safe;
+      Justify_self_end_safe;
+      Justify_self_start_safe;
       (* Place content *)
-      (Place_content_start, "place-content-start", place_content_start, 8);
-      (Place_content_end, "place-content-end", place_content_end, 5);
-      (Place_content_center, "place-content-center", place_content_center, 3);
-      (Place_content_between, "place-content-between", place_content_between, 2);
-      (Place_content_around, "place-content-around", place_content_around, 0);
-      (Place_content_evenly, "place-content-evenly", place_content_evenly, 7);
-      (Place_content_stretch, "place-content-stretch", place_content_stretch, 10);
-      ( Place_content_baseline,
-        "place-content-baseline",
-        place_content_baseline,
-        1 );
-      ( Place_content_center_safe,
-        "place-content-center-safe",
-        place_content_center_safe,
-        4 );
-      ( Place_content_end_safe,
-        "place-content-end-safe",
-        place_content_end_safe,
-        6 );
-      ( Place_content_start_safe,
-        "place-content-start-safe",
-        place_content_start_safe,
-        9 );
+      Place_content_start;
+      Place_content_end;
+      Place_content_center;
+      Place_content_between;
+      Place_content_around;
+      Place_content_evenly;
+      Place_content_stretch;
+      Place_content_baseline;
+      Place_content_center_safe;
+      Place_content_end_safe;
+      Place_content_start_safe;
       (* Place items *)
-      (Place_items_start, "place-items-start", place_items_start, 15);
-      (Place_items_end, "place-items-end", place_items_end, 13);
-      (Place_items_center, "place-items-center", place_items_center, 11);
-      (Place_items_stretch, "place-items-stretch", place_items_stretch, 17);
-      (Place_items_baseline, "place-items-baseline", place_items_baseline, 10);
-      ( Place_items_center_safe,
-        "place-items-center-safe",
-        place_items_center_safe,
-        12 );
-      (Place_items_end_safe, "place-items-end-safe", place_items_end_safe, 14);
-      ( Place_items_start_safe,
-        "place-items-start-safe",
-        place_items_start_safe,
-        16 );
+      Place_items_start;
+      Place_items_end;
+      Place_items_center;
+      Place_items_stretch;
+      Place_items_baseline;
+      Place_items_center_safe;
+      Place_items_end_safe;
+      Place_items_start_safe;
       (* Place self *)
-      (Place_self_auto, "place-self-auto", place_self_auto, 76000);
-      (Place_self_start, "place-self-start", place_self_start, 76005);
-      (Place_self_end, "place-self-end", place_self_end, 76003);
-      (Place_self_center, "place-self-center", place_self_center, 76001);
-      (Place_self_stretch, "place-self-stretch", place_self_stretch, 76006);
-      ( Place_self_center_safe,
-        "place-self-center-safe",
-        place_self_center_safe,
-        76002 );
-      (Place_self_end_safe, "place-self-end-safe", place_self_end_safe, 76004);
+      Place_self_auto;
+      Place_self_start;
+      Place_self_end;
+      Place_self_center;
+      Place_self_stretch;
+      Place_self_center_safe;
+      Place_self_end_safe;
     ]
 
-  (* Derived lookup tables *)
-  let to_style_map =
-    List.map (fun (t, _, style, _) -> (t, style)) alignment_data
+  let to_class t =
+    let cls, _, _ = data t in
+    cls
 
-  let to_class_map = List.map (fun (t, cls, _, _) -> (t, cls)) alignment_data
-  let suborder_map = List.map (fun (t, _, _, ord) -> (t, ord)) alignment_data
-  let of_class_map = List.map (fun (t, cls, _, _) -> (cls, t)) alignment_data
+  let to_style _theme t =
+    let _, s, _ = data t in
+    s
 
-  (* Handler functions derived from maps *)
-  let to_style _theme t = List.assoc t to_style_map
-  let to_class t = List.assoc t to_class_map
-  let suborder t = List.assoc t suborder_map
+  let suborder t =
+    let _, _, o = data t in
+    o
+
+  let of_class_map = List.map (fun t -> (to_class t, t)) all
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1335,17 +1335,25 @@ module Handler = struct
         match Color.parse_bracket_color v with
         | Some c -> c
         | None -> Css.Transparent)
-    | Color_source.Named _ | Color_source.Named_opacity _ -> assert false
+    | Color_source.Named _ | Color_source.Named_opacity _ ->
+        (* A palette colour resolves through the scheme, not into a plain CSS
+           colour; [to_style] answers those before it reaches here. *)
+        invalid_arg "backgrounds: a palette colour has no plain CSS colour"
 
   (** Extract opacity from a Color_source.t, if present *)
-  let opacity_of_source = function
+  let opacity_of_source : Color_source.t -> Color.opacity_modifier option =
+    function
     | Color_source.Current_opacity o
     | Color_source.Bracket_hex_opacity (_, o)
     | Color_source.Bracket_color_var_opacity (_, o)
     | Color_source.Bracket_var_opacity (_, o)
     | Color_source.Bracket_color_opacity (_, o) ->
         Some o
-    | _ -> None
+    | Color_source.Named _ | Color_source.Named_opacity _ | Color_source.Current
+    | Color_source.Inherit | Color_source.Transparent
+    | Color_source.Bracket_hex _ | Color_source.Bracket_color_var _
+    | Color_source.Bracket_var _ | Color_source.Bracket_color _ ->
+        None
 
   let to_style theme =
     let gradient_color_opacity ~prefix ~set_var ?(shade = 500) color opacity =
@@ -1371,8 +1379,15 @@ module Handler = struct
             let alpha = Color.opacity_to_percent opacity /. 100.0 in
             let color = Color.hex_to_oklab_alpha h alpha in
             gradient_simple ~prefix ~set_var color []
-        | _ -> (
-            (* All other sources: keyword, bracket var *)
+        | Color_source.Current | Color_source.Current_opacity _
+        | Color_source.Inherit | Color_source.Transparent
+        | Color_source.Bracket_hex _ | Color_source.Bracket_color_var _
+        | Color_source.Bracket_color_var_opacity _ | Color_source.Bracket_var _
+        | Color_source.Bracket_var_opacity _ | Color_source.Bracket_color _
+        | Color_source.Bracket_color_opacity _ -> (
+            (* A keyword or a bracket value: the colour is known without the
+               scheme. Spelled out rather than swept up, so a source added to
+               [Color_source.t] is a compile error here. *)
             let color = css_color_of_source src in
             match opacity_of_source src with
             | None -> gradient_simple ~prefix ~set_var color []

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -14,62 +14,105 @@ module Handler = struct
   let name = "cursor"
   let priority _ = 11
 
-  (* Single source of truth: (css value, class_suffix) *)
-  (* Alphabetically ordered - suborder derived from position *)
-  let cursor_data : (Css.cursor * string) list =
+  (* Class suffix and cascade suborder of one cursor keyword, alphabetical by
+     suffix. Written as a match rather than a lookup table: a constructor added
+     to [Css.cursor] without an entry here is a compile error, not a [Not_found]
+     raised out of [to_class] partway through rendering a sheet. The [url()]
+     form, the CSS-wide keywords and [var()] are spelled out for the same
+     reason. *)
+  let data : Css.cursor -> string * int = function
+    | Css.Alias -> ("alias", 10)
+    | Css.All_scroll -> ("all-scroll", 20)
+    | Css.Auto -> ("auto", 30)
+    | Css.Cell -> ("cell", 40)
+    | Css.Col_resize -> ("col-resize", 50)
+    | Css.Context_menu -> ("context-menu", 60)
+    | Css.Copy -> ("copy", 70)
+    | Css.Crosshair -> ("crosshair", 80)
+    | Css.Default -> ("default", 90)
+    | Css.E_resize -> ("e-resize", 100)
+    | Css.Ew_resize -> ("ew-resize", 110)
+    | Css.Grab -> ("grab", 120)
+    | Css.Grabbing -> ("grabbing", 130)
+    | Css.Help -> ("help", 140)
+    | Css.Move -> ("move", 150)
+    | Css.N_resize -> ("n-resize", 160)
+    | Css.Ne_resize -> ("ne-resize", 170)
+    | Css.Nesw_resize -> ("nesw-resize", 180)
+    | Css.No_drop -> ("no-drop", 190)
+    | Css.None -> ("none", 200)
+    | Css.Not_allowed -> ("not-allowed", 210)
+    | Css.Ns_resize -> ("ns-resize", 220)
+    | Css.Nw_resize -> ("nw-resize", 230)
+    | Css.Nwse_resize -> ("nwse-resize", 240)
+    | Css.Pointer -> ("pointer", 250)
+    | Css.Progress -> ("progress", 260)
+    | Css.Row_resize -> ("row-resize", 270)
+    | Css.S_resize -> ("s-resize", 280)
+    | Css.Se_resize -> ("se-resize", 290)
+    | Css.Sw_resize -> ("sw-resize", 300)
+    | Css.Text -> ("text", 310)
+    | Css.Vertical_text -> ("vertical-text", 320)
+    | Css.W_resize -> ("w-resize", 330)
+    | Css.Wait -> ("wait", 340)
+    | Css.Zoom_in -> ("zoom-in", 350)
+    | Css.Zoom_out -> ("zoom-out", 360)
+    | Css.Url _ | Css.Inherit | Css.Initial | Css.Unset | Css.Revert
+    | Css.Revert_layer | Css.Var _ ->
+        (* No cursor class names a url(), a CSS-wide keyword or a var(), so
+           [of_class] never builds one: the bracket and theme forms have their
+           own constructors. *)
+        invalid_arg "cursor: value has no class name"
+
+  (* Every keyword a class names, in suffix order, for the class-name lookup and
+     for placing a theme cursor among them. *)
+  let all : Css.cursor list =
     [
-      (Css.Alias, "alias");
-      (Css.All_scroll, "all-scroll");
-      (Css.Auto, "auto");
-      (Css.Cell, "cell");
-      (Css.Col_resize, "col-resize");
-      (Css.Context_menu, "context-menu");
-      (Css.Copy, "copy");
-      (Css.Crosshair, "crosshair");
-      (Css.Default, "default");
-      (Css.E_resize, "e-resize");
-      (Css.Ew_resize, "ew-resize");
-      (Css.Grab, "grab");
-      (Css.Grabbing, "grabbing");
-      (Css.Help, "help");
-      (Css.Move, "move");
-      (Css.N_resize, "n-resize");
-      (Css.Ne_resize, "ne-resize");
-      (Css.Nesw_resize, "nesw-resize");
-      (Css.No_drop, "no-drop");
-      (Css.None, "none");
-      (Css.Not_allowed, "not-allowed");
-      (Css.Ns_resize, "ns-resize");
-      (Css.Nw_resize, "nw-resize");
-      (Css.Nwse_resize, "nwse-resize");
-      (Css.Pointer, "pointer");
-      (Css.Progress, "progress");
-      (Css.Row_resize, "row-resize");
-      (Css.S_resize, "s-resize");
-      (Css.Se_resize, "se-resize");
-      (Css.Sw_resize, "sw-resize");
-      (Css.Text, "text");
-      (Css.Vertical_text, "vertical-text");
-      (Css.W_resize, "w-resize");
-      (Css.Wait, "wait");
-      (Css.Zoom_in, "zoom-in");
-      (Css.Zoom_out, "zoom-out");
+      Css.Alias;
+      Css.All_scroll;
+      Css.Auto;
+      Css.Cell;
+      Css.Col_resize;
+      Css.Context_menu;
+      Css.Copy;
+      Css.Crosshair;
+      Css.Default;
+      Css.E_resize;
+      Css.Ew_resize;
+      Css.Grab;
+      Css.Grabbing;
+      Css.Help;
+      Css.Move;
+      Css.N_resize;
+      Css.Ne_resize;
+      Css.Nesw_resize;
+      Css.No_drop;
+      Css.None;
+      Css.Not_allowed;
+      Css.Ns_resize;
+      Css.Nw_resize;
+      Css.Nwse_resize;
+      Css.Pointer;
+      Css.Progress;
+      Css.Row_resize;
+      Css.S_resize;
+      Css.Se_resize;
+      Css.Sw_resize;
+      Css.Text;
+      Css.Vertical_text;
+      Css.W_resize;
+      Css.Wait;
+      Css.Zoom_in;
+      Css.Zoom_out;
     ]
 
-  (* Derived lookup tables *)
-  let to_class_map =
-    List.map (fun (v, suffix) -> (v, "cursor-" ^ suffix)) cursor_data
-
-  let suborder_map = List.mapi (fun i (v, _) -> (v, (i + 1) * 10)) cursor_data
-
   let of_class_map =
-    List.map (fun (v, suffix) -> ("cursor-" ^ suffix, Keyword v)) cursor_data
+    List.map (fun v -> ("cursor-" ^ fst (data v), Keyword v)) all
 
-  (* Handler functions derived from maps *)
   let to_class = function
     | Bracket_var s -> "cursor-[" ^ s ^ "]"
     | Theme name -> "cursor-" ^ name
-    | Keyword v -> List.assoc v to_class_map
+    | Keyword v -> "cursor-" ^ fst (data v)
 
   let to_style theme = function
     | Bracket_var s ->
@@ -92,9 +135,9 @@ module Handler = struct
         | None -> style [ Css.cursor (Css.Var ref) ])
     | Keyword v -> style [ Css.cursor v ]
 
-  (* Sorted suffixes from cursor_data for computing theme suborder *)
-  let sorted_suffixes =
-    List.mapi (fun i (_, suffix) -> (suffix, (i + 1) * 10)) cursor_data
+  (* The keyword suffixes with their suborders, for placing a theme cursor among
+     them. *)
+  let sorted_suffixes = List.map data all
 
   let theme_suborder name =
     (* Find alphabetical position among known cursors *)
@@ -108,7 +151,7 @@ module Handler = struct
   let suborder = function
     | Bracket_var _ -> -1
     | Theme name -> theme_suborder name
-    | Keyword v -> List.assoc v suborder_map
+    | Keyword v -> snd (data v)
 
   let of_class _theme cls =
     let parts = Parse.split_class cls in

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -14,27 +14,54 @@ module Handler = struct
   let name = "flex_layout"
   let priority _ = 16
 
-  let flex_data =
+  (* Class suffix and cascade suborder of one utility, as a match rather than a
+     lookup table: a constructor added to either CSS value type without an entry
+     here is a compile error, not a [Not_found] raised out of [to_class] partway
+     through rendering a sheet. The CSS-wide keywords and the [var()] forms are
+     spelled out rather than swept up by a catch-all, for the same reason. *)
+  let data : t -> string * int = function
+    | Direction Css.Column -> ("col", 0)
+    | Direction Css.Column_reverse -> ("col-reverse", 1)
+    | Direction Css.Row -> ("row", 2)
+    | Direction Css.Row_reverse -> ("row-reverse", 3)
+    | Wrap Css.Nowrap -> ("nowrap", 10)
+    | Wrap Css.Wrap -> ("wrap", 11)
+    | Wrap Css.Wrap_reverse -> ("wrap-reverse", 12)
+    | Direction
+        ( Css.Inherit | Css.Initial | Css.Unset | Css.Revert | Css.Revert_layer
+        | Css.Var _ )
+    | Wrap
+        ( Css.Inherit | Css.Initial | Css.Unset | Css.Revert | Css.Revert_layer
+        | Css.Var _ ) ->
+        (* No flex class names a CSS-wide keyword or a var(), so [of_class]
+           never builds one. *)
+        invalid_arg "flex_layout: value has no class name"
+
+  (* Every constructor a class names, for the class-name lookup. *)
+  let all =
     [
-      (Direction Css.Column, "col", 0);
-      (Direction Css.Column_reverse, "col-reverse", 1);
-      (Direction Css.Row, "row", 2);
-      (Direction Css.Row_reverse, "row-reverse", 3);
-      (Wrap Css.Nowrap, "nowrap", 10);
-      (Wrap Css.Wrap, "wrap", 11);
-      (Wrap Css.Wrap_reverse, "wrap-reverse", 12);
+      Direction Css.Column;
+      Direction Css.Column_reverse;
+      Direction Css.Row;
+      Direction Css.Row_reverse;
+      Wrap Css.Nowrap;
+      Wrap Css.Wrap;
+      Wrap Css.Wrap_reverse;
     ]
 
-  let to_class_map = List.map (fun (t, s, _) -> (t, "flex-" ^ s)) flex_data
-  let suborder_map = List.map (fun (t, _, o) -> (t, o)) flex_data
-  let of_class_map = List.map (fun (t, s, _) -> ("flex-" ^ s, t)) flex_data
+  let to_class t =
+    let suffix, _ = data t in
+    "flex-" ^ suffix
+
+  let suborder t =
+    let _, o = data t in
+    o
 
   let to_style _theme = function
     | Direction d -> style [ Css.flex_direction d ]
     | Wrap w -> style [ Css.flex_wrap w ]
 
-  let suborder t = List.assoc t suborder_map
-  let to_class t = List.assoc t to_class_map
+  let of_class_map = List.map (fun t -> (to_class t, t)) all
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -450,6 +450,23 @@ module Handler = struct
     | Break_inside_avoid_column -> "break-inside-avoid-column"
     | Break_inside_avoid_page -> "break-inside-avoid-page"
 
+  (* An [object-<position>] class reads its keyword off
+     [--object-position-<pos>] when the theme binds one. The token name and the
+     keyword travel together with the constructor that names them, so there is
+     no second list of positions to keep in step with the first. *)
+  let object_position_style theme pos (default : Css.position_value) =
+    let name = "object-position-" ^ pos in
+    match Scheme.theme_value (Some theme) name with
+    | Some value ->
+        let theme_decl =
+          Css.custom_property ~layer:"theme" ("--" ^ name) value
+        in
+        let pos_ref : Css.position_value Css.var = Var.bracket name in
+        style [ theme_decl; object_position (Var pos_ref) ]
+    (* Without a theme override Tailwind writes the keyword, not a reference to
+       a token nothing declares. *)
+    | None -> style [ object_position default ]
+
   let to_style theme =
     let z_auto_style () = z_auto_style ~theme () in
     function
@@ -492,43 +509,23 @@ module Handler = struct
     | Object_fill -> style [ object_fit Fill ]
     | Object_none -> style [ object_fit None ]
     | Object_scale_down -> style [ object_fit Scale_down ]
-    | ( Object_center | Object_top | Object_bottom | Object_left | Object_right
-      | Object_bottom_left | Object_bottom_right | Object_left_bottom
-      | Object_left_top | Object_right_bottom | Object_right_top
-      | Object_top_left | Object_top_right ) as obj -> (
-        let name, (default : Css.position_value), _default_css =
-          match obj with
-          | Object_center -> ("object-position-center", Center, "center")
-          | Object_top -> ("object-position-top", Top, "top")
-          | Object_bottom -> ("object-position-bottom", Bottom, "bottom")
-          | Object_left -> ("object-position-left", Left, "left")
-          | Object_right -> ("object-position-right", Right, "right")
-          | Object_bottom_left ->
-              ("object-position-bottom-left", Bottom_left, "left bottom")
-          | Object_bottom_right ->
-              ("object-position-bottom-right", Bottom_right, "right bottom")
-          | Object_left_bottom ->
-              ("object-position-left-bottom", Left_bottom, "left bottom")
-          | Object_left_top -> ("object-position-left-top", Left_top, "left top")
-          | Object_right_bottom ->
-              ("object-position-right-bottom", Right_bottom, "right bottom")
-          | Object_right_top ->
-              ("object-position-right-top", Right_top, "right top")
-          | Object_top_left -> ("object-position-top-left", Top_left, "left top")
-          | Object_top_right ->
-              ("object-position-top-right", Top_right, "right top")
-          | _ -> assert false
-        in
-        match Scheme.theme_value (Some theme) name with
-        | Some value ->
-            let theme_decl =
-              Css.custom_property ~layer:"theme" ("--" ^ name) value
-            in
-            let pos_ref : Css.position_value Css.var = Var.bracket name in
-            style [ theme_decl; object_position (Var pos_ref) ]
-        (* Without a theme override Tailwind writes the keyword, not a reference
-           to a token nothing declares. *)
-        | None -> style [ object_position default ])
+    | Object_center -> object_position_style theme "center" Center
+    | Object_top -> object_position_style theme "top" Top
+    | Object_bottom -> object_position_style theme "bottom" Bottom
+    | Object_left -> object_position_style theme "left" Left
+    | Object_right -> object_position_style theme "right" Right
+    | Object_bottom_left ->
+        object_position_style theme "bottom-left" Bottom_left
+    | Object_bottom_right ->
+        object_position_style theme "bottom-right" Bottom_right
+    | Object_left_bottom ->
+        object_position_style theme "left-bottom" Left_bottom
+    | Object_left_top -> object_position_style theme "left-top" Left_top
+    | Object_right_bottom ->
+        object_position_style theme "right-bottom" Right_bottom
+    | Object_right_top -> object_position_style theme "right-top" Right_top
+    | Object_top_left -> object_position_style theme "top-left" Top_left
+    | Object_top_right -> object_position_style theme "top-right" Top_right
     | Object_arbitrary raw -> (
         (* Only a var() reference names a variable; anything else is a position
            value, which [object-[50%]] used to turn into [var(--50)]. *)

--- a/lib/overflow.ml
+++ b/lib/overflow.ml
@@ -34,40 +34,61 @@ module Handler = struct
   (* Overflow comes after alignment (17) in Tailwind's utility ordering. *)
   let priority _ = 18
 
-  (* Single source of truth: (handler, class_suffix, style_fn, suborder) *)
-  let overflow_data =
+  (* Class suffix, style and cascade suborder of one utility. Written as a
+     match, not a lookup table: a constructor added to [t] without an entry here
+     is a compile error rather than a [Not_found] raised out of [to_class]
+     halfway through rendering a sheet. *)
+  let data : t -> string * Style.t * int = function
+    | Auto -> ("auto", style [ overflow Auto ], 550)
+    | Clip -> ("clip", style [ overflow Clip ], 551)
+    | Hidden -> ("hidden", style [ overflow Hidden ], 552)
+    | Scroll -> ("scroll", style [ overflow Scroll ], 553)
+    | Visible -> ("visible", style [ overflow Visible ], 554)
+    | X_auto -> ("x-auto", style [ overflow_x Auto ], 555)
+    | X_clip -> ("x-clip", style [ overflow_x Clip ], 556)
+    | X_hidden -> ("x-hidden", style [ overflow_x Hidden ], 557)
+    | X_scroll -> ("x-scroll", style [ overflow_x Scroll ], 558)
+    | X_visible -> ("x-visible", style [ overflow_x Visible ], 559)
+    | Y_auto -> ("y-auto", style [ overflow_y Auto ], 560)
+    | Y_clip -> ("y-clip", style [ overflow_y Clip ], 561)
+    | Y_hidden -> ("y-hidden", style [ overflow_y Hidden ], 562)
+    | Y_scroll -> ("y-scroll", style [ overflow_y Scroll ], 563)
+    | Y_visible -> ("y-visible", style [ overflow_y Visible ], 564)
+
+  (* Every constructor, for the class-name lookup. A missing entry costs a class
+     that no longer parses, which the round-trip test reports. *)
+  let all =
     [
-      (Auto, "auto", (fun () -> style [ overflow Auto ]), 550);
-      (Clip, "clip", (fun () -> style [ overflow Clip ]), 551);
-      (Hidden, "hidden", (fun () -> style [ overflow Hidden ]), 552);
-      (Scroll, "scroll", (fun () -> style [ overflow Scroll ]), 553);
-      (Visible, "visible", (fun () -> style [ overflow Visible ]), 554);
-      (X_auto, "x-auto", (fun () -> style [ overflow_x Auto ]), 555);
-      (X_clip, "x-clip", (fun () -> style [ overflow_x Clip ]), 556);
-      (X_hidden, "x-hidden", (fun () -> style [ overflow_x Hidden ]), 557);
-      (X_scroll, "x-scroll", (fun () -> style [ overflow_x Scroll ]), 558);
-      (X_visible, "x-visible", (fun () -> style [ overflow_x Visible ]), 559);
-      (Y_auto, "y-auto", (fun () -> style [ overflow_y Auto ]), 560);
-      (Y_clip, "y-clip", (fun () -> style [ overflow_y Clip ]), 561);
-      (Y_hidden, "y-hidden", (fun () -> style [ overflow_y Hidden ]), 562);
-      (Y_scroll, "y-scroll", (fun () -> style [ overflow_y Scroll ]), 563);
-      (Y_visible, "y-visible", (fun () -> style [ overflow_y Visible ]), 564);
+      Auto;
+      Clip;
+      Hidden;
+      Scroll;
+      Visible;
+      X_auto;
+      X_clip;
+      X_hidden;
+      X_scroll;
+      X_visible;
+      Y_auto;
+      Y_clip;
+      Y_hidden;
+      Y_scroll;
+      Y_visible;
     ]
 
-  (* Derived lookup tables *)
-  let to_class_map =
-    List.map (fun (t, s, _, _) -> (t, "overflow-" ^ s)) overflow_data
+  let to_class t =
+    let suffix, _, _ = data t in
+    "overflow-" ^ suffix
 
-  let to_style_map = List.map (fun (t, _, f, _) -> (t, f)) overflow_data
-  let suborder_map = List.map (fun (t, _, _, o) -> (t, o)) overflow_data
+  let to_style _theme t =
+    let _, s, _ = data t in
+    s
 
-  let of_class_map =
-    List.map (fun (t, s, _, _) -> ("overflow-" ^ s, t)) overflow_data
+  let suborder t =
+    let _, _, o = data t in
+    o
 
-  (* Handler functions derived from maps *)
-  let suborder t = List.assoc t suborder_map
-  let to_class t = List.assoc t to_class_map
-  let to_style _theme t = (List.assoc t to_style_map) ()
+  let of_class_map = List.map (fun t -> (to_class t, t)) all
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -34,43 +34,41 @@ module Handler = struct
   (* Same priority as overflow (18) - these are related utilities *)
   let priority _ = 18
 
-  (* Single source of truth: (handler, class_suffix, style_fn, suborder) *)
-  let overscroll_data =
+  (* Class suffix, style and cascade suborder of one utility. Written as a
+     match, not a lookup table: a constructor added to [t] without an entry here
+     is a compile error rather than a [Not_found] raised out of [to_class]
+     halfway through rendering a sheet. *)
+  let data : t -> string * Style.t * int = function
+    | Auto -> ("auto", style [ overscroll_behavior [ Auto ] ], 600)
+    | Contain -> ("contain", style [ overscroll_behavior [ Contain ] ], 601)
+    | None_ -> ("none", style [ overscroll_behavior [ None ] ], 602)
+    | X_auto -> ("x-auto", style [ overscroll_behavior_x Auto ], 603)
+    | X_contain -> ("x-contain", style [ overscroll_behavior_x Contain ], 604)
+    | X_none -> ("x-none", style [ overscroll_behavior_x None ], 605)
+    | Y_auto -> ("y-auto", style [ overscroll_behavior_y Auto ], 606)
+    | Y_contain -> ("y-contain", style [ overscroll_behavior_y Contain ], 607)
+    | Y_none -> ("y-none", style [ overscroll_behavior_y None ], 608)
+
+  (* Every constructor, for the class-name lookup. A missing entry costs a class
+     that no longer parses, which the round-trip test reports. *)
+  let all =
     [
-      (Auto, "auto", (fun () -> style [ overscroll_behavior [ Auto ] ]), 600);
-      ( Contain,
-        "contain",
-        (fun () -> style [ overscroll_behavior [ Contain ] ]),
-        601 );
-      (None_, "none", (fun () -> style [ overscroll_behavior [ None ] ]), 602);
-      (X_auto, "x-auto", (fun () -> style [ overscroll_behavior_x Auto ]), 603);
-      ( X_contain,
-        "x-contain",
-        (fun () -> style [ overscroll_behavior_x Contain ]),
-        604 );
-      (X_none, "x-none", (fun () -> style [ overscroll_behavior_x None ]), 605);
-      (Y_auto, "y-auto", (fun () -> style [ overscroll_behavior_y Auto ]), 606);
-      ( Y_contain,
-        "y-contain",
-        (fun () -> style [ overscroll_behavior_y Contain ]),
-        607 );
-      (Y_none, "y-none", (fun () -> style [ overscroll_behavior_y None ]), 608);
+      Auto; Contain; None_; X_auto; X_contain; X_none; Y_auto; Y_contain; Y_none;
     ]
 
-  (* Derived lookup tables *)
-  let to_class_map =
-    List.map (fun (t, s, _, _) -> (t, "overscroll-" ^ s)) overscroll_data
+  let to_class t =
+    let suffix, _, _ = data t in
+    "overscroll-" ^ suffix
 
-  let to_style_map = List.map (fun (t, _, f, _) -> (t, f)) overscroll_data
-  let suborder_map = List.map (fun (t, _, _, o) -> (t, o)) overscroll_data
+  let to_style _theme t =
+    let _, s, _ = data t in
+    s
 
-  let of_class_map =
-    List.map (fun (t, s, _, _) -> ("overscroll-" ^ s, t)) overscroll_data
+  let suborder t =
+    let _, _, o = data t in
+    o
 
-  (* Handler functions derived from maps *)
-  let suborder t = List.assoc t suborder_map
-  let to_class t = List.assoc t to_class_map
-  let to_style _theme t = (List.assoc t to_style_map) ()
+  let of_class_map = List.map (fun t -> (to_class t, t)) all
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -44,47 +44,60 @@ module Handler = struct
     let decl, _ = Var.binding var value in
     style ~property_rules:touch_props [ decl; composable_touch_action () ]
 
-  (* Single source of truth: (touch-action value, class_suffix, style_fn) *)
-  (* Alphabetically ordered - suborder derived from position *)
-  let touch_data : (Css.touch_action * string * (unit -> Style.t)) list =
+  (* Class suffix, style and cascade suborder of one utility, alphabetical
+     except that the x-axis pans come before the y-axis ones. Written as a match
+     rather than a lookup table: a constructor added to [Css.touch_action]
+     without an entry here is a compile error, not a [Not_found] raised out of
+     [to_class] partway through rendering a sheet. The CSS-wide keywords and the
+     composed and var() forms are spelled out for the same reason. *)
+  let data : Css.touch_action -> string * Style.t * int = function
+    | Css.Auto -> ("auto", style [ touch_action Css.Auto ], 0)
+    | Css.Manipulation ->
+        ("manipulation", style [ touch_action Css.Manipulation ], 1)
+    | Css.None -> ("none", style [ touch_action Css.None ], 2)
+    | Css.Pan_left -> ("pan-left", composable_style tw_pan_x_var Css.Pan_left, 3)
+    | Css.Pan_right ->
+        ("pan-right", composable_style tw_pan_x_var Css.Pan_right, 4)
+    | Css.Pan_x -> ("pan-x", composable_style tw_pan_x_var Css.Pan_x, 5)
+    | Css.Pan_down -> ("pan-down", composable_style tw_pan_y_var Css.Pan_down, 6)
+    | Css.Pan_up -> ("pan-up", composable_style tw_pan_y_var Css.Pan_up, 7)
+    | Css.Pan_y -> ("pan-y", composable_style tw_pan_y_var Css.Pan_y, 8)
+    | Css.Pinch_zoom ->
+        ("pinch-zoom", composable_style tw_pinch_zoom_var Css.Pinch_zoom, 9)
+    | Css.Actions _ | Css.Inherit | Css.Initial | Css.Unset | Css.Revert
+    | Css.Revert_layer | Css.Vars _ | Css.Var _ ->
+        (* No touch class names a composed list, a CSS-wide keyword or a var(),
+           so [of_class] never builds one. *)
+        invalid_arg "touch: value has no class name"
+
+  (* Every value a class names, for the class-name lookup. *)
+  let all : Css.touch_action list =
     [
-      (Css.Auto, "auto", fun () -> style [ touch_action Css.Auto ]);
-      ( Css.Manipulation,
-        "manipulation",
-        fun () -> style [ touch_action Css.Manipulation ] );
-      (Css.None, "none", fun () -> style [ touch_action Css.None ]);
-      (* x-axis pan utilities come before y-axis *)
-      ( Css.Pan_left,
-        "pan-left",
-        fun () -> composable_style tw_pan_x_var Css.Pan_left );
-      ( Css.Pan_right,
-        "pan-right",
-        fun () -> composable_style tw_pan_x_var Css.Pan_right );
-      (Css.Pan_x, "pan-x", fun () -> composable_style tw_pan_x_var Css.Pan_x);
-      ( Css.Pan_down,
-        "pan-down",
-        fun () -> composable_style tw_pan_y_var Css.Pan_down );
-      (Css.Pan_up, "pan-up", fun () -> composable_style tw_pan_y_var Css.Pan_up);
-      (Css.Pan_y, "pan-y", fun () -> composable_style tw_pan_y_var Css.Pan_y);
-      ( Css.Pinch_zoom,
-        "pinch-zoom",
-        fun () -> composable_style tw_pinch_zoom_var Css.Pinch_zoom );
+      Css.Auto;
+      Css.Manipulation;
+      Css.None;
+      Css.Pan_left;
+      Css.Pan_right;
+      Css.Pan_x;
+      Css.Pan_down;
+      Css.Pan_up;
+      Css.Pan_y;
+      Css.Pinch_zoom;
     ]
 
-  (* Derived lookup tables *)
-  let to_class_map =
-    List.map (fun (v, suffix, _) -> (v, "touch-" ^ suffix)) touch_data
+  let to_class (Action v) =
+    let suffix, _, _ = data v in
+    "touch-" ^ suffix
 
-  let to_style_map = List.map (fun (v, _, style_fn) -> (v, style_fn)) touch_data
-  let suborder_map = List.mapi (fun i (v, _, _) -> (v, i)) touch_data
+  let to_style _theme (Action v) =
+    let _, s, _ = data v in
+    s
 
-  let of_class_map =
-    List.map (fun (v, suffix, _) -> ("touch-" ^ suffix, Action v)) touch_data
+  let suborder (Action v) =
+    let _, _, o = data v in
+    o
 
-  (* Handler functions derived from maps *)
-  let to_class (Action v) = List.assoc v to_class_map
-  let to_style _theme (Action v) = (List.assoc v to_style_map) ()
-  let suborder (Action v) = List.assoc v suborder_map
+  let of_class_map = List.map (fun v -> (to_class (Action v), Action v)) all
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with


### PR DESCRIPTION
Several handlers looked their conversions up in a tuple list, trading exhaustiveness for a runtime failure out of a pure conversion, and one re-matched thirteen constructors against a hand-copied list closing with an assertion. No failing input is demonstrated; this is the compiler check restored.