### PR TITLE
rule, modifiers, build: parse selectors and keep @theme order

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -679,9 +679,34 @@ let priority_seven_namespace = function
       else 5
   | None -> 5
 
+(* The position of a theme token within the project's [@theme] declaration list,
+   keyed by its bare name. [Scheme.token_overrides] preserves the source order
+   the CSS entrypoint (or [Scheme.with_overrides] caller) declared them in. *)
+let declared_index theme =
+  List.mapi (fun i (name, _) -> (name, i)) theme.Scheme.token_overrides
+
+(* [declared] is the bare-name -> declaration-index table [declared_index]
+   built; strips the leading [--] a custom declaration's name carries before
+   looking it up. *)
+let declared_order declared name =
+  match name with
+  | None -> None
+  | Some full ->
+      let bare =
+        if String.length full > 2 && String.sub full 0 2 = "--" then
+          String.sub full 2 (String.length full - 2)
+        else full
+      in
+      List.assoc_opt bare declared
+
 (* Sort declarations by their Var order metadata, namespace at a shared slot,
-   then alphabetical fallback. *)
-let sort_by_var_order decls =
+   declaration order within that slot, then alphabetical fallback. A project-
+   named family (--font-<name>, --text-<name>, --leading-<name>, ...) funnels
+   every member into one shared (priority, suborder) slot (see [Var.mli]), so
+   two project tokens tie there; Tailwind keeps the order the [@theme] block
+   wrote them in rather than sorting by name. *)
+let sort_by_var_order ~theme decls =
+  let declared = declared_index theme in
   decls
   |> List.map (fun d ->
       let name = Css.custom_declaration_name d in
@@ -690,8 +715,8 @@ let sort_by_var_order decls =
         | Some _ as order -> order
         | None -> Option.bind name Var.order
       in
-      (d, order, name))
-  |> List.sort (fun (_, a, na) (_, b, nb) ->
+      (d, order, name, declared_order declared name))
+  |> List.sort (fun (_, a, na, ia) (_, b, nb, ib) ->
       let c = compare_orders a b in
       if c <> 0 then c
       else
@@ -703,8 +728,12 @@ let sort_by_var_order decls =
                 (priority_seven_namespace nb)
           | _ -> 0
         in
-        if namespace_cmp <> 0 then namespace_cmp else compare na nb)
-  |> List.map (fun (d, _, _) -> d)
+        if namespace_cmp <> 0 then namespace_cmp
+        else
+          match (ia, ib) with
+          | Some ia, Some ib -> Int.compare ia ib
+          | _ -> compare na nb)
+  |> List.map (fun (d, _, _, _) -> d)
 
 (* Build theme layer rule from declarations *)
 let theme_layer_rule ~layers = function
@@ -848,11 +877,11 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
   pre @ extracted @ post
   |> List.filter_map (apply_token_override theme)
   |> List.map (inline_default_family theme)
-  |> sort_by_var_order |> theme_layer_rule ~layers
+  |> sort_by_var_order ~theme |> theme_layer_rule ~layers
 
-let theme_layer_of ?(default_decls = []) tw_classes =
+let theme_layer_of ?theme ?(default_decls = []) tw_classes =
   let selector_props = collect_selector_props tw_classes in
-  theme_layer_of_props ~default_decls selector_props
+  theme_layer_of_props ?theme ~default_decls selector_props
 
 let placeholder_supports =
   let placeholder = Css.Selector.Placeholder in

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -70,10 +70,15 @@ val to_inline_style : ?theme:Scheme.t -> Utility.t list -> string
 (** {1 Layer building} *)
 
 val theme_layer_of :
