### PR TITLE
modifiers, rule: give supports-* a typed condition

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1109,29 +1109,32 @@ let normalize_supports_condition condition_str =
     && cond.[1] = '-'
     && not (String.contains cond ':')
   then
-    (* Bare custom property: --test → (--test: var(--tw)) *)
-    "(" ^ cond ^ ": var(--tw))"
+    (* Bare custom property: --test tests against var(--tw), built directly
+       rather than assembled as "(--test: var(--tw))" and re-parsed. *)
+    Css.Supports.property cond "var(--tw)"
   else if cond <> "" && cond.[0] = '(' && cond.[String.length cond - 1] = ')'
   then
-    (* Already parenthesised, so it is the condition the author wrote. *)
-    cond
+    (* Already parenthesised, so it is the condition the author wrote; only the
+       real grammar reader can make sense of arbitrary authored text. *)
+    Css.Supports.of_string cond
   else if String.contains cond ':' then
-    (* [prop: value] -> [(prop:value)], the property test Tailwind emits. *)
+    (* [prop: value], the property test Tailwind emits, built directly. *)
     let i = String.index cond ':' in
     let prop = String.trim (String.sub cond 0 i) in
     let value =
       String.trim (String.sub cond (i + 1) (String.length cond - i - 1))
     in
-    String.concat "" [ "("; prop; ":"; value; ")" ]
+    Css.Supports.property prop value
   else if String.contains cond '(' then
-    (* Function call like font-format(opentype) or var(--test) *)
-    cond
+    (* Function call like font-format(opentype) or var(--test); again arbitrary
+       authored text, so the real grammar reader parses it. *)
+    Css.Supports.of_string cond
   else
