### PR TITLE
utility: give every named family an example of its property

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1924,6 +1924,7 @@ module Handler = struct
       Bg_clip_border;
       Bg_origin_border;
       Bg_current;
+      Bg_position Position.Center;
     ]
 end
 

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1184,6 +1184,8 @@ module Handler = struct
       Border_solid;
       Border_current;
       Outline_width 2;
+      Outline_offset 2;
+      Rounded (Corner.All, Rsz_sm);
     ]
 end
 

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -445,7 +445,7 @@ module Handler = struct
     | Order_last -> "order-last"
     | Order_none -> "order-none"
 
-  let examples = [ Flex_1; Flex_grow; Flex_shrink; Basis_0 ]
+  let examples = [ Flex_1; Flex_grow; Flex_shrink; Basis_0; Order 1 ]
 end
 
 open Handler

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -369,6 +369,7 @@ module Handler = struct
       Scroll_auto;
       Snap_x;
       Snap_start;
+      Snap_always;
       Snap_mandatory;
       Resize_none;
       Pointer_events_none;

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -744,6 +744,9 @@ module Handler = struct
       Clear_both;
       Object_contain;
       Object_center;
+      Break_before_page;
+      Break_after_page;
+      Break_inside_avoid;
     ]
 end
 

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1961,7 +1961,17 @@ module Handler = struct
     | Origin_arbitrary (s, _) -> "origin-[" ^ s ^ "]"
 
   let examples =
-    [ Origin_top; Perspective_none; Perspective_origin_top; Backface_hidden ]
+    [
+      Origin_top;
+      Perspective_none;
+      Perspective_origin_top;
+      Backface_hidden;
+      Transform_none;
+      Transform_style_flat;
+      Rotate 45;
+      Scale 50;
+      Translate_x 2;
+    ]
 end
 
 open Handler

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1391,7 +1391,8 @@ module Typography_early = struct
         let lh_extra, lh_value = lh_modifier_to_css lh_mod in
         style (fs_decls @ lh_extra @ [ line_height lh_value ])
 
-  let examples = [ Text_base; Font_normal ]
+  let examples =
+    [ Text_base; Font_normal; Font_sans; Italic; Text_center; Leading_none ]
 end
 
 (** Late typography handler - comes after color utilities (priority 24) *)

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -227,6 +227,43 @@ let test_order_of_property_skips_outline_carrier () =
     (Some (order_of "outline-solid"))
     (order_of_property (Key Outline_style))
 
+(* Tailwind sorts a declared [@utility] by the property it writes, so every
+   property a family is named for needs a slot. A family with no example
+   covering its property leaves a declared utility at the layer's tail. *)
+let test_order_of_property_covers_named_families () =
+  let open Tw.Utility in
+  let order_of cls =
+    match base_of_class Tw.Scheme.default cls with
+    | Ok b -> order b
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  List.iter
+    (fun (key, cls) ->
+      check
+        (option (pair int int))
+        (cls ^ " owns the property it is named for")
+        (Some (order_of cls))
+        (order_of_property key))
+    [
+      ((Key Order : Cascade.Css.Declaration.prop_key), "order-1");
+      (Key Rotate, "rotate-45");
+      (Key Scale, "scale-50");
+      (Key Translate, "translate-x-2");
+      (Key Transform, "transform-none");
+      (Key Transform_style, "transform-flat");
+      (Key Scroll_snap_stop, "snap-always");
+      (Key Break_before, "break-before-page");
+      (Key Break_after, "break-after-page");
+      (Key Break_inside, "break-inside-avoid");
+      (Key Border_radius, "rounded-sm");
+      (Key Outline_offset, "outline-offset-2");
+      (Key Background_position, "bg-center");
+      (Key Text_align, "text-center");
+      (Key Font_family, "font-sans");
+      (Key Font_style, "italic");
+      (Key Line_height, "leading-none");
+    ]
+
 let tests =
   [
     test_case "base_of_class valid input" `Quick test_base_of_class_valid;
@@ -240,6 +277,8 @@ let tests =
       test_order_of_property_skips_vendor_prefix;
     test_case "order_of_property skips the outline carrier" `Quick
       test_order_of_property_skips_outline_carrier;
+    test_case "order_of_property covers the named families" `Quick
+      test_order_of_property_covers_named_families;
     test_case "order returns correct priorities" `Quick test_order_priorities;
     test_case "order returns correct suborders" `Quick test_order_suborders;
     test_case "order is consistent" `Quick test_order_consistency;


### PR DESCRIPTION
Seventeen families listed no example for the property they are named after, so a declared utility setting that property had no slot to sort into.