### PR TITLE
rule, build, source_scan: stop recomputing what the caller has

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -406,7 +406,7 @@ let add_index triples =
       let selector_str = Buffer.contents buf in
       let media_key, nested_media_key = Sort.media_sort_keys typ nested in
       let responsive_media_key = Sort.responsive_media_key typ nested in
-      let variant_order = Rule.compute_variant_order base_class sel in
+      let variant_order = Rule.compute_variant_order ~selector_str base_class in
       ({
          index = i;
          rule_type = typ;

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1036,8 +1036,10 @@ let has_substring s pat =
 (** Compute variant_order from base_class and selector. A stacked candidate is
     placed by its highest-order modifier, matching the descending key list used
     by the comparator. For before/after, the base_class is the raw utility name
-    without prefix, so we detect them from the selector content. *)
-let compute_variant_order base_class selector =
+    without prefix, so we detect them from the selector content. [selector_str]
+    is the caller's already-rendered selector: [Build.add_index] renders it two
+    lines before calling this. *)
+let compute_variant_order ~selector_str base_class =
   let from_base_class bc =
     let modifiers, _ = Modifiers.of_string bc in
     List.fold_left
@@ -1052,11 +1054,9 @@ let compute_variant_order base_class selector =
      to avoid matching utility-generated pseudo-elements like prose's
      ::before. *)
   if vo > 0 then vo
-  else
-    let sel_str = Css.Selector.to_string selector in
-    if has_substring sel_str "before\\:" then 1600
-    else if has_substring sel_str "after\\:" then 1601
-    else 0
+  else if has_substring selector_str "before\\:" then 1600
+  else if has_substring selector_str "after\\:" then 1601
+  else 0
 
 (** Build the class name prefix for a not-* inner modifier. Handles shorthand
     forms like data-foo, has-checked, nth-2 that need different class names than

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -41,10 +41,11 @@ val outputs :
     Lower-level entry point used when constructing rules from an already-parsed
     modifier/selector/props triple. Prefer {!outputs} for normal use. *)
 
-val compute_variant_order : string option -> Css.Selector.t -> int
-(** [compute_variant_order base_class selector] computes the sort key for
+val compute_variant_order : selector_str:string -> string option -> int
+(** [compute_variant_order ~selector_str base_class] computes the sort key for
     modifier-prefixed rules. Returns 0 for plain rules; non-zero for rules
-    carrying a [not-*] or variant prefix. Used internally by {!Build}. *)
+    carrying a [not-*] or variant prefix. [selector_str] is the rendered
+    selector, which the caller already has. Used internally by {!Build}. *)
 
 val modifier_to_rule :
   ?inner_has_hover:bool ->

--- a/lib/tools/source_scan.ml
+++ b/lib/tools/source_scan.ml
@@ -22,20 +22,38 @@ let split_whitespace s =
 
 type decoded = { starts : int array; chars : int array }
 
+(* Grow the two arrays directly. Folding the file into lists first costs about
+   twelve words per character and keeps both lists live until the arrays are
+   built, and a source file is kilobytes. A byte can decode to at most one
+   character, so the source length is a safe initial capacity. *)
 let decoded_utf_8 source =
-  let chars_rev, starts_rev =
-    Uutf.String.fold_utf_8
-      (fun (chars, starts) byte_pos decoded ->
-        let code =
-          match decoded with `Uchar u -> Uchar.to_int u | `Malformed _ -> -1
-        in
-        (code :: chars, byte_pos :: starts))
-      ([], []) source
+  let cap = max 16 (String.length source) in
+  let starts = ref (Array.make (cap + 1) 0) in
+  let chars = ref (Array.make cap 0) in
+  let n = ref 0 in
+  let push start code =
+    if !n >= Array.length !chars then begin
+      let bigger = Array.make (2 * Array.length !chars) 0 in
+      Array.blit !chars 0 bigger 0 !n;
+      chars := bigger;
+      let bigger_starts = Array.make ((2 * Array.length !chars) + 1) 0 in
+      Array.blit !starts 0 bigger_starts 0 !n;
+      starts := bigger_starts
+    end;
+    !starts.(!n) <- start;
+    !chars.(!n) <- code;
+    incr n
   in
-  {
-    starts = Array.of_list (List.rev (String.length source :: starts_rev));
-    chars = Array.of_list (List.rev chars_rev);
-  }
+  Uutf.String.fold_utf_8
+    (fun () byte_pos decoded ->
+      match decoded with
+      | `Uchar u -> push byte_pos (Uchar.to_int u)
+      | `Malformed _ -> push byte_pos (-1))
+    () source;
+  (* [byte_at d stop] is read at [stop = length], so [starts] carries one more
+     entry than [chars]. *)
+  !starts.(!n) <- String.length source;
+  { starts = Array.sub !starts 0 (!n + 1); chars = Array.sub !chars 0 !n }
 
 let char_at d i = d.chars.(i)
 let byte_at d i = d.starts.(i)


### PR DESCRIPTION
`compute_variant_order` re-serialised a selector that `Build.add_index` had rendered two lines earlier, and scanned it with a `String.sub`-per-index search; it now takes the rendered string. `decoded_utf_8` folded a whole source file into two int lists before converting them to arrays, about twelve words per character with both lists live until the end, and now grows the arrays directly.

Output is unchanged; the cram CLI tests cover the scanner on multibyte input.