### PR TITLE
typography, transitions, backgrounds: four parity gaps

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1744,15 +1744,18 @@ module Handler = struct
     (* -bg-linear-[value] - negated bracket linear gradient (only angles) *)
     | [ ""; "bg"; "linear"; bracket ] when Parse.is_bracket_value bracket ->
         let inner = Parse.bracket_inner bracket in
-        (* Only accept angle values for negation: 125deg, 1.3rad, etc. *)
+        (* Only accept angle values for negation: 125deg, 1.3rad, 100grad, etc.
+           A [String.ends_with ~suffix:"rad"] check also matches "grad" (which
+           ends in "rad" too), stripping "100grad" down to "100g" and rejecting
+           it outright where Tailwind accepts it; reading it as a real CSS angle
+           tells "grad" and "rad" apart. *)
         let is_angle =
-          String.ends_with ~suffix:"deg" inner
-          && float_of_string_opt (String.sub inner 0 (String.length inner - 3))
-             <> None
-          || String.ends_with ~suffix:"rad" inner
-             && float_of_string_opt
-                  (String.sub inner 0 (String.length inner - 3))
-                <> None
+          match
+            Cascade.Cursor.try_parse_full_err Css.Values.read_angle
+              (Cascade.Cursor.of_string (Parse.decode_underscores inner))
+          with
+          | Ok _ -> true
+          | Error _ -> false
         in
         if is_angle then Ok (Bg_linear_bracket_neg inner)
         else Error (`Msg ("Invalid -bg-linear bracket value: " ^ inner))

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -449,6 +449,10 @@ module Handler = struct
         Cascade.Cursor.try_parse_full_err Css.Properties.read_timing_function
           cursor
       with
+      (* CSS Easing 1 sec. 2: an omitted <step-position> defaults to [end];
+         Tailwind's own minifier makes that default explicit, so match it rather
+         than leave the sheets disagreeing over what is a no-op. *)
+      | Ok (Steps (n, None)) -> Some (Steps (n, Some End))
       | Ok tf -> Some tf
       | Error _ -> None
 

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -740,18 +740,11 @@ module Typography_early = struct
     | [ "font"; v ] when Parse.is_bracket_value v -> (
         let inner = Parse.bracket_inner v in
         if String.length inner > 0 && inner.[0] = '"' then
-          (* font-["arial_rounded"] → quoted font family *)
-          let unquoted =
-            let s =
-              if
-                String.length inner >= 2
-                && inner.[String.length inner - 1] = '"'
-              then String.sub inner 1 (String.length inner - 2)
-              else inner
-            in
-            String.map (fun c -> if c = '_' then ' ' else c) s
-          in
-          Ok (Font_bracket_family_quoted (inner, unquoted))
+          (* font-["arial_rounded"] → the decoded bracket text becomes the
+             literal font-family value, quotes and all; Tailwind never wraps it
+             in another layer of quoting. *)
+          let decoded = Parse.decode_underscores inner in
+          Ok (Font_bracket_family_quoted (inner, decoded))
         else if
           String.length inner >= 12 && String.sub inner 0 12 = "family-name:"
         then
@@ -1468,7 +1461,21 @@ module Typography_early = struct
           | Some rule -> rule
         in
         style ~property_rules [ weight_util_decl; font_weight (Var var_ref) ]
-    | Font_bracket_family_quoted (_, s) -> style [ font_family (Name s) ]
+    | Font_bracket_family_quoted (_, decoded) ->
+        let n = String.length decoded in
+        if n >= 2 && decoded.[0] = '"' && decoded.[n - 1] = '"' then
+          (* font-["arial_rounded"] → the decoded text is one quoted family
+             name; strip the quotes cascade's own printer adds back. *)
+          style [ font_family (Name (String.sub decoded 1 (n - 2))) ]
+        else
+          (* font-["liga"_0x10] → not a single quoted name. The decoded text
+             already carries its own quoting (a quoted string mixed with other
+             tokens); tokenize it and pass the tokens through rather than
+             wrapping the whole string in one more layer of quotes. *)
+          let tokens =
+            Css.Values.read_invalid_value (Cascade.Cursor.of_string decoded)
+          in
+          style [ font_family (Invalid tokens) ]
     | Font_bracket_family_name (_, s) ->
         (* Parse known generic family names *)
         let family =

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2863,36 +2863,31 @@ module Typography_late = struct
         overflow Hidden;
       ]
 
+  (* A project [@theme] token is a namespace key, not a value Tailwind type-
+     checks at build time: any override of [--line-clamp-none], decimal or not,
+     switches the utility to the variable-driven form. Reading it with
+     [int_of_string_opt] let an OCaml-only spelling like [0x3] through by
+     accident and rejected a spelling like [banana] that Tailwind still honours,
+     so the branch no longer parses the value at all. *)
   let line_clamp_none_style ?theme () =
     match Scheme.theme_value theme "line-clamp-none" with
-    | Some value_str -> (
-        match int_of_string_opt value_str with
-        | Some n ->
-            let decl =
-              Css.custom_property ~layer:"theme" "--line-clamp-none"
-                (string_of_int n)
-            in
-            let ref : Css.webkit_line_clamp Css.var =
-              Var.theme_ref "line-clamp-none"
-                ~default:(Css.Unset : Css.webkit_line_clamp)
-                ~default_css:"unset"
-            in
-            style
-              [
-                decl;
-                webkit_line_clamp (Var ref);
-                webkit_box_orient Vertical;
-                display Webkit_box;
-                overflow Hidden;
-              ]
-        | None ->
-            style
-              [
-                webkit_line_clamp Unset;
-                webkit_box_orient Horizontal;
-                display Block;
-                overflow Visible;
-              ])
+    | Some value_str ->
+        let decl =
+          Css.custom_property ~layer:"theme" "--line-clamp-none" value_str
+        in
+        let ref : Css.webkit_line_clamp Css.var =
+          Var.theme_ref "line-clamp-none"
+            ~default:(Css.Unset : Css.webkit_line_clamp)
+            ~default_css:"unset"
+        in
+        style
+          [
+            decl;
+            webkit_line_clamp (Var ref);
+            webkit_box_orient Vertical;
+            display Webkit_box;
+            overflow Hidden;
+          ]
     | None ->
         style
           [

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -216,6 +216,27 @@ let test_bracket_gradient_radians () =
   has "bg-linear-[-0.5rad]" "--tw-gradient-position: -28.6479deg";
   has "bg-linear-[1.3rad]" "--tw-gradient-position: 74.4845deg"
 
+(* [-bg-linear-[value]] accepts only angles, gated by a check that used to spell
+   "is this an angle" as [String.ends_with ~suffix:"rad" value]. That suffix
+   also matches "grad" (gradians end in "rad" too), so it stripped "100grad"
+   down to "100g", failed to read it as a number, and rejected the class
+   outright where Tailwind accepts it and negates the value as calc(100grad *
+   -1). Reading the bracket as a real CSS angle tells grad and rad apart; a
+   non-angle bracket like [to_bottom] still has to be rejected. *)
+let test_bracket_gradient_negated_angle_units () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css_of cls))
+  in
+  has "-bg-linear-[100grad]" "calc(100grad * -1)";
+  match Tw.of_string "-bg-linear-[to_bottom]" with
+  | Ok _ -> Alcotest.fail "expected -bg-linear-[to_bottom] to be rejected"
+  | Error _ -> ()
+
 let suborder_matches_tailwind () =
   let open Tw in
   let colors = [ red; blue; green; yellow; purple; pink ] in
@@ -526,6 +547,8 @@ let tests =
     test_case "gradient direction" `Quick test_gradient_direction;
     test_case "bracket gradient angle in radians" `Quick
       test_bracket_gradient_radians;
+    test_case "negated bracket gradient angle units" `Quick
+      test_bracket_gradient_negated_angle_units;
     test_case "bracket image literal" `Quick test_bracket_image_literal;
     test_case "bracket length keywords" `Quick test_bracket_length_keywords;
     test_case "bg-position bracket keyword+length" `Quick

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -85,6 +85,21 @@ let test_invalid_arbitrary_ease () =
   renders "ease-[steps(4,end)]";
   renders "ease-[var(--my-ease)]"
 
+(* CSS Easing 1 sec. 2: an omitted <step-position> defaults to [end]. Tailwind's
+   own minifier makes that default explicit, so a bracket steps() without a
+   position must render the same explicit keyword tw's sheet would otherwise
+   silently disagree over. *)
+let test_arbitrary_ease_steps_default_position () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an omitted step position becomes an explicit end" true
+    (Astring.String.is_infix ~affix:"transition-timing-function: steps(4, end)"
+       (css "ease-[steps(4)]"))
+
 (* An [--ease-*] token the project declared in its [@theme] names a timing
    function the built-in scale has no slot for. Tailwind generates the utility
    from it, channel variable included; tw rejected the class outright. *)
@@ -118,6 +133,8 @@ let tests =
         test_invalid_arbitrary_property;
       Alcotest.test_case "invalid arbitrary ease" `Quick
         test_invalid_arbitrary_ease;
+      Alcotest.test_case "arbitrary ease steps default position" `Quick
+        test_arbitrary_ease_steps_default_position;
       Alcotest.test_case "project ease token" `Quick test_project_ease_token;
     ]
 

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -755,6 +755,29 @@ let test_invalid_font_family () =
   accepted "font-[var(--x)]";
   accepted "font-[600]"
 
