### PR TITLE
color: collapse the bracket colour-hint dispatch onto one reader

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2038,6 +2038,25 @@ module Handler = struct
                 | Ok c -> Some (to_css c 500)
                 | Error _ -> None))
 
+  (* What a bracket value names, once the [color:]/[var(] spellings are told
+     apart from a plain colour. Every colour-bearing utility (text, outline,
+     ring, shadow, fill, stroke, ...) reads the same bracket this way; only the
+     variant it stores the result in differs. *)
+  type bracket_hint =
+    | Typed_var of string (* [color:<var-or-value>], var part only *)
+    | Bare_var of string (* [var(--x)], the full "var(...)" text *)
+    | Plain_color of Css.color (* any other colour spelling *)
+
+  let parse_bracket_hint inner =
+    if String.starts_with ~prefix:"color:" inner then
+      let var_part = String.sub inner 6 (String.length inner - 6) in
+      Some (Typed_var var_part)
+    else if String.starts_with ~prefix:"var(" inner then Some (Bare_var inner)
+    else
+      match parse_bracket_color inner with
+      | Some c -> Some (Plain_color c)
+      | None -> None
+
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
@@ -2073,31 +2092,22 @@ module Handler = struct
       -> (
         let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
-        let starts prefix s =
-          String.length s >= String.length prefix
-          && String.sub s 0 (String.length prefix) = prefix
-        in
-        if starts "color:" base_inner then
-          let var_part =
-            String.sub base_inner 6 (String.length base_inner - 6)
-          in
-          match opacity with
-          | No_opacity -> Ok (Text_bracket_typed_var var_part)
-          | _ -> Ok (Text_bracket_typed_var_opacity (var_part, opacity))
-        else if starts "var(" base_inner then
-          match opacity with
-          | No_opacity -> Ok (Text_bracket_var base_inner)
-          | _ -> Ok (Text_bracket_var_opacity (base_inner, opacity))
-        else
-          match parse_bracket_color base_inner with
-          | Some css_color -> (
-              match opacity with
-              | No_opacity -> Ok (Text_bracket_color (base_inner, css_color))
-              | _ ->
-                  Ok
-                    (Text_bracket_color_opacity (base_inner, css_color, opacity))
-              )
-          | None -> Error (`Msg ("Invalid text bracket value: " ^ base_inner)))
+        match parse_bracket_hint base_inner with
+        | Some (Typed_var var_part) -> (
+            match opacity with
+            | No_opacity -> Ok (Text_bracket_typed_var var_part)
+            | _ -> Ok (Text_bracket_typed_var_opacity (var_part, opacity)))
+        | Some (Bare_var v) -> (
+            match opacity with
+            | No_opacity -> Ok (Text_bracket_var v)
+            | _ -> Ok (Text_bracket_var_opacity (v, opacity)))
+        | Some (Plain_color css_color) -> (
+            match opacity with
+            | No_opacity -> Ok (Text_bracket_color (base_inner, css_color))
+            | _ ->
+                Ok (Text_bracket_color_opacity (base_inner, css_color, opacity))
+            )
+        | None -> Error (`Msg ("Invalid text bracket value: " ^ base_inner)))
     | "text" :: color_parts when List.exists has_opacity color_parts -> (
         match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
@@ -2268,32 +2278,23 @@ module Handler = struct
       -> (
         let base_str, opacity = parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
-        let starts prefix s =
-          String.length s >= String.length prefix
-          && String.sub s 0 (String.length prefix) = prefix
-        in
-        if starts "color:" base_inner then
-          let var_part =
-            String.sub base_inner 6 (String.length base_inner - 6)
-          in
-          match opacity with
-          | No_opacity -> Ok (Outline_bracket_typed_var var_part)
-          | _ -> Ok (Outline_bracket_typed_var_opacity (var_part, opacity))
-        else if starts "var(" base_inner then
-          match opacity with
-          | No_opacity -> Ok (Outline_bracket_var base_inner)
-          | _ -> Ok (Outline_bracket_var_opacity (base_inner, opacity))
-        else
-          match parse_bracket_color base_inner with
-          | Some css_color -> (
-              match opacity with
-              | No_opacity -> Ok (Outline_bracket_color (base_inner, css_color))
-              | _ ->
-                  Ok
-                    (Outline_bracket_color_opacity
-                       (base_inner, css_color, opacity)))
-          | None ->
-              Error (`Msg ("Invalid outline bracket value: " ^ base_inner)))
+        match parse_bracket_hint base_inner with
+        | Some (Typed_var var_part) -> (
+            match opacity with
+            | No_opacity -> Ok (Outline_bracket_typed_var var_part)
+            | _ -> Ok (Outline_bracket_typed_var_opacity (var_part, opacity)))
+        | Some (Bare_var v) -> (
+            match opacity with
+            | No_opacity -> Ok (Outline_bracket_var v)
+            | _ -> Ok (Outline_bracket_var_opacity (v, opacity)))
+        | Some (Plain_color css_color) -> (
+            match opacity with
+            | No_opacity -> Ok (Outline_bracket_color (base_inner, css_color))
+            | _ ->
+                Ok
+                  (Outline_bracket_color_opacity (base_inner, css_color, opacity))
+            )
+        | None -> Error (`Msg ("Invalid outline bracket value: " ^ base_inner)))
     | "outline" :: color_parts when List.exists has_opacity color_parts -> (
         match shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
@@ -3381,6 +3382,13 @@ let shorten_hex_str = shorten_hex_str
 let bracket_color_to_custom = Handler.bracket_color_to_custom
 let css_color_to_hex = Handler.css_color_to_hex
 let parse_bracket_color = Handler.parse_bracket_color
+
+type bracket_hint = Handler.bracket_hint =
+  | Typed_var of string
+  | Bare_var of string
+  | Plain_color of Css.color
+
+let parse_bracket_hint = Handler.parse_bracket_hint
 let round_n = round_n
 
 let hex_alpha_color ?theme c shade opacity =

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -551,6 +551,20 @@ val parse_bracket_color : string -> Css.color option
     {!Css.color}. Handles hex, CSS color functions (rgba, hsl, oklch, ...), and
     Tailwind named colors. Returns [None] if not a recognized color. *)
 
+(** What a bracket value names, once the [color:]/[var(] spellings are told
+    apart from a plain color. Every color-bearing utility (text, outline, ring,
+    shadow, fill, stroke, ...) classifies its bracket content this way; only the
+    variant it stores the result in differs. *)
+type bracket_hint =
+  | Typed_var of string  (** [color:<value>], the part after [color:] *)
+  | Bare_var of string  (** [var(--x)], the full [var(...)] text *)
+  | Plain_color of Css.color  (** any other color spelling *)
+
+val parse_bracket_hint : string -> bracket_hint option
+(** [parse_bracket_hint inner] classifies a bracket's inner text as a typed var,
+    a bare var, or a plain color parsed via {!parse_bracket_color}. Returns
+    [None] when [inner] is none of these. *)
+
 val css_color_to_hex : Css.color -> Css.color option
 (** [css_color_to_hex c] converts a typed CSS color (Rgb, Rgba, Hsl) to a hex
     color for Tailwind parity. Returns [None] for color types that cannot be

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2472,121 +2472,92 @@ module Handler = struct
 
   let err_not_utility = Error (`Msg "Not an effects utility")
 
-  (** Try to parse a bracket inner string as a color: hex or CSS color function.
-      Returns [Some css_color] on success. *)
-  let parse_bracket_color inner =
-    let starts prefix s =
-      String.length s >= String.length prefix
-      && String.sub s 0 (String.length prefix) = prefix
-    in
-    (* A [#] prefix only names a colour when what follows is a hex spelling;
-       [Css.hex] raises on anything else, and this runs inside [of_class]. *)
-    if starts "#" inner then Css.hex_opt inner
-    else
-      let normalized = String.map (fun c -> if c = '_' then ' ' else c) inner in
-      if Parse.is_css_color_fn normalized then
-        match Css.parse_color normalized with Some c -> Some c | None -> None
-      else None
+  let starts prefix s =
+    String.length s >= String.length prefix
+    && String.sub s 0 (String.length prefix) = prefix
 
   let parse_ring_bracket kind v =
     let base_str, opacity = Color.parse_opacity_modifier v in
     let inner = Parse.bracket_inner base_str in
-    let starts prefix s =
-      String.length s >= String.length prefix
-      && String.sub s 0 (String.length prefix) = prefix
-    in
     match kind with
     | `Ring -> (
-        if starts "color:" inner then
-          let var_part = String.sub inner 6 (String.length inner - 6) in
-          match opacity with
-          | Color.No_opacity -> Ok (Ring_bracket_color_var var_part)
-          | _ -> Ok (Ring_bracket_color_var_opacity (var_part, opacity))
-        else if starts "var(" inner then
-          match opacity with
-          | Color.No_opacity -> Ok (Ring_bracket_var inner)
-          | _ -> Ok (Ring_bracket_var_opacity (inner, opacity))
-        else
-          match parse_bracket_color inner with
-          | Some c -> (
-              match opacity with
-              | Color.No_opacity -> Ok (Ring_bracket_color (inner, c))
-              | _ -> Ok (Ring_bracket_color_opacity (inner, c, opacity)))
-          | None -> (
-              if starts "length:" inner then Ok (Ring_bracket_length inner)
-              else
-                match parse_bracket_width_opt inner with
-                | Some _ -> Ok (Ring_bracket_length inner)
-                | None -> err_not_utility))
+        match Color.parse_bracket_hint inner with
+        | Some (Color.Typed_var var_part) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_bracket_color_var var_part)
+            | _ -> Ok (Ring_bracket_color_var_opacity (var_part, opacity)))
+        | Some (Color.Bare_var v) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_bracket_var v)
+            | _ -> Ok (Ring_bracket_var_opacity (v, opacity)))
+        | Some (Color.Plain_color c) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_bracket_color (inner, c))
+            | _ -> Ok (Ring_bracket_color_opacity (inner, c, opacity)))
+        | None -> (
+            if starts "length:" inner then Ok (Ring_bracket_length inner)
+            else
+              match parse_bracket_width_opt inner with
+              | Some _ -> Ok (Ring_bracket_length inner)
+              | None -> err_not_utility))
     | `Ring_offset -> (
-        if starts "color:" inner then
-          let var_part = String.sub inner 6 (String.length inner - 6) in
-          match opacity with
-          | Color.No_opacity -> Ok (Ring_offset_bracket_color_var var_part)
-          | _ -> Ok (Ring_offset_bracket_cvar_opacity (var_part, opacity))
-        else if starts "var(" inner then
-          match opacity with
-          | Color.No_opacity -> Ok (Ring_offset_bracket_var inner)
-          | _ -> Ok (Ring_offset_bracket_var_opacity (inner, opacity))
-        else
-          match parse_bracket_color inner with
-          | Some c -> (
-              match opacity with
-              | Color.No_opacity -> Ok (Ring_offset_bracket_color (inner, c))
-              | _ -> Ok (Ring_offset_bracket_color_opacity (inner, c, opacity)))
-          | None -> (
-              if starts "length:" inner then
-                Ok (Ring_offset_bracket_length inner)
-              else
-                match parse_bracket_width_opt inner with
-                | Some _ -> Ok (Ring_offset_bracket_length inner)
-                | None -> err_not_utility))
+        match Color.parse_bracket_hint inner with
+        | Some (Color.Typed_var var_part) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_offset_bracket_color_var var_part)
+            | _ -> Ok (Ring_offset_bracket_cvar_opacity (var_part, opacity)))
+        | Some (Color.Bare_var v) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_offset_bracket_var v)
+            | _ -> Ok (Ring_offset_bracket_var_opacity (v, opacity)))
+        | Some (Color.Plain_color c) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Ring_offset_bracket_color (inner, c))
+            | _ -> Ok (Ring_offset_bracket_color_opacity (inner, c, opacity)))
+        | None -> (
+            if starts "length:" inner then Ok (Ring_offset_bracket_length inner)
+            else
+              match parse_bracket_width_opt inner with
+              | Some _ -> Ok (Ring_offset_bracket_length inner)
+              | None -> err_not_utility))
     | `Inset_ring -> (
-        if starts "color:" inner then
-          let var_part = String.sub inner 6 (String.length inner - 6) in
-          match opacity with
-          | Color.No_opacity -> Ok (Inset_ring_bracket_color_var var_part)
-          | _ -> Ok (Inset_ring_bracket_cvar_opacity (var_part, opacity))
-        else if starts "var(" inner then
-          match opacity with
-          | Color.No_opacity -> Ok (Inset_ring_bracket_var inner)
-          | _ -> Ok (Inset_ring_bracket_var_opacity (inner, opacity))
-        else
-          match parse_bracket_color inner with
-          | Some c -> (
-              match opacity with
-              | Color.No_opacity -> Ok (Inset_ring_bracket_color (inner, c))
-              | _ -> Ok (Inset_ring_bracket_color_opacity (inner, c, opacity)))
-          | None -> (
-              if starts "length:" inner then
-                Ok (Inset_ring_bracket_length inner)
-              else
-                match parse_bracket_width_opt inner with
-                | Some _ -> Ok (Inset_ring_bracket_length inner)
-                | None -> err_not_utility))
+        match Color.parse_bracket_hint inner with
+        | Some (Color.Typed_var var_part) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Inset_ring_bracket_color_var var_part)
+            | _ -> Ok (Inset_ring_bracket_cvar_opacity (var_part, opacity)))
+        | Some (Color.Bare_var v) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Inset_ring_bracket_var v)
+            | _ -> Ok (Inset_ring_bracket_var_opacity (v, opacity)))
+        | Some (Color.Plain_color c) -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Inset_ring_bracket_color (inner, c))
+            | _ -> Ok (Inset_ring_bracket_color_opacity (inner, c, opacity)))
+        | None -> (
+            if starts "length:" inner then Ok (Inset_ring_bracket_length inner)
+            else
+              match parse_bracket_width_opt inner with
+              | Some _ -> Ok (Inset_ring_bracket_length inner)
+              | None -> err_not_utility))
 
   let parse_shadow_bracket v =
     let base_str, opacity = Color.parse_opacity_modifier v in
     let inner = Parse.bracket_inner base_str in
