### PR TITLE
tw, html, dom: give an unrecognised class one behaviour everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ let card =
 - **Type-safe** — utilities are typed constructors, so invalid combinations are
   compile errors rather than silent no-ops.
 - **String parsing** — `Tw.str "flex p-4 bg-blue-500"` turns class strings into
-  typed utilities for dynamic class lists.
+  typed utilities for dynamic class lists; `Tw.of_classes` also reports the
+  names it did not recognise.
 - **Pure OCaml** — no JavaScript toolchain required; the library also compiles
   to JavaScript with js_of_ocaml.
 
@@ -86,8 +87,13 @@ let css = Css.to_string ~minify:true stylesheet
 ### Parsing class strings
 
 ```ocaml
-(* [Tw.str] parses a class string into utilities (raises on unknown classes). *)
+(* [Tw.str] parses a class string into utilities, skipping names it does not
+   recognise. *)
 let styles = Tw.str "flex items-center gap-4 p-6 bg-white rounded-lg shadow-sm"
+
+(* [Tw.of_classes] also hands back the names it skipped, so a typo can be
+   reported rather than silently dropped. *)
+let utilities, unknown = Tw.of_classes "flex bg-blu-500 my-app-header"
 
 (* [Tw.of_string] parses a single class and returns a result. *)
 let parsed = Tw.of_string "hover:bg-blue-600" (* Ok _ *)

--- a/lib/dom/tw_dom.ml
+++ b/lib/dom/tw_dom.ml
@@ -122,9 +122,24 @@ let use styles =
   if !new_found then schedule_rebuild ();
   Tw.to_classes styles
 
+(* Names [use_str] was given that are no utility, newest-first and each recorded
+   once. Rendering must not stop for one: a class attribute legitimately carries
+   names this library knows nothing about, and a browser cannot tell those from
+   a typo any better than the parser can. The name reaches the element either
+   way; this list is what makes the typo findable. *)
+let unknown_seen : (string, unit) Hashtbl.t = Hashtbl.create 16
+let unknown_rev : string list ref = ref []
+let unknown_classes () = List.rev !unknown_rev
+
 let use_str s =
-  let styles = Tw.str s in
+  let styles, unknown = Tw.of_classes s in
   ignore (use styles);
+  List.iter
+    (fun cls ->
+      if not (Hashtbl.mem unknown_seen cls) then (
+        Hashtbl.add unknown_seen cls ();
+        unknown_rev := cls :: !unknown_rev))
+    unknown;
   s
 
 let css () =

--- a/lib/dom/tw_dom.mli
+++ b/lib/dom/tw_dom.mli
@@ -53,9 +53,16 @@ val flush : unit -> unit
     style element back within the task that registered the utilities. *)
 
 val use_str : string -> string
-(** [use_str s] parses a space-separated Tailwind class string, registers the
-    utilities, and returns the class name string. Raises [Invalid_argument] if
-    any class is not recognized. *)
+(** [use_str s] parses a space-separated class string, registers the utilities
+    it recognises, and returns [s] unchanged so that every name still reaches
+    the element. It never raises: a name that is no utility may be a framework
+    hook or a JS selector, and taking the page down over one is never the right
+    answer. {!unknown_classes} reports the names it could not parse. *)
+
+val unknown_classes : unit -> string list
+(** [unknown_classes ()] lists, in first-seen order and once each, every name
+    {!use_str} was given that {!Tw.of_classes} did not recognise as a utility.
+    This is how a typo among them is found. *)
 
 val css : unit -> string
 (** [css ()] returns the current accumulated CSS as a string. *)

--- a/lib/html/tw_html.ml
+++ b/lib/html/tw_html.ml
@@ -176,13 +176,14 @@ end
 
 type tw = Tw.t
 
-(* The utilities of a node and of everything below it. Concatenating a subtree's
+(* The utilities of a node and of everything below it, alongside the class names
+   its [class] attributes carried that are no utility. Concatenating a subtree's
    utilities into its parent copies that list once per level above it, so a
    document costs O(nodes x depth) to collect. The children are held unflattened
    instead and walked once, when the utilities are asked for. *)
-type tw_tree = { own : tw list; kids : tw_tree list }
+type tw_tree = { own : tw list; unknown : string list; kids : tw_tree list }
 
-let no_tw = { own = []; kids = [] }
+let no_tw = { own = []; unknown = []; kids = [] }
 
 (* Type that combines HTML element with its Tailwind classes *)
 type t = { el : El.html; tw : tw_tree; forms : bool }
@@ -204,12 +205,16 @@ end
 (* Internal helper to convert to El.html *)
 let to_htmlit t = t.el
 
-let to_tw t =
+(* Document order: a node's own names before its children's, children in the
+   order they were given. *)
+let collect_tree field tree =
   let rec collect acc node =
-    List.fold_left collect (List.rev_append node.own acc) node.kids
+    List.fold_left collect (List.rev_append (field node) acc) node.kids
   in
-  List.rev (collect [] t.tw)
+  List.rev (collect [] tree)
 
+let to_tw t = collect_tree (fun node -> node.own) t.tw
+let unknown_classes t = collect_tree (fun node -> node.unknown) t.tw
 let has_forms t = t.forms
 
 (* Text helpers *)
@@ -236,24 +241,15 @@ let class_atts tw_styles raw_classes other_atts =
   | "" -> List.rev other_atts
   | cls -> At.class' cls :: List.rev other_atts
 
-(* Parse a class string, returning (recognized_tw, raw_strings) *)
-let parse_class_value value =
-  let classes = Tw.split_whitespace value in
-  List.fold_left
-    (fun (tw_acc, raw_acc) cls ->
-      match Tw.of_string cls with
-      | Ok t -> (t :: tw_acc, raw_acc)
-      | Error _ -> (tw_acc, cls :: raw_acc))
-    ([], []) classes
-
 (* Extract class attrs from at, parse recognized Tw classes, keep unrecognized
-   as-is. Returns (tw_extras, raw_class_parts, other_atts) *)
+   as-is - a class attribute legitimately carries names this library knows
+   nothing about. Returns (tw_extras, raw_class_parts, other_atts) *)
 let extract_class_attrs atts =
   List.fold_left
     (fun (tw_extra, raw_cls, rest) ((name, value) as att) ->
       if name = "class" then
-        let tw_parsed, raw = parse_class_value value in
-        (List.rev tw_parsed @ tw_extra, List.rev raw @ raw_cls, rest)
+        let tw_parsed, raw = Tw.of_classes value in
+        (tw_parsed @ tw_extra, raw @ raw_cls, rest)
       else (tw_extra, raw_cls, att :: rest))
     ([], [], []) atts
 
@@ -267,7 +263,11 @@ let el_with_tw ?(forms = false) name ?at ?(tw = []) children =
   let child_els = List.map to_htmlit children in
   (* Collect all tw styles from this element and its children *)
   let all_tw =
-    { own = all_tw_styles; kids = List.map (fun c -> c.tw) children }
+    {
+      own = all_tw_styles;
+      unknown = raw_classes;
+      kids = List.map (fun c -> c.tw) children;
+    }
   in
   (* Propagate forms flag from children or this element *)
   let has_forms = forms || List.exists (fun c -> c.forms) children in
@@ -348,7 +348,7 @@ let void_el ?(forms = false) name ?at ?(tw = []) () =
   let atts_with_tw = class_atts all_tw raw_classes other_atts in
   {
     el = El.void_v ~at:atts_with_tw name;
-    tw = { own = all_tw; kids = [] };
+    tw = { own = all_tw; unknown = raw_classes; kids = [] };
     forms;
   }
 
@@ -366,7 +366,7 @@ let style ?at ?(tw = []) css =
   let atts_with_tw = class_atts all_tw raw_classes other_atts in
   {
     el = El.v ~at:atts_with_tw "style" [ El.unsafe_raw css ];
-    tw = { own = all_tw; kids = [] };
+    tw = { own = all_tw; unknown = raw_classes; kids = [] };
     forms = false;
   }
 

--- a/lib/html/tw_html.mli
+++ b/lib/html/tw_html.mli
@@ -351,6 +351,13 @@ val to_string : ?doctype:bool -> t -> string
 val to_tw : t -> tw list
 (** [to_tw t] extracts all styling classes from an HTML tree. *)
 
+val unknown_classes : t -> string list
+(** [unknown_classes t] lists, in document order, every name in the tree's
+    [class] attributes that {!Tw.of_classes} did not recognise as a utility.
+
+    Such a name is rendered as given - a framework hook or a JS selector belongs
+    in a [class] attribute - so this is how a typo among them is found. *)
+
 val has_forms : t -> bool
 (** [has_forms t] returns true if the HTML tree contains form elements (input,
     select, textarea) that benefit from the forms plugin base styles. *)

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -291,12 +291,22 @@ let of_string ?(theme = Scheme.default) class_str =
           | Error _ -> Error (`Msg ("Unknown class: " ^ class_str)))
       | None -> unknown_class_error ~base_class class_str)
 
