### PR TITLE
divide, masks: read the arbitrary width and size with the value parser

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1445,3 +1445,4 @@ let outline_offset_2 = utility (Outline_offset 2)
 let outline_offset_4 = utility (Outline_offset 4)
 let outline_offset_8 = utility (Outline_offset 8)
 let border_style_var = Handler.border_style_var
+let border_width_of_length = Handler.border_width_of_length

--- a/lib/borders.mli
+++ b/lib/borders.mli
@@ -637,4 +637,12 @@ val border_style_var : Cascade.Css.border_style Var.property_default
     utilities that read the same property cannot register a second, disagreeing
     slot for it. *)
 
+val border_width_of_length :
+  Cascade.Css.length -> Cascade.Css.border_width option
+(** [border_width_of_length len] transposes a length read from an arbitrary
+    value into the [Css.border_width] type a border/divide width sets;
+    [Css.length] and [Css.border_width] cover overlapping unit sets but are
+    distinct types. [None] for units the length grammar has that a border width
+    does not (the dynamic-viewport and container-query units). *)
+
 module Handler : Utility.Handler

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -434,22 +434,21 @@ module Handler = struct
     Stdlib.Option.map (Css.Pp.to_string (Css.pp_length ~always:true)) length
 
   (* The bracket text and the width it denotes. The text is what [to_class]
-     spells, so a class parsed here is reproduced verbatim. *)
+     spells, so a class parsed here is reproduced verbatim. [divide-x-[...]]
+     takes any CSS length, so the bracket is read with the value parser rather
+     than a hand-picked unit table; [Css.border_width] is a distinct type from
+     [Css.length], so the result is transposed through
+     [Borders.border_width_of_length]. *)
   let parse_bracket_width s : (string * Css.border_width) option =
     let len = String.length s in
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
-      if String.ends_with ~suffix:"px" inner then
-        let n = String.sub inner 0 (String.length inner - 2) in
-        match float_of_string_opt n with
-        | Some f -> Some (inner, Px f)
-        | None -> None
-      else if String.ends_with ~suffix:"rem" inner then
-        let n = String.sub inner 0 (String.length inner - 3) in
-        match float_of_string_opt n with
-        | Some f -> Some (inner, Rem f)
-        | None -> None
-      else None
+      match Parse.arbitrary_length inner with
+      | Some length -> (
+          match Borders.border_width_of_length length with
+          | Some width -> Some (inner, width)
+          | None -> None)
+      | None -> None
     else None
 
   let of_class theme class_name =

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -236,17 +236,10 @@ module Handler = struct
 
   (* Bracket notation helpers *)
 
-  let parse_bracket_len s =
-    if String.ends_with ~suffix:"px" s then
-      let n = String.sub s 0 (String.length s - 2) |> float_of_string_opt in
-      Option.map (fun f -> (Css.Px f : Css.length)) n
-    else if String.ends_with ~suffix:"%" s then
-      let n = String.sub s 0 (String.length s - 1) |> float_of_string_opt in
-      Option.map (fun f -> (Css.Pct f : Css.length)) n
-    else if String.ends_with ~suffix:"rem" s then
-      let n = String.sub s 0 (String.length s - 3) |> float_of_string_opt in
-      Option.map (fun f -> (Css.Rem f : Css.length)) n
-    else None
+  (* [mask-size-[...]], [mask-[size:...]] and [mask-[length:...]] take any CSS
+     length, so a token is read with the value parser rather than a hand-picked
+     unit table. *)
+  let parse_bracket_len s = Parse.arbitrary_length s
 
   let parse_bracket_size inner =
     let parts =
@@ -263,27 +256,11 @@ module Handler = struct
               ]
         | _ -> None)
     | [ v ] ->
-        let parse_size_val s : Css.background_size option =
-          if String.ends_with ~suffix:"px" s then
-            let n =
-              String.sub s 0 (String.length s - 2) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Length (Px f) : Css.background_size)) n
-          else if String.ends_with ~suffix:"%" s then
-            let n =
-              String.sub s 0 (String.length s - 1) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Length (Pct f) : Css.background_size)) n
-          else if String.ends_with ~suffix:"rem" s then
-            let n =
-              String.sub s 0 (String.length s - 3) |> float_of_string_opt
-            in
-            Option.map (fun f -> (Length (Rem f) : Css.background_size)) n
-          else None
-        in
         Option.map