+(* A quoted bracket font family carries its own quoting; Tailwind passes the
+   decoded text through rather than wrapping it in one more layer of quotes.
+   When the bracket mixes a quoted string with a trailing bare token
+   ([font-["liga"_0x10]]) the decoded text is not a single family name at all
+   (CSS Fonts 4 sec. 2.1 has no such shape); cascade's own reader marks it
+   [Invalid] and the printer drops the declaration, the same fate a browser
+   gives Tailwind's literal (spec-invalid) text, so the double-quoted mangling
+   must not appear either. *)
+let test_font_bracket_family_quoted () =
+  let css cls =
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u -> Tw.Css.to_string (Tw.to_css ~base:false [ u ])
+  in
+  Alcotest.(check bool)
+    "a single quoted name keeps exactly one layer of quotes" true
+    (Astring.String.is_infix ~affix:{|font-family: "arial rounded"|}
+       (css {|font-["arial_rounded"]|}));
+  Alcotest.(check bool)
+    "a quoted string mixed with a bare token is never double-quoted" false
+    (Astring.String.is_infix ~affix:{|font-family: "\"liga\"|}
+       (css {|font-["liga"_0x10]|}))
+
 (* An arbitrary decoration thickness takes any CSS length unit, not just the px
    the hand-rolled suffix parser knew; the percentage form keeps its em
    conversion. A bracket that is not a length is rejected by the parser rather
@@ -966,6 +989,8 @@ let tests =
       test_decoration_shadeless_opacity;
     test_case "bracket list-style" `Quick test_bracket_list_style;
     test_case "invalid font family" `Quick test_invalid_font_family;
+    test_case "font bracket family quoted" `Quick
+      test_font_bracket_family_quoted;
     test_case "font-features value" `Quick test_font_features_value;
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -134,6 +134,37 @@ let test_line_clamp () =
   check "line-clamp-0";
   check "line-clamp-3"
 
+(* A project [@theme] override of [--line-clamp-none] is a namespace key, not a
+   value Tailwind type-checks at build time: any override at all, decimal or
+   not, switches line-clamp-none to the variable-driven form. Reading the value
+   with [int_of_string_opt] read [0x3] as the integer 3 (an OCaml-only spelling)
+   yet rejected a non-numeric override like [banana], which Tailwind still
+   honours the same way. *)
+let test_line_clamp_none_theme_override () =
+  let css theme cls =
+    match Tw.of_string ~theme cls with
+    | Ok u -> Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let hex =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("line-clamp-none", "0x3") ]
+  in
+  let out = css hex "line-clamp-none" in
+  Alcotest.(check bool)
+    "a hex-looking override still drives the variable form" true
+    (Astring.String.is_infix ~affix:"-webkit-line-clamp: var(--line-clamp-none)"
+       out);
+  Alcotest.(check bool)
+    "the theme layer keeps the override text as authored" true
+    (Astring.String.is_infix ~affix:"--line-clamp-none: 0x3" out);
+  let non_numeric =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("line-clamp-none", "banana") ]
+  in
+  Alcotest.(check bool)
+    "a non-numeric override still drives the variable form, too" true
+    (Astring.String.is_infix ~affix:"-webkit-line-clamp: var(--line-clamp-none)"
+       (css non_numeric "line-clamp-none"))
+
 let test_text_overflow_wrap () =
   check "text-ellipsis";
   check "overflow-ellipsis";
