### PR TITLE
borders: read a line-width keyword in a width bracket

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -432,13 +432,25 @@ module Handler = struct
       float_of_string_opt str
     else None
 
+  (* The CSS line-width keywords are border widths, not lengths, so
+     [Css.parse_length] never sees them. They are the only idents a width
+     bracket takes: anything else there is a colour or a mistake. *)
+  let line_width_keyword : string -> Css.border_width option = function
+    | "thin" -> Some Thin
+    | "medium" -> Some Medium
+    | "thick" -> Some Thick
+    | _ -> None
+
   let parse_border_width inner : Css.border_width option =
-    match parse_length inner with
-    | Some len -> border_width_of_length len
+    match line_width_keyword inner with
+    | Some _ as w -> w
     | None -> (
-        match parse_bare_number inner with
-        | Some f -> Some (Px f)
-        | None -> None)
+        match parse_length inner with
+        | Some len -> border_width_of_length len
+        | None -> (
+            match parse_bare_number inner with
+            | Some f -> Some (Px f)
+            | None -> None))
 
   let parse_outline_width inner : Css.length option =
     match parse_length inner with
@@ -974,7 +986,11 @@ module Handler = struct
     | [ "border"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' || c = '-' in
-        if String.length inner > 0 && is_numeric_start inner.[0] then
+        let is_width =
+          (String.length inner > 0 && is_numeric_start inner.[0])
+          || line_width_keyword inner <> None
+        in
+        if is_width then
           match parse_border_width inner with
           | Some w -> Ok (Border_width_bracket (inner, w))
           | None -> err_not_utility
@@ -984,7 +1000,11 @@ module Handler = struct
            && Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' in
-        if String.length inner > 0 && is_numeric_start inner.[0] then
+        let is_width =
+          (String.length inner > 0 && is_numeric_start inner.[0])
+          || line_width_keyword inner <> None
+        in
+        if is_width then
           match parse_border_width inner with
           | Some w -> Ok (Border_side_width_bracket (side, inner, w))
           | None -> err_not_utility

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -353,6 +353,25 @@ let test_bracket_width_units () =
   emits "border-width: .5rem" "border-[0.5rem]";
   emits "border-top-width: 3vw" "border-t-[3vw]"
 
+(* The three CSS line-width keywords are border widths in their own right, so a
+   bracket naming one is a width and not an unknown class: Tailwind emits
+   border-width: thin for border-[thin], and the same for medium and thick on
+   every side. *)
+let test_bracket_line_width_keywords () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "border-width: thin" "border-[thin]";
+  emits "border-width: medium" "border-[medium]";
+  emits "border-width: thick" "border-[thick]";
+  emits "border-top-width: thin" "border-t-[thin]";
+  emits "border-left-width: thick" "border-l-[thick]"
+
 (* A bracket whose content is not a length is not an outline or border width:
    the parser rejects it, rather than accepting it and raising from the length
    conversion once the sheet is rendered. *)
@@ -373,6 +392,8 @@ let tests =
   [
     test_case "bracket width units" `Quick test_bracket_width_units;
     test_case "invalid bracket widths" `Quick test_invalid_bracket_widths;
+    test_case "bracket line-width keywords" `Quick
+      test_bracket_line_width_keywords;
     test_case "rounded-sm default radius" `Quick test_rounded_sm_default;
     test_case "rounded-xs default radius" `Quick test_rounded_xs;
     test_case "rounded-4xl default radius" `Quick test_rounded_4xl;


### PR DESCRIPTION
`border-[thin]` and its `medium` and `thick` siblings were rejected as unknown classes, on every side, where Tailwind emits `border-width: thin`. The bracket was gated on a numeric first character, so the three CSS line-width keywords never reached the width reader that `Css.border_width` already models.