### PR TITLE
typography: read every unitless decoration bracket as a colour

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1400,22 +1400,18 @@ module Typography_late = struct
   open Style
   open Css
 
-  (* A bare number is not a CSS length, but Tailwind admits [decoration-[2]] and
-     emits it as a thickness, so it reads as px. *)
-  let parse_bare_number str =
+  (* Tailwind reads the bracket as a colour unless it is a length or a
+     percentage, so a bare number lands on the colour branch whether it is
+     written [2] or [1.5]. *)
+  let is_bare_number str =
     let is_number_char c = (c >= '0' && c <= '9') || c = '.' || c = '-' in
-    if str <> "" && String.for_all is_number_char str then
-      float_of_string_opt str
-    else None
+    str <> ""
+    && String.for_all is_number_char str
+    && float_of_string_opt str <> None
 
   (* An arbitrary decoration thickness is any CSS length. *)
   let parse_decoration_thickness inner : Css.length option =
-    match Parse.arbitrary_length inner with
-    | Some _ as len -> len
-    | None -> (
-        match parse_bare_number inner with
-        | Some n -> Some (Px n)
-        | None -> None)
+    Parse.arbitrary_length inner
 
   (* Tailwind converts a percentage thickness to em: 50% -> .5em. *)
   let parse_decoration_pct inner : Css.length option =
@@ -1697,7 +1693,7 @@ module Typography_late = struct
                 match parse_decoration_pct inner with
                 | Some len -> Ok (Decoration_bracket_pct (inner, len))
                 | None -> err_not_utility
-              else if Result.is_ok (Parse.int_any inner) then
+              else if is_bare_number inner then
                 (* Tailwind resolves the ambiguous unitless spelling through the
                    colour candidate path. Its declaration is invalid CSS and
                    browsers discard it; accepting an inert candidate is

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -712,19 +712,26 @@ let test_decoration_bracket_thickness () =
   rejected "decoration-[.]";
   rejected "decoration-[1e]"
 
-(* Tailwind treats a unitless arbitrary decoration value as a colour candidate.
-   The resulting colour declaration is invalid CSS and has no browser effect; TW
-   must keep the candidate accepted without turning it into a visible pixel
-   thickness. *)
+(* Tailwind treats a unitless arbitrary decoration value as a colour candidate,
+   whether it is written as an integer or with a fractional part. The resulting
+   colour declaration is invalid CSS and has no browser effect; TW must keep the
+   candidate accepted without turning it into a visible pixel thickness. *)
 let test_decoration_bracket_unitless_is_color () =
-  let css =
-    match Tw.of_string "decoration-[2]" with
+  let css cls =
+    match Tw.of_string cls with
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.fail m
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  Alcotest.(check bool)
-    "does not turn the invalid colour into a thickness" false
-    (Astring.String.is_infix ~affix:"text-decoration-thickness" css)
+  let inert cls =
+    Alcotest.(check bool)
+      (cls ^ " does not turn the invalid colour into a thickness")
+      false
+      (Astring.String.is_infix ~affix:"text-decoration-thickness" (css cls))
+  in
+  List.iter inert
+    [
+      "decoration-[0]"; "decoration-[2]"; "decoration-[1.5]"; "decoration-[.5]";
+    ]
 
 (* A shadeless decoration colour takes an opacity modifier the same way every
    other colour family does, and keeps its shadeless class name. *)


### PR DESCRIPTION
`decoration-[1.5]` painted a 1.5px underline where Tailwind writes a colour a browser cannot paint, so tw showed a line that should not be there. The integer case was already inert; this extends it to any bare number.