### PR TITLE
typography: split a comma-separated bracket font family

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1477,22 +1477,40 @@ module Typography_early = struct
           in
           style [ font_family (Invalid tokens) ]
     | Font_bracket_family_name (_, s) ->
-        (* Parse known generic family names *)
+        (* Each comma segment is its own [<family-name>] (CSS Fonts 4 sec. 2.1),
+           so a generic keyword only matches a segment on its own, not the
+           bracket as a whole; [font-[Papyrus,fantasy]] is the two-entry stack
+           [Papyrus, fantasy], never the single literal name
+           ["Papyrus,fantasy"]. A quoted segment is always a custom-ident
+           literal, so it never resolves to a generic keyword either. *)
+        let family_of_entry entry : Css.font_family =
+          let entry = String.trim entry in
+          let n = String.length entry in
+          if
+            n >= 2
+            && (entry.[0] = '"' || entry.[0] = '\'')
+            && entry.[n - 1] = entry.[0]
+          then Css.Name (String.sub entry 1 (n - 2))
+          else
+            match entry with
+            | "ui-sans-serif" -> Css.Ui_sans_serif
+            | "ui-serif" -> Css.Ui_serif
+            | "ui-monospace" -> Css.Ui_monospace
+            | "ui-rounded" -> Css.Ui_rounded
+            | "sans-serif" -> Css.Sans_serif
+            | "serif" -> Css.Serif
+            | "monospace" -> Css.Monospace
+            | "cursive" -> Css.Cursive
+            | "fantasy" -> Css.Fantasy
+            | "system-ui" -> Css.System_ui
+            | "emoji" -> Css.Emoji
+            | "math" -> Css.Math
+            | name -> Css.Name name
+        in
         let family =
-          match s with
-          | "ui-sans-serif" -> Css.Ui_sans_serif
-          | "ui-serif" -> Css.Ui_serif
-          | "ui-monospace" -> Css.Ui_monospace
-          | "ui-rounded" -> Css.Ui_rounded
-          | "sans-serif" -> Css.Sans_serif
-          | "serif" -> Css.Serif
-          | "monospace" -> Css.Monospace
-          | "cursive" -> Css.Cursive
-          | "fantasy" -> Css.Fantasy
-          | "system-ui" -> Css.System_ui
-          | "emoji" -> Css.Emoji
-          | "math" -> Css.Math
-          | _ -> Css.Name s
+          match String.split_on_char ',' s with
+          | [ single ] -> family_of_entry single
+          | entries -> Css.List (List.map family_of_entry entries)
         in
         style [ font_family family ]
     | Font_bracket_family_var (_, var_str) ->

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -809,6 +809,21 @@ let test_font_bracket_family_quoted () =
     (Astring.String.is_infix ~affix:{|font-family: "\"liga\"|}
        (css {|font-["liga"_0x10]|}))
 
+(* A comma-separated bracket family list ([font-[Papyrus,fantasy]]) is a
+   fallback stack, not one literal name: each comma segment is its own
+   [<family-name>], so a bare generic keyword among them (here [fantasy]) stays
+   an unquoted keyword rather than folding into one quoted string. *)
+let test_font_bracket_family_comma_list () =
+  let css cls =
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "unquoted comma list, generic keyword kept bare" true
+    (Astring.String.is_infix ~affix:"font-family:Papyrus,fantasy"
+       (css "font-[Papyrus,fantasy]"))
+
 (* An arbitrary decoration thickness takes any CSS length unit, not just the px
    the hand-rolled suffix parser knew; the percentage form keeps its em
    conversion. A bracket that is not a length is rejected by the parser rather
@@ -1022,6 +1037,8 @@ let tests =
     test_case "invalid font family" `Quick test_invalid_font_family;
     test_case "font bracket family quoted" `Quick
       test_font_bracket_family_quoted;
+    test_case "font bracket family comma list" `Quick
+      test_font_bracket_family_comma_list;
     test_case "font-features value" `Quick test_font_features_value;
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;


### PR DESCRIPTION
`font-[Papyrus,fantasy]` emitted `font-family: "Papyrus,fantasy"`, one quoted literal, where Tailwind emits `Papyrus, fantasy`. A comma list is a fallback stack: each segment is its own family name, so a bare generic keyword among them stays an unquoted keyword.