### PR TITLE
test, ci, scrollbar: run the rendering comparison, and stop folding a keyword

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
         # shifts output (units, calc folding, palette rounding).
         run: npm ci
 
+      # test/helpers/test_helpers.ml loads both sheets in headless Chromium and
+      # compares computed styles. npm ci installs the Playwright package but not
+      # the browser it drives, and the check skips silently when it cannot
+      # launch one, so without this step eight suites report no rendering
+      # differences because they never looked.
+      - name: Install the Chromium the rendering comparison drives
+        run: npx playwright install --with-deps chromium
+
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
@@ -45,6 +53,10 @@ jobs:
         run: opam exec -- dune build
 
       - name: Test
+        # TW_BROWSER_TESTS=1 turns a missing browser into a failure, so the
+        # rendering comparison cannot go back to passing by not running.
+        env:
+          TW_BROWSER_TESTS: 1
         run: opam exec -- dune runtest
 
   lint:

--- a/lib/property.ml
+++ b/lib/property.ml
@@ -6,6 +6,16 @@ let split statements =
       match Css.as_property stmt with Some _ -> true | None -> false)
     statements
 
+(* Keeps the FIRST rule for a name. CSS Properties and Values API 1 says a later
+   [@property] replaces an earlier one, so this looks backwards, and it is
+   deliberate: tw's contract is Tailwind parity, and Tailwind resolves the
+   collision the same way. Measured 2026-08-28 with an entrypoint declaring
+   [@property --tw-shadow-color] with its own syntax and initial-value after
+   [@import "tailwindcss"]: both tw and the real CLI emit one rule for that
+   name, the built-in, and neither carries the author's initial-value.
+
+   So there is no reproducer here today. Turn this into last-wins only when one
+   exists, because doing it on the spec alone would move tw off Tailwind. *)
 let dedup property_rules =
   let seen = Hashtbl.create 16 in
   List.filter

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -114,9 +114,14 @@ module Handler = struct
       Css.custom_property ~layer:"utilities" (Var.css_name set_var) k
     in
     match spec with
-    (* Tailwind keeps these keywords literal in the custom property, where
-       cascade's typed pp would fold them ([#0000] / [currentColor]). *)
-    | Transparent -> ([ keyword "transparent" ], [])
+    (* [currentcolor] goes in as text: cascade's typed colour prints the
+       [currentColor] a colour property takes, and Tailwind writes the lowercase
+       spelling a token stream folds to. [transparent] does not need the same
+       treatment - a token stream is what the optimizer folds to [#0000], so
+       writing it as text produced the very divergence the text was meant to
+       avoid. *)
+    | Transparent ->
+        ([ fst (Var.binding set_var (Css.Transparent : Css.color)) ], [])
     | Current -> ([ keyword "currentcolor" ], [])
     | Inherit -> ([ fst (Var.binding set_var (Css.Inherit : Css.color)) ], [])
     | Theme (color, shade, Color.No_opacity) ->

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -327,6 +327,21 @@ let browser_available root =
   && Sys.file_exists (Filename.concat root browser_script)
   && Sys.command "node --version > /dev/null 2>&1" = 0
 
+(* Skipping is right on a developer machine with no browser, and wrong on CI,
+   where it reports eight suites as finding no rendering difference because they
+   never looked. Set TW_BROWSER_TESTS=1 where the browser is meant to be present
+   and a missing one fails instead. *)
+let browser_required () = Sys.getenv_opt "TW_BROWSER_TESTS" = Some "1"
+
+let unavailable test_name reason =
+  if browser_required () then
+    Alcotest.failf "%s: TW_BROWSER_TESTS=1 but no usable browser: %s" test_name
+      reason
+  else begin
+    Fmt.epr "browser rendering unavailable: %s@." reason;
+    Alcotest.skip ()
+  end
+
 let write_file path content =
   let oc = open_out path in
   output_string oc content;
@@ -386,7 +401,8 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
   let root =
     match Lazy.force project_root with Some r -> r | None -> Alcotest.skip ()
   in
-  if not (browser_available root) then Alcotest.skip ();
+  if not (browser_available root) then
+    unavailable test_name "node, Playwright or the compare script is missing";
   let classnames = List.map Tw.pp utilities in
   let elements = render_elements classnames in
   let tailwind = tailwind_css ~forms classnames in
@@ -415,10 +431,8 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
         (read_file out)
   | _ ->
       (* No usable browser (Chromium not downloaded, sandbox refused to start).
-         Report it and skip: it is a missing tool, not a difference. *)
-      Fmt.epr "browser rendering unavailable: %s@."
-        (String.trim (read_file err));
-      Alcotest.skip ()
+         A missing tool, not a difference. *)
+      unavailable test_name (String.trim (read_file err))
 
 let check_ordering_matches ?forms ~test_name utilities =
   let diff = ordering_diff ?forms utilities in

--- a/test/test_scrollbar.ml
+++ b/test/test_scrollbar.ml
@@ -66,11 +66,30 @@ let test_declares_what_it_references () =
     "the properties read are the properties set" (names ~read:false)
     (names ~read:true)
 
+(* Tailwind writes [transparent] into the custom property, and the optimizer
+   folds a token stream to [#0000]. Spelling the keyword as text therefore
+   produced the fold it was written to avoid, and the roundtrip checks above
+   never looked at the value. *)
+let test_transparent_keeps_its_keyword () =
+  let css =
+    match Tw.of_string "scrollbar-thumb-transparent" with
+    | Ok u ->
+        Tw.to_css ~base:false [ u ]
+        |> Tw.Css.optimize ~prune_unused_custom_props:true
+        |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "scrollbar-thumb-transparent: %s" m
+  in
+  Alcotest.(check bool)
+    "the utility keeps the transparent keyword" true
+    (Astring.String.is_infix ~affix:"--tw-scrollbar-thumb:transparent" css)
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "declares what it references" `Quick
         test_declares_what_it_references;
+      Alcotest.test_case "transparent keeps its keyword" `Quick
+        test_transparent_keeps_its_keyword;
     ]
 
 let suite = ("scrollbar", tests)


### PR DESCRIPTION
`npm ci` installs the Playwright package but not the browser it drives, and the harness skips when it cannot launch one, so the eight suites calling `check_rendering_matches` reported no rendering difference because they never looked. That skip was also the documented compensating control for pruning unused custom properties at every differ call site. CI now installs Chromium, and `TW_BROWSER_TESTS=1` turns a missing browser into a failure rather than a skip, so the check cannot go back to passing by not running. Locally the suite goes from 300s to 1107s with the browser required, and stays green.

The scrollbar commits are separate and came out of reading a comment that turned out to be backwards. `transparent` was written into the custom property as text to stop cascade folding it, but a token stream is precisely what the optimizer folds to `#0000`, so the utility emitted the hex where Tailwind writes `transparent`; the typed binding survives the fold. The roundtrip tests never looked at the value, hence the regression test. `currentcolor` still goes in as text for a real reason, which the comment now states accurately.