### PR TITLE
effects: record a bracket alpha as the author wrote it

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -311,14 +311,17 @@ module Handler = struct
 
   let shorten_hex = Color.shorten_hex_str
 
-  let shadow_alpha_decl percent =
-    Css.custom_property ~layer:"utilities" "--tw-shadow-alpha"
-      (pp_float percent ^ "%")
-
+  (* A bracket alpha with no [%] records the author's own number, unscaled and
+     without a unit, which is what Tailwind writes: [shadow-lg/[25]] gives
+     [--tw-shadow-alpha: 25]. Every other spelling stays a percentage. The alpha
+     the shadow actually paints with is computed separately. *)
   let opacity_css_value opacity =
     match Color.opacity_var_bare_of opacity with
     | Some name -> "var(--" ^ name ^ ")"
-    | None -> pp_float (Color.opacity_to_percent opacity) ^ "%"
+    | None -> (
+        match opacity with
+        | Color.Opacity_arbitrary n -> pp_float n.value
+        | _ -> pp_float (Color.opacity_to_percent opacity) ^ "%")
 
   let shadow_opacity_decl opacity =
     Css.custom_property ~layer:"utilities" "--tw-shadow-alpha"
@@ -476,12 +479,11 @@ module Handler = struct
       [ d_shadow; box_shadow_composition v_shadow ]
 
   let shadow_shape_opacity_style shape opacity =
-    let percent = Color.opacity_to_percent opacity in
     let d_shadow, v_shadow =
       Var.binding shadow_var (shape_shadow_opacity_value shape opacity)
     in
     style ~property_rules:shadow_property_rules
-      [ shadow_alpha_decl percent; d_shadow; box_shadow_composition v_shadow ]
+      [ shadow_opacity_decl opacity; d_shadow; box_shadow_composition v_shadow ]
 
   let shadow_2xs = shadow_shape_style Two_xs
   let shadow_xs = shadow_shape_style Xs
@@ -1081,10 +1083,6 @@ module Handler = struct
 
   (* ============ Inset shadow helpers ============ *)
 
-  let inset_shadow_alpha_decl percent =
-    Css.custom_property ~layer:"utilities" "--tw-inset-shadow-alpha"
-      (pp_float percent ^ "%")
-
   let inset_shadow_opacity_decl opacity =
     Css.custom_property ~layer:"utilities" "--tw-inset-shadow-alpha"
       (opacity_css_value opacity)
@@ -1184,7 +1182,7 @@ module Handler = struct
     in
     style ~property_rules:shadow_property_rules
       [
-        inset_shadow_alpha_decl percent;
+        inset_shadow_opacity_decl opacity;
         d_inset_shadow;
         inset_box_shadow_composition v_inset_shadow;
       ]

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -350,6 +350,33 @@ let test_arbitrary_shadow_colour_opacity () =
     "--tw-inset-shadow-alpha:var(--x)";
   has "inset-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
 
+(* A bracket alpha modifier with no [%] sign (shadow-lg/[25]) tracks the
+   modifier's own written text in --tw-shadow-alpha, the way Tailwind does,
+   rather than scaling it into a percentage: the alpha the shadow paints with
+   comes from a separate, correctly-scaled computation, so --tw-shadow-alpha
+   here is a plain, unconverted echo of what the class wrote. *)
+let test_shadow_bracket_alpha_tracking () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  let lacks cls affix =
+    Alcotest.(check bool) cls false (Astring.String.is_infix ~affix (css cls))
+  in
+  has "shadow-lg/[25]" "--tw-shadow-alpha:25;";
+  lacks "shadow-lg/[25]" "--tw-shadow-alpha:2500%";
+  has "shadow-[0_1px_2px_#000]/[25]" "--tw-shadow-alpha:25;";
+  has "inset-shadow-sm/[25]" "--tw-inset-shadow-alpha:25;";
+  lacks "inset-shadow-sm/[25]" "--tw-inset-shadow-alpha:2500%";
+  (* A bracket alpha that does carry a [%] sign, or the plain percent form, both
+     keep behaving as a percentage. *)
+  has "shadow-lg/[25%]" "--tw-shadow-alpha:25%";
+  has "shadow-lg/50" "--tw-shadow-alpha:50%"
+
 (* An arbitrary shadow that is not a shadow is not a utility: it used to fall
    back to the zero shadow. *)
 let test_invalid_arbitrary_shadow () =
@@ -490,6 +517,8 @@ let tests =
   [
     test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     test_case "project shadow tokens" `Quick test_project_shadow_tokens;
+    test_case "shadow bracket alpha tracking" `Quick
+      test_shadow_bracket_alpha_tracking;
     test_case "undefined colour shade" `Quick test_undefined_shade;
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
     test_case "shadow-inner" `Quick test_shadow_inner;
@@ -497,6 +526,8 @@ let tests =
     test_case "arbitrary shadow lengths" `Quick test_arbitrary_shadow_lengths;
     test_case "arbitrary shadow colour opacity" `Quick
       test_arbitrary_shadow_colour_opacity;
+    test_case "shadow bracket alpha tracking" `Quick
+      test_shadow_bracket_alpha_tracking;
     test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;


### PR DESCRIPTION
`shadow-lg/[25]` wrote `--tw-shadow-alpha: 2500%` where Tailwind writes `25`: a bracket alpha with no `%` was scaled as if it were a fraction. The channel now echoes the author's own number, unscaled and unitless, and every other spelling (`/[25%]`, `/50`) stays a percentage. The alpha the shadow paints with is computed separately and did not move.

Verified against the live CLI on `shadow-lg/[25]`, `shadow-lg/[25%]`, `shadow-lg/50`, `shadow-lg/[0.5]`, `inset-shadow-sm/[25]`, `inset-shadow-sm/25` and `shadow-red-500/50`.