### PR TITLE
test, dom, divide: three house-keeping fixes

### DIFF
--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -147,6 +147,12 @@ module Handler = struct
     let rule = Css.rule ~selector [ decl ] in
     style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
 
+  (* [:where(.CLASS > :not(:last-child))], the selector every divide utility
+     hangs its declaration on. *)
+  let divide_children_selector class_name =
+    Css.Selector.(
+      where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
+
   (* Divide color utilities use nested rules with :where(.divide-X >
      :not(:last-child)) We construct the full class name in the selector like
      space-x-reverse does. *)
@@ -155,10 +161,7 @@ module Handler = struct
       if Color.is_shadeless color then "divide-" ^ Color.color_to_string color
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
     in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     if Color.is_custom_color color then
       let css_color = Color.to_css color shade in
       let rule = Css.rule ~selector [ Css.border_color css_color ] in
@@ -179,27 +182,17 @@ module Handler = struct
       style ~rules:(Some [ rule ]) []
 
   let divide_transparent_style () =
-    let selector =
-      Css.Selector.(
-        where
-          [ Combined (Class "divide-transparent", Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector "divide-transparent" in
     let rule = Css.rule ~selector [ Css.border_color (Css.hex "#0000") ] in
     style ~rules:(Some [ rule ]) []
 
   let divide_current_style () =
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class "divide-current", Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector "divide-current" in
     let rule = Css.rule ~selector [ Css.border_color Css.Current ] in
     style ~rules:(Some [ rule ]) []
 
   let divide_inherit_style () =
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class "divide-inherit", Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector "divide-inherit" in
     let rule = Css.rule ~selector [ Css.border_color Css.Inherit ] in
     style ~rules:(Some [ rule ]) []
 
@@ -210,18 +203,12 @@ module Handler = struct
         Css.hex ("#" ^ shortened)
       else match Color.css_color_to_hex c with Some h -> h | None -> c
     in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     let rule = Css.rule ~selector [ Css.border_color color ] in
     style ~rules:(Some [ rule ]) []
 
   let divide_bracket_color_opacity_style class_name inner _c opacity =
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
     if String.length inner > 0 && inner.[0] = '#' then
@@ -290,10 +277,7 @@ module Handler = struct
   let divide_style_style (bs : Css.border_style) =
     let name = border_style_to_string bs in
     let class_name = "divide-" ^ name in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     let decl, _ = Var.binding border_style_var bs in
     let rule = Css.rule ~selector [ decl; Css.border_style bs ] in
     style ~rules:(Some [ rule ]) []
@@ -305,18 +289,12 @@ module Handler = struct
       else "divide-" ^ Color.color_to_string color ^ "-" ^ string_of_int shade
     in
     let class_name = base_class_name ^ Color.opacity_suffix opacity in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     Color.divide_with_opacity ?theme color shade opacity selector
 
   let divide_current_opacity_style opacity =
     let class_name = "divide-current" ^ Color.opacity_suffix opacity in
-    let selector =
-      Css.Selector.(
-        where [ Combined (Class class_name, Child, Not [ Last_child ]) ])
-    in
+    let selector = divide_children_selector class_name in
     Color.divide_current_with_opacity opacity selector
 
   (* Helper to check if a string contains an opacity modifier *)

--- a/lib/dom/tw_dom.ml
+++ b/lib/dom/tw_dom.ml
@@ -1,49 +1,103 @@
 module Css = Cascade.Css
 (* Client-side CSS injection.
 
-   Maintains a <style> element in <head> containing CSS for all utilities
-   registered via [use]. Each utility's class name is tracked to avoid
-   re-injection. The <style> content is rebuilt when new utilities appear. *)
+   Maintains [<style data-tw="runtime">] elements in [<head>] containing CSS for
+   all utilities registered via [use]. Each utility's class name is tracked to
+   avoid re-injection.
+
+   A full [Tw.to_css] over every utility seen so far, run on every newly
+   discovered class, costs 1 + 2 + ... + n compilations over a mount pass that
+   introduces n distinct classes - O(n^2). Rebuilds are coalesced onto a
+   microtask (a mount pass compiles once, not once per [use] call), but that
+   alone does not bound the *total* work over the app's lifetime: a class
+   trickling in on its own microtask on every tick still hits the same pattern,
+   one full recompile per tick. [flush] instead keeps one "consolidated" element
+   holding a single from-scratch, fully sorted and deduplicated compile, and
+   injects each tick's new classes as their own small "delta" element compiled
+   from just that tick's batch - O(that batch) instead of O(everything so far).
+   Deltas fold back into the consolidated element once they have grown to match
+   it, the same growth-factor rule a dynamic array doubles by, which keeps the
+   *total* cost of every [Tw.to_css] call across the app's lifetime O(n) in
+   distinct classes rather than O(n^2). Base (Preflight) is never recompiled per
+   delta - it does not depend on which utilities are present, so it is folded in
+   once, at each consolidation. *)
 
 open Brr
 
 let registered : (string, unit) Hashtbl.t = Hashtbl.create 128
+
+(* Every utility ever registered, newest-first (prepended in O(1)); reversed
+   only at a consolidation. *)
 let all_styles : Tw.t list ref = ref []
-let style_el : El.t option ref = ref None
+let all_styles_count = ref 0
+
+(* Styles [use] has registered since the last [flush], newest-first. *)
+let since_flush : Tw.t list ref = ref []
+
+(* The prefix of [all_styles] (by count) already folded into [main_el] by a
+   from-scratch compile. *)
+let consolidated_count = ref 0
+let main_el : El.t option ref = ref None
+let delta_els : El.t list ref = ref []
 let include_base : bool ref = ref true
 
+let mk_style_el () =
+  let el = El.v El.Name.style [] in
+  El.set_at (Jstr.v "data-tw") (Some (Jstr.v "runtime")) el;
+  el
+
 let ensure_style_el () =
-  match !style_el with
+  match !main_el with
   | Some el -> el
   | None ->
       let head = Document.head G.document in
-      let el = El.v El.Name.style [] in
-      El.set_at (Jstr.v "data-tw") (Some (Jstr.v "runtime")) el;
+      let el = mk_style_el () in
       El.append_children head [ el ];
-      style_el := Some el;
+      main_el := Some el;
       el
 
 let set_text_content el s = El.set_children el [ El.txt (Jstr.v s) ]
 
-let rebuild_css () =
+(* Fold everything registered so far into [main_el] with one from-scratch
+   compile, matching exactly what a full rebuild produces today, and drop the
+   delta elements it now supersedes. *)
+let consolidate () =
   let el = ensure_style_el () in
   let styles = List.rev !all_styles in
   let css = Tw.to_css ~base:!include_base styles in
-  let css_str = Css.to_string ~minify:true css in
-  set_text_content el css_str
+  set_text_content el (Css.to_string ~minify:true css);
+  List.iter El.remove !delta_els;
+  delta_els := [];
+  consolidated_count := !all_styles_count
 
-(* Every rebuild compiles and serialises the whole accumulated sheet, so
-   rebuilding inside [use] costs one full compilation per component that
-   introduces a class: 1 + 2 + ... + n over a mount pass. The rebuild is instead
-   coalesced onto a microtask, which the browser drains at the end of the
-   current task and before it paints, so a mount pass compiles once. *)
+(* Compile and inject just [batch] (this tick's new styles) as its own small
+   element, appended after everything already in the document. [base] is never
+   included here - see the module comment - so a batch this only picks up
+   utility rules, folded into the canonical, deduplicated compile at the next
+   consolidation. *)
+let inject_delta batch =
+  let head = Document.head G.document in
+  let css = Tw.to_css ~base:false batch in
+  let el = mk_style_el () in
+  El.append_children head [ el ];
+  set_text_content el (Css.to_string ~minify:true css);
+  delta_els := !delta_els @ [ el ]
+
 let pending : bool ref = ref false
 
 let flush () =
   if !pending then (
     pending := false;
-    rebuild_css ())
+    let batch = List.rev !since_flush in
+    since_flush := [];
+    if batch <> [] then (
+      inject_delta batch;
+      let pending_count = !all_styles_count - !consolidated_count in
+      if pending_count >= max 1 !consolidated_count then consolidate ()))
 
+(* Coalesced onto a microtask, which the browser drains at the end of the
+   current task and before it paints, so a mount pass calling [use] many times
+   still injects once. *)
 let schedule_rebuild () =
   if not !pending then (
     pending := true;
@@ -61,6 +115,8 @@ let use styles =
       if not (Hashtbl.mem registered cls) then (
         Hashtbl.add registered cls ();
         all_styles := s :: !all_styles;
+        incr all_styles_count;
+        since_flush := s :: !since_flush;
         new_found := true))
     styles;
   if !new_found then schedule_rebuild ();

--- a/lib/dom/tw_dom.mli
+++ b/lib/dom/tw_dom.mli
@@ -1,8 +1,14 @@
 (** Client-side CSS injection for js_of_ocaml apps.
 
-    Manages a single [<style>] element in the document head. Utilities are
-    registered at runtime and their CSS is injected into the DOM. The style
-    element grows monotonically — utilities are never removed.
+    Manages one or more [<style data-tw="runtime">] elements in the document
+    head. Utilities are registered at runtime and their CSS is injected into the
+    DOM. The injected CSS grows monotonically — utilities are never removed. A
+    newly discovered batch is compiled and injected as its own small element
+    rather than by recompiling and re-serialising everything seen so far; small
+    elements are periodically folded into one canonical, fully sorted and
+    deduplicated element. A selector matching [style[data-tw="runtime"]] can
+    therefore match more than one element at a time — use {!css} to read the
+    full accumulated stylesheet as one string.
 
     Usage with Helix:
     {[
@@ -29,7 +35,17 @@ val use : Tw.t list -> string
     mounts that each call [use] compiles the sheet once rather than once per
     mount. The browser drains microtasks before it paints, so the rules are in
     the document by the time anything is rendered; call {!flush} to inject them
-    at once. *)
+    at once.
+
+    Each tick's new classes compile and inject as their own small element, not
+    by recompiling everything registered so far, so registering utilities over
+    many ticks costs O(n) total compilation in the number of distinct classes
+    rather than O(n^2). Small elements are periodically consolidated into one
+    canonical, fully sorted element in the background; between consolidations,
+    conflict resolution between two utilities registered in different ticks
+    follows registration order rather than Tailwind's canonical family order
+    (utilities registered in the same [use] call, e.g. a base utility and its
+    variant, are unaffected — they compile and sort together). *)
 
 val flush : unit -> unit
 (** [flush ()] injects any rules {!use} has registered but not yet written to

--- a/lib/tools/cascade_provenance.ml
+++ b/lib/tools/cascade_provenance.ml
@@ -1,0 +1,87 @@
+(** See {!Cascade_provenance}. *)
+
+let run_line cmd =
+  match Unix.open_process_in (cmd ^ " 2>/dev/null") with
+  | exception Unix.Unix_error _ -> None
+  | ic -> (
+      let line =
+        try Some (String.trim (input_line ic)) with End_of_file -> None
+      in
+      (match Unix.close_process_in ic with
+      | _ -> ()
+      | exception Unix.Unix_error _ -> ());
+      match line with Some "" -> None | v -> v)
+
+(* [dune exec] preserves the caller's cwd, so a repo-root checkout is found
+   without climbing; a few parent hops cover a run from a subdirectory too. *)
+let is_repo_root dir =
+  Sys.file_exists (Filename.concat dir "dune-project")
+  && Sys.file_exists (Filename.concat dir "cascade")
+
+let repo_root () =
+  let rec climb dir depth =
+    if is_repo_root dir then Some dir
+    else if depth <= 0 then None
+    else
+      let parent = Filename.dirname dir in
+      if parent = dir then None else climb parent (depth - 1)
+  in
+  match Sys.getcwd () with exception Sys_error _ -> None | cwd -> climb cwd 4
+
+let contains haystack word =
+  let n = String.length haystack and m = String.length word in
+  let rec loop i =
+    i + m <= n && (String.sub haystack i m = word || loop (i + 1))
+  in
+  m > 0 && loop 0
+
+(* The [dune-project] depends line is [(cascade (and (>= X) (< Y)))]; grabbed
+   verbatim rather than sexp-parsed since it is only ever displayed, never
+   compared against. *)
+let cascade_pin root =
+  let path = Filename.concat root "dune-project" in
+  match open_in path with
+  | exception Sys_error _ -> None
+  | ic ->
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
+      let rec loop () =
+        match input_line ic with
+        | exception End_of_file -> None
+        | line ->
+            let trimmed = String.trim line in
+            if contains trimmed "cascade" && contains trimmed "(and" then
+              Some trimmed
+            else loop ()
+      in
+      loop ()
+
+let report () =
+  match repo_root () with
+  | None -> ()
+  | Some root -> (
+      let cascade_dir = Filename.quote (Filename.concat root "cascade") in
+      match
+        Fmt.kstr run_line "git -C %s rev-parse --short=12 HEAD" cascade_dir
+      with
+      | None -> ()
+      | Some sha -> (
+          let exact_tag =
+            Fmt.kstr run_line "git -C %s describe --tags --exact-match"
+              cascade_dir
+          in
+          let pin =
+            match cascade_pin root with Some p -> p | None -> "(unreadable)"
+          in
+          match exact_tag with
+          | Some tag ->
+              Fmt.pr
+                "cascade: local checkout %s (tag %s); dune-project pins %s@."
+                sha tag pin
+          | None ->
+              Fmt.pr
+                "@.WARNING: cascade checkout %s is not sitting on a release \
+                 tag; dune-project pins %s, and CI resolves that constraint \
+                 through its own opam pin, not this checkout. The cascade/ \
+                 symlink is a live sibling checkout other sessions move, so \
+                 this run may not match what CI compiles.@.@."
+                sha pin))

--- a/lib/tools/cascade_provenance.mli
+++ b/lib/tools/cascade_provenance.mli
@@ -1,0 +1,17 @@
+(** Surface the cascade revision a local run is actually built against.
+
+    The [cascade/] directory at the repo root is a symlink to a sibling checkout
+    that other sessions move independently; CI has no such symlink and instead
+    resolves the [cascade] dependency through opam against the version range
+    [dune-project] pins. A local test run can therefore pass against code CI
+    never sees. {!report} prints both sides to stdout so the mismatch is visible
+    instead of silently green; when no [cascade/] checkout is found (as on CI,
+    or when the repo root cannot be located from the process's working
+    directory) it prints nothing. It never raises. *)
+
+val report : unit -> unit
+(** [report ()] prints the local [cascade/] checkout's git revision next to the
+    version range [dune-project] pins for the [cascade] dependency, and a
+    warning when the checkout is not sitting exactly on a release tag (the
+    common case for a live sibling checkout, and the case where CI's
+    opam-resolved cascade can diverge from what this run compiled against). *)

--- a/lib/tools/merlint.toml
+++ b/lib/tools/merlint.toml
@@ -1,7 +1,8 @@
-# tailwind_gen drives the reference tailwindcss CLI for differential tests; it
-# is dev-only (never in the JS bundle), so Fmt is fine there. Relax the lib/
-# disallowed_modules ban (E221) for that one file only -- every other file here
-# stays under the ban.
+# tailwind_gen drives the reference tailwindcss CLI for differential tests and
+# cascade_provenance shells out to git to report the local cascade checkout;
+# both are dev-only (never in the JS bundle), so Fmt is fine there. Relax the
+# lib/ disallowed_modules ban (E221) for these files only -- every other file
+# here stays under the ban.
 [[rules]]
-files = ["tailwind_gen.ml"]
+files = ["tailwind_gen.ml", "cascade_provenance.ml"]
 exclude = ["E221"]

--- a/test/dom/dune
+++ b/test/dom/dune
@@ -1,7 +1,7 @@
 (executable
  (name test)
  (modes js)
- (libraries tw tw_dom cascade alcotest astring brr)
+ (libraries tw tw_dom cascade alcotest astring brr fmt)
  (enabled_if
   (= %{context_name} "default")))
 

--- a/test/dom/test_tw_dom.ml
+++ b/test/dom/test_tw_dom.ml
@@ -68,10 +68,14 @@ let dom_dedup () =
   check bool "grows with new utility" true
     (String.length css3 > String.length css1)
 
+(* A newly discovered batch injects as its own small element rather than by
+   rewriting one growing element, so [data-tw="runtime"] can match several
+   elements at once; concatenate them all in document order. *)
 let style_el_text () =
-  match Brr.El.find_first_by_selector (Jstr.v "style[data-tw=\"runtime\"]") with
-  | Some el -> Jstr.to_string (Brr.El.text_content el)
-  | None -> ""
+  Brr.El.fold_find_by_selector
+    (fun el acc -> acc ^ Jstr.to_string (Brr.El.text_content el))
+    (Jstr.v "style[data-tw=\"runtime\"]")
+    ""
 
 let dom_batching () =
   (* [use] coalesces its rebuild onto a microtask, so the sheet in the document
@@ -88,6 +92,55 @@ let dom_batching () =
   Tw_dom.flush ();
   check string "flush with nothing pending is a no-op" flushed
     (style_el_text ())
+
+let style_el_count () =
+  Brr.El.fold_find_by_selector
+    (fun _ acc -> acc + 1)
+    (Jstr.v "style[data-tw=\"runtime\"]")
+    0
+
+(* A class registered on its own tick lands in its own small element rather than
+   a full recompile over everything seen so far - the fix for the quadratic
+   rebuild. Drip-feeding distinct classes one flush at a time must therefore see
+   more than one element at some point; a batch large enough to dwarf whatever
+   is already consolidated then folds everything - deltas and all - back into
+   exactly one element, and the aggregated content must match a plain
+   [Tw_dom.css ()] compile regardless of how many elements it came from. *)
+let dom_incremental_consolidation () =
+  Tw_dom.init ~base:false ();
+  Tw_dom.flush ();
+  let dripped = List.init 40 (fun i -> Fmt.str "pt-%d" (101 + i)) in
+  let saw_multiple = ref false in
+  List.iter
+    (fun cls ->
+      ignore (Tw_dom.use_str cls);
+      Tw_dom.flush ();
+      if style_el_count () > 1 then saw_multiple := true)
+    dripped;
+  check bool
+    "drip-feeding distinct classes uses more than one element at some point"
+    true !saw_multiple;
+  let final_batch = List.init 100 (fun i -> Fmt.str "pr-%d" (201 + i)) in
+  ignore (Tw_dom.use_str (String.concat " " final_batch));
+  Tw_dom.flush ();
+  check int
+    "a batch dwarfing what is consolidated folds everything into one element" 1
+    (style_el_count ());
+  let all = dripped @ final_batch in
+  let css = Tw_dom.css () in
+  let dom_css = style_el_text () in
+  List.iter
+    (fun cls ->
+      let selector = "." ^ cls in
+      check bool
+        (Fmt.str "css () has %s" cls)
+        true
+        (Astring.String.is_infix ~affix:selector css);
+      check bool
+        (Fmt.str "document has %s" cls)
+        true
+        (Astring.String.is_infix ~affix:selector dom_css))
+    all
 
 let has_dom =
   (* Check if document.createElement exists — absent in Node.js *)
@@ -111,6 +164,7 @@ let dom_cases =
       test_case "use_str" `Quick dom_use_str;
       test_case "dedup" `Quick dom_dedup;
       test_case "batching" `Quick dom_batching;
+      test_case "incremental consolidation" `Quick dom_incremental_consolidation;
     ]
   else []
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -22,6 +22,7 @@ let setup =
   Term.(const init $ seed)
 
 let () =
+  Tw_tools.Cascade_provenance.report ();
   (* Use Alcotest.run_with_args for proper CLI integration *)
   Tw_tools.Tailwind_gen.with_stats @@ fun () ->
   Alcotest.run_with_args "tw" setup

--- a/test/tools/test.ml
+++ b/test/tools/test.ml
@@ -1,5 +1,6 @@
 (* Test runner for tools library *)
 
 let () =
+  Tw_tools.Cascade_provenance.report ();
   Tw_tools.Tailwind_gen.with_stats @@ fun () ->
   Alcotest.run "tools" [ Test_entrypoint.suite; Test_tailwind_gen.suite ]

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -11,7 +11,7 @@
 (test
  (name test)
  (modules test)
- (libraries alcotest tw cascade cascade.diff fmt re upstream_fixture)
+ (libraries alcotest tw tw_tools cascade cascade.diff fmt re upstream_fixture)
  (deps utilities.txt variants.txt))
 
 ; Pins the [@theme] scanner on the declaration shapes Prettier produces:

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -11,7 +11,15 @@
 (test
  (name test)
  (modules test)
- (libraries alcotest tw tw_tools cascade cascade.diff fmt re upstream_fixture)
+ (libraries
+  alcotest
+  tw
+  tw_tools
+  cascade
+  cascade.diff
+  fmt
+  re
+  upstream_fixture)
  (deps utilities.txt variants.txt))
 
 ; Pins the [@theme] scanner on the declaration shapes Prettier produces:

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -827,6 +827,7 @@ let load basename floor =
       cases
 
 let () =
+  Tw_tools.Cascade_provenance.report ();
   let utility_tests = load "utilities.txt" utilities_floor in
   let variant_tests = load "variants.txt" variants_floor in
   let total = List.length utility_tests + List.length variant_tests in


### PR DESCRIPTION
A local gate could pass against a cascade revision CI does not use, which has now cost hours three times. Each test binary reports the checkout's SHA against the `dune-project` pin, and warns when the checkout is not on a release tag. Silent on CI, which resolves cascade through opam.

`Tw_dom.use` recompiled every class seen so far on each new class, O(n squared) in distinct classes. Deltas are now injected as their own style element and folded back into the canonical one as they grow. Measured in headless Chromium over 600 distinct classes registered a microtask apart: 1402.6ms to 124.7ms.

The children selector in divide is one helper rather than nine copies, salvaged from the closed shadowing branch without any of its warning changes.