### PR TITLE
var, build, entrypoint: retire two cascade workarounds

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -277,16 +277,19 @@ let indexed_rule_to_statement ?(verbatim = fun _ -> false)
         Css.supports ~condition
           [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
 
-(* Deduplicate typed triples while preserving first occurrence order *)
+(* Deduplicate typed triples while preserving first occurrence order. Selectors
+   are compared with cascade's structural equality; the bucket key carries their
+   hash, which cascade keeps consistent with that equality. *)
 let deduplicate_typed_triples triples =
   let seen = Hashtbl.create (List.length triples) in
   List.filter
     (fun (typ, sel, props, _order, nested, _base_class, _merge_key, _not_order)
        ->
-      let key = (typ, Css.Selector.to_string sel, props, nested) in
-      if Hashtbl.mem seen key then false
+      let bucket = (typ, Css.Selector.hash sel, props, nested) in
+      if List.exists (Css.Selector.equal sel) (Hashtbl.find_all seen bucket)
+      then false
       else (
-        Hashtbl.add seen key ();
+        Hashtbl.add seen bucket sel;
         true))
     triples
 

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -754,9 +754,7 @@ let is_utility_statement stmt =
 let rec merge_same_selector = function
   | a :: b :: rest -> (
       match (Css.as_rule a, Css.as_rule b) with
-      | Some (sa, da, []), Some (sb, db, [])
-        when Cascade.Selector.to_string ~minify:true sa
-             = Cascade.Selector.to_string ~minify:true sb ->
+      | Some (sa, da, []), Some (sb, db, []) when Css.Selector.equal sa sb ->
           merge_same_selector (Css.rule ~selector:sa (da @ db) :: rest)
       | _ -> a :: merge_same_selector (b :: rest))
   | stmts -> stmts

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -226,57 +226,6 @@ let (meta_of_info : info -> Css.meta), (info_of_meta : Css.meta -> info option)
 
 let layer_name = function (Theme : layer) -> "theme" | Utility -> "utilities"
 
-(* Convert a [Css.kind] witness to the matching [Css.Properties.kind]. *)
-let properties_kind_of_kind : type a. a Css.kind -> a Css.Properties.kind =
-  let open Css in
-  function
-  | Length -> Css.Properties.Length
-  | Color -> Css.Properties.Color
-  | Rgb -> Css.Properties.Rgb
-  | Int -> Css.Properties.Int
-  | Number -> Css.Properties.Number
-  | Float -> Css.Properties.Float
-  | Percentage -> Css.Properties.Percentage
-  | Length_percentage -> Css.Properties.Length_percentage
-  | Number_percentage -> Css.Properties.Number_percentage
-  | Opacity -> Css.Properties.Opacity
-  | Value -> Css.Properties.Value
-  | Duration -> Css.Properties.Duration
-  | Aspect_ratio -> Css.Properties.Aspect_ratio
-  | Border_style -> Css.Properties.Border_style
-  | Outline_style -> Css.Properties.Outline_style
-  | Border -> Css.Properties.Border
-  | Font_weight -> Css.Properties.Font_weight
-  | Font_size -> Css.Properties.Font_size
-  | Line_height -> Css.Properties.Line_height
-  | Font_family -> Css.Properties.Font_family
-  | Font_feature_settings -> Css.Properties.Font_feature_settings
-  | Font_variation_settings -> Css.Properties.Font_variation_settings
-  | Numeric -> Css.Properties.Numeric
-  | Font_variant_numeric_token -> Css.Properties.Font_variant_numeric_token
-  | Blend_mode -> Css.Properties.Blend_mode
-  | Scroll_snap_strictness -> Css.Properties.Scroll_snap_strictness
-  | Angle -> Css.Properties.Angle
-  | Rotate -> Css.Properties.Rotate
-  | Scale -> Css.Properties.Scale
-  | Shadow -> Css.Properties.Shadow
-  | Content -> Css.Properties.Content
-  | Gradient_stop -> Css.Properties.Gradient_stop
-  | Gradient_direction -> Css.Properties.Gradient_direction
-  | Gradient_position -> Css.Properties.Gradient_position
-  | Radial_shape -> Css.Properties.Radial_shape
-  | Radial_size -> Css.Properties.Radial_size
-  | Position_value -> Css.Properties.Position_value
-  | Animation -> Css.Properties.Animation
-  | Timing_function -> Css.Properties.Timing_function
-  | Transform -> Css.Properties.Transform
-  | Touch_action -> Css.Properties.Touch_action
-  | Transition_property_value -> Css.Properties.Transition_property_value
-  | Background_image -> Css.Properties.Background_image
-  | Z_index -> Css.Properties.Z_index
-  | Filter -> Css.Properties.Filter
-  | Font_src -> Css.Properties.Font_src
-
 (* Create a variable template *)
 let v : type a r.
     a Css.kind ->
@@ -363,8 +312,7 @@ let string_of_kind_value : type a. a Css.kind -> a -> string =
   | Css.Color -> Css.Pp.to_string ~minify:true Css.Values.pp_color value
   | Css.Gradient_position ->
       Css.Pp.to_string ~minify:true Css.Properties.pp_gradient_position value
-  | _ ->
-      Css.Properties.string_of_kind_value (properties_kind_of_kind kind) value
+  | _ -> Css.Properties.string_of_kind_value kind value
 
 (* Helper to create @property with correct syntax based on kind *)
 let property_universal : type a.

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -600,6 +600,23 @@ let test_md_media_dedup () =
        ~selector:(Css.Selector.class_ "md:p-4")
        css)
 
