### PR TITLE
animations: key @keyframes off the animation a value names

### DIFF
--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -37,6 +37,109 @@ module Handler = struct
   (* Match Tailwind ordering: animations after transforms, before cursor *)
   let priority _ = 10
 
+  (* The animations Tailwind's default theme carries [@keyframes] for, in the
+     order the theme declares them: a value naming several gets them back in
+     that order. *)
+  let builtin_keyframes =
+    [
+      ( "spin",
+        Css.keyframes "spin"
+          [
+            {
+              Css.Stylesheet.selector =
+                Css.Keyframe.Positions [ Css.Keyframe.To ];
+              declarations = [ Css.Declaration.transform (Rotate (Deg 360.)) ];
+            };
+          ] );
+      ( "ping",
+        Css.keyframes "ping"
+          [
+            {
+              Css.Stylesheet.selector =
+                Css.Keyframe.Positions
+                  [ Css.Keyframe.Percent 75.; Css.Keyframe.To ];
+              declarations =
+                [
+                  Css.Declaration.opacity (Opacity_number 0.0);
+                  Css.Declaration.transform (Scale (Num 2.0, opt_none));
+                ];
+            };
+          ] );
+      ( "pulse",
+        Css.keyframes "pulse"
+          [
+            {
+              Css.Stylesheet.selector =
+                Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
+              declarations = [ Css.Declaration.opacity (Opacity_number 0.5) ];
+            };
+          ] );
+      ( "bounce",
+        Css.keyframes "bounce"
+          [
+            {
+              Css.Stylesheet.selector =
+                Css.Keyframe.Positions
+                  [ Css.Keyframe.Percent 0.; Css.Keyframe.To ];
+              declarations =
+                [
+                  Css.Declaration.animation_timing_function
+                    (Cubic_bezier (0.8, 0., 1., 1.));
+                  Css.Declaration.transform (Translate_y (Pct (-25.)));
+                ];
+            };
+            {
+              Css.Stylesheet.selector =
+                Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
+              declarations =
+                [
+                  Css.Declaration.animation_timing_function
+                    (Cubic_bezier (0., 0., 0.2, 1.));
+                  Css.Declaration.transform None;
+                ];
+            };
+          ] );
+    ]
+
+  (* The animation a shorthand names, when it names one. *)
+  let shorthand_name (anim : Css.animation) : string option =
+    match anim with
+    | Shorthand { name = Some (Name n | Ambiguous n | Quoted n); _ } -> Some n
+    | _ -> opt_none
+
+  (* The animations a [--animate-*] value names, read through the animation
+     grammar rather than off the text, so a substring of a longer ident or a
+     function argument cannot pass for a name. *)
+  let animation_names value =
+    let cursor = Cascade.Cursor.of_string value in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Properties.read_animations cursor
+    with
+    | Ok anims -> List.filter_map shorthand_name anims
+    | Error _ -> []
+
+  (* Tailwind carries the built-in [@keyframes] of the animations a value names,
+     not of the token holding it: a [@theme] redefining [--animate-ping] keeps
+     [@keyframes ping] as long as the value still says [ping], one pointing the
+     token at another built-in pulls that one in instead, and one naming an
+     animation with no built-in keyframes gets none invented. *)
+  let keyframes_rules names =
+    match
+      List.filter_map
+        (fun (name, frames) ->
+          if List.mem name names then Some frames else opt_none)
+        builtin_keyframes
+    with
+    | [] -> opt_none
+    | frames -> opt_some frames
+
+  (* The keyframes for a [--animate-*] token, read off the theme's value for it
+     and falling back to the animation the built-in default names. *)
+  let theme_keyframes ?theme ~token default =
+    match Scheme.theme_value theme token with
+    | Some value -> keyframes_rules (animation_names value)
+    | Option.None -> keyframes_rules (Option.to_list (shorthand_name default))
+
   let animate_none ?theme () =
     (* If theme defines --animate-none, use the theme variable. Otherwise use
        animation: none directly. *)
@@ -81,23 +184,7 @@ module Handler = struct
         }
     in
     let theme_decl, spin_var = Var.binding animate_spin_var spin_animation in
