### PR TITLE
columns, divide, typography: read a class-name integer as plain decimal

### DIFF
--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -132,7 +132,7 @@ module Handler = struct
         let len = String.length n in
         if len > 2 && n.[0] = '[' && n.[len - 1] = ']' then
           let inner = String.sub n 1 (len - 2) in
-          match int_of_string_opt inner with
+          match Parse.decimal_int inner with
           | Some i -> Ok (Columns_arbitrary i)
           | None when parse_columns_length inner <> None ->
               Ok (Columns_arbitrary_len inner)

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -480,14 +480,14 @@ module Handler = struct
         match parse_bracket_width value with
         | Some (spelling, w) -> Ok (X_arb (spelling, w))
         | None -> (
-            match int_of_string_opt value with
+            match Parse.decimal_int value with
             | Some n when n >= 0 -> Ok (X n)
             | _ -> Error (`Msg "Not a divide utility")))
     | [ "divide"; "y"; value ] -> (
         match parse_bracket_width value with
         | Some (spelling, w) -> Ok (Y_arb (spelling, w))
         | None -> (
-            match int_of_string_opt value with
+            match Parse.decimal_int value with
             | Some n when n >= 0 -> Ok (Y n)
             | _ -> Error (`Msg "Not a divide utility")))
     | [ "divide"; "transparent" ] -> Ok Transparent

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -640,7 +640,7 @@ module Typography_early = struct
       | Stdlib.Option.Some lh -> Stdlib.Option.Some (Bracket (inner, lh))
       | Stdlib.Option.None -> Stdlib.Option.None
     else
-      match int_of_string_opt s with
+      match Parse.decimal_int s with
       | Stdlib.Option.Some n when n >= 0 -> Stdlib.Option.Some (Spacing n)
       | _ ->
           if
@@ -717,7 +717,7 @@ module Typography_early = struct
           let rest = String.sub inner 7 (String.length inner - 7) in
           Ok (Font_bracket_weight_var (inner, rest))
         else
-          match int_of_string_opt inner with
+          match Parse.decimal_int inner with
           | Some n -> Ok (Font_bracket_weight (inner, n))
           | None ->
               if Parse.is_var inner then
@@ -2006,7 +2006,7 @@ module Typography_late = struct
     | [ "line"; "clamp"; "none" ] -> Ok Line_clamp_none
     | [ "line"; "clamp"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in
-        match int_of_string_opt inner with
+        match Parse.decimal_int inner with
         | Some i -> Ok (Line_clamp_arbitrary i)
         | None -> err_not_utility)
     | [ "line"; "clamp"; n ] ->

--- a/test/test_columns.ml
+++ b/test/test_columns.ml
@@ -28,6 +28,21 @@ let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns";
   Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns-abc"
 
+(* An integer in a class name is written in plain decimal. A hex or
+   underscore-separated spelling is not that integer under another name: reading
+   it renames the class, so [columns-[0x10]] would generate a rule selecting
+   [.columns-\[16\]] that the markup can never match. Tailwind passes the
+   bracket through as [columns: 0x10], which no browser accepts. *)
+let test_non_decimal_integers () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "columns-[0x10]";
+  rejected "columns-[1_0]";
+  rejected "columns-[+3]"
+
 (* columns-[16rem] is a column-WIDTH (columns: 16rem), distinct from the integer
    count form (columns-[3]). *)
 let test_columns_arbitrary_width () =
@@ -89,6 +104,7 @@ let tests =
   @ [
       Alcotest.test_case "columns arbitrary width" `Quick
         test_columns_arbitrary_width;
+      Alcotest.test_case "non-decimal integers" `Quick test_non_decimal_integers;
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "numeric order" `Quick test_numeric_order;
       Alcotest.test_case "arbitrary order" `Quick test_arbitrary_order;

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -144,6 +144,19 @@ let test_invalid_bracket_hex () =
     "divide-[#ff0000] still emits the colour" true
     (Astring.String.is_infix ~affix:"border-color:#f00" (css "divide-[#ff0000]"))
 
+(* The divide width suffix is a plain decimal integer. [divide-x-0x10] was read
+   as 16 and emitted a rule selecting [.divide-x-16], a class the author never
+   wrote; Tailwind emits nothing for it. *)
+let test_non_decimal_widths () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "divide-x-0x10";
+  rejected "divide-y-0x10";
+  rejected "divide-x-1_0"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -158,6 +171,7 @@ let tests =
       Alcotest.test_case "renders like Tailwind" `Slow
         rendering_matches_tailwind;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+      Alcotest.test_case "non-decimal widths" `Quick test_non_decimal_widths;
     ]
 
 let suite = ("divide", tests)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -887,10 +887,26 @@ let test_invalid_decoration_bracket_hex () =
     (Astring.String.is_infix ~affix:"text-decoration-color:#f00"
        (css "decoration-[#ff0000]"))
 
+(* Integers in a class name are plain decimal here too: the leading modifier
+   [text-lg/0x10] was read as /16 and the font-weight bracket [font-[0x10]] as
+   16, so tw painted a weight where Tailwind, which passes [0x10] through for
+   the browser to drop, paints nothing. *)
+let test_non_decimal_integers () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "text-lg/0x10";
+  rejected "font-[0x10]";
+  rejected "line-clamp-[0x10]";
+  rejected "line-clamp-[1_0]"
+
 let tests =
   [
     test_case "invalid decoration bracket hex" `Quick
       test_invalid_decoration_bracket_hex;
+    test_case "non-decimal integers" `Quick test_non_decimal_integers;
     test_case "decoration bracket thickness" `Quick
       test_decoration_bracket_thickness;
     test_case "unitless decoration bracket is a colour" `Quick


### PR DESCRIPTION
`int_of_string_opt` accepted OCaml integer spellings in class names, so `columns-[0x10]` generated a rule selecting `.columns-[16]`, a class no markup carries, and `divide-x-0x10` and `text-lg/0x10` did the same where Tailwind emits nothing at all. `font-[0x10]` was the sharpest: tw painted `font-weight: 16` where Tailwind passes `0x10` through for the browser to drop.

`Parse.decimal_int` is the reader the rest of the parser already uses for this.