### PR TITLE
backgrounds: read the bg-linear bracket angle typed, not by suffix

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -828,17 +828,21 @@ module Handler = struct
 
   (** Convert a bracket gradient value to its CSS string. "125deg" → "125deg",
       "1.3rad" → "74.4845deg", "to_bottom" → "to bottom", "circle_at_center" →
-      "circle at center" *)
+      "circle at center". "100grad" stays "100grad": gradians are a distinct CSS
+      angle unit from radians, even though the word ends in the same three
+      letters. Reading the value as a real [<angle>] tells the two apart instead
+      of matching on the "rad" suffix, which "grad" also has. *)
   let bracket_value_to_css inner =
-    if String.ends_with ~suffix:"rad" inner then
-      let rad_s = String.sub inner 0 (String.length inner - 3) in
-      match float_of_string_opt rad_s with
-      | Some rad ->
-          let deg = rad *. 180.0 /. Float.pi in
-          (* Round to 4 decimal places to match Lightning CSS *)
-          Cascade.Pp.string_of_float ~max_decimals:4 deg ^ "deg"
-      | None -> String.map (fun c -> if c = '_' then ' ' else c) inner
-    else String.map (fun c -> if c = '_' then ' ' else c) inner
+    let decoded = String.map (fun c -> if c = '_' then ' ' else c) inner in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Values.read_angle
+        (Cascade.Cursor.of_string decoded)
+    with
+    | Ok (Css.Rad rad) ->
+        let deg = rad *. 180.0 /. Float.pi in
+        (* Round to 4 decimal places to match Lightning CSS *)
+        Cascade.Pp.string_of_float ~max_decimals:4 deg ^ "deg"
+    | Ok _ | Error _ -> decoded
 
   (* [interp_decl] for a typed direction [dir_val]: [With_interpolation] typed
      when [ci_opt] covers the modifier, printing [dir_val] back to CSS rather

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -237,6 +237,23 @@ let test_bracket_gradient_negated_angle_units () =
   | Ok _ -> Alcotest.fail "expected -bg-linear-[to_bottom] to be rejected"
   | Error _ -> ()
 
+(* The positive (non-negated) [bg-linear-[<value>]] bracket shares the same "is
+   this a rad value" question as the negated form: a [String.ends_with
+   ~suffix:"rad"] test also matches "grad", since gradians end in "rad" too.
+   bg-linear-[100grad] must keep its gradian unit rather than being read as a
+   radian value with a stray "g" prefix. *)
+let test_bracket_gradient_grad_unit () =
+  let css_of cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css_of cls))
+  in
+  has "bg-linear-[100grad]" "--tw-gradient-position: 100grad";
+  has "bg-linear-[100grad]" "linear-gradient(var(--tw-gradient-stops, 100grad))"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let colors = [ red; blue; green; yellow; purple; pink ] in
@@ -549,6 +566,8 @@ let tests =
       test_bracket_gradient_radians;
     test_case "negated bracket gradient angle units" `Quick
       test_bracket_gradient_negated_angle_units;
+    test_case "bracket gradient grad unit" `Quick
+      test_bracket_gradient_grad_unit;
     test_case "bracket image literal" `Quick test_bracket_image_literal;
     test_case "bracket length keywords" `Quick test_bracket_length_keywords;
     test_case "bg-position bracket keyword+length" `Quick


### PR DESCRIPTION
The positive `bg-linear-[<value>]` form tested for a radian value with `String.ends_with ~suffix:"rad"`, which also matches `grad`, and assembled the converted result as a string. It produced correct output only because the parse failure fell through to a passthrough that happened to equal the leave-gradians-alone rule. It now reads the angle with cascade’s typed reader.