-    (* Only include @keyframes when theme doesn't define the animation *)
-    let rules =
-      if Scheme.theme_value theme "animate-spin" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "spin"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions [ Css.Keyframe.To ];
-                  declarations =
-                    [ Css.Declaration.transform (Rotate (Deg 360.)) ];
-                };
-              ];
-          ]
-    in
+    let rules = theme_keyframes ?theme ~token:"animate-spin" spin_animation in
     style ~rules [ theme_decl; Css.animation (Css.Var spin_var) ]
 
   (* Theme variable for animate-ping - order (7, 14) places it after
@@ -120,26 +207,7 @@ module Handler = struct
         }
     in
     let theme_decl, ping_var = Var.binding animate_ping_var ping_animation in
-    let rules =
-      if Scheme.theme_value theme "animate-ping" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "ping"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions
-                      [ Css.Keyframe.Percent 75.; Css.Keyframe.To ];
-                  declarations =
-                    [
-                      Css.Declaration.opacity (Opacity_number 0.0);
-                      Css.Declaration.transform (Scale (Num 2.0, opt_none));
-                    ];
-                };
-              ];
-          ]
-    in
+    let rules = theme_keyframes ?theme ~token:"animate-ping" ping_animation in
     style ~rules [ theme_decl; Css.animation (Css.Var ping_var) ]
 
   (* Theme variable for animate-pulse - order (7, 15) places it after
@@ -162,22 +230,7 @@ module Handler = struct
         }
     in
     let theme_decl, pulse_var = Var.binding animate_pulse_var pulse_animation in
-    let rules =
-      if Scheme.theme_value theme "animate-pulse" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "pulse"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
-                  declarations =
-                    [ Css.Declaration.opacity (Opacity_number 0.5) ];
-                };
-              ];
-          ]
-    in
+    let rules = theme_keyframes ?theme ~token:"animate-pulse" pulse_animation in
     style ~rules [ theme_decl; Css.animation (Css.Var pulse_var) ]
 
   (* Theme variable for animate-bounce - order (7, 16) places it after
@@ -204,100 +257,52 @@ module Handler = struct
       Var.binding animate_bounce_var bounce_animation
     in
     let rules =
-      if Scheme.theme_value theme "animate-bounce" <> opt_none then opt_none
-      else
-        opt_some
-          [
-            Css.keyframes "bounce"
-              [
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions
-                      [ Css.Keyframe.Percent 0.; Css.Keyframe.To ];
-                  declarations =
-                    [
-                      Css.Declaration.animation_timing_function
-                        (Cubic_bezier (0.8, 0., 1., 1.));
-                      Css.Declaration.transform (Translate_y (Pct (-25.)));
-                    ];
-                };
-                {
-                  Css.Stylesheet.selector =
-                    Css.Keyframe.Positions [ Css.Keyframe.Percent 50. ];
-                  declarations =
-                    [
-                      Css.Declaration.animation_timing_function
-                        (Cubic_bezier (0., 0., 0.2, 1.));
-                      Css.Declaration.transform None;
-                    ];
-                };
-              ];
-          ]
+      theme_keyframes ?theme ~token:"animate-bounce" bounce_animation
     in
     style ~rules [ theme_decl; Css.animation (Css.Var bounce_var) ]
 
-  (* Known @keyframes for bracket animation references *)
-  let spin_keyframes =
-    Css.keyframes "spin"
-      [
-        {
-          Css.Stylesheet.selector = Css.Keyframe.Positions [ Css.Keyframe.To ];
-          declarations = [ Css.Declaration.transform (Rotate (Deg 360.)) ];
-        };
-      ]
-
-  let known_keyframes = function
-    | "spin" -> Some spin_keyframes
-    | _ -> Option.None
-
-  (* Tailwind moves the animation name to the end of the shorthand, so the
-     bracket reads as (name, shorthand). *)
-  let animation_parts value =
+  (* Tailwind moves the animation name to the end of the shorthand. *)
+  let animation_shorthand value =
     let css_value = String.map (fun c -> if c = '_' then ' ' else c) value in
     match String.split_on_char ' ' css_value with
