### PR TITLE
build, rule: stop rebuilding work the caller already has

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1312,8 +1312,10 @@ let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
   layers_without_property @ property_rules_css @ keyframes_css
 
 (* Extract variables, set var names, and property rules from all utilities *)
-let extract_vars_and_rules theme utilities =
-  let styles = List.map (Utility.to_style theme) utilities in
+(* Takes the already-built styles rather than the utilities: [layers] has just
+   built the same tree, and [Utility.to_style] dispatches through every
+   registered handler and allocates the whole declaration tree per class. *)
+let extract_vars_and_rules styles =
   let results = List.map extract_style_vars_and_rules styles in
   let vars_list, set_names_list, prop_rules_list =
     List.fold_right
@@ -1441,7 +1443,7 @@ let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
     tw_classes statements =
   let styles = List.map (Utility.to_style theme) tw_classes in
   let vars_from_utilities, set_var_names, property_rules_lists =
-    extract_vars_and_rules theme tw_classes
+    extract_vars_and_rules styles
   in
   (* Build first-usage order from ALL vars per utility in utility order. For
      each utility, collects SET vars then REFERENCED vars needing @property.

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2211,9 +2211,12 @@ let handle_group class_name util_inner styles extract_fn =
       List.map2 extract_item styles util_items |> List.concat
   | _ -> List.concat_map (extract_fn class_name util_inner) styles
 
-(** Replace placeholder selector "_" with the actual utility class selector *)
+(** Replace placeholder selector "_" with the actual utility class selector.
+    Matches the node rather than rendering the selector to compare it: this runs
+    per rule for every utility carrying an explicit [rule_list] (prose, forms,
+    gradients). *)
 let resolve_placeholder_selector sel selector =
-  if Css.Selector.to_string selector = "._" then sel else selector
+  match selector with Css.Selector.Class "_" -> sel | _ -> selector
 
 let extract_rule_outputs build_output statements =
   statements


### PR DESCRIPTION
`Build.layers` mapped `Utility.to_style` over the classes and then `extract_vars_and_rules` mapped it over the same list again, so every class was compiled twice per render; it now takes the styles the caller already built. `resolve_placeholder_selector` rendered a full selector to a string to compare it against `._` at three call sites, and matches the node instead.

Output is unchanged.