### PR TITLE
effects: accept shadows the project named in its theme

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -58,6 +58,8 @@ module Handler = struct
     | Shadow_2xl
     | Shadow_inner
     | Shadow_arbitrary of string
+    | Shadow_theme of string (* shadow from a --shadow-* token *)
+    | Inset_shadow_theme of string (* shadow from an --inset-shadow-* token *)
     | Shadow_arbitrary_opacity of string * Color.opacity_modifier
     | Shadow_shape_opacity of shadow_shape * Color.opacity_modifier
     (* Shadows — color utilities *)
@@ -602,6 +604,29 @@ module Handler = struct
               [ d_shadow; box_shadow_composition v_shadow ]
         | None -> shadow_none)
 
+  let is_theme_shadow theme n =
+    Scheme.theme_value (Some theme) ("shadow-" ^ n) <> None
+
+  let is_theme_inset_shadow theme n =
+    Scheme.theme_value (Some theme) ("inset-shadow-" ^ n) <> None
+
+  (* A shadow the project named in its [@theme]. Tailwind inlines the token's
+     value rather than referencing it, routing the colour through the family's
+     shadow-colour channel exactly as an arbitrary shadow does. *)
+  let shadow_theme theme name =
+    match Scheme.theme_value (Some theme) ("shadow-" ^ name) with
+    | None -> style []
+    | Some raw -> (
+        match Css.parse_shadow raw with
+        | None -> style []
+        | Some shadow ->
+            let shadow_value =
+              wrap_shadow_colors ~color_var:shadow_color_var shadow
+            in
+            let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
+            style ~property_rules:shadow_property_rules
+              [ d_shadow; box_shadow_composition v_shadow ])
+
   let shadow_arbitrary_opacity (arb : string) opacity =
     match parse_arbitrary_shadow arb with
     | Some { h_offset; v_offset; blur; spread; color } -> (
@@ -910,6 +935,16 @@ module Handler = struct
     in
     style ~property_rules:shadow_property_rules
       [ d_inset_shadow; Css.box_shadows box_shadow_vars ]
+
+  let inset_shadow_theme theme name =
+    match Scheme.theme_value (Some theme) ("inset-shadow-" ^ name) with
+    | None -> style []
+    | Some raw -> (
+        match Css.parse_shadow raw with
+        | None -> style []
+        | Some shadow ->
+            inset_shadow_compose
+              (wrap_shadow_colors ~color_var:inset_shadow_color_var shadow))
 
   (* v4.3.1 default inset-shadow scale (verified against the bare CLI). The
      named utilities are inset-shadow-{2xs,xs,sm}; each is a single inset
@@ -2194,6 +2229,8 @@ module Handler = struct
     | Shadow_2xl -> shadow_2xl
     | Shadow_inner -> shadow_inner
     | Shadow_arbitrary arb -> shadow_arbitrary arb
+    | Shadow_theme name -> shadow_theme theme name
+    | Inset_shadow_theme name -> inset_shadow_theme theme name
     | Shadow_arbitrary_opacity (arb, op) -> shadow_arbitrary_opacity arb op
     | Shadow_shape_opacity (shape, op) -> shadow_shape_opacity_style shape op
     | Shadow_color (c, s) -> set_shadow_color c s
@@ -2659,6 +2696,8 @@ module Handler = struct
         | Ok (c, s, opacity) -> Ok (Shadow_color_opacity (c, s, opacity))
         | Error _ -> err_not_utility)
     (* A shadeless colour has no shade segment: shadow-white, shadow-black. *)
+    | [ "shadow"; name ] when is_theme_shadow theme name ->
+        Ok (Shadow_theme name)
     | [ "shadow"; color ] -> (
         match Color.shade_of_strings [ color ] with
         | Ok (c, s) -> Ok (Shadow_color (c, s))
@@ -2674,6 +2713,8 @@ module Handler = struct
       when Scheme.theme_value (Some theme) "inset-shadow" <> None ->
         Ok Inset_shadow
     | [ "inset"; "shadow" ] -> err_not_utility
+    | [ "inset"; "shadow"; name ] when is_theme_inset_shadow theme name ->
+        Ok (Inset_shadow_theme name)
     | [ "inset"; "shadow"; "inherit" ] -> Ok Inset_shadow_inherit
     | [ "inset"; "shadow"; "transparent" ] -> Ok Inset_shadow_transparent
     | [ "inset"; "shadow"; current_str ]
@@ -2909,6 +2950,8 @@ module Handler = struct
     | Shadow_2xl -> "shadow-2xl"
     | Shadow_inner -> "shadow-inner"
     | Shadow_arbitrary arb -> "shadow-[" ^ arb ^ "]"
+    | Shadow_theme name -> "shadow-" ^ name
+    | Inset_shadow_theme name -> "inset-shadow-" ^ name
     | Shadow_arbitrary_opacity (arb, op) ->
         "shadow-[" ^ arb ^ "]/" ^ Color.pp_opacity op
     | Shadow_shape_opacity (shape, op) ->
@@ -3122,7 +3165,7 @@ module Handler = struct
        within-group order: bracket values ([) sort before named (none/sm/xl) *)
     | Shadow | Shadow_2xs | Shadow_xs | Shadow_2xl | Shadow_inner | Shadow_lg
     | Shadow_md | Shadow_none | Shadow_sm | Shadow_xl | Shadow_arbitrary _
-    | Shadow_bracket_shadow _ | Shadow_bracket_var _ ->
+    | Shadow_bracket_shadow _ | Shadow_bracket_var _ | Shadow_theme _ ->
         30000
     (* Shadow color utilities *)
     | Shadow_color _ | Shadow_color_opacity _ | Shadow_current
@@ -3152,7 +3195,7 @@ module Handler = struct
        decides *)
     | Inset_shadow | Inset_shadow_2xs | Inset_shadow_xs | Inset_shadow_none
     | Inset_shadow_sm | Inset_shadow_arbitrary _ | Inset_shadow_bracket_shadow _
-    | Inset_shadow_bracket_var _ ->
+    | Inset_shadow_bracket_var _ | Inset_shadow_theme _ ->
         31000
     (* Inset shadow color utilities *)
     | Inset_shadow_color _ | Inset_shadow_color_opacity _ | Inset_shadow_current

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -459,9 +459,37 @@ let test_arbitrary_opacity_rejects_non_number () =
       | Error (`Msg _) -> ())
     [ "opacity-[abc]"; "opacity-[]" ]
 
+(* A [--shadow-*] or [--inset-shadow-*] token the project declared in its
+   [@theme] names a shadow the built-in scale has no slot for. Tailwind
+   generates the utility from each, routing the colour through the family's
+   shadow-colour channel; tw rejected both outright. *)
+let test_project_shadow_tokens () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [
+        ("shadow-halo", "0 0 8px #f00");
+        ("inset-shadow-dent", "inset 0 1px 2px #000");
+      ]
+  in
+  let css cls =
+    match Tw.of_string ~theme cls with
+    | Ok u -> Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "--tw-shadow: 0 0 8px var(--tw-shadow-color, #f00)" "shadow-halo";
+  emits "--tw-inset-shadow: inset 0 1px 2px var(--tw-inset-shadow-color, #000)"
+    "inset-shadow-dent";
+  Alcotest.(check bool)
+    "an undeclared shadow name is rejected" true
+    (Result.is_error (Tw.of_string ~theme "shadow-nope"))
+
 let tests =
   [
     test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+    test_case "project shadow tokens" `Quick test_project_shadow_tokens;
     test_case "undefined colour shade" `Quick test_undefined_shade;
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;


### PR DESCRIPTION
A `--shadow-*` or `--inset-shadow-*` token was rejected outright, so a project shadow emitted nothing while Tailwind generated the utility, routing the colour through the family's shadow-colour channel.

This closes the sixteen `@theme` namespaces: every one now generates its utility.