### PR TITLE
modifiers, text_shadow: read a bare selector and a shadow through cascade

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1001,13 +1001,22 @@ let try_has_shorthand s =
 
 (* A bare arbitrary variant with no [&] anchor compounds onto the utility's own
    class, so it has to be a single compound selector: [[code]] and [[.line]] are
-   fine, [[>img]] and [[@media_print]] are not. *)
+   fine, [[>img]] and [[@media_print]] are not. The bracket is read as a
+   selector rather than scanned for combinator characters, because [~] and [|]
+   spell an attribute operator as well as a combinator: [[data-size~=large]] is
+   a compound and [[p_~_span]] is not, and only the grammar separates them. [_]
+   stands for a space here, the decoding {!nest_selector} applies. *)
 let is_compound_selector inner =
-  (match inner.[0] with
-    | 'a' .. 'z' | 'A' .. 'Z' | '.' | '#' | '[' | ':' | '*' -> true
-    | _ | (exception _) -> false)
-  && not
-       (String.exists (fun c -> c = '_' || c = '>' || c = '+' || c = '~') inner)
+  let s = String.map (fun c -> if c = '_' then ' ' else c) inner in
+  let cursor = Cascade.Cursor.of_string s in
+  match Css.Selector.read_strict_selector_list cursor with
+  | exception (Cascade.Cursor.Parse_error _ | Invalid_argument _) -> false
+  | List _ | Combined _ | Relative _ -> false
+  | _ ->
+      (* The reader stops at the first thing it cannot use, so trailing rubbish
+         has to be refused here: it is not part of the compound. *)
+      Cascade.Cursor.ws cursor;
+      Cascade.Cursor.is_done cursor
 
 (* A plain identifier: what a group/peer name or a bare data attribute may be
    spelled with. *)

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -109,7 +109,10 @@ module Handler = struct
 
   (* ============ Parse arbitrary shadow ============ *)
 
-  let parse_arbitrary_shadow (s : string) :
+  (* The two colours the utility has to keep as written: a [#] hex it
+     re-shortens and a var() it wraps. Everything else in the value is read as a
+     length, so a colour spelled any other way lands in a length slot. *)
+  let scan_verbatim_colour (s : string) :
       (length * length * length option * arb_color) option =
     let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
     let parts = String.split_on_char ' ' normalized in
@@ -143,6 +146,29 @@ module Handler = struct
           | [ h; v ] -> Some (h, v, Stdlib.Option.None, color)
           | [ h; v; blur ] -> Some (h, v, Some blur, color)
           | _ -> Stdlib.Option.None)
+
+  (* What the scan above cannot spell goes to the value parser, which reads the
+     rest of the CSS colour grammar: [red] is a colour to it and a failed length
+     to the scan. This is the fallback the box-shadow family already has. *)
+  let parse_arbitrary_shadow (s : string) :
+      (length * length * length option * arb_color) option =
+    match scan_verbatim_colour s with
+    | Some _ as shadow -> shadow
+    | Stdlib.Option.None -> (
+        let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
+        match Css.parse_shadow normalized with
+        (* CSS text-shadow has no spread, so a body carrying one is not one. *)
+        | Some
+            (Shadow
+               { h_offset; v_offset; blur; spread = Stdlib.Option.None; color })
+          ->
+            let color =
+              match color with
+              | Some c -> Css_color c
+              | Stdlib.Option.None -> No_color
+            in
+            Some (h_offset, v_offset, blur, color)
+        | _ -> Stdlib.Option.None)
 
   (* ============ Shape definitions ============ *)
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -917,6 +917,37 @@ let test_attribute_brackets_still_parse () =
   emits "[data-dragging]" "peer-data-[dragging]:flex";
   emits "[data-modified]" "group-data-modified:flex"
 
