### PR TITLE
var, test: report what actually went wrong

### DIFF
--- a/lib/var.ml
+++ b/lib/var.ml
@@ -556,7 +556,11 @@ let property_info_to_declaration_value (Css.Property_info info) =
                   match v with
                   | Zero -> "0"
                   | _ -> Css.Pp.to_string (pp_length ~always:true) v)
-              | Number -> Pp.float v ^ "%"
+              (* A [<number>] initial value is a number: appending [%] made it a
+                 percentage, which is a different type. Unreachable today
+                 because [property_typed] emits no Number syntax, so this is the
+                 arm a new one would land on. *)
+              | Number -> Pp.float v
               | syntax -> Css.Pp.to_string (pp_value syntax) v)))
 
 let name var = var.name

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -579,7 +579,13 @@ let spacing_values =
 let test_rng =
   let seed =
     match Sys.getenv_opt "TEST_SEED" with
-    | Some s -> int_of_string s
+    | Some s -> (
+        match int_of_string_opt s with
+        | Some n -> n
+        | None ->
+            (* Raising here aborts the whole suite at module initialisation with
+               a message that never mentions the variable. *)
+            Fmt.failwith "TEST_SEED is not an integer: %S" s)
     | None ->
         Random.self_init ();
         Random.bits ()


### PR DESCRIPTION
A registered `<number>` initial value was serialised with a `%` appended, turning it into a percentage. No syntax reaches that arm today, so nothing in the emitted CSS moves; it is the arm a new one would land on.

A malformed `TEST_SEED` aborted the whole suite at module initialisation with `Failure "int_of_string"`, which never mentioned the variable.