### PR TITLE
color, tw: mix a bracket colour with its opacity modifier

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1534,9 +1534,9 @@ module Handler = struct
           | None -> css_color
         in
         style [ Css.background_color c ]
-    | Bg_bracket_color_opacity (orig, _, opacity) ->
-        let c = Color.bracket_color_to_custom orig in
-        bg_with_opacity c 500 opacity
+    | Bg_bracket_color_opacity (_, css_color, opacity) ->
+        Color.bracket_color_opacity_style ~property:Css.background_color
+          css_color opacity
     | Bg_current -> style [ Css.background_color Css.Current ]
     | Bg_current_opacity opacity -> Color.bg_current_with_opacity ~theme opacity
     | Bg_transparent -> style [ Css.background_color (Css.hex "#0000") ]

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2819,24 +2819,30 @@ module Handler = struct
     in
     style ~rules:(Some [ supports_block ]) [ fallback_decl ]
 
-  (** Convert a bracket color string to a custom Hex color for opacity handling.
-      Named colors like "black" are converted to their hex equivalent so they go
-      through the direct oklab path (is_custom_color = true). *)
-  let bracket_color_to_custom inner =
-    if String.length inner > 0 && inner.[0] = '#' then
-      mk_color_hex (String.sub inner 1 (String.length inner - 1))
-    else
-      match color_of_string inner with
-      | Ok Black -> mk_color_hex "000000"
-      | Ok White -> mk_color_hex "ffffff"
-      | Ok c ->
-          let oklch = to_oklch c 500 in
-          let rgb = oklch_to_rgb oklch in
-          mk_color_hex (rgb_to_hex rgb)
-      | Error _ -> mk_color_hex "000000"
+  (* The bracket colour as a palette-shaped [Hex], so an opacity modifier folds
+     the alpha in the same way it does for a hex bracket. [None] for a colour
+     with no hex form: [currentcolor], a [var()], or a colour whose channels are
+     not all static. *)
+  let bracket_color_to_custom css_color =
+    let c = Cascade.Values.nonkeyword_color css_color in
+    let c = match css_color_to_hex c with Some hex -> hex | None -> c in
+    match c with
+    | Hex { r; g; b; _ } | Authored_hex { r; g; b; _ } ->
+        Some (mk_color_hex (hex_string_of_rgb (r, g, b)))
+    | _ -> None
 
-  let outline_bracket_color_opacity_style inner opacity =
-    let c = bracket_color_to_custom inner in
+  (* A bracket colour arrives already parsed into a typed [Css.color], and an
+     opacity modifier applies to that value. Reading the bracket text back
+     through the palette parser answered black for every colour the palette does
+     not name. *)
+  let bracket_color_opacity_style ?merge_key ~property css_color opacity =
+    match bracket_color_to_custom css_color with
+    | Some c -> color_with_opacity_style ~property ?merge_key c 500 opacity
+    | None ->
+        let base = resolve_bracket_css_color css_color in
+        style ?merge_key [ property (apply_alpha opacity base) ]
+
+  let outline_bracket_color_opacity_style inner css_color opacity =
     let merge_key =
       if String.length inner > 0 && inner.[0] = '#' then
         (* Hex bracket colors: strip bracket+opacity for merging *)
@@ -2847,7 +2853,7 @@ module Handler = struct
            but Tailwind keeps them separate. *)
         "outline-[" ^ inner ^ "]" ^ opacity_suffix opacity
     in
-    color_with_opacity_style ~property:Css.outline_color ~merge_key c 500
+    bracket_color_opacity_style ~property:Css.outline_color ~merge_key css_color
       opacity
 
   let outline_bracket_var_opacity_style v opacity =
@@ -2881,10 +2887,6 @@ module Handler = struct
     in
     style ~merge_key:"outline-" ~rules:(Some [ supports_block ])
       [ fallback_decl ]
-
-  let border_bracket_color_opacity_style inner opacity =
-    let c = bracket_color_to_custom inner in
-    color_with_opacity_style ~property:Css.border_color c 500 opacity
 
   let with_pseudo pseudo = function
     | Style.Style s -> Style.Style { s with pseudo_suffix = Some pseudo }
