### PR TITLE
docs: record where a bracket value lands on a different property

### DIFF
--- a/docs/parity.md
+++ b/docs/parity.md
@@ -183,6 +183,13 @@ Tailwind splices the value into CSS anyway. The docs pages carry literal
 the 45 rules the site comparison reports as added directly under
 `@layer utilities`.
 
+A bracket value neither property can take is placed differently by the two:
+`border-[50%]` is `border-color: 50%` in Tailwind and `border-width: 50%` in tw,
+and `decoration-[2]` is `text-decoration-color: 2` in Tailwind and nothing in
+tw. `Css.color` has no numeric inhabitant, so tw cannot spell the Tailwind form
+without an untyped escape hatch. Browsers drop both declarations either way, so
+the rendered result matches.
+
 Three more differences come from lightningcss on the reference side:
 
 - It rewrites `@supports (backdrop-filter: var(--tw))` to accept the `-webkit-`


### PR DESCRIPTION
`border-[50%]` and `decoration-[2]` are the two brackets Tailwind assigns to a property tw cannot spell: `Css.color` has no numeric inhabitant. Browsers drop both declarations, so this is a diff residual with no rendered effect, and `docs/parity.md` is where the site comparison's tolerated residuals are recorded.