### PR TITLE
rule: keep a variant's at-rule when it decorates a media query

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -275,9 +275,10 @@ let indexed_rule_to_statement ?(verbatim = fun _ -> false)
       Css.rule ~selector:r.selector ?merge_key ~nested:filtered_nested
         filtered_props
   | `Starting ->
-      (* Wrap selector+declarations in @starting-style block
-         (Tailwind-compatible format) *)
-      Css.starting_style [ Css.rule ~selector:r.selector filtered_props ]
+      (* As for [`Media]: a variant stacked under [starting:] carries the inner
+         query in [nested] and has no declarations of its own. *)
+      if filtered_nested <> [] then Css.starting_style filtered_nested
+      else Css.starting_style [ Css.rule ~selector:r.selector filtered_props ]
   | `Media condition ->
       (* For compound modifiers (e.g., dark:hover:), nested contains the inner
          media query. Otherwise, just emit a simple rule inside the media. *)
@@ -295,8 +296,10 @@ let indexed_rule_to_statement ?(verbatim = fun _ -> false)
         Css.container ~condition
           [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
   | `Supports condition ->
-      Css.supports ~condition
-        [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
+      if filtered_nested <> [] then Css.supports ~condition filtered_nested
+      else
+        Css.supports ~condition
+          [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
 
 (* Deduplicate typed triples while preserving first occurrence order *)
 let deduplicate_typed_triples triples =
@@ -380,17 +383,18 @@ let rule_to_triple order_map = function
       triple (`Container condition) ~selector ~props
         ~order:(order_of_base order_map base_class selector)
         ~nested ~base_class ~merge_key:None ~not_order:0
-  | Starting_style { selector; props; base_class } ->
+  | Starting_style { selector; props; base_class; nested } ->
       triple `Starting ~selector ~props
         ~order:(order_of_base order_map base_class selector)
-        ~nested:[] ~base_class ~merge_key:None ~not_order:0
+        ~nested ~base_class ~merge_key:None ~not_order:0
   | Supports_query
-      { condition; selector; props; base_class; merge_key; not_order } ->
+      { condition; selector; props; base_class; merge_key; not_order; nested }
+    ->
       let order =
         apply_not_order (order_of_base order_map base_class selector) not_order
       in
-      triple (`Supports condition) ~selector ~props ~order ~nested:[]
-        ~base_class ~merge_key ~not_order
+      triple (`Supports condition) ~selector ~props ~order ~nested ~base_class
+        ~merge_key ~not_order
 
 (* Add index to each triple for stable sorting *)
 let add_index triples =
@@ -485,9 +489,16 @@ let statements_of_sorted_rules ?verbatim sorted_rules =
     | (r : Sort.indexed_rule) :: rest when is_starting r ->
         let run, rest = take_run [ r ] rest in
         let inner =
-          List.map
+          List.concat_map
             (fun (x : Sort.indexed_rule) ->
-              Css.rule ~selector:x.selector (filter_utility_properties x.props))
+              (* A variant stacked under [starting:] carries its query in
+                 [nested] and has no declarations of its own. *)
+              if x.nested <> [] then filter_theme_from_statements x.nested
+              else
+                [
+                  Css.rule ~selector:x.selector
+                    (filter_utility_properties x.props);
+                ])
             run
         in
         go (Css.starting_style inner :: acc) rest

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -32,6 +32,7 @@ type t =
       selector : Css.Selector.t;
       props : Css.declaration list;
       base_class : string option;
+      nested : Css.statement list;
     }
   | Supports_query of {
       condition : Css.Supports.t;
@@ -40,6 +41,7 @@ type t =
       base_class : string option;
       merge_key : string option;
       not_order : int;
+      nested : Css.statement list;
     }
 
 type by_type = {
@@ -62,13 +64,21 @@ let media_query ~condition ~selector ~props ?base_class ?(nested = [])
 let container_query ~condition ~selector ~props ?base_class ?(nested = []) () =
   Container_query { condition; selector; props; base_class; nested }
 
-let starting_style ~selector ~props ?base_class () =
-  Starting_style { selector; props; base_class }
+let starting_style ~selector ~props ?base_class ?(nested = []) () =
+  Starting_style { selector; props; base_class; nested }
 
 let supports_query ~condition ~selector ~props ?base_class ?merge_key
-    ?(not_order = 0) () =
+    ?(not_order = 0) ?(nested = []) () =
   Supports_query
-    { condition; selector; props; base_class; merge_key; not_order }
+    { condition; selector; props; base_class; merge_key; not_order; nested }
+
+let base_class = function
+  | Regular { base_class; _ }
+  | Media_query { base_class; _ }
+  | Container_query { base_class; _ }
+  | Starting_style { base_class; _ }
+  | Supports_query { base_class; _ } ->
+      base_class
 
 let pp = function
   | Regular { selector; _ } ->

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -50,6 +50,7 @@ type t =
       selector : Css.Selector.t;
       props : Css.declaration list;
       base_class : string option;
+      nested : Css.statement list;
     }
   | Supports_query of {
       condition : Css.Supports.t;
@@ -58,6 +59,7 @@ type t =
       base_class : string option;
       merge_key : string option;
       not_order : int;
+      nested : Css.statement list;
     }
 
 (** {1 Smart constructors}
@@ -105,6 +107,7 @@ val starting_style :
   selector:Css.Selector.t ->
   props:Css.declaration list ->
   ?base_class:string ->
+  ?nested:Css.statement list ->
   unit ->
   t
 (** [starting_style ~selector ~props ()] constructs a
@@ -117,10 +120,14 @@ val supports_query :
   ?base_class:string ->
   ?merge_key:string ->
   ?not_order:int ->
+  ?nested:Css.statement list ->
   unit ->
   t
 (** [supports_query ~condition ~selector ~props ()] constructs a
     {!constructor-Supports_query} rule wrapped in [@supports condition]. *)
+
+val base_class : t -> string option
+(** [base_class rule] is the class name [rule] was built for, if it has one. *)
 
 val pp : t -> string
 (** [pp r] returns a short human-readable description of [r], e.g.

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2003,6 +2003,30 @@ let rebase_on_selector ~base_class ~selector rules =
           | rule -> rule)
         rules
 
+(* Variants whose whole effect is an at-rule around the utility, rather than a
+   change to its selector. Applied to a rule that is already a query, they have
+   to keep that at-rule and nest the inner query inside it; the selector-rewrite
+   arms cannot express them. *)
+let wraps_in_at_rule = function
+  | Style.Supports _ | Style.Starting | Style.Container _
+  | Style.Not (Style.Supports _) ->
+      true
+  | _ -> false
+
+(* Put [inner] inside the at-rule the variant just built. The wrapper is built
+   from an empty rule, so its own body is empty and [inner] is all it
+   carries. *)
+let nest_inside_at_rule inner = function
+  | Output.Supports_query ({ nested; _ } as r) ->
+      Output.Supports_query { r with nested = inner :: nested }
+  | Output.Starting_style ({ nested; _ } as r) ->
+      Output.Starting_style { r with nested = inner :: nested }
+  | Output.Container_query ({ nested; _ } as r) ->
+      Output.Container_query { r with nested = inner :: nested }
+  | Output.Media_query ({ nested; _ } as r) ->
+      Output.Media_query { r with nested = inner :: nested }
+  | other -> other
+
 (* Extract selector and properties from a single Utility *)
 (* Apply modifier to extracted rule *)
 let rec apply_modifier_to_rule ?theme modifier = function
@@ -2056,6 +2080,32 @@ let rec apply_modifier_to_rule ?theme modifier = function
                 bc selector props;
             ]
           with Invalid_argument _ -> []))