@@ -2939,9 +2941,8 @@ module Handler = struct
     | Text_bracket_color (_orig, css_color) ->
         let c = resolve_bracket_css_color css_color in
         style ~merge_key:"text-" [ Css.color c ]
-    | Text_bracket_color_opacity (inner, _css_color, opacity) ->
-        let c = bracket_color_to_custom inner in
-        color_with_opacity_style ~property:Css.color c 500 opacity
+    | Text_bracket_color_opacity (_orig, css_color, opacity) ->
+        bracket_color_opacity_style ~property:Css.color css_color opacity
     | Text_bracket_var v ->
         let bare_name = Parse.extract_var_name v in
         style ~merge_key:"text-" [ Css.color (Css.Var (Var.bracket bare_name)) ]
@@ -2991,8 +2992,8 @@ module Handler = struct
     | Border_bracket_color (_orig, css_color) ->
         let c = resolve_bracket_css_color css_color in
         style ~merge_key:"border-" [ Css.border_color c ]
-    | Border_bracket_color_opacity (inner, _css_color, opacity) ->
-        border_bracket_color_opacity_style inner opacity
+    | Border_bracket_color_opacity (_orig, css_color, opacity) ->
+        bracket_color_opacity_style ~property:Css.border_color css_color opacity
     | Accent (color, shade) -> accent' color shade
     | Accent_opacity (color, shade, opacity) ->
         accent_with_opacity color shade opacity
@@ -3004,9 +3005,8 @@ module Handler = struct
     | Accent_bracket_color (_orig, css_color) ->
         let c = resolve_bracket_css_color css_color in
         style ~merge_key:"accent-" [ Css.accent_color c ]
-    | Accent_bracket_color_opacity (inner, _css_color, opacity) ->
-        let c = bracket_color_to_custom inner in
-        color_with_opacity_style ~property:Css.accent_color c 500 opacity
+    | Accent_bracket_color_opacity (_orig, css_color, opacity) ->
+        bracket_color_opacity_style ~property:Css.accent_color css_color opacity
     | Caret (color, shade) -> caret' color shade
     | Caret_opacity (color, shade, opacity) ->
         caret_with_opacity color shade opacity
@@ -3018,9 +3018,8 @@ module Handler = struct
     | Caret_bracket_color (_orig, css_color) ->
         let c = resolve_bracket_css_color css_color in
         style ~merge_key:"caret-" [ Css.caret_color c ]
-    | Caret_bracket_color_opacity (inner, _css_color, opacity) ->
-        let c = bracket_color_to_custom inner in
-        color_with_opacity_style ~property:Css.caret_color c 500 opacity
+    | Caret_bracket_color_opacity (_orig, css_color, opacity) ->
+        bracket_color_opacity_style ~property:Css.caret_color css_color opacity
     | Outline (color, shade) -> outline' color shade
     | Outline_opacity (color, shade, opacity) ->
         outline_with_opacity color shade opacity
@@ -3032,8 +3031,8 @@ module Handler = struct
     | Outline_bracket_color (_orig, css_color) ->
         let c = resolve_bracket_css_color css_color in
         style ~merge_key:"outline-" [ Css.outline_color c ]
-    | Outline_bracket_color_opacity (inner, _css_color, opacity) ->
-        outline_bracket_color_opacity_style inner opacity
+    | Outline_bracket_color_opacity (inner, css_color, opacity) ->
+        outline_bracket_color_opacity_style inner css_color opacity
     | Outline_bracket_var v -> outline_bracket_var_style v
     | Outline_bracket_var_opacity (v, opacity) ->
         outline_bracket_var_opacity_style v opacity
@@ -3059,10 +3058,9 @@ module Handler = struct
         let c = resolve_bracket_css_color css_color in
         let s = style [ Css.color c ] in
         with_pseudo Css.Selector.Placeholder s
-    | Placeholder_bracket_color_opacity (inner, _css_color, opacity) ->
-        let c = bracket_color_to_custom inner in
+    | Placeholder_bracket_color_opacity (_orig, css_color, opacity) ->
         with_pseudo Css.Selector.Placeholder
