### PR TITLE
rule, parse: drop an unbounded cache and respect quotes

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -226,7 +226,11 @@ let normalize_css_math_operators s =
   Buffer.contents buf
 
 (* Tailwind's [--spacing(N)] shorthand: the spacing scale as a function. It is
-   not CSS, so a value holding it fails to parse and the utility drops out. *)
+   not CSS, so a value holding it fails to parse and the utility drops out. The
+   scan skips over quoted CSS strings ['...'] and ["..."] verbatim (with their
+   backslash escapes), so the same bytes inside a string literal - e.g. an
+   arbitrary [content:'--spacing(1)'] - are left as literal text rather than
+   expanded. *)
 let expand_spacing_fn s =
   let len = String.length s in
   let buf = Buffer.create len in
@@ -241,18 +245,39 @@ let expand_spacing_fn s =
   in
   let rec go i =
     if i >= len then ()
-    else if i + 10 <= len && String.sub s i 10 = "--spacing(" then (
-      let stop, next = close_paren (i + 9) 0 in
-      let n = String.sub s (i + 10) (stop - i - 10) in
-      (* [--spacing(1)] is the scale itself; only a multiplier needs calc. *)
-      if String.trim n = "1" then Buffer.add_string buf "var(--spacing)"
-      else
-        Buffer.add_string buf
-          (String.concat "" [ "calc(var(--spacing) * "; n; ")" ]);
-      go next)
-    else (
-      Buffer.add_char buf s.[i];
-      go (i + 1))
+    else
+      match s.[i] with
+      | ('\'' | '"') as quote ->
+          Buffer.add_char buf quote;
+          in_string quote (i + 1)
+      | _ ->
+          if i + 10 <= len && String.sub s i 10 = "--spacing(" then (
+            let stop, next = close_paren (i + 9) 0 in
+            let n = String.sub s (i + 10) (stop - i - 10) in
+            (* [--spacing(1)] is the scale itself; only a multiplier needs
+               calc. *)
+            if String.trim n = "1" then Buffer.add_string buf "var(--spacing)"
+            else
+              Buffer.add_string buf
+                (String.concat "" [ "calc(var(--spacing) * "; n; ")" ]);
+            go next)
+          else (
+            Buffer.add_char buf s.[i];
+            go (i + 1))
+  and in_string quote i =
+    if i >= len then ()
+    else
+      match s.[i] with
+      | '\\' when i + 1 < len ->
+          Buffer.add_char buf s.[i];
+          Buffer.add_char buf s.[i + 1];
+          in_string quote (i + 2)
+      | c when c = quote ->
+          Buffer.add_char buf c;
+          go (i + 1)
+      | c ->
+          Buffer.add_char buf c;
+          in_string quote (i + 1)
   in
   go 0;
   Buffer.contents buf

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -17,27 +17,15 @@ let string_of_breakpoint = function
   | `Xl -> "xl"
   | `Xl_2 -> "2xl"
 
-(* Small memoization for escaping, as many utilities reuse the same base class
-   names across modifiers. *)
-let escape_cache : (string, string) Hashtbl.t = Hashtbl.create 256
-
+(* Delegate escaping to the selector printer for correctness and parity with the
+   rest of the system. This covers all special characters per CSS rules,
+   including ones Tailwind often uses (e.g., !, |, ^, ~, etc.) We strip the
+   leading '.' from the rendered class selector. *)
 let escape_class_name name =
-  match Hashtbl.find_opt escape_cache name with
-  | Some v -> v
-  | None ->
-      (* Delegate escaping to the selector printer for correctness and parity
-         with the rest of the system. This covers all special characters per CSS
-         rules, including ones Tailwind often uses (e.g., !, |, ^, ~, etc.) We
-         strip the leading '.' from the rendered class selector. *)
-      let sel = Css.Selector.class_ name in
-      let rendered = Css.Selector.to_string sel in
-      let escaped =
-        if String.length rendered > 0 && rendered.[0] = '.' then
-          String.sub rendered 1 (String.length rendered - 1)
-        else rendered
-      in
-      Hashtbl.add escape_cache name escaped;
-      escaped
+  let rendered = Css.Selector.to_string (Css.Selector.class_ name) in
+  if String.length rendered > 0 && rendered.[0] = '.' then
+    String.sub rendered 1 (String.length rendered - 1)
+  else rendered
 
 (* ======================================================================== *)
 (* Rule Extraction - Convert Core.t to CSS rules *)

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -141,6 +141,24 @@ let test_double_bracket_class_rejected () =
   accepted "text-[10px]/[1.5]";
   accepted "bg-red-500/[0.5]"
 
+(* [--spacing(N)] is Tailwind's spacing-scale shorthand, expanded outside any
+   quoting. The same bytes inside a quoted string are a CSS string literal, not
+   the function, so [expand_spacing_fn] must leave them alone. *)
+let test_spacing_shorthand_ignored_in_quotes () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "single-quoted content keeps the literal text" true
+    (Astring.String.is_infix ~affix:{|content: '--spacing(1)'|}
+       (css {|[content:'--spacing(1)']|}));
+  Alcotest.(check bool)
+    "double-quoted content keeps the literal text" true
+    (Astring.String.is_infix ~affix:{|content: "--spacing(1)"|}
+       (css {|[content:"--spacing(1)"]|}))
+
 let tests =
   Alcotest.
     [
@@ -160,6 +178,8 @@ let tests =
         test_redundant_zero_spellings_are_rejected;
       test_case "parsing is independent of parse history" `Quick
         test_parse_is_independent_of_history;
+      test_case "--spacing() shorthand ignored inside quotes" `Quick
+        test_spacing_shorthand_ignored_in_quotes;
     ]
 
 let suite = ("parse", tests)


### PR DESCRIPTION
`escape_class_name` memoised into a process-global Hashtbl keyed on class names, and class names carry arbitrary bracket values, so a long-lived process grew it without bound. Interleaved measurement put the cache within noise of no cache (5.4-6.3ms per run either way over 810 utilities), so it goes.

`expand_spacing_fn` scanned for the literal `--spacing(` with no awareness of quotes, so `[content:'--spacing(1)']` expanded the shorthand inside a quoted string where Tailwind leaves it alone.