-    | name :: (_ :: _ as rest) -> (name, String.concat " " (rest @ [ name ]))
-    | _ -> (css_value, css_value)
+    | name :: (_ :: _ as rest) -> String.concat " " (rest @ [ name ])
+    | _ -> css_value
 
   (* The animation an [animate-[...]] bracket denotes. [None] is a bracket the
      animation grammar cannot read, and [of_class] refuses the utility rather
      than leaving [to_style] to raise. *)
   let arbitrary_animation value : Css.animation option =
-    let _, reordered = animation_parts value in
-    let cursor = Cascade.Cursor.of_string reordered in
+    let cursor = Cascade.Cursor.of_string (animation_shorthand value) in
     match
       Cascade.Cursor.try_parse_full_err Css.Properties.read_animation cursor
     with
     | Ok anim -> Some anim
     | Error _ -> None
 
-  let animate_bracket value anim =
-    let anim_name, _ = animation_parts value in
-    let rules =
-      match known_keyframes anim_name with
-      | Some kf -> opt_some [ kf ]
-      | Option.None -> opt_none
-    in
+  let animate_bracket anim =
+    let rules = keyframes_rules (Option.to_list (shorthand_name anim)) in
     style ~rules [ Css.animation anim ]
 
-  let animate_named name =
+  let animate_named ?theme name =
     let var_name = "animate-" ^ name in
     let tv = Var.theme Css.Animation var_name ~order:(7, 16) in
-    let theme_decl, theme_ref =
-      Var.binding tv
-        (Shorthand
-           {
-             name = Some (Name name);
-             duration = None;
-             timing_function = None;
-             delay = None;
-             iteration_count = None;
-             direction = None;
-             fill_mode = None;
-             play_state = None;
-             timeline = None;
-           })
+    let animation : Css.animation =
+      Shorthand
+        {
+          name = Some (Name name);
+          duration = None;
+          timing_function = None;
+          delay = None;
+          iteration_count = None;
+          direction = None;
+          fill_mode = None;
+          play_state = None;
+          timeline = None;
+        }
     in
-    style [ theme_decl; Css.animation (Css.Var theme_ref) ]
+    let theme_decl, theme_ref = Var.binding tv animation in
+    let rules = theme_keyframes ?theme ~token:var_name animation in
+    style ~rules [ theme_decl; Css.animation (Css.Var theme_ref) ]
 
   let to_style theme =
     let animate_none () = animate_none ~theme () in
@@ -311,8 +316,8 @@ module Handler = struct
     | Ping -> animate_ping ()
     | Pulse -> animate_pulse ()
     | Bounce -> animate_bounce ()
-    | Bracket (value, anim) -> animate_bracket value anim
-    | Named name -> animate_named name
+    | Bracket (_, anim) -> animate_bracket anim
+    | Named name -> animate_named ~theme name
 
   let suborder = function
     | Bracket _ -> 0

--- a/test/test_animations.ml
+++ b/test/test_animations.ml
@@ -124,6 +124,64 @@ let test_invalid_arbitrary_animation () =
   renders "animate-[spin_1s_linear_infinite]";
   renders "animate-[bounce_1s]"
 
