### PR TITLE
modifiers: carry the custom variants on the theme

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -99,25 +99,6 @@ let arbitrary_length_class prefix (l : Css.length) cls =
   let len_str = compact_length l in
   Css.Selector.Class (prefix ^ "[" ^ len_str ^ "]:" ^ cls)
 
-(** Legacy registry for callers of [Modifiers.apply] without an explicit
-    breakpoint list. [Tw.of_string] always supplies its threaded scheme. *)
-let custom_breakpoints : (string * float) list ref = ref []
-
-let register_custom_breakpoints bps = custom_breakpoints := bps
-let clear_custom_breakpoints () = custom_breakpoints := []
-
-type custom_variant = { values : (string * string) list; template : string }
-(** A [matchVariant]-registered variant: a value map (including a [DEFAULT]
-    entry under the key [""]) and a selector template containing [{}] where the
-    resolved value is substituted. *)
-
-(** Registry for [matchVariant] custom variants (set per-test by the harness or
-    by callers that mirror a Tailwind plugin). *)
-let custom_variants : (string * custom_variant) list ref = ref []
-
-let register_custom_variants vs = custom_variants := vs
-let clear_custom_variants () = custom_variants := []
-
 (* Substitute the resolved value into a template's [{}] placeholder. *)
 let custom_variant_apply template value =
   let tlen = String.length template in
@@ -132,10 +113,10 @@ let custom_variant_apply template value =
       ^ String.sub template (i + 2) (tlen - i - 2)
   | None -> template
 
-(* Parse [is-data], [is-data-foo], or [is-data-[potato]] against the registry,
-   returning the (token, resolved-selector) for a [Custom_variant]. *)
-let try_custom_variant s =
-  let resolve name cv =
+(* Parse [is-data], [is-data-foo], or [is-data-[potato]] against the theme's own
+   variants, returning the (token, resolved-selector) for a [Custom_variant]. *)
+let try_custom_variant (theme : Scheme.t) s =
+  let resolve name (cv : Scheme.custom_variant) =
     if s = name then
       Option.map
         (fun v -> Custom_variant (s, custom_variant_apply cv.template v))
@@ -163,16 +144,7 @@ let try_custom_variant s =
           value
       else None
   in
-  List.find_map (fun (name, cv) -> resolve name cv) !custom_variants
-
-(** Registry for [@custom-variant]s whose body is a container query (e.g.
-    [@custom-variant has-a { @container style(--a) { @slot } }]). Kept separate
-    from {!custom_variants} because the condition is structural
-    ([Css.Container.t]) so the [not-] prefix can negate it soundly. *)
-let container_variants : (string * Css.Container.t) list ref = ref []
-
-let register_container_variants vs = container_variants := vs
-let clear_container_variants () = container_variants := []
+  List.find_map (fun (name, cv) -> resolve name cv) theme.custom_variants
 
 (* Negate a container condition, cancelling double-negation and pushing through
    a named container: [not (not C)] = [C]; [name (C)] -> [name (not C)]. *)
@@ -183,10 +155,10 @@ let rec negate_container (c : Css.Container.t) : Css.Container.t =
       Css.Container.Named (name, negate_container x)
   | x -> Css.Container.Not x
 
-(* Parse [has-a] (registered) or [not-has-a] (negated) against the
-   container-variant registry, yielding a [Container_style] modifier. *)
-let try_container_variant s =
-  let lookup name = List.assoc_opt name !container_variants in
+(* Parse [has-a] (declared) or [not-has-a] (negated) against the theme's
+   container variants, yielding a [Container_style] modifier. *)
+let try_container_variant (theme : Scheme.t) s =
+  let lookup name = List.assoc_opt name theme.container_variants in
   match lookup s with
   | Some cond -> Some (Container_style (s, cond))
   | None ->
@@ -1894,7 +1866,7 @@ and try_scoped_container_query s =
         | _ -> None)
 
 (* Parse a modifier string into a typed Style.modifier *)