+  | Media_query
+      { condition = inner_condition; selector; props; base_class; nested; _ }
+    when wraps_in_at_rule modifier ->
+      let bc = Option.value base_class ~default:"" in
+      let wrappers =
+        apply_modifier_to_rule ?theme modifier
+          (regular ~selector:(Css.Selector.Class bc) ~props:[] ~base_class:bc ())
+      in
+      let nest wrapper =
+        let modified_class =
+          match Output.base_class wrapper with Some c -> c | None -> bc
+        in
+        let rename =
+          rename_class_in_stmt ~old_class:bc ~new_class:modified_class
+        in
+        let inner_selector =
+          Rules_selector.replace_class_in_selector ~old_class:bc
+            ~new_class:modified_class selector
+        in
+        let inner_media =
+          Css.media ~condition:inner_condition
+            (Css.rule ~selector:inner_selector props :: List.map rename nested)
+        in
+        nest_inside_at_rule inner_media wrapper
+      in
+      List.map nest wrappers
   | Media_query
       { condition = inner_condition; selector; props; base_class; nested; _ } ->
       apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -962,6 +962,39 @@ let test_supports_property_is_unprefixed () =
   unprefixed "supports-text-size-adjust:flex";
   unprefixed "supports-backdrop-filter:flex"
 
+(* A variant that wraps the utility in an at-rule keeps that at-rule when the
+   variant it decorates already produced a media query. [supports-grid:sm:flex]
+   used to render as [.sm\:flex] inside the breakpoint alone: the feature query
+   and the [supports-grid] half of the class name both disappeared, so the rule
+   applied unconditionally and matched a class the author never wrote. Tailwind
+   nests the two in the order the class spells them. *)
+let test_at_rule_variant_over_media () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls affixes =
+    let out = css cls in
+    List.iter
+      (fun affix ->
+        check bool
+          (cls ^ " emits " ^ affix)
+          true
+          (Astring.String.is_infix ~affix out))
+      affixes
+  in
+  emits "supports-grid:sm:flex"
+    [
+      "@supports (grid: var(--tw))";
+      "min-width: 40rem";
+      ".supports-grid\\:sm\\:flex";
+    ];
+  emits "not-supports-grid:sm:flex"
+    [ "@supports not (grid: var(--tw))"; "min-width: 40rem" ];
+  emits "starting:sm:flex" [ "@starting-style"; "min-width: 40rem" ];
+  emits "@md:sm:flex" [ "@container"; "min-width: 40rem" ]
+
 (* Extend the suite with new tests *)
 let tests =
   tests
@@ -971,6 +1004,8 @@ let tests =
       test_case "valid bracket modifiers" `Quick test_valid_bracket_modifiers;
       test_case "supports property is unprefixed" `Quick
         test_supports_property_is_unprefixed;
+      test_case "at-rule variant over a media query" `Quick
+        test_at_rule_variant_over_media;
       test_case "empty attribute brackets" `Quick test_empty_attribute_brackets;
       test_case "padded attribute brackets" `Quick
         test_padded_attribute_brackets;


### PR DESCRIPTION
`supports-grid:sm:flex` rendered as `.sm\:flex` inside the breakpoint alone: the feature query and the `supports-grid` half of the class name both disappeared, so the rule applied unconditionally and selected a class the author never wrote. `not-supports-*`, `starting:` and the container variants lost their at-rule the same way, because all four fell through to the arm that only rewrites a selector.

Each now nests the inner query inside its own at-rule, in the order the class spells them, which is what Tailwind emits. `Supports_query` and `Starting_style` gained the `nested` field `Media_query` and `Container_query` already had.