-          (color_with_opacity_style ~property:Css.color c 500 opacity)
+          (bracket_color_opacity_style ~property:Css.color css_color opacity)
 
   (* Suborder for the non-text color families: border (0-9999) then bg
      (10000-19999). text-color runs at priority 26 (see [priority]) with a fixed
@@ -3375,7 +3373,7 @@ let opacity_to_percent = Handler.opacity_to_percent
 let opacity_var_bare = Handler.opacity_var_bare
 let opacity_var_bare_of = Handler.opacity_var_name
 let shorten_hex_str = shorten_hex_str
-let bracket_color_to_custom = Handler.bracket_color_to_custom
+let bracket_color_opacity_style = Handler.bracket_color_opacity_style
 let css_color_to_hex = Handler.css_color_to_hex
 let parse_bracket_color = Handler.parse_bracket_color
 

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -542,9 +542,16 @@ val rgb_to_oklab : rgb -> float * float * float
 val shorten_hex_str : string -> string
 (** [shorten_hex_str hex] shortens a hex color string if possible. *)
 
-val bracket_color_to_custom : string -> color
-(** [bracket_color_to_custom inner] converts a bracket color string to a custom
-    color for opacity handling. *)
+val bracket_color_opacity_style :
+  ?merge_key:string ->
+  property:(Css.color -> Css.declaration) ->
+  Css.color ->
+  opacity_modifier ->
+  Style.t
+(** [bracket_color_opacity_style ~property c opacity] sets [property] to the
+    bracket colour [c] with [opacity] mixed into it. [c] is the colour the
+    bracket was parsed into, so a CSS keyword or colour function keeps its own
+    value rather than being read back through the palette. *)
 
 val parse_bracket_color : string -> Css.color option
 (** [parse_bracket_color inner] parses a bracket color value into a typed

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -135,10 +135,28 @@ let split_importance base_class =
     (`Suffix, String.sub base_class 0 (n - 1))
   else (`None, base_class)
 
+(* The alpha a [theme()] path carries, as the percentage to mix at: a percentage
+   as written, a bare number as the fraction Tailwind reads it for. *)
+let theme_alpha_percent a =
+  let n = String.length a in
+  if n > 1 && a.[n - 1] = '%' then float_of_string_opt (String.sub a 0 (n - 1))
+  else Stdlib.Option.map (fun f -> f *. 100.) (float_of_string_opt a)
+
+(* Tailwind applies a [theme()] alpha by mixing the colour with transparent,
+   which reads whatever the [@theme] bound the palette entry to. *)
+let theme_color_with_alpha base a =
+  match (Cascade.Css.parse_color base, theme_alpha_percent a) with
+  | Some color, Some percent1 ->
+      Some
+        (Cascade.Css.Pp.to_string Cascade.Css.pp_color
+           (Cascade.Css.color_mix ~in_space:Oklab ~percent1 color
+              Cascade.Css.Transparent))
+  | _ -> None
+
 (* Resolve a Tailwind theme() dot-path to its static value:
    colors.<name>.<shade> (optionally with a /<alpha> suffix) becomes the
-   colour's oklch value, and spacing.<n> becomes <n * 0.25>rem. Returns None for
-   paths not resolved. *)
+   colour's value mixed with the alpha, and spacing.<n> becomes <n * 0.25>rem.
+   Returns None for paths not resolved. *)
 let theme_resolve_path ~theme inner =
   let path, alpha =
     match String.index_opt inner '/' with
@@ -150,7 +168,7 @@ let theme_resolve_path ~theme inner =
   match String.split_on_char '.' path with
   | [ "colors"; name; shade ] -> (
       match (Color.of_string name, int_of_string_opt shade) with
-      | Ok c, Some sh ->
+      | Ok c, Some sh -> (
           (* A project that renames a palette entry in its [@theme] gets its own
              value back here, the way [bg-<name>-<shade>] already does. *)
           let token = String.concat "-" [ "color"; name; shade ] in
@@ -159,16 +177,9 @@ let theme_resolve_path ~theme inner =
             | Some v -> v
             | None -> Color.to_oklch_css c sh
           in
-          Some
-            (match alpha with
-            | Some a
-              when String.length base > 0 && base.[String.length base - 1] = ')'
-              ->
-                (* oklch(L C H) -> oklch(L C H / a); cascade folds the alpha
-                   form to Tailwind's oklab(...) under canonical comparison. *)
-                String.concat ""
-                  [ String.sub base 0 (String.length base - 1); " / "; a; ")" ]
-            | _ -> base)
+          match alpha with
+          | Some a -> theme_color_with_alpha base a
+          | None -> Some base)
       | _ -> None)
   | [ "spacing"; n ] -> (
       match float_of_string_opt n with

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -65,8 +65,8 @@ let test_property_calc_operators () =
        (css "[width:calc(var(--a)-var(--b))]"))
 
 (* theme() dot-notation inside an arbitrary value resolves statically:
-   theme(colors.red.500) to the red-500 oklch (with /alpha appended for the
-   opacity form), and the class name round-trips via its alias. *)
+   theme(colors.red.500) to the red-500 oklch, the opacity form to that colour
+   mixed with the alpha, and the class name round-trips via its alias. *)
 let test_theme_dot_notation () =
   let g =
     "bg-[image:linear-gradient(to_right,theme(colors.red.500)_75%,theme(colors.red.500/25%))]"
@@ -75,8 +75,10 @@ let test_theme_dot_notation () =
     "theme(colors.red.500) resolves to the red-500 oklch" true
     (Astring.String.is_infix ~affix:"oklch(63.7%" (css g));
   Alcotest.(check bool)
-    "theme(colors.red.500/25%) appends the alpha" true
-    (Astring.String.is_infix ~affix:"25.331 / 25%" (css g));
+    "theme(colors.red.500/25%) mixes the alpha in" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, oklch(63.7% .237 25.331) 25%, transparent)"
+       (css g));
   Alcotest.(check string)
     "theme() class round-trips" g
     (Tw.pp (Result.get_ok (Tw.of_string g)))

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -327,6 +327,53 @@ let test_bracket_css_colors () =
   (* a CSS keyword still beats the palette entry of the same name *)
   has "bg-[red]" "background-color:red"
 
