### PR TITLE
modifiers: refuse a container query as a not-* inner

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1522,12 +1522,14 @@ let try_not_shorthand inner =
 
 (** Check if a modifier is compatible with not-* negation. Pseudo-elements,
     starting style, children/descendants, and container queries cannot be
-    negated. *)
+    negated: a container query has no negated selector form, and tw used to
+    build [.not-\@md\:flex:not(.flex)] for one, negating the utility's own class
+    so the rule matched nothing. *)
 let is_not_compatible = function
   | Pseudo_before | Pseudo_after | Pseudo_marker | Pseudo_selection
   | Pseudo_placeholder | Pseudo_backdrop | Pseudo_file | Pseudo_first_letter
   | Pseudo_first_line | Pseudo_details_content | Starting | Children
-  | Descendants | Prose_element _ ->
+  | Descendants | Prose_element _ | Container _ ->
       false
   | _ -> true
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -995,6 +995,24 @@ let test_at_rule_variant_over_media () =
   emits "starting:sm:flex" [ "@starting-style"; "min-width: 40rem" ];
   emits "@md:sm:flex" [ "@container"; "min-width: 40rem" ]
 
+(* A container query is not a [not-*] inner. Tailwind rejects the class
+   outright; tw built a rule whose selector negates the utility's own class
+   ([.not-\@md\:flex:not(.flex)]), which can never match anything. *)
+let test_not_container_rejected () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  rejected "not-@md:flex";
+  rejected "not-@lg:flex";
+  rejected "not-@min-[30rem]:flex";
+  (* The negatable inners still parse. *)
+  check bool "not-hover still parses" true
+    (Result.is_ok (Tw.of_string "not-hover:flex"));
+  check bool "not-first still parses" true
+    (Result.is_ok (Tw.of_string "not-first:flex"))
+
 (* Extend the suite with new tests *)
 let tests =
   tests
@@ -1006,6 +1024,7 @@ let tests =
         test_supports_property_is_unprefixed;
       test_case "at-rule variant over a media query" `Quick
         test_at_rule_variant_over_media;
+      test_case "not-container is rejected" `Quick test_not_container_rejected;
       test_case "empty attribute brackets" `Quick test_empty_attribute_brackets;
       test_case "padded attribute brackets" `Quick
         test_padded_attribute_brackets;


### PR DESCRIPTION
`not-@md:flex` built `.not-\@md\:flex:not(.flex)`, a selector that negates the utility's own class and so matches nothing. Tailwind rejects the class outright. The doc comment on `is_not_compatible` already said container queries cannot be negated; the list did not include them.