### PR TITLE
utility: read past a doubled or carried declaration for the slot

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1176,7 +1176,15 @@ module Handler = struct
     | Neg_outline_offset n -> "-outline-offset-" ^ string_of_int n
     | Neg_outline_offset_var v -> "-outline-offset-[" ^ v ^ "]"
 
-  let examples = [ Border_0; Border_x; Border_y; Border_solid; Border_current ]
+  let examples =
+    [
+      Border_0;
+      Border_x;
+      Border_y;
+      Border_solid;
+      Border_current;
+      Outline_width 2;
+    ]
 end
 
 open Handler

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -71,21 +71,51 @@ let rec style_declarations (s : Style.t) =
   | Style.Modified (_, inner) -> style_declarations inner
   | Style.Group inner -> List.concat_map style_declarations inner
 
+(* A width utility writes the style property as a bare reference to the style
+   utilities' channel, so the declaration says nothing about which family the
+   utility belongs to. No cascade API tells a bare var() carrier from a real
+   value, so the two carriers are named here. *)
 let is_ordering_carrier decl =
   match Cascade.Css.Declaration.property_key decl with
   | Key Border_style ->
       Cascade.Css.declaration_value ~minify:true decl = "var(--tw-border-style)"
+  | Key Outline_style ->
+      Cascade.Css.declaration_value ~minify:true decl
+      = "var(--tw-outline-style)"
   | _ -> false
 