+(* Duplicate rules are dropped on cascade's structural selector equality, so a
+   class repeated in the input reaches the utilities layer once, and two
+   distinct selectors are never taken for one another. *)
+let test_duplicate_selector_dedup () =
+  let count css sel =
+    extract_utilities_layer_rules css
+    |> List.filter_map Css.statement_selector
+    |> List.filter (Css.Selector.equal sel)
+    |> List.length
+  in
+  let repeated = Tw.Build.to_css [ p 4; p 4 ] in
+  check int "repeated p-4 emits one rule" 1
+    (count repeated (Css.Selector.class_ "p-4"));
+  let distinct = Tw.Build.to_css [ p 4; m 4 ] in
+  check int "p-4 kept beside m-4" 1 (count distinct (Css.Selector.class_ "p-4"));
+  check int "m-4 kept beside p-4" 1 (count distinct (Css.Selector.class_ "m-4"))
+
 let test_md_hover_extra_media () =
   (* A responsive prefix wraps the hover rule's own (hover:hover) gate rather
      than replacing it, which is the structure Tailwind emits. *)
@@ -996,6 +1013,7 @@ let tests =
     test_case "rule_sets_groups_md_media_query" `Quick test_rule_sets_md_media;
     test_case "multi-breakpoint grouping+order" `Quick test_media_grouping_order;
     test_case "md media dedup" `Quick test_md_media_dedup;
+    test_case "duplicate selector dedup" `Quick test_duplicate_selector_dedup;
     test_case "md:hover nests the hover gate" `Quick test_md_hover_extra_media;
     test_case "container hover nests the gate" `Quick test_container_hover_nests;
     test_case "container + media together" `Quick test_container_and_media;

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -144,6 +144,33 @@ let test_hoist_theme_keyframes () =
        \  @keyframes flash { to { opacity: 0 } }\n\
         }\n")
 
+(* One [@apply] pulls in a rule per utility, each decorating the same [&]. They
+   are merged on selector equality, so the author's rule comes back once holding
+   every declaration rather than once per utility. *)
+let test_apply_merges_one_rule () =
+  let path = "apply-entry.css" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc "@import \"tailwindcss\";\n.btn { @apply p-4 m-4; }\n");
+  let out =
+    Fun.protect
+      ~finally:(fun () -> Sys.remove path)
+      (fun () ->
+        splice_into_entrypoint ~theme:Tw.Scheme.default ~path (Cascade.Css.v []))
+  in
+  let btn = Cascade.Selector.class_ "btn" in
+  let rules =
+    Cascade.Css.statements out
+    |> List.filter_map Cascade.Css.statement_selector
+    |> List.filter (Cascade.Selector.equal btn)
+  in
+  check int "one .btn rule" 1 (List.length rules);
+  check string "holding both declarations"
+    ".btn{margin:calc(var(--spacing)*4);padding:calc(var(--spacing)*4)}"
+    (Cascade.Css.to_string ~minify:true out)
+
 let tests =
   [
     test_case "variant segments" `Quick test_variant_segments;
@@ -159,6 +186,7 @@ let tests =
     test_case "custom utilities taken" `Quick test_take_custom_utilities;
     test_case "directives dropped" `Quick test_drop_directives;
     test_case "theme keyframes hoisted" `Quick test_hoist_theme_keyframes;
+    test_case "@apply merges into one rule" `Quick test_apply_merges_one_rule;
   ]
 
 let suite = ("entrypoint", tests)


### PR DESCRIPTION
`properties_kind_of_kind` was a 50-arm identity function: cascade declares `type 'a kind = 'a Properties.kind = | ...`, a type equation re-exporting the constructors, so the two are the same type. Every kind cascade added had to be added here too. It now calls `Css.Properties.string_of_kind_value` directly.

Selectors are compared structurally rather than by rendering them: `merge_same_selector` uses `Css.Selector.equal` instead of two minified renders, and `deduplicate_typed_triples` buckets on `Css.Selector.hash`, so a stringified selector is no longer spliced into a polymorphically-compared tuple.

A third retirement was attempted and abandoned: `escape_class_name` is not a workaround. It has no production caller and exists to agree with the selector printer, which hex-escapes non-ASCII where `Parser.escape_ident` emits raw UTF-8; swapping it would make it disagree with the selectors tw emits.