### PR TITLE
color, utility: drop a dead error path and name the right function

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1342,22 +1342,26 @@ let utilities_order color_name =
 (* Helper function to extract color order with shade for utilities like
    bg-blue-500, text-red-400, etc. *)
 let suborder_with_shade color_part =
-  try
-    let last_dash = String.rindex color_part '-' in
-    let color_name = String.sub color_part 0 last_dash in
-    let shade_str =
-      String.sub color_part (last_dash + 1)
-        (String.length color_part - last_dash - 1)
-    in
-    let shade = int_of_string shade_str in
-    let _, color_order = utilities_order color_name in
-    (color_order * 1000) + shade
-  with Not_found | Failure _ -> (
-    (* Non-numeric or single-color names like "black", "white" *)
-    try
-      let _, color_order = utilities_order color_part in
-      color_order * 1000
-    with Not_found | Failure _ -> failwith ("Unknown color: " ^ color_part))
+  (* A shadeless name like [black] or [white] has no trailing [-<digits>], and
+     [utilities_order] answers for any name, so there is nothing here that can
+     fail. *)
+  let shadeless () =
+    let _, color_order = utilities_order color_part in
+    color_order * 1000
+  in
+  match String.rindex_opt color_part '-' with
+  | None -> shadeless ()
+  | Some last_dash -> (
+      let color_name = String.sub color_part 0 last_dash in
+      let shade_str =
+        String.sub color_part (last_dash + 1)
+          (String.length color_part - last_dash - 1)
+      in
+      match int_of_string_opt shade_str with
+      | None -> shadeless ()
+      | Some shade ->
+          let _, color_order = utilities_order color_name in
+          (color_order * 1000) + shade)
 
 (* Get theme layer order for a color variable with shade. Formula: (priority=2,
    base_order * 1000 + shade) This ensures color variables are grouped by color

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -188,7 +188,7 @@ let class_of_base u =
   in
   match List.find_map visit !handlers with
   | Some class_name -> class_name
-  | None -> failwith "name_of_base"
+  | None -> failwith "class_of_base"
 
 let base_of_class theme class_name =
   let rec try_handlers = function


### PR DESCRIPTION
`suborder_with_shade` guarded a total function: everything inside its inner `try` is `utilities_order`, which is `List.assoc_opt` with a default and cannot raise, so the `Unknown color` failure was unreachable. It now reads the shade with `String.rindex_opt` and `int_of_string_opt` instead of using exceptions for control flow.

`class_of_base` failed with the message `name_of_base`, copied from the function above it, so two different failures reported the same name.