### PR TITLE
cli: lead with the properties layer a declared utility hoists

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -282,10 +282,19 @@ let native_stylesheet ~(opts : gen_opts) ~include_base all_classes =
     Tw.to_css ~theme:opts.theme ~base:include_base ~extra:routed_extra
       (List.map snd known)
   in
+  (* A declared utility hoists the same [@layer properties] fallback block the
+     generated sheet emits, and that block belongs where the sheet puts its own:
+     ahead of the theme, not after the utilities it initialises. The rest of
+     what it hoists follows the sheet. *)
+  let is_properties_layer stmt =
+    match Css.layer_block_name stmt with
+    | Some name -> Css.Stylesheet.equal_layer_name name [ "properties" ]
+    | None -> false
+  in
   let stylesheet =
-    match routed_stmts with
-    | [] -> stylesheet
-    | extra -> Css.v (Css.statements stylesheet @ extra)
+    match List.partition is_properties_layer routed_stmts with
+    | [], [] -> stylesheet
+    | lead, trail -> Css.v (lead @ Css.statements stylesheet @ trail)
   in
   let stylesheet =
     match opts.input_css_path with

--- a/test/cli/utility.t
+++ b/test/cli/utility.t
@@ -119,3 +119,19 @@ border-style utilities join the real style family after the width family.
   .border-double{--tw-border-style:double;border-style:double}
   .custom-alpha{border-style:groove}
   .custom-zebra{border-style:ridge}
+
+The [@layer properties] fallback block a declared utility brings is the same
+block the generated sheet emits, and it belongs where that one sits: ahead of
+the theme, not after the utilities it initialises.
+
+  $ cat > slot.css <<EOF
+  > @import "tailwindcss";
+  > @utility line-t { @apply border-t }
+  > EOF
+  $ cat > slot.html <<EOF
+  > <div class="line-t"></div>
+  > EOF
+  $ tw --minify --input-css slot.css slot.html | grep -oE '@layer (properties|theme|utilities)\{' | head -3
+  @layer properties{
+  @layer theme{
+  @layer utilities{


### PR DESCRIPTION
The hoisted layer landed after the utilities it initialises, where both Tailwind and tw's own sheet put it first.