-    let starts prefix s =
-      String.length s >= String.length prefix
-      && String.sub s 0 (String.length prefix) = prefix
-    in
     if starts "shadow:" inner then
       let shadow_part = String.sub inner 7 (String.length inner - 7) in
       Ok (Shadow_bracket_shadow shadow_part)
-    else if starts "color:" inner then
-      let var_part = String.sub inner 6 (String.length inner - 6) in
-      match opacity with
-      | Color.No_opacity -> Ok (Shadow_bracket_color_var var_part)
-      | _ -> Ok (Shadow_bracket_color_var_opacity (var_part, opacity))
-    else if starts "var(" inner then
-      match opacity with
-      | Color.No_opacity -> Ok (Shadow_bracket_var inner)
-      | _ -> err_not_utility
     else
-      match parse_bracket_color inner with
-      | Some c -> (
+      match Color.parse_bracket_hint inner with
+      | Some (Color.Typed_var var_part) -> (
+          match opacity with
+          | Color.No_opacity -> Ok (Shadow_bracket_color_var var_part)
+          | _ -> Ok (Shadow_bracket_color_var_opacity (var_part, opacity)))
+      | Some (Color.Bare_var v) -> (
+          match opacity with
+          | Color.No_opacity -> Ok (Shadow_bracket_var v)
+          | _ -> err_not_utility)
+      | Some (Color.Plain_color c) -> (
           match opacity with
           | Color.No_opacity -> Ok (Shadow_bracket_color (inner, c))
           | _ -> Ok (Shadow_bracket_color_opacity (inner, c, opacity)))
@@ -2602,25 +2573,20 @@ module Handler = struct
   let parse_inset_shadow_bracket v =
     let base_str, opacity = Color.parse_opacity_modifier v in
     let inner = Parse.bracket_inner base_str in
-    let starts prefix s =
-      String.length s >= String.length prefix
-      && String.sub s 0 (String.length prefix) = prefix
-    in
     if starts "shadow:" inner then
       let shadow_part = String.sub inner 7 (String.length inner - 7) in
       Ok (Inset_shadow_bracket_shadow shadow_part)
-    else if starts "color:" inner then
-      let var_part = String.sub inner 6 (String.length inner - 6) in
-      match opacity with
-      | Color.No_opacity -> Ok (Inset_shadow_bracket_color_var var_part)
-      | _ -> Ok (Inset_shadow_bracket_cvar_opacity (var_part, opacity))
-    else if starts "var(" inner then
-      match opacity with
-      | Color.No_opacity -> Ok (Inset_shadow_bracket_var inner)
-      | _ -> err_not_utility
     else
-      match parse_bracket_color inner with
-      | Some c -> (
+      match Color.parse_bracket_hint inner with
+      | Some (Color.Typed_var var_part) -> (
+          match opacity with
+          | Color.No_opacity -> Ok (Inset_shadow_bracket_color_var var_part)
+          | _ -> Ok (Inset_shadow_bracket_cvar_opacity (var_part, opacity)))
+      | Some (Color.Bare_var v) -> (
+          match opacity with
+          | Color.No_opacity -> Ok (Inset_shadow_bracket_var v)
+          | _ -> err_not_utility)
+      | Some (Color.Plain_color c) -> (
           match opacity with
           | Color.No_opacity -> Ok (Inset_shadow_bracket_color (inner, c))
           | _ -> Ok (Inset_shadow_bracket_color_opacity (inner, c, opacity)))

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -313,46 +313,39 @@ module Handler = struct
   let parse_bracket_fill v =
     let base_str, opacity = Color.parse_opacity_modifier v in
     let base_inner = Parse.bracket_inner base_str in
-    if starts "color:" base_inner then
-      let var_part = String.sub base_inner 6 (String.length base_inner - 6) in
-      match opacity with
-      | Color.No_opacity -> Ok (Fill_bracket_typed_var var_part)
-      | _ -> Ok (Fill_bracket_typed_var_opacity (var_part, opacity))
-    else if starts "var(" base_inner then
-      match opacity with
-      | Color.No_opacity -> Ok (Fill_bracket_var base_inner)
-      | _ -> Ok (Fill_bracket_var_opacity (base_inner, opacity))
-    else
-      match Color.parse_bracket_color base_inner with
-      | Some css_color -> (
-          match opacity with
-          | Color.No_opacity -> Ok (Fill_bracket_color (base_inner, css_color))
-          | _ ->
-              Ok (Fill_bracket_color_opacity (base_inner, css_color, opacity)))
-      | None -> err_not_utility
+    match Color.parse_bracket_hint base_inner with
+    | Some (Color.Typed_var var_part) -> (
+        match opacity with
+        | Color.No_opacity -> Ok (Fill_bracket_typed_var var_part)
+        | _ -> Ok (Fill_bracket_typed_var_opacity (var_part, opacity)))
+    | Some (Color.Bare_var v) -> (
+        match opacity with
+        | Color.No_opacity -> Ok (Fill_bracket_var v)
+        | _ -> Ok (Fill_bracket_var_opacity (v, opacity)))
+    | Some (Color.Plain_color css_color) -> (
+        match opacity with
+        | Color.No_opacity -> Ok (Fill_bracket_color (base_inner, css_color))
+        | _ -> Ok (Fill_bracket_color_opacity (base_inner, css_color, opacity)))
+    | None -> err_not_utility
 
   let parse_bracket_stroke_color v =
     let base_str, opacity = Color.parse_opacity_modifier v in
     let base_inner = Parse.bracket_inner base_str in
-    if starts "color:" base_inner then
-      let var_part = String.sub base_inner 6 (String.length base_inner - 6) in
-      match opacity with
-      | Color.No_opacity -> Ok (Stroke_bracket_typed_var var_part)
-      | _ -> Ok (Stroke_bracket_typed_var_opacity (var_part, opacity))
-    else if starts "var(" base_inner then
-      match opacity with
-      | Color.No_opacity -> Ok (Stroke_bracket_var base_inner)
-      | _ -> Ok (Stroke_bracket_var_opacity (base_inner, opacity))
-    else
-      match Color.parse_bracket_color base_inner with
-      | Some css_color -> (
-          match opacity with
-          | Color.No_opacity ->
-              Ok (Stroke_bracket_color (base_inner, css_color))
-          | _ ->
-              Ok (Stroke_bracket_color_opacity (base_inner, css_color, opacity))
-          )
-      | None -> err_not_utility
+    match Color.parse_bracket_hint base_inner with
+    | Some (Color.Typed_var var_part) -> (
+        match opacity with
+        | Color.No_opacity -> Ok (Stroke_bracket_typed_var var_part)
+        | _ -> Ok (Stroke_bracket_typed_var_opacity (var_part, opacity)))
+    | Some (Color.Bare_var v) -> (
+        match opacity with
+        | Color.No_opacity -> Ok (Stroke_bracket_var v)
+        | _ -> Ok (Stroke_bracket_var_opacity (v, opacity)))
+    | Some (Color.Plain_color css_color) -> (
+        match opacity with
+        | Color.No_opacity -> Ok (Stroke_bracket_color (base_inner, css_color))
+        | _ ->
+            Ok (Stroke_bracket_color_opacity (base_inner, css_color, opacity)))
+    | None -> err_not_utility
 
   (* Parse bracket value for stroke width: [1.5], [12px], [50%], [2em],
      [calc(1rem_+_2px)], [length:var(...)], [number:var(...)],


### PR DESCRIPTION
The bracket-colour-hint dispatch was copy-pasted across the colour, svg and effects families, and effects carried a weaker private fork of `Color.parse_bracket_color`. One `Color.parse_bracket_hint` replaces nine of those sites and deletes the fork, so ring and shadow bracket colours now get the same palette-name and `--alpha()` handling as every other colour utility.

backgrounds, typography and text_shadow keep their own readers: each has a different fallback (gradient positions, decoration thickness, arbitrary shadows) that folding into one hint type would change.