+(* An opacity modifier applies to the colour the bracket was parsed into. The
+   modifier read the bracket text back through the palette parser, which
+   answered black for every CSS colour the palette does not name, and answered
+   the palette entry for the names it shares with CSS. *)
+let test_bracket_colour_opacity () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  (* the value a class sets for [prop], so two spellings of one colour compare
+     without their class names *)
+  let value prop cls =
+    let sheet = css cls in
+    let key = prop ^ ":" in
+    match Astring.String.find_sub ~sub:key sheet with
+    | None -> Alcotest.failf "%s sets no %s: %s" cls prop sheet
+    | Some i ->
+        let start = i + String.length key in
+        Astring.String.with_range ~first:start sheet
+        |> Astring.String.take ~sat:(fun c -> c <> ';' && c <> '}')
+  in
+  let same prop cls hex =
+    Alcotest.(check string)
+      (cls ^ " is " ^ hex)
+      (value prop hex) (value prop cls)
+  in
+  same "color" "text-[rebeccapurple]/50" "text-[#663399]/50";
+  same "color" "text-[hsl(200_50%_50%)]/50" "text-[#4095bf]/50";
+  (* a CSS keyword still beats the palette entry of the same name *)
+  same "background-color" "bg-[red]/50" "bg-[#ff0000]/50";
+  same "border-color" "border-[rebeccapurple]/50" "border-[#663399]/50";
+  same "accent-color" "accent-[rebeccapurple]/50" "accent-[#663399]/50";
+  same "caret-color" "caret-[rebeccapurple]/50" "caret-[#663399]/50";
+  same "outline-color" "outline-[rebeccapurple]/50" "outline-[#663399]/50";
+  same "color" "placeholder-[rebeccapurple]/50" "placeholder-[#663399]/50";
+  (* an alpha read from a var names the property in the mix *)
+  same "color" "text-[rebeccapurple]/(--a)" "text-[#663399]/(--a)";
+  (* the colour the palette cannot name is not black *)
+  Alcotest.(check bool)
+    "text-[rebeccapurple]/50 is not black" false
+    (Astring.String.is_infix ~affix:"oklab(0%" (css "text-[rebeccapurple]/50"));
+  (* a bracket that names no colour at all is still not a class *)
+  Alcotest.(check bool)
+    "text-[notacolour]/50 is not a class" true
+    (Result.is_error (Tw.of_string "text-[notacolour]/50"))
+
 (* An hsl() hue takes any angle unit. Folding one to a hex colour used to keep
    only bare numbers and [deg] and read every other unit as 0, so a half turn
    painted red instead of cyan. *)