-let str s =
-  let classes = split_whitespace s in
-  List.map
-    (fun cls ->
-      match of_string cls with Ok t -> t | Error (`Msg msg) -> invalid_arg msg)
-    classes
+(* A name the parser rejects may be a typo or a deliberate non-tw class - a
+   framework hook, a JS selector - and nothing here can tell the two apart. So
+   parsing a class string never fails: it hands back what it recognised and what
+   it did not, and the caller judges. *)
+let of_classes ?theme s =
+  let styles, unknown =
+    List.fold_left
+      (fun (styles, unknown) cls ->
+        match of_string ?theme cls with
+        | Ok t -> (t :: styles, unknown)
+        | Error _ -> (styles, cls :: unknown))
+      ([], []) (split_whitespace s)
+  in
+  (List.rev styles, List.rev unknown)
+
+let str s = fst (of_classes s)
 
 (** {1 Module Exports} *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -3907,9 +3907,25 @@ val split_whitespace : string -> string list
     let names = split_whitespace "flex\n  items-center"
     ]} *)
 
+val of_classes : ?theme:Scheme.t -> string -> t list * string list
+(** [of_classes s] parses a whitespace-separated string of class names into the
+    utilities it recognised and, in source order, the names it did not. It never
+    raises.
+
+    A name that is no utility may be a typo or a deliberate non-tw class - a
+    framework hook, a JS selector, a third-party widget - and parsing cannot
+    tell the two apart, so it reports both and leaves the judgement to the
+    caller. The [Tw_html] and [Tw_dom] renderers pass such a name through to the
+    rendered [class] attribute and report it the same way.
+
+    Example:
+    {[
+    let styles, unknown = of_classes "flex my-app-header"
+    ]} *)
+
 val str : string -> t list
-(** [str s] parses a whitespace-separated string of Tailwind class names into a
-    list of styles. Raises [Invalid_argument] if any class is not recognized.
+(** [str s] is the utilities of {!of_classes} [s], dropping the names it did not
+    recognise. Use {!of_classes} to see them.
 
     Example:
     {[

--- a/test/dom/test_tw_dom.ml
+++ b/test/dom/test_tw_dom.ml
@@ -142,6 +142,20 @@ let dom_incremental_consolidation () =
         (Astring.String.is_infix ~affix:selector dom_css))
     all
 
+(* A class the parser does not recognise must not take the page down: the
+   renderer registers what it recognised, hands the whole string back so the
+   unknown name still reaches the element, and records it for inspection. *)
+let dom_use_str_unknown_class () =
+  Tw_dom.init ~base:false ();
+  let cls = Tw_dom.use_str "flex bg-blu-500 my-app-header" in
+  check string "returns input" "flex bg-blu-500 my-app-header" cls;
+  Tw_dom.flush ();
+  check bool "css has the utility it recognised" true
+    (Astring.String.is_infix ~affix:".flex" (Tw_dom.css ()));
+  check (list string) "unknown names reported, in first-seen order"
+    [ "bg-blu-500"; "my-app-header" ]
+    (Tw_dom.unknown_classes ())
+
 let has_dom =
   (* Check if document.createElement exists — absent in Node.js *)
   try
@@ -162,6 +176,7 @@ let dom_cases =
     [
       test_case "use" `Quick dom_use;
       test_case "use_str" `Quick dom_use_str;
+      test_case "use_str with unknown class" `Quick dom_use_str_unknown_class;
       test_case "dedup" `Quick dom_dedup;
       test_case "batching" `Quick dom_batching;
       test_case "incremental consolidation" `Quick dom_incremental_consolidation;

--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -356,6 +356,32 @@ let test_repeated_utilities_emit_one_sheet () =
   in
   check string "sheet is the same" (sheet once) (sheet repeated)
 
+(* A class the parser does not recognise still reaches the rendered attribute -
+   a framework hook or a JS selector belongs there - but it is no longer
+   invisible: [unknown_classes] reports it so a typo can be caught. *)
+let test_unknown_class_passes_through () =
+  let elem = div ~at:[ At.v "class" "flex bg-blu-500 my-app-header" ] [] in
+  check string "unknown names still rendered"
+    "<div class=\"flex bg-blu-500 my-app-header\"></div>" (to_string elem);
+  check (list string) "only the utility compiles" [ "flex" ]
+    (List.map Tw.pp (to_tw elem));
+  check (list string) "unknown names reported, in source order"
+    [ "bg-blu-500"; "my-app-header" ]
+    (unknown_classes elem)
+
+(* Reported the way utilities are: a node's own names before its children's,
+   children in document order. *)
+let test_unknown_classes_document_order () =
+  let hook n = span ~at:[ At.v "class" n ] [] in
+  let tree =
+    div
+      ~at:[ At.v "class" "outer-hook flex" ]
+      [ section [ hook "a-hook"; div [ hook "b-hook" ] ]; hook "c-hook" ]
+  in
+  check (list string) "pre-order, own before children"
+    [ "outer-hook"; "a-hook"; "b-hook"; "c-hook" ]
+    (unknown_classes tree)
+
 let suite =
   ( "tw_html",
     [
@@ -380,4 +406,8 @@ let suite =
         test_class_attribute_whitespace;
       test_case "repeated utilities emit one sheet" `Quick
         test_repeated_utilities_emit_one_sheet;
+      test_case "unknown class passes through" `Quick
+        test_unknown_class_passes_through;
+      test_case "unknown classes document order" `Quick
+        test_unknown_classes_document_order;
     ] )

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -1173,11 +1173,40 @@ let property_order_cross_family () =
        (fun c -> Result.get_ok (Tw.of_string c))
        [ "outline"; "font-normal"; "leading-snug"; "tracking-wide" ])
 