-    (* Bare property name: backdrop-filter -> (backdrop-filter: var(--tw)), the
-       same expansion as the bare custom property above. A lone identifier is
-       not a condition the CSS grammar has a production for, so leaving it
-       raised a parse error out of the scanner. *)
-    "(" ^ cond ^ ": var(--tw))"
+    (* Bare property name: backdrop-filter tests against var(--tw), the same
+       expansion as the bare custom property above. A lone identifier is not a
+       condition the CSS grammar has a production for, so leaving it raised a
+       parse error out of the scanner. *)
+    Css.Supports.property cond "var(--tw)"
 
 (* Validate that a supports-[...] bracket normalizes to a condition the
    [@supports] grammar has a production for. An empty or half-written one used
@@ -1140,7 +1143,7 @@ let is_valid_supports_condition cond =
   cond <> ""
   &&
     try
-      ignore (Css.Supports.of_string (normalize_supports_condition cond));
+      ignore (normalize_supports_condition cond);
       true
     with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> false
 

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -836,7 +836,7 @@ let print styles = wrap Print styles
 let portrait styles = wrap Portrait styles
 let landscape styles = wrap Landscape styles
 let forced_colors styles = wrap Forced_colors styles
-let supports cond styles = wrap (Supports cond) styles
+let supports cond styles = wrap (Supports_condition cond) styles
 
 (* Prose element variants *)
 let prose_headings styles = wrap (Prose_element "headings") styles
@@ -1215,7 +1215,8 @@ let bracket_value_patterns s =
     (fun () -> try_nth "nth-[" (fun e -> Nth e));
     (fun () ->
       let* cond = extract_bracket_content ~prefix:"supports-[" s in
-      if is_valid_supports_condition cond then Some (Supports cond) else None);
+      if is_valid_supports_condition cond then Some (Supports_condition cond)
+      else None);
     (fun () ->
       try_with "group-["
         (fun sel ->
@@ -1243,8 +1244,8 @@ let bracket_value_patterns s =
 
 let bracket_patterns s = bracket_named_patterns s @ bracket_value_patterns s
 
-(* Try supports-<property> shorthand: supports-grid → Supports "grid:
-   var(--tw)" *)
+(* Try supports-<property> shorthand: supports-grid → Supports_property
+   "grid" *)
 let try_supports_shorthand s =
   if
     String.length s > 9
@@ -1253,7 +1254,7 @@ let try_supports_shorthand s =
     && not (String.contains s '/')
   then
     let prop = String.sub s 9 (String.length s - 9) in
-    Some (Supports (prop ^ ": var(--tw)"))
+    Some (Supports_property prop)
   else None
 
 let try_bracketed_modifier s =
@@ -1499,7 +1500,7 @@ let try_not_shorthand inner =
     && not (String.contains inner '/')
   then
     let prop = String.sub inner 9 (String.length inner - 9) in
-    Some (Not (Supports (prop ^ ": var(--tw)")))
+    Some (Not (Supports_property prop))
     (* data-X shorthand — attribute presence check *)
   else if String.length inner > 5 && String.sub inner 0 5 = "data-" then
     let attr = String.sub inner 5 (String.length inner - 5) in
@@ -2021,7 +2022,7 @@ let not_variant_order = function
   | Nth_of_type _ -> 3600
   | Nth_last_of_type _ -> 3650
   (* @supports *)
-  | Supports _ -> 4000
+  | Supports_property _ | Supports_condition _ -> 4000
   (* Media: accessibility preferences *)
   | Motion_safe -> 5000
   | Motion_reduce -> 5100

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -31,12 +31,15 @@ val prose_element_inner_selector : string -> Css.Selector.t
 val is_hover : modifier -> bool
 (** [is_hover m] returns true if the modifier generates a :hover rule. *)
 
-val normalize_supports_condition : string -> string
-(** [normalize_supports_condition cond] is the [supports-[...]] bracket content
-    as a CSS [@supports] condition: underscores become spaces, and a bare
-    property or custom property expands to a [(prop: var(--tw))] test. The
-    modifier parser validates its result, so only conditions that parse reach a
-    rule. *)
+val normalize_supports_condition : string -> Css.Supports.t
+(** [normalize_supports_condition cond] builds the [supports-[...]] bracket
+    content as a typed CSS [@supports] condition: underscores become spaces, and
+    a bare property or custom property expands to a [(prop: var(--tw))] test,
+    built directly through {!Css.Supports.property} rather than assembled as a
+    string and re-parsed. An already-parenthesised condition or a function call
+    is the text the author wrote, so it is parsed with {!Css.Supports.of_string}
+    instead. The modifier parser validates the result, so only conditions that
+    parse reach a rule. *)
 
 (** {1 State Variants} *)
 

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -33,10 +33,10 @@ val is_hover : modifier -> bool
 
 val normalize_supports_condition : string -> string
 (** [normalize_supports_condition cond] is the [supports-[...]] bracket content
-    as a CSS [@supports] condition: underscores become spaces, a bare property
-    or custom property expands to a [(prop: var(--tw))] test, and a property
-    test is repeated once per vendor prefix Tailwind checks. The modifier parser
-    validates its result, so only conditions that parse reach a rule. *)
+    as a CSS [@supports] condition: underscores become spaces, and a bare
+    property or custom property expands to a [(prop: var(--tw))] test. The
+    modifier parser validates its result, so only conditions that parse reach a
+    rule. *)
 
 (** {1 State Variants} *)
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -971,8 +971,7 @@ let handle_supports_condition_modifier condition_str base_class selector props =
     Rules_selector.replace_class_in_selector ~old_class:base_class
       ~new_class:modified_class selector
   in
-  let condition_input = normalize_supports_condition condition_str in
-  let condition = Css.Supports.of_string condition_input in
+  let condition = normalize_supports_condition condition_str in
   supports_query ~condition ~selector:new_selector ~props
     ~base_class:modified_class ()
 
@@ -1216,8 +1215,7 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
           ~base_class:modified_class ();
       ]
   | Style.Supports_condition condition_str ->
-      let condition_input = normalize_supports_condition condition_str in
-      let inner_condition = Css.Supports.of_string condition_input in
+      let inner_condition = normalize_supports_condition condition_str in
       [
         supports_query ~not_order:nvo
           ~condition:(Css.Supports.Not inner_condition)
@@ -1681,9 +1679,7 @@ let at_rule_variant content ~selector base_class props =
     starting_style ~selector ~props ~base_class:modified_class ()
   else
     let cond = String.trim (String.sub content 9 (String.length content - 9)) in
-    let condition =
-      Css.Supports.of_string (normalize_supports_condition cond)
-    in
+    let condition = normalize_supports_condition cond in
     supports_query ~condition ~selector ~props ~base_class:modified_class ()
 
 (* A [matchVariant]-registered custom variant. The class name is the token

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -951,17 +951,22 @@ let handle_pseudo_element_modifier modifier base_class props =
 
 let normalize_supports_condition = Modifiers.normalize_supports_condition
 
-(** Handle [@supports] modifier: builds modified class name, updates selector,
-    normalizes condition, and emits a supports query rule. *)
-let handle_supports_modifier condition_str base_class selector props =
-  (* Use shorthand class name for supports-<property> patterns, otherwise use
-     bracket notation *)
-  let modified_class =
-    if String.ends_with ~suffix:": var(--tw)" condition_str then
-      let prop_len = String.length condition_str - 11 in
-      "supports-" ^ String.sub condition_str 0 prop_len ^ ":" ^ base_class
-    else "supports-[" ^ condition_str ^ "]:" ^ base_class
+(** Handle [supports-<property>] modifier: builds the shorthand class name and
+    emits [\@supports (prop: var(--tw))] directly, typed. *)
+let handle_supports_property_modifier prop base_class selector props =
+  let modified_class = "supports-" ^ prop ^ ":" ^ base_class in
+  let new_selector =
+    Rules_selector.replace_class_in_selector ~old_class:base_class
+      ~new_class:modified_class selector
   in
+  let condition = Css.Supports.property prop "var(--tw)" in
+  supports_query ~condition ~selector:new_selector ~props
+    ~base_class:modified_class ()
+
+(** Handle [supports-[condition]] modifier: builds the bracket class name,
+    normalizes the author's condition text, and emits a supports query rule. *)
+let handle_supports_condition_modifier condition_str base_class selector props =
+  let modified_class = "supports-[" ^ condition_str ^ "]:" ^ base_class in
   let new_selector =
     Rules_selector.replace_class_in_selector ~old_class:base_class
       ~new_class:modified_class selector
@@ -1061,9 +1066,7 @@ let not_class_prefix inner_modifier =
   | Style.Nth_last expr -> Style.pp_nth "nth-last" expr
   | Style.Nth_of_type expr -> Style.pp_nth "nth-of-type" expr
   | Style.Nth_last_of_type expr -> Style.pp_nth "nth-last-of-type" expr
-  | Style.Supports cond when String.ends_with ~suffix:": var(--tw)" cond ->
-      let prop_len = String.length cond - 11 in
-      "supports-" ^ String.sub cond 0 prop_len
+  | Style.Supports_property prop -> "supports-" ^ prop
   | inner -> Modifiers.pp_modifier inner
 
 (* The relative selector a [group-not-]/[peer-not-] variant contributes:
@@ -1205,7 +1208,14 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
       let condition = Option.get (media_condition_of_modifier inner_modifier) in
       not_media_rule ~nvo ~condition:(negate_media condition) modified_class
         props
-  | Style.Supports condition_str ->
+  | Style.Supports_property prop ->
+      [
+        supports_query ~not_order:nvo
+          ~condition:(Css.Supports.Not (Css.Supports.property prop "var(--tw)"))
+          ~selector:(Css.Selector.Class modified_class) ~props
+          ~base_class:modified_class ();
+      ]
+  | Style.Supports_condition condition_str ->
       let condition_input = normalize_supports_condition condition_str in
       let inner_condition = Css.Supports.of_string condition_input in
       [
@@ -1735,8 +1745,10 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
       handle_media_like_modifier modifier ~condition ~inner_has_hover base_class
         selector props
   (* Supports feature query *)
-  | Style.Supports condition_str ->
-      handle_supports_modifier condition_str base_class selector props
+  | Style.Supports_property prop ->
+      handle_supports_property_modifier prop base_class selector props
+  | Style.Supports_condition condition_str ->
+      handle_supports_condition_modifier condition_str base_class selector props
   (* Responsive and container *)
   | Style.Responsive breakpoint ->
       responsive_rule ?theme ~inner_has_hover breakpoint base_class selector
@@ -1996,8 +2008,10 @@ let rebase_on_selector ~base_class ~selector rules =
    to keep that at-rule and nest the inner query inside it; the selector-rewrite
    arms cannot express them. *)
 let wraps_in_at_rule = function
-  | Style.Supports _ | Style.Starting | Style.Container _
-  | Style.Not (Style.Supports _) ->
+  | Style.Supports_property _ | Style.Supports_condition _ | Style.Starting
+  | Style.Container _
+  | Style.Not (Style.Supports_property _)
+  | Style.Not (Style.Supports_condition _) ->
       true
   | _ -> false
 

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -195,7 +195,8 @@ type modifier =
   | Any_pointer_coarse
   | Any_pointer_fine
   | Noscript
-  | Supports of string
+  | Supports_property of string
+  | Supports_condition of string
   | Group_hocus
   | Peer_hocus
   | Custom_responsive of string
@@ -623,15 +624,8 @@ let rec pp_modifier = function
   | Any_pointer_coarse -> "any-pointer-coarse"
   | Any_pointer_fine -> "any-pointer-fine"
   | Noscript -> "noscript"
-  | Supports cond ->
-      (* Handle shorthand supports-<property> vs supports-[condition] *)
-      if String.ends_with ~suffix:": var(--tw)" cond then
-        let prop_len =
-          String.length cond - 11
-          (* ": var(--tw)" is 11 chars *)
-        in
-        "supports-" ^ String.sub cond 0 prop_len
-      else "supports-[" ^ cond ^ "]"
+  | Supports_property prop -> "supports-" ^ prop
+  | Supports_condition cond -> "supports-[" ^ cond ^ "]"
   | Custom_responsive name -> name
   | Min_custom name -> "min-" ^ name
   | Max_custom name -> "max-" ^ name

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -209,7 +209,12 @@ type modifier =
   | Any_pointer_coarse
   | Any_pointer_fine
   | Noscript
-  | Supports of string
+  | Supports_property of string
+      (** [supports-<property>]: the bare property name, tested against
+          [var(--tw)] the way Tailwind's shorthand does. *)
+  | Supports_condition of string
+      (** [supports-[condition]]: the raw bracket text, parsed as a CSS
+          [\@supports] condition. *)
   | Group_hocus
   | Peer_hocus
   | Custom_responsive of string


### PR DESCRIPTION
`supports-<property>` was encoded in band: the literal `": var(--tw)"` was appended to the property name, re-synthesised in two more places, and decoded at three sites with `String.ends_with` and a hardcoded `- 11`. Changing that sentinel produced class names like `supports-gri:flex` rather than a compile error. Two constructors, `Supports_property` and `Supports_condition`, remove all seven sites.

`normalize_supports_condition` also returned a string that every caller re-parsed with `Css.Supports.of_string`; it builds the condition typed now.

Emitted CSS is unchanged.