### PR TITLE
cli: give the Tailwind backend the project entrypoint over files

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -335,7 +335,8 @@ let process_files paths flag ~(opts : gen_opts) =
         in
         let css =
           Tw_tools.Tailwind_gen.generate ~minify:opts.minify
-            ~optimize:opts.optimize ~forms:true all_classes
+            ~optimize:opts.optimize ~forms:true ?input_css:opts.input_css
+            all_classes
         in
         print_string css;
         `Ok ()

--- a/test/cli/options.t
+++ b/test/cli/options.t
@@ -3,3 +3,41 @@ not an implicit preference for one of them:
 
   $ tw -s flex --tailwind --diff 2>&1 | grep -c 'mutually exclusive'
   1
+
+The Tailwind backend generates against the project's own entrypoint, so a
+[--tailwind] run over files reads the same [@theme] the native run does.
+A stub CLI stands in for the real one and echoes the entrypoint it was given:
+
+  $ mkdir -p stub
+  $ cat > stub/tailwindcss <<'EOF'
+  > #!/bin/sh
+  > if [ "$1" = "--version" ]; then echo "tailwindcss v4.3.3"; exit 0; fi
+  > in=input.css
+  > out=output.css
+  > while [ $# -gt 0 ]; do
+  >   case "$1" in
+  >     -i) in=$2; shift 2 ;;
+  >     -o) out=$2; shift 2 ;;
+  >     *) shift ;;
+  >   esac
+  > done
+  > cat "$in" > "$out"
+  > EOF
+  $ chmod +x stub/tailwindcss
+  $ export PATH="$PWD/stub:$PATH"
+
+  $ cat > app.css <<EOF
+  > @import "tailwindcss";
+  > @theme { --text-huge: 9rem; }
+  > EOF
+  $ cat > index.html <<EOF
+  > <div class="text-huge"></div>
+  > EOF
+
+  $ tw --tailwind --input-css app.css index.html | grep -c -- '--text-huge: 9rem;'
+  1
+
+The single-class path already did:
+
+  $ tw --tailwind --input-css app.css -s text-huge | grep -c -- '--text-huge: 9rem;'
+  1


### PR DESCRIPTION
The reference sheet was generated against the default theme, so every project-token class was compared against a Tailwind that had never seen the project's theme. The diff path already passed it.