+(* A class name that is not a tw utility is not a fatal error anywhere in the
+   library: [str] returns the utilities it did recognise, and [of_classes] hands
+   the names it rejected back so a typo is reportable rather than invisible. *)
+let unknown_class_never_raises () =
+  Alcotest.(check (list string))
+    "unknown name skipped" [ "flex"; "items-center" ]
+    (List.map Tw.pp (Tw.str "flex bg-blu-500 items-center"))
+
+let unknown_class_is_reported () =
+  let styles, unknown = Tw.of_classes "flex bg-blu-500 items-center" in
+  Alcotest.(check (list string))
+    "utilities recognised" [ "flex"; "items-center" ] (List.map Tw.pp styles);
+  Alcotest.(check (list string))
+    "unknown names, in source order" [ "bg-blu-500" ] unknown
+
+(* A deliberate non-tw class - a framework hook or a JS selector - reads exactly
+   like a typo to the parser, so both come back and the caller judges which is
+   which. *)
+let unknown_class_keeps_source_order () =
+  let _, unknown = Tw.of_classes "my-app-header flex js-toggle bg-blu-500" in
+  Alcotest.(check (list string))
+    "every non-utility name, in source order"
+    [ "my-app-header"; "js-toggle"; "bg-blu-500" ]
+    unknown
+
 (* ===== TEST SUITE ===== *)
 
 let core_tests =
   [
     test_case "debug artefacts" `Quick debug_artefacts;
+    test_case "unknown class never raises" `Quick unknown_class_never_raises;
+    test_case "unknown class is reported" `Quick unknown_class_is_reported;
+    test_case "unknown class keeps source order" `Quick
+      unknown_class_keeps_source_order;
     test_case "empty test" `Quick empty_test;
     test_case "upstream utilities parse parity" `Quick
       (check_upstream_positive_fixture_parse "utilities.txt");


### PR DESCRIPTION
One input had three outcomes across one library: `Tw.str` raised `Invalid_argument`, `Tw_html` copied the name into the rendered attribute and reported nothing, and `Tw_dom.use_str` crashed the browser render.

The parser cannot tell a typo (`bg-blu-500`) from a deliberate non-tw class (`js-toggle`), so it no longer guesses: an unrecognised name always passes through, never raises from a rendering path, and is always reportable. `Tw.of_classes` returns the utilities alongside the names it did not recognise, and `Tw_html.unknown_classes` and `Tw_dom.unknown_classes` expose the same list. `Tw.str` keeps its signature and skips unknown names instead of raising.

`Tw.of_string` is untouched, so the CLI still reports an unknown class as an error, which is right for a name typed deliberately. `Tw_html.parse_class_value` is gone in favour of `Tw.of_classes`, so the three entry points cannot drift apart again. The README claim that `Tw.str` raises was wrong after this and is updated.