### PR TITLE
build, sort, parse: share the comparator, the prefix test and the splitter

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -14,33 +14,10 @@ open Output
     name. Modifier prefixes come before the utility name. Colons inside bracket
     values (e.g., [family-name:var(...)]) are not modifier separators. *)
 let extract_base_utility class_name_no_pseudo =
-  let len = String.length class_name_no_pseudo in
-  (* Find the last colon that is NOT inside brackets or parens *)
-  let rec find_last_colon i bracket_depth paren_depth last_colon =
-    if i >= len then last_colon
-    else
-      match class_name_no_pseudo.[i] with
-      | '[' ->
-          find_last_colon (i + 1) (bracket_depth + 1) paren_depth last_colon
-      | ']' ->
-          find_last_colon (i + 1)
-            (max 0 (bracket_depth - 1))
-            paren_depth last_colon
-      | '(' ->
-          find_last_colon (i + 1) bracket_depth (paren_depth + 1) last_colon
-      | ')' ->
-          find_last_colon (i + 1) bracket_depth
-            (max 0 (paren_depth - 1))
-            last_colon
-      | ':' when bracket_depth = 0 && paren_depth = 0 ->
-          find_last_colon (i + 1) bracket_depth paren_depth (Some i)
-      | _ -> find_last_colon (i + 1) bracket_depth paren_depth last_colon
-  in
   let base =
-    match find_last_colon 0 0 0 None with
-    | Some colon_pos ->
-        String.sub class_name_no_pseudo (colon_pos + 1) (len - colon_pos - 1)
-    | None -> class_name_no_pseudo
+    match List.rev (Parse.split_on_colon class_name_no_pseudo) with
+    | last :: _ -> last
+    | [] -> class_name_no_pseudo
   in
   (* Strip a leading [!] important marker so [!flex] orders like [flex] rather
      than failing to parse and falling to the default (last) order. *)

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -322,8 +322,8 @@ let deduplicate_typed_triples triples =
    Tailwind v4, where pseudo-elements appear late). *)
 let adjust_pseudo class_name (prio, suborder) =
   if
-    Parse.has_prefix ~prefix:"before:" class_name
-    || Parse.has_prefix ~prefix:"after:" class_name
+    String.starts_with ~prefix:"before:" class_name
+    || String.starts_with ~prefix:"after:" class_name
   then (prio, suborder + 5000)
   else (prio, suborder)
 

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1086,7 +1086,12 @@ let compare_property_vars ~get_family_order ~get_first_usage n1 n2 po1 po2 fam1
         compare_property_vars_same_rank ~get_family_order ~get_first_usage n1 n2
           po1 po2 fam1 fam2
 
-let sort_properties_by_order first_usage_order initial_values =
+(* Shared by [sort_properties_by_order] (the @layer properties initial values)
+   and [sort_property_rules_by_usage] (the @property rules): the two MUST sort
+   variable names in lockstep, since one produces the initial-value order and
+   the other the @property emission order for the same variables, and a mismatch
+   would emit a properties layer that contradicts its own @property rules. *)
+let property_var_comparator first_usage_order =
   let family_order = family_order first_usage_order in
   let get_family_order name =
     match Var.family name with
@@ -1101,14 +1106,17 @@ let sort_properties_by_order first_usage_order initial_values =
     | Some idx -> idx
     | None -> 10000
   in
-  let cmp (n1, _) (n2, _) =
+  fun n1 n2 ->
     let fam1 = Var.family n1 in
     let fam2 = Var.family n2 in
     let po1 = property_order_from n1 in
     let po2 = property_order_from n2 in
     compare_property_vars ~get_family_order ~get_first_usage n1 n2 po1 po2 fam1
       fam2
-  in
+
+let sort_properties_by_order first_usage_order initial_values =
+  let cmp_name = property_var_comparator first_usage_order in
+  let cmp (n1, _) (n2, _) = cmp_name n1 n2 in
   List.sort cmp initial_values
 
 (* Build property layer content with browser detection *)
@@ -1239,28 +1247,13 @@ let layer_declaration ~has_properties ~include_base =
    order determines @property order). Falls back to family order then
    property_order for cross-family sorting. *)
 let sort_property_rules_by_usage first_usage_order property_rules_for_end =