-          (fun s -> [ Css.webkit_mask_size s; Css.mask_size s ])
-          (parse_size_val v)
+          (fun l ->
+            let size : Css.background_size = Length l in
+            [ Css.webkit_mask_size size; Css.mask_size size ])
+          (parse_bracket_len v)
     | _ -> None
 
   (* A bracket mask-position: the whole [<position>] grammar, one position per
@@ -532,9 +509,18 @@ module Handler = struct
         | "contain" -> Ok Bracket_contain
         | "cover" -> Ok Bracket_cover
         | _ when String.length inner > 7 && String.sub inner 0 7 = "length:" ->
-            Ok (Bracket_length (String.sub inner 7 (String.length inner - 7)))
+            (* The [length:] hint forces a mask-size; a value the size grammar
+               cannot take is not a utility. It used to fall through to a
+               plausible-looking [auto]. *)
+            let v = String.sub inner 7 (String.length inner - 7) in
+            if parse_bracket_size v = None then
+              Error (`Msg ("Unknown mask bracket length: " ^ v))
+            else Ok (Bracket_length v)
         | _ when String.length inner > 5 && String.sub inner 0 5 = "size:" ->
-            Ok (Bracket_size (String.sub inner 5 (String.length inner - 5)))
+            let v = String.sub inner 5 (String.length inner - 5) in
+            if parse_bracket_size v = None then
+              Error (`Msg ("Unknown mask bracket size: " ^ v))
+            else Ok (Bracket_size v)
         | _ when String.length inner > 9 && String.sub inner 0 9 = "position:"
           -> (
             (* The [position:] data-type hint forces a mask-position; a value

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -19,11 +19,27 @@ let test_roundtrip () =
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide";
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-foo";
-  (* Units the width reader does not read are refused rather than accepted and
-     spelled as something else. *)
-  Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-x-[2em]";
-  Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-y-[3vw]";
+  (* A bracket with no number is not a length, so it is refused rather than read
+     as a bare identifier. *)
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-x-[rem]"
+
+(* divide-x-[2em] and divide-y-[3vw] used to be refused: the width reader only
+   knew px and rem, so an em or a vw stop fell through to "not a divide utility"
+   instead of reading as the length it is. *)
+let test_arbitrary_width_units () =
+  check "divide-x-[2em]";
+  check "divide-y-[3vw]";
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "divide-x-[2em] carries the em unit into the calc" true
+    (Astring.String.is_infix ~affix:"calc(2em*" (css "divide-x-[2em]"));
+  Alcotest.(check bool)
+    "divide-y-[3vw] carries the vw unit into the calc" true
+    (Astring.String.is_infix ~affix:"calc(3vw*" (css "divide-y-[3vw]"))
 
 (* Every arbitrary width the reader accepts is spelled back exactly as it was
    written, so the selector matches the class in the markup. A width the reader
@@ -184,6 +200,8 @@ let tests =
         test_arbitrary_width_roundtrip;
       Alcotest.test_case "typed arbitrary width" `Quick
         test_typed_arbitrary_width;
+      Alcotest.test_case "arbitrary width units" `Quick
+        test_arbitrary_width_units;
       Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
       Alcotest.test_case "reverse class order matches Tailwind" `Slow
         reverse_class_order_matches_tailwind;

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -88,7 +88,27 @@ let test_invalid_bracket_value () =
   in
   rejected "mask-size-[<value>]";
   rejected "mask-position-[<value>]";
-  rejected "mask-[position:nope]"
+  rejected "mask-[position:nope]";
+  (* mask-[length:nope] and mask-[size:nope] used to be accepted unvalidated and
+     silently emit mask-size:auto under a selector that matches the class. *)
+  rejected "mask-[length:nope]";
+  rejected "mask-[size:nope]"
+
+(* mask-size-[...], mask-[size:...] and mask-[length:...] only read px, %, and
+   rem before; every CSS length unit does now, matching real Tailwind's
+   mask-size-[2em]. *)
+let test_bracket_size_units () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "mask-size-[2em]" "mask-size:2em";
+  has "mask-[size:2em]" "mask-size:2em";
+  has "mask-[length:2em]" "mask-size:2em"
 
 (* A mask-position bracket takes the whole CSS grammar, the same as
    background-position: a single edge keyword and the edge/offset form. Both
@@ -143,6 +163,7 @@ let tests =
         test_invalid_bracket_value;
       Alcotest.test_case "bracket position grammar" `Quick
         test_bracket_position_grammar;
+      Alcotest.test_case "bracket size units" `Quick test_bracket_size_units;
       Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;
     ]
 


### PR DESCRIPTION
Both utilities matched unit suffixes by hand, so each accepted only the units its own table listed. They now read the bracket through cascade’s value parser and accept every CSS length unit.