@@ -1006,6 +1037,8 @@ let tests =
     test_case "line height" `Quick test_line_height;
     test_case "letter spacing" `Quick test_letter_spacing;
     test_case "line clamp" `Quick test_line_clamp;
+    test_case "line-clamp-none theme override" `Quick
+      test_line_clamp_none_theme_override;
     test_case "text overflow/wrap" `Quick test_text_overflow_wrap;
     test_case "word/overflow wrap" `Quick test_word_overflow_wrap;
     test_case "hyphens" `Quick test_hyphens;


### PR DESCRIPTION
Four divergences from the live CLI, each with its test committed first.

A bracket font-family carrying quoted tokens was quoted again, so `font-["liga"_0x10]` emitted `font-family: "\"liga\" 0x10"`.

An arbitrary `steps()` ease dropped the position keyword: Tailwind writes `steps(4, end)`.

`line-clamp-none` type-checked its `@theme` override before using it. Tailwind does not check the value at all, it switches to the variable-driven form for any override, so `--line-clamp-none: 0x3` was read as 3 and a non-numeric override diverged too. The branch is presence-based now, which is what the CLI does.

`-bg-linear-[100grad]` was rejected outright, because the acceptance gate tested `String.ends_with ~suffix:"rad"` and "grad" ends with "rad". Reading the bracket through cascade's angle reader fixes it; the positive form was already correct by accident.