-let rec parse_modifier ~breakpoints s : modifier option =
+let rec parse_modifier ~(theme : Scheme.t) s : modifier option =
   let fns =
     [
       (fun () -> List.assoc_opt s simple_modifiers);
@@ -1902,25 +1874,25 @@ let rec parse_modifier ~breakpoints s : modifier option =
       (fun () -> try_bracketed_modifier s);
       (fun () -> try_aria_shorthand s);
       (fun () -> try_has_shorthand s);
-      (fun () -> try_has_variant ~breakpoints s);
+      (fun () -> try_has_variant ~theme s);
       (fun () -> try_numeric_nth s);
       (fun () -> try_compound_named_group s);
       (fun () -> try_in_modifier s);
       (fun () -> try_not_in_modifier s);
       (fun () -> try_group_peer_not s);
-      (fun () -> try_group_peer_not_variant ~breakpoints s);
+      (fun () -> try_group_peer_not_variant ~theme s);
       (* Before [try_not_modifier]: a container variant handles its own [not-]
          (negating the structural condition), not the generic [Not] wrapper. *)
-      (fun () -> try_container_variant s);
+      (fun () -> try_container_variant theme s);
       (fun () -> try_not_modifier s);
       (fun () -> try_bare_data_aria s);
       (fun () -> try_prose_element s);
-      (fun () -> try_custom_breakpoint breakpoints s);
-      (fun () -> try_custom_variant s);
+      (fun () -> try_custom_breakpoint (Scheme.breakpoint_names theme) s);
+      (fun () -> try_custom_variant theme s);
       (* Last: a [not-] over any other variant negates the selector it produces.
          The readings above come first because several [not-] spellings need
          their own handling. *)
-      (fun () -> try_not_of_modifier ~breakpoints s);
+      (fun () -> try_not_of_modifier ~theme s);
     ]
   in
   List.find_map (fun f -> f ()) fns
@@ -1928,7 +1900,7 @@ let rec parse_modifier ~breakpoints s : modifier option =
 (* [group-not-has-[...]] and [peer-not-...]: the inner is any variant, read on
    its own. The reading above only knows the simple state names and a bare
    bracket. *)
-and try_group_peer_not_variant ~breakpoints s =
+and try_group_peer_not_variant ~theme s =
   let try_prefix prefix make =
     let plen = String.length prefix in
     if String.length s <= plen || String.sub s 0 plen <> prefix then None
@@ -1936,7 +1908,7 @@ and try_group_peer_not_variant ~breakpoints s =
       let base, name =
         split_name (String.sub s plen (String.length s - plen))
       in
-      match parse_modifier ~breakpoints base with
+      match parse_modifier ~theme base with
       | Some m when is_not_compatible m -> Some (make m name)
       | Some _ | None -> None
   in
@@ -1947,29 +1919,22 @@ and try_group_peer_not_variant ~breakpoints s =
 (* [has-<variant>]: the argument is any variant, and that variant's own selector
    goes inside [:has()]. The shorthand reading only knows the state names and a
    bracket, so [has-peer-checked] fell through. *)
-and try_has_variant ~breakpoints s =
+and try_has_variant ~theme s =
   if String.length s > 4 && String.sub s 0 4 = "has-" then
-    match
-      parse_modifier ~breakpoints (String.sub s 4 (String.length s - 4))
-    with
+    match parse_modifier ~theme (String.sub s 4 (String.length s - 4)) with
     | Some m when is_not_compatible m -> Some (Has_variant m)
     | Some _ | None -> None
   else None
 
-and try_not_of_modifier ~breakpoints s =
+and try_not_of_modifier ~theme s =
   if not (String.length s > 4 && String.sub s 0 4 = "not-") then None
   else