-  let family_order = family_order first_usage_order in
-  let get_family_order name =
-    match Var.family name with
-    | Some fam -> (
-        match Hashtbl.find_opt family_order fam with
-        | Some o -> o
-        | None -> 1000)
-    | None -> 1000
-  in
-  let get_first_usage name =
-    match Hashtbl.find_opt first_usage_order name with
-    | Some idx -> idx
-    | None -> 10000
-  in
+  let cmp_name = property_var_comparator first_usage_order in
   property_rules_for_end
   |> List.sort (fun s1 s2 ->
       match (Css.as_property s1, Css.as_property s2) with
       | ( Some (Css.Property_info { name = n1; _ }),
           Some (Css.Property_info { name = n2; _ }) ) ->
-          compare_property_vars ~get_family_order ~get_first_usage n1 n2
-            (property_order_from n1) (property_order_from n2) (Var.family n1)
-            (Var.family n2)
+          cmp_name n1 n2
       | _ -> 0)
 
 (** Deduplicate keyframes by name, keeping first occurrence, then convert to CSS

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2129,30 +2129,30 @@ let variant_order_of_prefix prefix =
   (* @starting-style: comes after all media queries including dark:hover *)
   | "starting" -> 95000
   | _ ->
-      if Parse.has_prefix ~prefix:"group-" prefix then 500
-      else if Parse.has_prefix ~prefix:"peer-" prefix then 600
-      else if Parse.has_prefix ~prefix:"has-" prefix then 30600
-      else if Parse.has_prefix ~prefix:"aria-" prefix then
+      if String.starts_with ~prefix:"group-" prefix then 500
+      else if String.starts_with ~prefix:"peer-" prefix then 600
+      else if String.starts_with ~prefix:"has-" prefix then 30600
+      else if String.starts_with ~prefix:"aria-" prefix then
         if String.length prefix > 5 && prefix.[5] <> '[' then 30700 else 30790
-      else if Parse.has_prefix ~prefix:"data-" prefix then
+      else if String.starts_with ~prefix:"data-" prefix then
         if String.length prefix > 5 && prefix.[5] = '[' then 30810 else 30800
       else if
-        Parse.has_prefix ~prefix:"supports-" prefix
-        || Parse.has_prefix ~prefix:"supports" prefix
+        String.starts_with ~prefix:"supports-" prefix
+        || String.starts_with ~prefix:"supports" prefix
       then 40000
       else if prefix = "motion-safe" then 50000
       else if prefix = "motion-reduce" then 50100
       else if prefix = "contrast-more" then 50200
       else if prefix = "contrast-less" then 50300
-      else if Parse.has_prefix ~prefix:"pointer-" prefix then 50400
-      else if Parse.has_prefix ~prefix:"any-pointer-" prefix then 50500
+      else if String.starts_with ~prefix:"pointer-" prefix then 50400
+      else if String.starts_with ~prefix:"any-pointer-" prefix then 50500
       else if
         prefix = "sm" || prefix = "md" || prefix = "lg" || prefix = "xl"
         || prefix = "2xl"
-        || Parse.has_prefix ~prefix:"min-" prefix
-        || Parse.has_prefix ~prefix:"max-" prefix
+        || String.starts_with ~prefix:"min-" prefix
+        || String.starts_with ~prefix:"max-" prefix
       then 60000
-      else if Parse.has_prefix ~prefix:"prose-" prefix then
+      else if String.starts_with ~prefix:"prose-" prefix then
         let name = String.sub prefix 6 (String.length prefix - 6) in
         prose_element_variant_order name
       else if String.length prefix > 0 && prefix.[0] = '[' then 100000

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -1,13 +1,3 @@
-(* [prefix_loop] is top-level so it captures nothing and allocates no closure -
-   unlike [String.starts_with]'s inner [aux], which allocates one per call in a
-   non-flambda build. Indices are kept in bounds by [has_prefix]. *)
-let rec prefix_loop prefix s i lp =
-  i = lp || (prefix.[i] = s.[i] && prefix_loop prefix s (i + 1) lp)
-
-let has_prefix ~prefix s =
-  let lp = String.length prefix in
-  lp <= String.length s && prefix_loop prefix s 0 lp
-
 let is_digits s =
   s <> "" && String.for_all (function '0' .. '9' -> true | _ -> false) s
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -404,6 +404,49 @@ let split_class_uncached class_name =
   parts := Buffer.contents buf :: !parts;
   List.rev !parts
 
+(** Split a variant chain on ':', treating '[...]' and '(...)' as atomic so a
+    colon inside an arbitrary value or a shorthand var reference (e.g.
+    "hover:bg-[color:var(--x)]") is not read as a variant separator. Always
+    yields (colon count + 1) tokens: joining the result back with ':'
+    reconstructs the input. *)
+let split_on_colon s =
+  let len = String.length s in
+  let buf = Buffer.create 16 in
+  let parts = ref [] in
+  let i = ref 0 in
+  while !i < len do
+    let c = s.[!i] in
+    if c = '[' then (
+      let depth = ref 1 in
+      Buffer.add_char buf c;
+      incr i;
+      while !i < len && !depth > 0 do
+        let c = s.[!i] in
+        Buffer.add_char buf c;
+        if c = '[' then incr depth else if c = ']' then decr depth;
+        incr i
+      done)
+    else if c = '(' then (
+      let depth = ref 1 in
+      Buffer.add_char buf c;
+      incr i;
+      while !i < len && !depth > 0 do
+        let c = s.[!i] in
+        Buffer.add_char buf c;
+        if c = '(' then incr depth else if c = ')' then decr depth;
+        incr i
+      done)
+    else if c = ':' then (
+      parts := Buffer.contents buf :: !parts;
+      Buffer.clear buf;
+      incr i)
+    else (
+      Buffer.add_char buf c;
+      incr i)
+  done;
+  parts := Buffer.contents buf :: !parts;
+  List.rev !parts
+
 (* Utility.base_of_class offers one class name to every handler in turn until
    one accepts it, and most handlers open by splitting that same name, so a
    single class is split once per handler tried. The split is a pure function of

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -5,11 +5,6 @@
     results. All functions return [result] with [`Msg] error messages instead of
     raising. *)
 
-val has_prefix : prefix:string -> string -> bool
-(** [has_prefix ~prefix s] is [true] when [s] starts with [prefix]. Like
-    [String.starts_with] but allocation-free (no per-call closure), for hot
-    prefix tests in ordering. *)
-
 val decimal_int : string -> int option
 (** [decimal_int s] reads the canonical plain-decimal spelling of an integer.
     OCaml-only forms such as [0x10] and [1_0], and redundant leading zeroes, are

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -118,3 +118,11 @@ val split_class : string -> string list
 (** [split_class class_name] splits a class name on ['-'] but treats ['[...]']
     and ['(...)'] as atomic, so brackets and parentheses containing dashes are
     preserved. E.g. ["m-[var(--value)]"] becomes [["m"; "[var(--value)]"]]. *)
+
+val split_on_colon : string -> string list
+(** [split_on_colon s] splits a variant chain on [':'] but treats ['[...]'] and
+    ['(...)'] as atomic, so a colon inside an arbitrary value or a shorthand var
+    reference (e.g. ["hover:bg-[color:var(--x)]"]) is not read as a variant
+    separator. Always yields (colon count + 1) tokens: e.g. ["hover:focus:p-4"]
+    becomes [["hover"; "focus"; "p-4"]], and a string with no unbracketed colon
+    becomes a single-element list. *)

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -843,9 +843,9 @@ let compare_by_base_class r1 r2 =
   if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
 
 let supports_suffix s =
-  if String.length s > 9 && String.sub s 0 9 = "supports-" then
+  if String.starts_with ~prefix:"supports-" s then
     Some (String.sub s 9 (String.length s - 9))
-  else if String.length s > 13 && String.sub s 0 13 = "not-supports-" then
+  else if String.starts_with ~prefix:"not-supports-" s then
     Some (String.sub s 13 (String.length s - 13))
   else None
 
@@ -906,9 +906,9 @@ let variant_prefix = function
 (* Compute variant order for a modifier prefix, stripping group-/peer-
    wrappers *)
 let strip_group_peer_vo p =
-  if Parse.has_prefix ~prefix:"group-" p then
+  if String.starts_with ~prefix:"group-" p then
     Modifiers.variant_order_of_prefix (String.sub p 6 (String.length p - 6))
-  else if Parse.has_prefix ~prefix:"peer-" p then
+  else if String.starts_with ~prefix:"peer-" p then
     Modifiers.variant_order_of_prefix (String.sub p 5 (String.length p - 5))
   else Modifiers.variant_order_of_prefix p
 
@@ -988,8 +988,8 @@ let container_value_of_token token =
     let body = String.sub token 1 (n - 1) in
     let body =
       if
-        Parse.has_prefix ~prefix:"min-" body
-        || Parse.has_prefix ~prefix:"max-" body
+        String.starts_with ~prefix:"min-" body
+        || String.starts_with ~prefix:"max-" body
       then String.sub body 4 (String.length body - 4)
       else body
     in
@@ -1026,8 +1026,8 @@ let inner_vo prefix =
   | Some j ->
       let outer = String.sub prefix 0 j in
       if
-        Parse.has_prefix ~prefix:"group-" outer
-        || Parse.has_prefix ~prefix:"peer-" outer
+        String.starts_with ~prefix:"group-" outer
+        || String.starts_with ~prefix:"peer-" outer
       then
         let parts = split_on_colon_outside_brackets prefix in
         List.fold_left (fun acc p -> max acc (strip_group_peer_vo p)) 0 parts
@@ -1036,10 +1036,10 @@ let inner_vo prefix =
         let inner = String.sub prefix (j + 1) (String.length prefix - j - 1) in
         Modifiers.variant_order_of_prefix inner
   | None ->
-      if Parse.has_prefix ~prefix:"group-" prefix then
+      if String.starts_with ~prefix:"group-" prefix then
         Modifiers.variant_order_of_prefix
           (String.sub prefix 6 (String.length prefix - 6))
-      else if Parse.has_prefix ~prefix:"peer-" prefix then
+      else if String.starts_with ~prefix:"peer-" prefix then
         Modifiers.variant_order_of_prefix
           (String.sub prefix 5 (String.length prefix - 5))
       else 0
@@ -1072,8 +1072,8 @@ let token_order_key token =
   let primary = Modifiers.variant_order_of_prefix token in
   let secondary =
     if
-      Parse.has_prefix ~prefix:"group-" token
-      || Parse.has_prefix ~prefix:"peer-" token
+      String.starts_with ~prefix:"group-" token
+      || String.starts_with ~prefix:"peer-" token
     then strip_group_peer_vo token
     else 0
   in

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -912,50 +912,6 @@ let strip_group_peer_vo p =
     Modifiers.variant_order_of_prefix (String.sub p 5 (String.length p - 5))
   else Modifiers.variant_order_of_prefix p
 
-(* Find the first ':' in a string that is not inside brackets. Returns None if
-   all colons are inside bracket pairs. *)
-let index_colon_outside_brackets s =
-  let len = String.length s in
-  let rec loop i depth =
-    if i >= len then None
-    else
-      match s.[i] with
-      | '[' -> loop (i + 1) (depth + 1)
-      | ']' -> loop (i + 1) (max 0 (depth - 1))
-      | ':' when depth = 0 -> Some i
-      | _ -> loop (i + 1) depth
-  in
-  loop 0 0
-
-(* Split a string on ':' but respecting bracket nesting, so colons inside [...]
-   are not treated as separators. *)
-let split_on_colon_outside_brackets s =
-  let len = String.length s in
-  let buf = Buffer.create 16 in
-  let acc = ref [] in
-  let rec loop i depth =
-    if i >= len then (
-      let last = Buffer.contents buf in
-      if last <> "" then acc := last :: !acc;
-      List.rev !acc)
-    else
-      match s.[i] with
-      | '[' ->
-          Buffer.add_char buf '[';
-          loop (i + 1) (depth + 1)
-      | ']' ->
-          Buffer.add_char buf ']';
-          loop (i + 1) (max 0 (depth - 1))
-      | ':' when depth = 0 ->
-          acc := Buffer.contents buf :: !acc;
-          Buffer.clear buf;
-          loop (i + 1) depth
-      | c ->
-          Buffer.add_char buf c;
-          loop (i + 1) depth
-  in
-  loop 0 0
-
 (* What Tailwind sorts a container variant on. It reads the value off the class
    rather than the width that value resolves to, and keys it by the unit -- or,
    when the value is a call, by the name before the parenthesis. A size off the
@@ -1005,8 +961,7 @@ let container_value_of_token token =
     else Some { name = "rem"; call = false; text = body }
 
 let container_value_of_prefix prefix =
-  List.find_map container_value_of_token
-    (split_on_colon_outside_brackets prefix)
+  List.find_map container_value_of_token (Parse.split_on_colon prefix)
 
 (* Only a call keys on a name the resolved length cannot carry, so every other
    pair keeps the length key, which already orders the way Tailwind does. *)
@@ -1022,20 +977,9 @@ let compare_container_values r1 r2 p1 p2 =
 
 (* Compute the inner variant order for a compound prefix like "hover:focus" *)
 let inner_vo prefix =
-  match index_colon_outside_brackets prefix with
-  | Some j ->
-      let outer = String.sub prefix 0 j in
-      if
-        String.starts_with ~prefix:"group-" outer
-        || String.starts_with ~prefix:"peer-" outer
-      then
-        let parts = split_on_colon_outside_brackets prefix in
-        List.fold_left (fun acc p -> max acc (strip_group_peer_vo p)) 0 parts
-        + 1
-      else
-        let inner = String.sub prefix (j + 1) (String.length prefix - j - 1) in
-        Modifiers.variant_order_of_prefix inner
-  | None ->
+  match Parse.split_on_colon prefix with
+  | [] -> 0
+  | [ _ ] ->
       if String.starts_with ~prefix:"group-" prefix then
         Modifiers.variant_order_of_prefix
           (String.sub prefix 6 (String.length prefix - 6))
@@ -1043,6 +987,14 @@ let inner_vo prefix =
         Modifiers.variant_order_of_prefix
           (String.sub prefix 5 (String.length prefix - 5))
       else 0
+  | outer :: _ :: _ as parts ->
+      if
+        String.starts_with ~prefix:"group-" outer
+        || String.starts_with ~prefix:"peer-" outer
+      then
+        List.fold_left (fun acc p -> max acc (strip_group_peer_vo p)) 0 parts
+        + 1
+      else Modifiers.variant_order_of_prefix (String.concat ":" (List.tl parts))
 
 (* Effective inner variant order: prefer prefix-derived, fall back to nested
    media *)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -713,7 +713,7 @@ module Typography_early = struct
      size; nor does a token whose value is not a length. *)
   let is_theme_text_size theme n =
     (not (is_named_size n))
-    && (not (Parse.has_prefix ~prefix:"shadow-" n))
+    && (not (String.starts_with ~prefix:"shadow-" n))
     && List.for_all (fun seg -> seg <> "") (String.split_on_char '-' n)
     && Scheme.theme_value (Some theme) ("color-" ^ n) = None
     &&

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -592,7 +592,7 @@ let bracket ?fallback name =
     | Some _ -> None
     | None ->
         let expression =
-          if Parse.has_prefix ~prefix:"var(" name then Some name
+          if String.starts_with ~prefix:"var(" name then Some name
           else if String.contains name ',' then Some ("var(--" ^ name ^ ")")
           else None
         in


### PR DESCRIPTION
Three duplications that had to be kept in step by hand:

The properties layer and the `@property` rules were ordered by two byte-identical comparator blocks, so fixing one alone produces a sheet whose `@property` order contradicts its properties layer. They now share one.

Prefix checks existed in three idioms; everything moves to `String.starts_with` and `Parse.has_prefix` goes. That also fixes an off-by-one in `sort.ml`'s `supports_suffix`, where `String.length s > 9` excluded the exact-length `"supports-"` match.

Variant-colon splitting was written four times; `Parse.split_on_colon` is now the only bracket-aware splitter.