+(* The animations the [@keyframes] rules of a sheet define, sorted so the check
+   reads as a set. *)
+let keyframes_names css =
+  Css.fold
+    (fun acc stmt ->
+      match Css.as_keyframes stmt with
+      | Some (name, _) -> name :: acc
+      | None -> acc)
+    [] css
+  |> List.sort String.compare
+
+let theme_token name value =
+  { Tw.Scheme.default with token_overrides = [ (name, value) ] }
+
+let animate_keyframes ?(theme = Tw.Scheme.default) cls =
+  match Tw.of_string ~theme cls with
+  | Ok u -> keyframes_names (Tw.to_css ~theme ~base:false [ u ])
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+(* Tailwind keys the built-in [@keyframes] off the animation the value names,
+   not off whether the [--animate-*] token carries its default: a project
+   [@theme] redefining [--animate-ping] keeps [@keyframes ping], one pointing
+   the token at another built-in pulls that one in instead, and one naming an
+   animation Tailwind has no keyframes for gets none invented. *)
+let test_keyframes_follow_the_animation_name () =
+  let check msg expected theme =
+    Alcotest.(check (list string))
+      msg expected
+      (animate_keyframes ~theme "animate-ping")
+  in
+  check "default theme" [ "ping" ] Tw.Scheme.default;
+  check "redefined token still names ping" [ "ping" ]
+    (theme_token "animate-ping" "ping 2s linear infinite");
+  check "token pointed at another built-in" [ "spin" ]
+    (theme_token "animate-ping" "spin 1s linear infinite");
+  check "both animations of a list" [ "ping"; "spin" ]
+    (theme_token "animate-ping"
+       "ping 1s linear infinite, spin 2s linear infinite");
+  check "no keyframes invented for an unknown animation" []
+    (theme_token "animate-ping" "wiggle 1s ease-in-out infinite");
+  check "a longer ident is not the animation" []
+    (theme_token "animate-ping" "pinger 1s linear infinite")
+
+(* A theme-declared animation and an [animate-[...]] bracket name their
+   animation the same way, so they pull in the same built-in keyframes. *)
+let test_keyframes_for_theme_and_bracket_names () =
+  Alcotest.(check (list string))
+    "theme animation naming a built-in" [ "spin" ]
+    (animate_keyframes
+       ~theme:(theme_token "animate-slow-spin" "spin 3s linear infinite")
+       "animate-slow-spin");
+  Alcotest.(check (list string))
+    "bracket naming a built-in" [ "ping" ]
+    (animate_keyframes "animate-[ping_2s_linear_infinite]");
+  Alcotest.(check (list string))
+    "bracket naming an unknown animation" []
+    (animate_keyframes "animate-[wiggle_1s_ease-in-out_infinite]")
+
 let tests =
   [
     test_case "transitions" `Quick test_transitions;
@@ -135,6 +193,10 @@ let tests =
       suborder_matches_tailwind;
     test_case "invalid arbitrary animation" `Quick
       test_invalid_arbitrary_animation;
+    test_case "keyframes follow the animation name" `Quick
+      test_keyframes_follow_the_animation_name;
+    test_case "keyframes for theme and bracket names" `Quick
+      test_keyframes_for_theme_and_bracket_names;
   ]
 
 let suite = ("animations", tests)

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -257,6 +257,19 @@ let theme_config ~declared config expected =
 
 let canonical_stylesheet_css css = String.trim css
 
+(* Tailwind compiled the corpus from each case's own [@theme] block, with no
+   default theme behind it, so the [@keyframes] that theme declares are in no
+   expected sheet: even [animate-spin] comes out without [@keyframes spin]. tw
+   renders against the built-in theme, which carries them, so they are dropped
+   here rather than read as rules Tailwind failed to emit. The same classes
+   compiled against a real entrypoint do get them, and [tw --diff] covers
+   that. *)
+let drop_theme_keyframes stylesheet =
+  Css.v
+    (List.filter
+       (fun stmt -> Option.is_none (Css.as_keyframes stmt))
+       (Css.statements stylesheet))
+
 (* [color-mix(in oklab, C p%, transparent)] denotes the concrete colour C at
    alpha p, which LightningCSS folds to an [oklab(...)] in the fixtures. tw
    keeps the colour itself (exact and shorter once cascade folds it to a hex),
@@ -676,7 +689,10 @@ let run_test_case test () =
     if test.expected = "" then incr stat_expected_empty_cases;
     let our_stylesheet =
       if utilities = [] then None
-      else Some (Tw.to_css ~theme:scheme ~base:false ~layers:false utilities)
+      else
+        Some
+          (drop_theme_keyframes
+             (Tw.to_css ~theme:scheme ~base:false ~layers:false utilities))
     in
     let our_css =
       match our_stylesheet with


### PR DESCRIPTION
Each built-in `@keyframes` was gated on the theme leaving its `--animate-*` token alone, so a project retiming `--animate-ping` got `animation: var(--animate-ping)` with no `@keyframes ping` and the animation never ran. The keyframes now follow the animation the value names, read through cascade's own grammar rather than by splitting the shorthand on separators, which handles the comma-separated list for free and invents nothing when the value names no animation.

That also closes a token pointed at a different built-in (`--animate-ping: spin 1s` now pulls in `@keyframes spin`) and `animate-[...]` brackets, whose table knew only `spin`.