+(* A bare [[...]] variant compounds its selector onto the utility's own class,
+   so what the brackets hold has to be a compound selector. [~] is both the
+   sibling combinator and the [~=] whitespace-list attribute operator, and only
+   reading the bracket as a selector tells them apart: a character scan that
+   rejects every [~] rejects [[data-size~=large]] along with [p_~_span]. *)
+let test_bare_selector_variant_attribute_operators () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    check bool cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  emits "[data-size~=large]" "[[data-size~=large]]:underline";
+  emits "[data-size~=large]" "group-[[data-size~=large]]:underline";
+  emits "[data-size~=large]" "peer-[[data-size~=large]]:underline";
+  (* the attribute operators that never collided with a combinator stay put *)
+  emits "[lang|=en]" "[[lang|=en]]:underline";
+  emits "[href^=https]" "[[href^=https]]:underline";
+  (* a combinator really is one, and none of these is a compound *)
+  rejected "[p_~_span]:underline";
+  rejected "[>img]:underline";
+  rejected "[.a_.b]:underline";
+  rejected "[@media_print]:underline"
+
 (* The valid spellings the validation must keep accepting. *)
 let test_valid_bracket_modifiers () =
   let css cls =
@@ -1053,6 +1084,8 @@ let tests =
         test_padded_attribute_brackets;
       test_case "attribute brackets still parse" `Quick
         test_attribute_brackets_still_parse;
+      test_case "bare selector variant attribute operators" `Quick
+        test_bare_selector_variant_attribute_operators;
       test_case "not-[selector] arbitrary negation" `Quick
         test_not_bracket_arbitrary_selector;
       test_case "group arbitrary prefix anchor" `Quick

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -110,6 +110,33 @@ let test_arbitrary_colour_opacity () =
   has "text-shadow-[0_0_8px_#f00]/[var(--x)]" "--tw-text-shadow-alpha:var(--x)";
   has "text-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
 
+(* An arbitrary text-shadow takes a named colour, the same as the box-shadow
+   twin [shadow-[0_1px_2px_red]] does. The reader recognised a [#] hex, a var()
+   and a colour function and nothing else, so a name fell through to the length
+   slot, failed to read as a length, and took the whole utility down with it. *)
+let test_arbitrary_named_colour () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
+    | Error _ -> ()
+  in
+  emits "text-shadow-[0_1px_2px_red]"
+    "text-shadow:0 1px 2px var(--tw-text-shadow-color,red)";
+  emits "text-shadow-[1px_1px_rebeccapurple]"
+    "text-shadow:1px 1px var(--tw-text-shadow-color,rebeccapurple)";
+  emits "text-shadow-[0_1px_2px_currentColor]"
+    "var(--tw-text-shadow-color,currentcolor)";
+  (* a word that names neither a length nor a colour is still not a shadow *)
+  rejected "text-shadow-[0_1px_notacolour]"
+
 (* A [#] value is only a colour when what follows is a hex spelling, both as the
    whole bracket and as the colour of an arbitrary shadow. The reader kept the
    text after the [#] as-is and the raising constructor saw it when the sheet
@@ -149,6 +176,8 @@ let tests =
         test_arbitrary_color_function;
       Alcotest.test_case "arbitrary colour opacity" `Quick
         test_arbitrary_colour_opacity;
+      Alcotest.test_case "arbitrary named colour" `Quick
+        test_arbitrary_named_colour;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
     ]
 


### PR DESCRIPTION
`is_compound_selector` was a character predicate that rejected any string containing `~`, so every `[attr~=value]` whitespace-list attribute selector was turned down as if the operator were the sibling combinator. It now decodes `_` to a space and runs the bracket through `Css.Selector.read_strict_selector_list`, joining the three siblings in the same file that already go through cascade. That also unlocks `[:has(>_img)]` and `[[data-a][data-b]]` while still rejecting `[>img]`, `[.a_.b]` and `[@media_print]`.

`lib/text_shadow.ml` had the same hand tokenizer as `lib/effects.ml` but without its `Css.parse_shadow` fallback, so a named colour matched none of its three shapes and the whole class was rejected: `text-shadow-[0_1px_2px_red]` failed where the box-shadow twin `shadow-[0_1px_2px_red]` worked. A body carrying a spread is still refused, since CSS text-shadow has none.