-    match
-      parse_modifier ~breakpoints (String.sub s 4 (String.length s - 4))
-    with
+    match parse_modifier ~theme (String.sub s 4 (String.length s - 4)) with
     | Some m when is_not_compatible m -> Some (Not m)
     | Some _ | None -> None
 
 (* Apply a list of modifier strings to a base utility *)
-let apply ?breakpoints modifiers base_utility =
-  let breakpoints =
-    Option.value ~default:(List.map fst !custom_breakpoints) breakpoints
-  in
+let apply ?(theme = Scheme.default) modifiers base_utility =
   (* Convert utility to a list for wrapping *)
   let to_list = function
     | Utility.Group styles -> styles
@@ -1980,7 +1945,7 @@ let apply ?breakpoints modifiers base_utility =
     match acc with
     | None -> None
     | Some u -> (
-        match parse_modifier ~breakpoints modifier_str with
+        match parse_modifier ~theme modifier_str with
         | Some m -> Some (wrap m (to_list u))
         | None -> None)
   in

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -38,34 +38,6 @@ val normalize_supports_condition : string -> string
     test is repeated once per vendor prefix Tailwind checks. The modifier parser
     validates its result, so only conditions that parse reach a rule. *)
 
-val register_custom_breakpoints : (string * float) list -> unit
-(** [register_custom_breakpoints bps] sets the legacy custom breakpoint names
-    used only when {!apply} receives no [breakpoints]. Prefer passing a
-    [Scheme.t] to [Tw.of_string]. *)
-
-val clear_custom_breakpoints : unit -> unit
-(** [clear_custom_breakpoints ()] clears the custom breakpoint registry. *)
-
-type custom_variant = { values : (string * string) list; template : string }
-(** A [matchVariant]-registered variant: a value map (the [DEFAULT] value under
-    key [""]) and a selector template with [{}] where the value is substituted.
-    [&] in the template denotes the element's own class. *)
-
-val register_custom_variants : (string * custom_variant) list -> unit
-(** [register_custom_variants vs] sets the [matchVariant] custom variants used
-    during modifier parsing. *)
-
-val clear_custom_variants : unit -> unit
-(** [clear_custom_variants ()] clears the custom variant registry. *)
-
-val register_container_variants : (string * Css.Container.t) list -> unit
-(** [register_container_variants vs] sets the [@custom-variant]s whose body is a
-    container query (e.g. [has-a] -> [@container style(--a)]). The [not-] prefix
-    on these negates the condition structurally. *)
-
-val clear_container_variants : unit -> unit
-(** [clear_container_variants ()] clears the container-variant registry. *)
-
 (** {1 State Variants} *)
 
 val hover : t list -> t
@@ -700,9 +672,10 @@ val pp_modifier : modifier -> string
 (** [pp_modifier m] returns the string prefix for a modifier (e.g., "hover" for
     Hover). *)
 
-val apply : ?breakpoints:string list -> string list -> t -> t option
-(** [apply ?breakpoints modifiers style] applies a list of modifier strings to a
-    base style. Returns [None] if any modifier is unrecognized. Example:
+val apply : ?theme:Scheme.t -> string list -> t -> t option
+(** [apply ?theme modifiers style] applies a list of modifier strings to a base
+    style, reading the custom breakpoints and [\@custom-variant]s from [theme].
+    Returns [None] if any modifier is unrecognized. Example:
     [apply ["hover"; "sm"] (bg blue 500)] creates a hover:sm:bg-blue-500 style.
 *)
 

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -12,6 +12,11 @@ type color_value =
   | Oklch of { l : float; c : float; h : float }
       (** e.g., oklch(63.7% 0.237 25.331) *)
 
+type custom_variant = { values : (string * string) list; template : string }
+(** A [matchVariant]-registered variant: a value map (including a [DEFAULT]
+    entry under the key [""]) and a selector template containing [{}] where the
+    resolved value is substituted. *)
+
 type t = {
   colors : (string * color_value) list;
       (** Color overrides. Key is color name like "red-500". When a color is
@@ -47,6 +52,13 @@ type t = {
           variable name without the leading [--] (e.g. "text-shadow-2xs"), value
           is the CSS string. Threaded replacement for the global
           [Var.theme_value_overrides]. *)
+  custom_variants : (string * custom_variant) list;
+      (** The [@custom-variant]s this [@theme] declared as a value map plus a
+          selector template. *)
+  container_variants : (string * Css.Container.t) list;
+      (** The [@custom-variant]s this [@theme] declared with a container-query
+          body. Kept apart from {!custom_variants} because the condition is
+          structural, so the [not-] prefix can negate it soundly. *)
 }
 (** Theme scheme configuration *)
 
@@ -77,6 +89,8 @@ let default : t =
     token_overrides = [];
     inline_tokens = [];
     static_theme = false;
+    custom_variants = [];
+    container_variants = [];
   }
 
 let pp t =

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -12,6 +12,11 @@ type color_value =
   | Oklch of { l : float; c : float; h : float }
       (** e.g., oklch(63.7% 0.237 25.331) *)
 
+type custom_variant = { values : (string * string) list; template : string }
+(** A [\@custom-variant] registered with a value map (the [DEFAULT] value under
+    key [""]) and a selector template with [{}] where the value is substituted.
+    [&] in the template denotes the element's own class. *)
+
 type t = {
   colors : (string * color_value) list;
       (** Color overrides. Key is color name like "red-500". When a color is
@@ -51,6 +56,15 @@ type t = {
   static_theme : bool;
       (** Whether the package was imported with [theme(static)], which emits
           every theme variable rather than only the ones a utility used. *)
+  custom_variants : (string * custom_variant) list;
+      (** The [\@custom-variant]s this [\@theme] declared, each a value map and
+          a selector template. A variant belongs to the theme that declared it,
+          so two stylesheets built in one process cannot see each other's. *)
+  container_variants : (string * Css.Container.t) list;
+      (** The [\@custom-variant]s this [\@theme] declared with a container-query
+          body (e.g. [has-a] -> [\@container style(--a)]). Kept apart from
+          {!custom_variants} because the condition is structural, so the [not-]
+          prefix negates it soundly. *)
 }
 (** Theme scheme configuration *)
 

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -248,11 +248,7 @@ let of_string ?(theme = Scheme.default) class_str =
       | `Suffix -> Utility.important ~suffix:true base_util
       | `None -> base_util
     in
-    match
-      Modifiers.apply
-        ~breakpoints:(Scheme.breakpoint_names theme)
-        modifiers base_util
-    with
+    match Modifiers.apply ~theme modifiers base_util with
     | Some u -> Ok u
     | None -> Error (`Msg ("Unknown modifier in: " ^ class_str))
   in

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -364,36 +364,35 @@ let test_arbitrary_breakpoint_rejects_non_length () =
    stylesheets built in one process read different themes, so a variant the
    first declared must be unknown to the second. *)
 let test_custom_variant_is_theme_local () =
-  let declaring = Tw.Scheme.default in
-  let other =
-    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-mine", "red") ]
-  in
-  Fun.protect ~finally:Tw.Modifiers.clear_custom_variants (fun () ->
-      Tw.Modifiers.register_custom_variants
+  let declaring : Tw.Scheme.t =
+    {
+      Tw.Scheme.default with
+      custom_variants =
         [
           ( "is-data",
-            Tw.Modifiers.
-              { values = [ ("", "&[data-x]") ]; template = "&:is({})" } );
+            Tw.Scheme.{ values = [ ("", "&[data-x]") ]; template = "&:is({})" }
+          );
         ];
-      check bool "the declaring theme resolves its own variant" true
-        (Result.is_ok (Tw.of_string ~theme:declaring "is-data:flex"));
-      check bool "a second theme does not see it" true
-        (Result.is_error (Tw.of_string ~theme:other "is-data:flex")))
+    }
+  in
+  check bool "the declaring theme resolves its own variant" true
+    (Result.is_ok (Tw.of_string ~theme:declaring "is-data:flex"));
+  check bool "a second theme does not see it" true
+    (Result.is_error (Tw.of_string ~theme:Tw.Scheme.default "is-data:flex"))
 
 (* Same for a [@custom-variant] whose body is a container query: it is held in
-   its own registry, so it leaks the same way. *)
+   its own field, and belongs to its own theme just the same. *)
 let test_container_variant_is_theme_local () =
-  let declaring = Tw.Scheme.default in
-  let other =
-    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-mine", "red") ]
+  let declaring : Tw.Scheme.t =
+    {
+      Tw.Scheme.default with
+      container_variants = [ ("has-a", Css.Container.of_string "style(--a)") ];
+    }
   in
-  Fun.protect ~finally:Tw.Modifiers.clear_container_variants (fun () ->
-      Tw.Modifiers.register_container_variants
-        [ ("has-a", Css.Container.of_string "style(--a)") ];
-      check bool "the declaring theme resolves its own variant" true
-        (Result.is_ok (Tw.of_string ~theme:declaring "has-a:flex"));
-      check bool "a second theme does not see it" true
-        (Result.is_error (Tw.of_string ~theme:other "has-a:flex")))
+  check bool "the declaring theme resolves its own variant" true
+    (Result.is_ok (Tw.of_string ~theme:declaring "has-a:flex"));
+  check bool "a second theme does not see it" true
+    (Result.is_error (Tw.of_string ~theme:Tw.Scheme.default "has-a:flex"))
 
 (* Test suite *)
 (* The [!] prefix marks the utility's own declarations !important, leaves theme

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -360,6 +360,41 @@ let test_arbitrary_breakpoint_rejects_non_length () =
       | Error (`Msg _) -> ())
     [ "min-[abc]:flex"; "max-[abc]:flex"; "min-[]:flex" ]
 
+(* A [@custom-variant] belongs to the [@theme] block that declared it. Two
+   stylesheets built in one process read different themes, so a variant the
+   first declared must be unknown to the second. *)
+let test_custom_variant_is_theme_local () =
+  let declaring = Tw.Scheme.default in
+  let other =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-mine", "red") ]
+  in
+  Fun.protect ~finally:Tw.Modifiers.clear_custom_variants (fun () ->
+      Tw.Modifiers.register_custom_variants
+        [
+          ( "is-data",
+            Tw.Modifiers.
+              { values = [ ("", "&[data-x]") ]; template = "&:is({})" } );
+        ];
+      check bool "the declaring theme resolves its own variant" true
+        (Result.is_ok (Tw.of_string ~theme:declaring "is-data:flex"));
+      check bool "a second theme does not see it" true
+        (Result.is_error (Tw.of_string ~theme:other "is-data:flex")))
+
+(* Same for a [@custom-variant] whose body is a container query: it is held in
+   its own registry, so it leaks the same way. *)
+let test_container_variant_is_theme_local () =
+  let declaring = Tw.Scheme.default in
+  let other =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-mine", "red") ]
+  in
+  Fun.protect ~finally:Tw.Modifiers.clear_container_variants (fun () ->
+      Tw.Modifiers.register_container_variants
+        [ ("has-a", Css.Container.of_string "style(--a)") ];
+      check bool "the declaring theme resolves its own variant" true
+        (Result.is_ok (Tw.of_string ~theme:declaring "has-a:flex"));
+      check bool "a second theme does not see it" true
+        (Result.is_error (Tw.of_string ~theme:other "has-a:flex")))
+
 (* Test suite *)
 (* The [!] prefix marks the utility's own declarations !important, leaves theme
    tokens (--spacing) normal, preserves the class name, and nests under a
@@ -976,6 +1011,10 @@ let tests =
         test_arbitrary_breakpoint_spelling;
       test_case "arbitrary breakpoint rejects non-length" `Quick
         test_arbitrary_breakpoint_rejects_non_length;
+      test_case "custom variant is theme-local" `Quick
+        test_custom_variant_is_theme_local;
+      test_case "container variant is theme-local" `Quick
+        test_container_variant_is_theme_local;
     ]
 
 let suite = ("modifiers", tests)

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -217,7 +217,10 @@ let check_list tw_styles = check_exact_match tw_styles
 
 (* ===== UPSTREAM PARSE PARITY ============================================= *)
 
-let register_upstream_variant_directives directives =
+(* The case's own [@custom-variant]s, as the two scheme fields that carry them.
+   Directive form: "name <template> KEY=value ...", DEFAULT mapped to the
+   default slot; "container <name> <header>" for a container-query body. *)
+let upstream_variants directives =
   let parse_variant_directive d =
     match String.split_on_char ' ' d with
     | "container" :: _ -> None
@@ -233,7 +236,7 @@ let register_upstream_variant_directives directives =
               | None -> None)
             pairs
         in
-        Some (name, Tw.Modifiers.{ values; template })
+        Some (name, Tw.Scheme.{ values; template })
     | _ -> None
   in
   let parse_container_directive d =
@@ -253,10 +256,8 @@ let register_upstream_variant_directives directives =
         try Some (name, container_of_header header) with Failure _ -> None)
     | _ -> None
   in
-  Tw.Modifiers.register_custom_variants
-    (List.filter_map parse_variant_directive directives);
-  Tw.Modifiers.register_container_variants
-    (List.filter_map parse_container_directive directives)
+  ( List.filter_map parse_variant_directive directives,
+    List.filter_map parse_container_directive directives )
 
 let upstream_positive_cases basename =
   match Upstream_fixture.path basename with
@@ -268,7 +269,8 @@ let upstream_positive_cases basename =
 
 (* Build the per-test scheme from the @theme tokens in the expected CSS, so
    of_string validates custom tokens against the threaded theme. *)
-let upstream_scheme (config : Upstream_fixture.config) theme_vars expected =
+let upstream_scheme (config : Upstream_fixture.config) theme_vars variants
+    expected =
   let overrides =
     match config with
     | Run | Theme | Theme_inline | Theme_reference | Theme_inline_reference ->
@@ -298,7 +300,18 @@ let upstream_scheme (config : Upstream_fixture.config) theme_vars expected =
     in
     overrides @ extra
   in
-  Tw.Scheme.with_overrides Tw.Scheme.default overrides
+  let custom_variants, container_variants = upstream_variants variants in
+  let base : Tw.Scheme.t =
+    {
+      Tw.Scheme.default with
+      (* The breakpoint names the fixture corpus declares in its own [@theme]
+         blocks; a case that uses one has it in the theme it is parsed with. *)
+      breakpoints = [ ("xs", 320.); ("10xl", 1600.); ("lg-sm-potato", 1600.) ];
+      custom_variants;
+      container_variants;
+    }
+  in
+  Tw.Scheme.with_overrides base overrides
 
 let class_is_emitted expected cls =
   String.contains expected '.'
@@ -308,13 +321,12 @@ let class_is_emitted expected cls =
 
 let check_upstream_positive_fixture_parse filename () =
   let cases = upstream_positive_cases filename in
-  Tw.Modifiers.register_custom_breakpoints
-    [ ("xs", 320.); ("10xl", 1600.); ("lg-sm-potato", 1600.) ];
   let rejected =
     cases
     |> List.concat_map (fun (c : Upstream_fixture.case) ->
-        register_upstream_variant_directives c.variants;
-        let theme = upstream_scheme c.config c.theme_vars c.expected in
+        let theme =
+          upstream_scheme c.config c.theme_vars c.variants c.expected
+        in
         c.classes
         |> List.filter (class_is_emitted c.expected)
         |> List.filter_map (fun cls ->
@@ -426,7 +438,6 @@ let responsive_breakpoints () =
   check (md [ p 8 ])
 
 let custom_breakpoint_theme_is_local () =
-  Tw.Modifiers.clear_custom_breakpoints ();
   let theme : Tw.Scheme.t =
     { Tw.Scheme.default with breakpoints = [ ("10xl", 1600.) ] }
   in

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -154,6 +154,7 @@ let scheme_from_expected_css expected : Tw.Scheme.t =
   let default_outline_width = extract_outline_width expected in
   let breakpoints = extract_breakpoints_from_css expected in
   {
+    Tw.Scheme.default with
     colors = [ ("red-500", Tw.Scheme.Hex "#ef4444") ];
     spacing;
     radius;
@@ -161,24 +162,12 @@ let scheme_from_expected_css expected : Tw.Scheme.t =
     default_border_width;
     default_outline_width;
     breakpoints;
-    token_overrides = [];
-    inline_tokens = [];
-    static_theme = false;
   }
 
 let setup_scheme_for_test expected =
-  let scheme = scheme_from_expected_css expected in
-  (* The scheme is threaded into Tw.to_css via ~theme below; the per-module
-     set_scheme globals are no longer used for rendering. *)
-  (* Register custom breakpoints for modifier parsing *)
-  let standard_names = [ "sm"; "md"; "lg"; "xl"; "2xl" ] in
-  let custom_bps =
-    List.filter
-      (fun (name, _) -> not (List.mem name standard_names))
-      scheme.breakpoints
-  in
-  Tw.Modifiers.register_custom_breakpoints custom_bps;
-  scheme
+  (* The scheme is threaded into Tw.of_string and Tw.to_css via ~theme; the
+     custom breakpoints it carries are what the modifier parser reads. *)
+  scheme_from_expected_css expected
 
 (** Extract all CSS variable names referenced in expected CSS text. *)
 let extract_var_names expected =
@@ -614,7 +603,7 @@ let run_test_case test () =
                 | None -> None)
               pairs
           in
-          Some (name, Tw.Modifiers.{ values; template })
+          Some (name, Tw.Scheme.{ values; template })
       | _ -> None
     in
     (* [@custom-variant <name> { @container <header> { @slot } }] directives,
@@ -639,25 +628,18 @@ let run_test_case test () =
           try Some (name, container_of_header header) with Failure _ -> None)
       | _ -> None
     in
-    Tw.Modifiers.register_custom_variants
-      (List.filter_map parse_variant_directive test.variants);
-    Tw.Modifiers.register_container_variants
-      (List.filter_map parse_container_directive test.variants);
-    (* Register custom breakpoints before parsing classes. The resulting scheme
-       (base plus any custom breakpoints) is the one threaded to [Tw.to_css]
-       below via [~theme]. *)
+    (* The case's own [@custom-variant]s and custom breakpoints ride on the
+       scheme threaded to [Tw.of_string] and [Tw.to_css] below, so they are
+       local to this case rather than left in a registry the next one reads. *)
     let custom_bps = extract_custom_breakpoints test.classes test.expected in
     let scheme =
-      if custom_bps = [] then base_scheme
-      else
-        let updated_scheme =
-          {
-            base_scheme with
-            breakpoints = base_scheme.breakpoints @ custom_bps;
-          }
-        in
-        Tw.Modifiers.register_custom_breakpoints custom_bps;
-        updated_scheme
+      {
+        base_scheme with
+        breakpoints = base_scheme.breakpoints @ custom_bps;
+        custom_variants = List.filter_map parse_variant_directive test.variants;
+        container_variants =
+          List.filter_map parse_container_directive test.variants;
+      }
     in
     (* Thread the @theme token overrides into the scheme so utilities read them
        from ~theme (parse and render); the Var global is no longer consulted. *)


### PR DESCRIPTION
Custom and container variants lived in process-global tables that nothing cleared, so two stylesheets built in one process from different themes saw each other's variants. They now travel on the theme, and the six registration functions and the legacy breakpoint global are gone.