### PR TITLE
grid_template, modifiers: read an arbitrary length through one reader

### DIFF
--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -189,7 +189,7 @@ module Handler = struct
             (* A math-function track (min()/max()/clamp()/calc()), a var() or
                the [--spacing()] shorthand: all lengths the suffix-based parse
                above does not recognise. *)
-            match Css.parse_length (Parse.decode_arbitrary_value value) with
+            match Parse.arbitrary_length value with
             | Some l -> Some (Length l)
             | None -> None)
 

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1043,11 +1043,10 @@ let extract_bracket_content_with_name ~prefix s =
     | _ -> None
   else None
 
-(* Parse a CSS length from a string like "600px", "40rem", "100vh" *)
-let parse_css_length s : Css.length option =
-  (* Decode arbitrary-value syntax first so [min-[calc(1000px+12em)]] becomes a
-     spec-valid [calc(1000px + 12em)] the length reader accepts. *)
-  Css.parse_length (Parse.decode_arbitrary_value s)
+(* Parse a CSS length from a string like "600px", "40rem", "100vh". Arbitrary
+   value syntax is decoded first, so [min-[calc(1000px+12em)]] becomes a
+   spec-valid [calc(1000px + 12em)] the length reader accepts. *)
+let parse_css_length s : Css.length option = Parse.arbitrary_length s
 
 (* Parse a pixel value from a string like "600px" or "600", keeping the
    spelling: it is what the variant's own class is named after. *)


### PR DESCRIPTION
Both sites spelled out `Css.parse_length (Parse.decode_arbitrary_value ...)`, which is what `Parse.arbitrary_length` is. Output is unchanged; the point is that a future change to how an arbitrary length reads lands in one place.