-  ?default_decls:Css.declaration list -> Utility.t list -> Css.t
-(** [theme_layer_of ?default_decls utilities] builds the [@layer theme] block
-    containing all CSS custom property variables referenced by [utilities], plus
-    any [default_decls] (e.g. baseline font-family declarations). *)
+  ?theme:Scheme.t ->
+  ?default_decls:Css.declaration list ->
+  Utility.t list ->
+  Css.t
+(** [theme_layer_of ?theme ?default_decls utilities] builds the [@layer theme]
+    block containing all CSS custom property variables referenced by
+    [utilities], plus any [default_decls] (e.g. baseline font-family
+    declarations). [theme] (default {!Scheme.default}) supplies the token
+    overrides and their declaration order. *)
 
 val rule_sets : Utility.t list -> Css.statement list
 (** [rule_sets utilities] extracts and sorts CSS statements for [utilities] with

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1059,32 +1059,19 @@ let parse_px_value s =
   | Some px -> Some ({ px; text = s } : Style.arbitrary_px)
   | None -> None
 
-(* Preprocess a has-selector string: & → * and ensure combinator spacing. *)
-let preprocess_has_selector s =
-  let buf = Buffer.create (String.length s + 4) in
-  let len = String.length s in
-  for i = 0 to len - 1 do
-    match s.[i] with
-    | '&' -> Buffer.add_char buf '*'
-    | ('+' | '>' | '~') as c ->
-        if
-          Buffer.length buf > 0
-          &&
-          let b = Buffer.contents buf in
-          b.[String.length b - 1] <> ' '
-        then Buffer.add_char buf ' ';
-        Buffer.add_char buf c;
-        if i + 1 < len && s.[i + 1] <> ' ' then Buffer.add_char buf ' '
-    | c -> Buffer.add_char buf c
-  done;
-  Buffer.contents buf
+(* Parse a has-selector string as a relative CSS selector ([:has()] accepts a
+   bare leading combinator, e.g. [>div] or [~img]), with [&] resolved to the
+   universal selector via {!Cascade.Nest.substitute}, the same substitution
+   {!nest_selector} performs for anchored templates. *)
+let has_relative_selector s =
+  let sel = Css.Selector.read_relative (Cascade.Cursor.of_string s) in
+  Cascade.Nest.substitute ~parent:Css.Selector.universal sel
 
 (* Validate that a has-selector string can be parsed as a CSS selector. Rejects
    invalid selectors like "@media_print" at parse time. *)
 let is_valid_has_selector sel =
   try
-    let processed = preprocess_has_selector sel in
-    ignore (Css.Selector.read_relative (Cascade.Cursor.of_string processed));
+    ignore (has_relative_selector sel);
     true
   with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> false
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -451,29 +451,14 @@ let container_rule ?(inner_has_hover = false) query base_class selector props =
     container_query ~condition ~selector:new_selector ~props
       ~base_class:modified_class ()
 
-(** Preprocess a has-[...] selector string for CSS parsing. Replaces & with *
-    (nesting reference) and ensures combinators (+, >, ~) have proper spacing.
-*)
-let preprocess_has_selector s =
-  let buf = Buffer.create (String.length s + 4) in
-  let len = String.length s in
-  let i = ref 0 in
-  while !i < len do
-    (match s.[!i] with
-    | '&' -> Buffer.add_char buf '*'
-    | ('+' | '>' | '~') as c ->
-        (* Add space before combinator if not already present *)
-        if
-          Buffer.length buf = 0
-          || Buffer.contents buf |> fun b -> b.[String.length b - 1] <> ' '
-        then Buffer.add_char buf ' ';
-        Buffer.add_char buf c;
-        (* Add space after combinator if not already present *)
-        if !i + 1 < len && s.[!i + 1] <> ' ' then Buffer.add_char buf ' '
-    | c -> Buffer.add_char buf c);
-    incr i
-  done;
-  Buffer.contents buf
+(** Parse a has-[...] selector string as a relative CSS selector ([:has()]
+    accepts a bare leading combinator, e.g. [>div] or [~img]), with [&] (the
+    utility's own element) resolved to the universal selector - the same
+    substitution {!Modifiers.nest_selector} performs for [group-[...]] /
+    [peer-[...]] templates, via {!Cascade.Nest.substitute}. *)
+let has_relative_selector s =
+  let sel = Css.Selector.read_relative (Cascade.Cursor.of_string s) in
+  Cascade.Nest.substitute ~parent:Css.Selector.universal sel
 
 (* The selector a has-shorthand name stands for. [has-<state>] takes the same
    state names as the group/peer variants and matches what that state matches,
@@ -497,10 +482,7 @@ let has_inner_selector raw =
   let str =
     if Style.is_has_shorthand raw then resolve_has_shorthand raw else raw
   in
-  match
-    Css.Selector.read_relative
-      (Cascade.Cursor.of_string (preprocess_has_selector str))
-  with
+  match has_relative_selector str with
   | Css.Selector.List sels when not (Style.is_has_shorthand raw) ->
       Css.Selector.is_ sels
   | sel -> sel
@@ -532,9 +514,8 @@ let route_regular ~selector ~base_class ~modified_class ~modified ?has_hover
 let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
     ~selector selector_str base_class props =
   let open Css.Selector in
-  let processed = preprocess_has_selector selector_str in
   let parsed_selector =
-    match Css.Selector.read_relative (Cascade.Cursor.of_string processed) with
+    match has_relative_selector selector_str with
     (* A bracket list is one relative selector, so it goes in an [:is()]. The
        [hocus] shorthand is genuinely two, and stays a list. *)
     | List sels when shorthand = None -> is_ sels
@@ -1403,12 +1384,11 @@ let handle_not_bracket content base_class props =
        [:not(.os-macos <star>)]. Parse the transformed string as a selector so
        combinators and compounds flatten, rather than escaping it as a single
        class name. *)
-    let sel_str =
-      content
-      |> String.map (fun c -> if c = '_' then ' ' else c)
-      |> String.split_on_char '&' |> String.concat "*"
+    let sel_str = String.map (fun c -> if c = '_' then ' ' else c) content in
+    let inner =
+      Cascade.Nest.substitute ~parent:Css.Selector.universal
+        (Css.Selector.read (Cascade.Cursor.of_string sel_str))
     in
-    let inner = Css.Selector.read (Cascade.Cursor.of_string sel_str) in
     [
       regular ~not_order:nvo
         ~selector:

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -918,9 +918,37 @@ let test_starting_style_merges () =
   check bool "both utilities are in it" true
     (count ".starting\\:opacity-0" = 1 && count ".starting\\:scale-90" = 1)
 
+(* A project [@theme] can name a family member the built-in scale has no slot
+   for ([--font-<name>]); every such member funnels into one shared (priority,
+   suborder) slot (see [Typography.font_named_var]), so the two tokens tie
+   there. Tailwind keeps the order the [@theme] block declared them in rather
+   than re-sorting the tie alphabetically by name. *)
+let test_theme_named_family_declaration_order () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("font-zeta", "Zeta, serif"); ("font-alpha", "Alpha, serif") ]
+  in
+  let utilities =
+    [ "font-zeta"; "font-alpha" ]
+    |> List.map (fun c -> Result.get_ok (Tw.of_string ~theme c))
+  in
+  let css =
+    Css.to_string ~minify:true (Tw.to_css ~theme ~base:false utilities)
+  in
+  let position needle =
+    match Astring.String.find_sub ~sub:needle css with
+    | Some i -> i
+    | None -> Alcotest.failf "%s not found in %s" needle css
+  in
+  let zeta = position "--font-zeta:" and alpha = position "--font-alpha:" in
+  check bool "--font-zeta declared before --font-alpha, as in the @theme block"
+    true (zeta < alpha)
+
 let tests =
   [
     test_case "starting-style blocks merge" `Quick test_starting_style_merges;
+    test_case "theme-named family keeps @theme declaration order" `Quick
+      test_theme_named_family_declaration_order;
     test_case "referenced theme token emitted" `Quick
       test_referenced_theme_token;
     test_case "spacing-0 prunes --spacing" `Quick check_spacing_zero_prune;


### PR DESCRIPTION
The `has-[]`/`not-[]` rewrites scanned bytes for `&` where the anchor substitution already went through the typed selector API. They parse and go through `Nest.substitute` now; `&` was already reaching `Css.Selector.Nesting` natively, so the byte-scan was dead weight.

The theme layer sorted project `@theme` tokens alphabetically where Tailwind keeps declaration order: `--font-zeta` declared first came out after `--font-alpha`. Every project-named family member shares one slot, and the tie-break fell to the name. `Scheme.token_overrides` already preserves declaration order, so `sort_by_var_order` uses it as the tie-break before falling back to alphabetical.

The utilities layer is alphabetical in Tailwind too and was already correct.