@@ -803,6 +850,7 @@ let tests =
     ("Border color var", `Quick, test_border_color_var);
     ("Border side color opacity", `Quick, test_border_side_color_opacity);
     ("Bracket CSS colors", `Quick, test_bracket_css_colors);
+    ("Bracket colour opacity", `Quick, test_bracket_colour_opacity);
     ("hsl hue units", `Quick, test_hsl_hue_units);
     ("hsl non-percentage channels", `Quick, test_hsl_non_percentage_channels);
     ("rgb non-numeric channels", `Quick, test_rgb_non_numeric_channels);

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -454,6 +454,40 @@ let theme_function_reads_the_project_palette () =
     (Astring.String.is_infix ~affix:"oklch"
        (css "[color:theme(colors.blue.500)]"))
 
+(* [theme(colors.<name>.<shade>/<alpha>)] mixes the alpha into whatever value
+   the theme bound the colour to, the way Tailwind does. The alpha was spliced
+   in by chopping the value's closing paren, so a project that bound its palette
+   entry to a hex kept the colour and silently lost the alpha. *)
+let theme_function_alpha_reads_any_palette_value () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-red-500", "#ef4444") ]
+  in
+  let css cls =
+    match Tw.of_string ~theme cls with
+    | Ok u -> Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "a hex palette value keeps the alpha" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, #ef4444 25%, transparent)"
+       (css "[color:theme(colors.red.500/25%)]"));
+  Alcotest.(check bool)
+    "a fraction is the same alpha as the percentage" true
+    (Astring.String.is_infix
+       ~affix:"color-mix(in oklab, #ef4444 25%, transparent)"
+       (css "[color:theme(colors.red.500/0.25)]"));
+  Alcotest.(check bool)
+    "an unoverridden colour mixes its own value" true
+    (Astring.String.is_infix ~affix:"color-mix(in oklab, oklch("
+       (css "[color:theme(colors.blue.500/25%)]"));
+  (* an alpha that names no number leaves the call verbatim, the way an unknown
+     path already does, rather than dropping the alpha *)
+  Alcotest.(check bool)
+    "theme(colors.red.500/abc) stays verbatim" true
+    (Astring.String.is_infix ~affix:"theme(colors.red"
+       (css "[color:theme(colors.red.500/abc)]"))
+
 let custom_breakpoint_theme_is_local () =
   let theme : Tw.Scheme.t =
     { Tw.Scheme.default with breakpoints = [ ("10xl", 1600.) ] }
@@ -1199,6 +1233,8 @@ let core_tests =
       custom_breakpoint_theme_is_local;
     test_case "theme() reads the project palette" `Quick
       theme_function_reads_the_project_palette;
+    test_case "theme() alpha reads any palette value" `Quick
+      theme_function_alpha_reads_any_palette_value;
     test_case "layout" `Slow layout;
     test_case "opacity" `Slow opacity_effects;
     test_case "extended colors" `Slow extended_colors;


### PR DESCRIPTION
A bracket colour carrying an opacity modifier rendered black. `bracket_color_to_custom` took the bracket text and ran it through the Tailwind-palette parser, whose failure arm answered black, while the already-parsed `Css.color` sat in hand and was discarded. `text-[rebeccapurple]/50`, `text-[hsl(200_50%_50%)]/50` and every sibling arm across `lib/color.ml` and `lib/backgrounds.ml` now use the typed value. `bg-[red]/50` was separately reading the palette red-500 rather than CSS red.

Second commit pair: a `theme()` alpha was applied by printing the colour, chopping its closing paren and concatenating ` / a)`, which silently dropped the alpha whenever the base colour was a hex. Tailwind does not splice at all, it emits `color-mix(in oklab, <value> <alpha>, transparent)`, so tw builds that typed and a hex-bound palette entry keeps its alpha.