### PR TITLE
utility: let the element's own property decide the family

### DIFF
--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -47,14 +47,26 @@ let handlers : handler list ref = ref []
    properties they set, and the lowest order among the ones setting a property
    is that property's slot. The ordering itself stays declared once, on the
    utilities - nothing here restates it. *)
+(* [true] on an entry means it came from a property the utility writes on the
+   element itself, which outranks one it writes only inside a nested rule. *)
 let property_slots :
-    (Cascade.Css.Declaration.prop_key, int * int) Hashtbl.t option ref =
+    (Cascade.Css.Declaration.prop_key, bool * (int * int)) Hashtbl.t option ref
+    =
   ref None
 
 let register (type a) (module M : Handler with type t = a) =
   let internal_h = H (module M : Handler with type t = a) in
   property_slots := None;
   handlers := internal_h :: !handlers
+
+(* The declarations a style writes on the element itself: a pseudo-element
+   suffix or a rule of its own moves them off it. *)
+let rec style_own_declarations (s : Style.t) =
+  match s with
+  | Style.Style { pseudo_suffix = Some _; _ } -> []
+  | Style.Style { props; _ } -> props
+  | Style.Modified (_, inner) -> style_own_declarations inner
+  | Style.Group inner -> List.concat_map style_own_declarations inner
 
 (* The declarations a style writes, its own and those of the rules it
    carries. *)
@@ -107,10 +119,10 @@ let is_prefixed_duplicate decl rest =
 let ordering_property declarations =
   let rec scan = function
     | [] -> None
-    | decl :: rest ->
+    | decl :: rest -> (
         if is_ordering_carrier decl || is_prefixed_duplicate decl rest then
           scan rest
-        else (
+        else
           match Cascade.Css.Declaration.property_key decl with
           | Key (Custom_property _) | Key (Unknown_property _) -> scan rest
           | key -> Some key)
@@ -119,25 +131,34 @@ let ordering_property declarations =
 
 let build_property_slots () =
   let tbl = Hashtbl.create 512 in
-  let record key order =
+  (* A property a utility writes on the element itself decides that utility's
+     family; one it writes only inside a rule it carries does not, unless
+     nothing else claims the property. [placeholder-transparent] writes [color]
+     in a [::placeholder] rule, and the [color] slot belongs to the text
+     colours. *)
+  let record ~own key order =
     match Hashtbl.find_opt tbl key with
-    | Some existing when existing <= order -> ()
-    | _ -> Hashtbl.replace tbl key order
+    | Some (true, _) when not own -> ()
+    | Some (had_own, existing) when had_own = own && existing <= order -> ()
+    | _ -> Hashtbl.replace tbl key (own, order)
   in
   List.iter
     (fun (H (module M)) ->
       List.iter
         (fun example ->
           let order = (M.priority example, M.suborder example) in
+          let style = M.to_style Scheme.default example in
           (* The property a utility claims is the first named property it
              writes: the one it is named for. Theme-token declarations that make
              that value available are not slots of their own. A later named
              declaration is incidental - line-clamp ends with [display:
              -webkit-box] but the display slot belongs to the display utilities,
              which sort elsewhere. *)
-          style_declarations (M.to_style Scheme.default example)
-          |> ordering_property
-          |> Option.iter (fun key -> record key order))
+          match ordering_property (style_own_declarations style) with
+          | Some key -> record ~own:true key order
+          | None ->
+              ordering_property (style_declarations style)
+              |> Option.iter (fun key -> record ~own:false key order))
         M.examples)
     !handlers;
   tbl
@@ -151,7 +172,7 @@ let order_of_property key =
         property_slots := Some tbl;
         tbl
   in
-  Hashtbl.find_opt tbl key
+  Option.map snd (Hashtbl.find_opt tbl key)
 
 let name_of_base u =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -151,7 +151,10 @@ val order_of_property : Cascade.Css.Declaration.prop_key -> (int * int) option
 (** [order_of_property k] is the [(priority, suborder)] of the utility family
     that sets property [k], or [None] when no registered handler claims it. This
     is where a declared [@utility] gets its place: Tailwind sorts one by the
-    property it declares, not by its name. *)
+    property it declares, not by its name. A family that writes [k] on the
+    element itself outranks one that writes it only on a pseudo-element, so
+    [color] resolves to the text colours rather than to
+    [placeholder-transparent]. *)
 
 val ordering_property :
   Cascade.Css.declaration list -> Cascade.Css.Declaration.prop_key option

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -300,16 +300,11 @@ let upstream_scheme (config : Upstream_fixture.config) theme_vars variants
     in
     overrides @ extra
   in
+  (* Every custom breakpoint a case uses arrives as a [--breakpoint-*] token in
+     [overrides], so the parse reads it from the threaded theme. *)
   let custom_variants, container_variants = upstream_variants variants in
   let base : Tw.Scheme.t =
-    {
-      Tw.Scheme.default with
-      (* The breakpoint names the fixture corpus declares in its own [@theme]
-         blocks; a case that uses one has it in the theme it is parsed with. *)
-      breakpoints = [ ("xs", 320.); ("10xl", 1600.); ("lg-sm-potato", 1600.) ];
-      custom_variants;
-      container_variants;
-    }
+    { Tw.Scheme.default with custom_variants; container_variants }
   in
   Tw.Scheme.with_overrides base overrides
 

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -156,10 +156,12 @@ let test_order_of_property () =
     "margin skips its spacing token declaration"
     (Some (order_of "m-auto"))
     (order_of_property (Key Margin));
+  (* [placeholder-transparent] writes [color] too, but inside a [::placeholder]
+     rule: the slot belongs to the utilities that colour the element itself. *)
   check
     (option (pair int int))
-    "color skips its palette token declaration"
-    (Some (order_of "placeholder-transparent"))
+    "color resolves to the text-colour utilities"
+    (Some (order_of "text-transparent"))
     (order_of_property (Key Color));
   check
     (option (pair int int))


### PR DESCRIPTION
A vendor-prefixed spelling shadowed the real property in four families, and the placeholder colour claimed the slot belonging to the text colours.