+(* The property name a vendor-prefixed one stands in for: [-webkit-user-select]
+   is [user-select]. *)
+let unprefixed_name name =
+  if String.length name > 1 && name.[0] = '-' then
+    Option.map
+      (fun i -> String.sub name (i + 1) (String.length name - i - 1))
+      (String.index_from_opt name 1 '-')
+  else None
+
+(* A prefixed declaration a later one repeats unprefixed is the same property
+   written twice for reach, and the slot belongs to the standard spelling. One
+   with no unprefixed twin ([-webkit-line-clamp]) is the utility's own. *)
+let is_prefixed_duplicate decl rest =
+  match unprefixed_name (Cascade.Css.Declaration.property_name decl) with
+  | None -> false
+  | Some plain ->
+      List.exists
+        (fun d -> String.equal (Cascade.Css.Declaration.property_name d) plain)
+        rest
+
 let ordering_property declarations =
-  List.find_map
-    (fun decl ->
-      if is_ordering_carrier decl then None
-      else
-        match Cascade.Css.Declaration.property_key decl with
-        | Key (Custom_property _) | Key (Unknown_property _) -> None
-        | key -> Some key)
-    declarations
+  let rec scan = function
+    | [] -> None
+    | decl :: rest ->
+        if is_ordering_carrier decl || is_prefixed_duplicate decl rest then
+          scan rest
+        else (
+          match Cascade.Css.Declaration.property_key decl with
+          | Key (Custom_property _) | Key (Unknown_property _) -> scan rest
+          | key -> Some key)
+  in
+  scan declarations
 
 let build_property_slots () =
   let tbl = Hashtbl.create 512 in

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -156,9 +156,11 @@ val order_of_property : Cascade.Css.Declaration.prop_key -> (int * int) option
 val ordering_property :
   Cascade.Css.declaration list -> Cascade.Css.Declaration.prop_key option
 (** [ordering_property declarations] is the first property that determines a
-    utility's Tailwind family. It skips theme-token declarations and incidental
-    carrier declarations such as the [border-style] reference emitted by a
-    border-width utility. *)
+    utility's Tailwind family. It skips theme-token declarations, the carrier
+    declarations a width utility emits to reference the style channel
+    ([border-style], [outline-style]), and a vendor-prefixed spelling a later
+    declaration repeats unprefixed. A prefixed property with no unprefixed twin
+    ([-webkit-line-clamp]) is the utility's own and keeps its slot. *)
 
 val base_of_class : Scheme.t -> string -> (base, [ `Msg of string ]) result
 (** [base_of_class theme class_name] parses a class name into a base utility

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -167,6 +167,66 @@ let test_order_of_property () =
     (Some (order_of "border-solid"))
     (order_of_property (Key Border_style))
 
+(* A utility writes a property twice when the vendor-prefixed spelling still
+   buys reach ([-webkit-user-select] then [user-select]). The slot belongs to
+   the standard spelling, so a declared [@utility] setting it sorts with the
+   family rather than at the layer's tail. A prefixed property with no
+   unprefixed twin ([-webkit-line-clamp]) is the utility's own and keeps its
+   slot. *)
+let test_order_of_property_skips_vendor_prefix () =
+  let open Tw.Utility in
+  let order_of cls =
+    match base_of_class Tw.Scheme.default cls with
+    | Ok b -> order b
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check
+    (option (pair int int))
+    "user-select resolves to the select utilities"
+    (Some (order_of "select-none"))
+    (order_of_property (Key User_select));
+  check
+    (option (pair int int))
+    "hyphens resolves to the hyphens utilities"
+    (Some (order_of "hyphens-auto"))
+    (order_of_property (Key Hyphens));
+  check
+    (option (pair int int))
+    "backdrop-filter resolves to the backdrop utilities"
+    (Some (order_of "backdrop-filter-none"))
+    (order_of_property (Key Backdrop_filter));
+  check
+    (option (pair int int))
+    "mask-image resolves to the mask utilities"
+    (Some (order_of "mask-none"))
+    (order_of_property (Key Mask_image));
+  check
+    (option (pair int int))
+    "a prefixed property with no twin keeps its own slot"
+    (Some (order_of "line-clamp-2"))
+    (order_of_property (Key Webkit_line_clamp))
+
+(* [outline-2] writes [outline-style: var(--tw-outline-style)] as a carrier for
+   the style utilities, the same shape [border-2] uses. The width utility owns
+   the width slot and the style utilities own the style slot. *)
+let test_order_of_property_skips_outline_carrier () =
+  let open Tw.Utility in
+  let order_of cls =
+    match base_of_class Tw.Scheme.default cls with
+    | Ok b -> order b
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  check
+    (option (pair int int))
+    "outline width skips the style carrier"
+    (Some (order_of "outline-2"))
+    (order_of_property (Key Outline_width));
+  check
+    (option (pair int int))
+    "outline style resolves to the style utilities"
+    (Some (order_of "outline-dashed"))
+    (order_of_property (Key Outline_style))
+
 let tests =
   [
     test_case "base_of_class valid input" `Quick test_base_of_class_valid;
@@ -176,6 +236,10 @@ let tests =
     (* test_case "css_of_string valid input" `Quick test_css_of_string_valid; *)
     (* test_case "css_of_string invalid input" `Quick test_css_of_string_invalid; *)
     test_case "order_of_property" `Quick test_order_of_property;
+    test_case "order_of_property skips a vendor prefix" `Quick
+      test_order_of_property_skips_vendor_prefix;
+    test_case "order_of_property skips the outline carrier" `Quick
+      test_order_of_property_skips_outline_carrier;
     test_case "order returns correct priorities" `Quick test_order_priorities;
     test_case "order returns correct suborders" `Quick test_order_suborders;
     test_case "order is consistent" `Quick test_order_consistency;

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -188,7 +188,7 @@ let test_order_of_property_skips_vendor_prefix () =
   check
     (option (pair int int))
     "hyphens resolves to the hyphens utilities"
-    (Some (order_of "hyphens-auto"))
+    (Some (order_of "hyphens-none"))
     (order_of_property (Key Hyphens));
   check
     (option (pair int int))
@@ -197,13 +197,13 @@ let test_order_of_property_skips_vendor_prefix () =
     (order_of_property (Key Backdrop_filter));
   check
     (option (pair int int))
-    "mask-image resolves to the mask utilities"
-    (Some (order_of "mask-none"))
+    "mask-image resolves to the mask-gradient utilities"
+    (Some (order_of "mask-linear-0"))
     (order_of_property (Key Mask_image));
   check
     (option (pair int int))
     "a prefixed property with no twin keeps its own slot"
-    (Some (order_of "line-clamp-2"))
+    (Some (order_of "line-clamp-none"))
     (order_of_property (Key Webkit_line_clamp))
 
 (* [outline-2] writes [outline-style: var(--tw-outline-style)] as a carrier for
@@ -224,7 +224,7 @@ let test_order_of_property_skips_outline_carrier () =
   check
     (option (pair int int))
     "outline style resolves to the style utilities"
-    (Some (order_of "outline-dashed"))
+    (Some (order_of "outline-solid"))
     (order_of_property (Key Outline_style))
 
 let tests =


### PR DESCRIPTION
A family's slot was read from its first declaration, which for several families is a theme variable or a carrier such as `outline-style`, so a declared utility setting that property sorted into the wrong place or none at all.