### PR TITLE
scheme, build, modifiers, color: honour a theme that removes a token

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -922,7 +922,7 @@ module Handler = struct
           | None -> err_not_utility
         else err_not_utility
     | "border" :: color_parts -> (
-        match Color.shade_of_strings color_parts with
+        match Color.shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Border_color (color, shade))
         | Error _ -> err_not_utility)
     (* Border radius utilities (parametric). [rounded] / [rounded-<size>] target

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -794,10 +794,16 @@ let referenced_theme_decls ~theme ~exclude selector_props =
             Some decl
         | _ -> Color.Handler.theme_color_decl ~theme bare)
 
-(* [--default-font-family] points at [--font-sans]. When the project declared
-   that token in an [@theme inline] block it has no declaration of its own, so
-   the default carries its value instead of a reference nothing resolves. *)
-let inline_default_family theme decl =
+(* [--default-font-family] points at [--font-sans], [--default-mono-font-family]
+   at [--font-mono]. Tailwind spells the pair [--theme(--font-sans, initial)],
+   which reads two ways. When the project declared the source token in an
+   [@theme inline] block it has no declaration of its own, so the default
+   carries its value instead of a reference nothing resolves. When the project
+   took the source token out of its theme the [initial] fallback applies, and
+   the default goes with it rather than naming a variable nothing declares. A
+   default the project gave a value of its own points elsewhere, so neither
+   reading touches it. *)
+let resolve_default_family theme decl =
   match Css.custom_declaration_name decl with
   | Some name -> (
       let token =
@@ -808,14 +814,15 @@ let inline_default_family theme decl =
       in
       match token with
       | Some t
-        when Scheme.is_inline_token theme t
-             && String.trim (Css.declaration_value decl) = "var(--" ^ t ^ ")"
-        -> (
-          match Scheme.theme_value (Some theme) t with
-          | Some v -> Css.custom_property ~layer:"theme" name v
-          | None -> decl)
-      | _ -> decl)
-  | None -> decl
+        when String.trim (Css.declaration_value decl) = "var(--" ^ t ^ ")" ->
+          if Scheme.is_removed theme t then None
+          else if Scheme.is_inline_token theme t then
+            match Scheme.theme_value (Some theme) t with
+            | Some v -> Some (Css.custom_property ~layer:"theme" name v)
+            | None -> Some decl
+          else Some decl
+      | _ -> Some decl)
+  | None -> Some decl
 
 (* Tailwind derives the default font-feature settings from the sans and mono
    tokens the project declared. *)
@@ -879,7 +886,7 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
      built-in defaults carry the same token names as the extracted ones. *)
   pre @ extracted @ post
   |> List.filter_map (apply_token_override theme)
-  |> List.map (inline_default_family theme)
+  |> List.filter_map (resolve_default_family theme)
   |> sort_by_var_order ~theme |> theme_layer_rule ~layers
 
 let theme_layer_of ?theme ?(default_decls = []) tw_classes =

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1583,6 +1583,25 @@ let parse_opacity_modifier ?theme s =
 (* Parse color and shade from string list. A name the palette does not know is
    still a colour when the [\@theme] block declared [--color-<name>]; such a
    token carries no shade, and its name may span several segments. *)
+(* The named palette colours read a [--color-<name>] token, shaded or not; the
+   arbitrary spellings carry their own value and read nothing, and a
+   [Theme_named] one is looked up against the theme already. *)
+let palette_token color shade =
+  match color with
+  | Hex _ | Rgb _ | Oklch _ | Css _ | Theme_named _ -> None
+  | _ ->
+      let base = pp color in
+      if is_shadeless color then Some ("color-" ^ base)
+      else Some (Pp.str [ "color-"; base; "-"; string_of_int shade ])
+
+(* A [@theme] block that removed the token a palette colour reads leaves the
+   utility painting a variable nothing declares, so the colour stops resolving
+   the way a project colour the block never declared does. *)
+let palette_is_declared theme color shade =
+  match (theme, palette_token color shade) with
+  | Some scheme, Some token -> not (Scheme.is_removed scheme token)
+  | (Some _ | None), _ -> true
+
 let shade_of_strings ?theme parts =
   let theme_named () =
     let name = String.concat "-" parts in
@@ -1600,14 +1619,16 @@ let shade_of_strings ?theme parts =
           | Some shade
             when shade >= 0
                  && (not (is_shadeless color))
-                 && is_valid_shade color shade ->
+                 && is_valid_shade color shade
+                 && palette_is_declared theme color shade ->
               Ok (color, shade)
           | _ -> theme_named ())
       | Error _ -> theme_named ())
   | [ color_str ] -> (
       match of_string color_str with
-      | Ok color -> Ok (color, 500) (* Default shade *)
-      | Error _ -> theme_named ())
+      | Ok color when palette_is_declared theme color 500 ->
+          Ok (color, 500) (* Default shade *)
+      | Ok _ | Error _ -> theme_named ())
   | [] -> Error (`Msg "No color specified")
   | _ -> theme_named ()
 
@@ -1639,7 +1660,8 @@ let shade_and_opacity_of_strings ?theme parts =
           | Some shade
             when shade >= 0
                  && (not (is_shadeless color))
-                 && is_valid_shade color shade ->
+                 && is_valid_shade color shade
+                 && palette_is_declared theme color shade ->
               Ok (color, shade, opacity)
           | _ -> theme_named ())
       | Error _ -> theme_named ())
@@ -1662,8 +1684,9 @@ let shade_and_opacity_of_strings ?theme parts =
       | Some keyword -> Ok (Css keyword, 500, opacity)
       | None -> (
           match of_string base_str with
-          | Ok color -> Ok (color, 500, opacity)
-          | Error _ -> theme_named ()))
+          | Ok color when palette_is_declared theme color 500 ->
+              Ok (color, 500, opacity)
+          | Ok _ | Error _ -> theme_named ()))
   | [] -> Error (`Msg "No color specified")
   | _ -> theme_named ()
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1580,9 +1580,6 @@ let parse_opacity_modifier ?theme s =
       | Some opacity -> (base, opacity)
       | None -> (s, No_opacity))
 
-(* Parse color and shade from string list. A name the palette does not know is
-   still a colour when the [\@theme] block declared [--color-<name>]; such a
-   token carries no shade, and its name may span several segments. *)
 (* The named palette colours read a [--color-<name>] token, shaded or not; the
    arbitrary spellings carry their own value and read nothing, and a
    [Theme_named] one is looked up against the theme already. *)
@@ -1602,6 +1599,9 @@ let palette_is_declared theme color shade =
   | Some scheme, Some token -> not (Scheme.is_removed scheme token)
   | (Some _ | None), _ -> true
 
+(* Parse color and shade from string list. A name the palette does not know is
+   still a colour when the [\@theme] block declared [--color-<name>]; such a
+   token carries no shade, and its name may span several segments. *)
 let shade_of_strings ?theme parts =
   let theme_named () =
     let name = String.concat "-" parts in

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -525,7 +525,7 @@ module Handler = struct
             then Ok (Named_color_opacity (Theme_named base, 500, opacity))
             else Error (`Msg ("Invalid divide color: " ^ name)))
     | "divide" :: color_parts -> (
-        match Color.shade_of_strings color_parts with
+        match Color.shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Named_color (color, shade))
         | Error _ ->
             (* Try as theme-named color - check both generic and property-scoped

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2640,7 +2640,7 @@ module Handler = struct
         | "transparent", op -> Ok (Shadow_transparent_opacity op)
         (* Not a size: a shadeless colour with an alpha, e.g. shadow-white/10 *)
         | base, op -> (
-            match Color.shade_of_strings [ base ] with
+            match Color.shade_of_strings ~theme [ base ] with
             | Ok (c, s) -> Ok (Shadow_color_opacity (c, s, op))
             | Error _ -> err_not_utility))
     | [ "shadow"; color; shade ] -> (
@@ -2652,7 +2652,7 @@ module Handler = struct
     | [ "shadow"; name ] when is_theme_shadow theme name ->
         Ok (Shadow_theme name)
     | [ "shadow"; color ] -> (
-        match Color.shade_of_strings [ color ] with
+        match Color.shade_of_strings ~theme [ color ] with
         | Ok (c, s) -> Ok (Shadow_color (c, s))
         | Error _ -> err_not_utility)
     | [ "inset"; "shadow"; "none" ] -> Ok Inset_shadow_none
@@ -2691,7 +2691,7 @@ module Handler = struct
         | "sm", op -> Ok (Inset_shadow_shape_opacity (Ish_sm, op))
         | "transparent", op -> Ok (Inset_shadow_transparent_opacity op)
         | base, op -> (
-            match Color.shade_of_strings [ base ] with
+            match Color.shade_of_strings ~theme [ base ] with
             | Ok (c, s) -> Ok (Inset_shadow_color_opacity (c, s, op))
             | Error _ -> err_not_utility))
     | [ "inset"; "shadow"; color; shade ] -> (
@@ -2700,7 +2700,7 @@ module Handler = struct
         | Ok (c, s, opacity) -> Ok (Inset_shadow_color_opacity (c, s, opacity))
         | Error _ -> err_not_utility)
     | [ "inset"; "shadow"; color ] -> (
-        match Color.shade_of_strings [ color ] with
+        match Color.shade_of_strings ~theme [ color ] with
         | Ok (c, s) -> Ok (Inset_shadow_color (c, s))
         | Error _ -> err_not_utility)
     | [ "opacity"; n ] when String.length n > 0 && n.[0] = '[' ->

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1504,7 +1504,7 @@ module Handler = struct
                   Ok (Drop_shadow_keyword_color_opacity (Css.Current, base, op))
                 else
                   match
-                    Color.shade_and_opacity_of_strings
+                    Color.shade_and_opacity_of_strings ~theme
                       (String.split_on_char '-' base)
                   with
                   | Ok (c, shade, _) ->

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -977,7 +977,7 @@ module Handler = struct
     else None
 
   (* Parse directional from/to with support for values and paren refs *)
-  let parse_directional dir pos_end rest =
+  let parse_directional ~theme dir pos_end rest =
     let suffix = String.concat "-" rest in
     match parse_paren_var suffix with
     | Some (`Color, var_name) -> Ok (Mask_color_ref (dir, pos_end, var_name))
@@ -999,7 +999,7 @@ module Handler = struct
               | [ "transparent" ] -> keyword Css.Transparent
               | [ "current" ] -> keyword Css.current_color
               | _ -> (
-                  match Color.shade_of_strings rest with
+                  match Color.shade_of_strings ~theme rest with
                   | Ok (c, shade) ->
                       Some (Mask_stop_color (dir, pos_end, c, shade))
                   | Error _ -> None)
@@ -1012,44 +1012,44 @@ module Handler = struct
                      ("Invalid mask-" ^ direction_short dir ^ "-"
                     ^ position_end_name pos_end ^ " value"))))
 
-  let of_class _theme class_name =
+  let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
     (* mask-t-from-*, mask-t-to-* *)
     | "mask" :: "t" :: "from" :: rest when rest <> [] ->
-        parse_directional Top From rest
+        parse_directional ~theme Top From rest
     | "mask" :: "t" :: "to" :: rest when rest <> [] ->
-        parse_directional Top To rest
+        parse_directional ~theme Top To rest
     (* mask-r-from-*, mask-r-to-* *)
     | "mask" :: "r" :: "from" :: rest when rest <> [] ->
-        parse_directional Right From rest
+        parse_directional ~theme Right From rest
     | "mask" :: "r" :: "to" :: rest when rest <> [] ->
-        parse_directional Right To rest
+        parse_directional ~theme Right To rest
     (* mask-b-from-*, mask-b-to-* *)
     | "mask" :: "b" :: "from" :: rest when rest <> [] ->
-        parse_directional Bottom From rest
+        parse_directional ~theme Bottom From rest
     | "mask" :: "b" :: "to" :: rest when rest <> [] ->
-        parse_directional Bottom To rest
+        parse_directional ~theme Bottom To rest
     (* mask-l-from-*, mask-l-to-* *)
     | "mask" :: "l" :: "from" :: rest when rest <> [] ->
-        parse_directional Left From rest
+        parse_directional ~theme Left From rest
     | "mask" :: "l" :: "to" :: rest when rest <> [] ->
-        parse_directional Left To rest
+        parse_directional ~theme Left To rest
     (* mask-x-from-*, mask-x-to-* *)
     | "mask" :: "x" :: "from" :: rest when rest <> [] ->
-        parse_directional X From rest
+        parse_directional ~theme X From rest
     | "mask" :: "x" :: "to" :: rest when rest <> [] ->
-        parse_directional X To rest
+        parse_directional ~theme X To rest
     (* mask-y-from-*, mask-y-to-* *)
     | "mask" :: "y" :: "from" :: rest when rest <> [] ->
-        parse_directional Y From rest
+        parse_directional ~theme Y From rest
     | "mask" :: "y" :: "to" :: rest when rest <> [] ->
-        parse_directional Y To rest
+        parse_directional ~theme Y To rest
     (* mask-linear-from-*, mask-linear-to-* *)
     | "mask" :: "linear" :: "from" :: rest when rest <> [] ->
-        parse_directional Linear From rest
+        parse_directional ~theme Linear From rest
     | "mask" :: "linear" :: "to" :: rest when rest <> [] ->
-        parse_directional Linear To rest
+        parse_directional ~theme Linear To rest
     (* mask-linear-N (angle), mask-linear-[arb] *)
     | [ "mask"; "linear"; n ] -> (
         if Parse.is_bracket_value n then
@@ -1092,14 +1092,14 @@ module Handler = struct
           else Error (`Msg ("Invalid mask-radial-at position: " ^ position))
     (* mask-radial-from-*, mask-radial-to-* *)
     | "mask" :: "radial" :: "from" :: rest when rest <> [] ->
-        parse_directional Radial From rest
+        parse_directional ~theme Radial From rest
     | "mask" :: "radial" :: "to" :: rest when rest <> [] ->
-        parse_directional Radial To rest
+        parse_directional ~theme Radial To rest
     (* mask-conic-from-*, mask-conic-to-* *)
     | "mask" :: "conic" :: "from" :: rest when rest <> [] ->
-        parse_directional Conic From rest
+        parse_directional ~theme Conic From rest
     | "mask" :: "conic" :: "to" :: rest when rest <> [] ->
-        parse_directional Conic To rest
+        parse_directional ~theme Conic To rest
     (* mask-conic-N (angle), mask-conic-[arb] *)
     | [ "mask"; "conic"; n ] -> (
         if Parse.is_bracket_value n then

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1574,6 +1574,23 @@ let simple_modifiers =
     ("@7xl", Container Container_7xl);
   ]
 
+(* [simple_modifiers] holds the built-in breakpoints as a fixed set, so a
+   [@theme] block that removed one is only visible through the scheme: [md:]
+   then names a breakpoint the project does not have, and stops resolving the
+   way an unknown variant does. *)
+let modifier_breakpoint_is_defined theme m =
+  match m with
+  | Responsive bp | Min_responsive bp | Max_responsive bp ->
+      Scheme.has_breakpoint theme (Style.pp_modifier (Responsive bp))
+  | _ -> true
+
+(* Look a variant up in [simple_modifiers], honouring the theme's
+   breakpoints. *)
+let lookup_simple theme s =
+  match List.assoc_opt s simple_modifiers with
+  | Some m when modifier_breakpoint_is_defined theme m -> Some m
+  | Some _ | None -> None
+
 (* Try looking up a custom breakpoint (e.g., "10xl", "min-10xl", "max-10xl") *)
 let try_custom_breakpoint breakpoints s =
   (* Direct name: e.g., "10xl" → Custom_responsive *)
@@ -1779,12 +1796,13 @@ let try_group_peer_not s =
   | None -> try_prefix "peer-not-" (fun i n -> Peer_not (i, n))
 
 (* Try not-* prefix: wrap inner modifier in Not *)
-let try_not_modifier s =
+let try_not_modifier theme s =
   if not (String.length s > 4 && String.sub s 0 4 = "not-") then None
   else
     let inner = String.sub s 4 (String.length s - 4) in
     match List.assoc_opt inner simple_modifiers with
-    | Some m when is_not_compatible m -> Some (Not m)
+    | Some m when is_not_compatible m ->
+        if modifier_breakpoint_is_defined theme m then Some (Not m) else None
     | Some _ -> None
     | None ->
         let fns =
@@ -1973,7 +1991,7 @@ and try_scoped_container_query s =
 let rec parse_modifier ~(theme : Scheme.t) s : modifier option =
   let fns =
     [
-      (fun () -> List.assoc_opt s simple_modifiers);
+      (fun () -> lookup_simple theme s);
       (fun () -> try_container_query s);
       (fun () -> try_bracketed_modifier s);
       (fun () -> try_aria_shorthand s);
@@ -1988,7 +2006,7 @@ let rec parse_modifier ~(theme : Scheme.t) s : modifier option =
       (* Before [try_not_modifier]: a container variant handles its own [not-]
          (negating the structural condition), not the generic [Not] wrapper. *)
       (fun () -> try_container_variant theme s);
-      (fun () -> try_not_modifier s);
+      (fun () -> try_not_modifier theme s);
       (fun () -> try_bare_data_aria s);
       (fun () -> try_prose_element s);
       (fun () -> try_custom_breakpoint (Scheme.breakpoint_names theme) s);

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1578,8 +1578,7 @@ let simple_modifiers =
    [@theme] block that removed one is only visible through the scheme: [md:]
    then names a breakpoint the project does not have, and stops resolving the
    way an unknown variant does. *)
-let modifier_breakpoint_is_defined theme m =
-  match m with
+let modifier_breakpoint_is_defined theme = function
   | Responsive bp | Min_responsive bp | Max_responsive bp ->
       Scheme.has_breakpoint theme (Style.pp_modifier (Responsive bp))
   | _ -> true

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -267,6 +267,11 @@ let all_breakpoints scheme =
         in
         Option.map (fun length -> (name, length)) length)
 
+(** [has_breakpoint scheme name] is whether [scheme] still defines the
+    breakpoint [name], reading the same set as {!all_breakpoints} so a variant
+    and a container agree on what the theme has. *)
+let has_breakpoint scheme name = List.mem_assoc name (all_breakpoints scheme)
+
 (** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
     on top of any existing token overrides (new entries win). *)
 let with_overrides ?(inline = []) scheme overrides =

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -196,14 +196,19 @@ let in_nested_scale namespace name =
       String.equal name nested || String.starts_with ~prefix:(nested ^ "-") name)
     (Option.value ~default:[] (List.assoc_opt namespace nested_scales))
 
-let clears_namespace name (key, value) =
-  String.equal value removed_value
-  && String.length key > 2
+let clears_one_namespace name key =
+  String.length key > 2
   && String.equal (String.sub key (String.length key - 2) 2) "-*"
   &&
   let namespace = String.sub key 0 (String.length key - 2) in
   String.starts_with ~prefix:namespace name
   && not (in_nested_scale namespace name)
+
+(* [--ns-*: initial] resets one namespace; the bare [--*: initial] names no
+   namespace at all and resets the whole theme. *)
+let clears_namespace name (key, value) =
+  String.equal value removed_value
+  && (String.equal key "*" || clears_one_namespace name key)
 
 (** Whether a [@theme] block removed [name], either outright or by resetting the
     namespace it belongs to. A token the block goes on to declare survives its

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -89,11 +89,12 @@ val token_default : string -> string option
 
 val is_removed : t -> string -> bool
 (** [is_removed t name] is whether the [\@theme] block removed [name]. Tailwind
-    reads [--name: initial] as "remove this token" and [--namespace-*: initial]
-    as "remove the whole namespace", and a candidate that needed the token stops
-    resolving. A token the block declares in its own right survives a reset of
-    its namespace, and so does a nested scale that merely shares the prefix:
-    [--font-*: initial] leaves [--font-weight-*] alone. *)
+    reads [--name: initial] as "remove this token", [--namespace-*: initial] as
+    "remove the whole namespace" and the bare [--*: initial] as "remove every
+    token", and a candidate that needed the token stops resolving. A token the
+    block declares in its own right survives a reset, and so does a nested scale
+    that merely shares the prefix: [--font-*: initial] leaves [--font-weight-*]
+    alone. *)
 
 val token_override : t -> string -> string option
 (** [token_override t name] returns the per-render override for [name], if any.

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -154,6 +154,11 @@ val all_breakpoints : t -> (string * Css.length) list
     [\@theme] block set, and the legacy px-only {!breakpoints} field. A
     breakpoint the block removed is left out. *)
 
+val has_breakpoint : t -> string -> bool
+(** [has_breakpoint t name] is whether [t] still defines the breakpoint [name],
+    reading the same set as {!all_breakpoints}. A breakpoint the [\@theme] block
+    removed is gone for the variants that name it. *)
+
 val breakpoint_names : t -> string list
 (** [breakpoint_names t] returns the custom breakpoint names available while
     parsing variants. *)

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -794,11 +794,11 @@ module Handler = struct
         (* Not a size: a shadeless colour, which the multi-segment colour cases
            below never see because it fits in this single segment. *)
         | Stdlib.Option.None, Color.No_opacity -> (
-            match Color.shade_of_strings [ base ] with
+            match Color.shade_of_strings ~theme [ base ] with
             | Ok (color, shade) -> Ok (Text_shadow_color (color, shade))
             | Error e -> Error e)
         | Stdlib.Option.None, op -> (
-            match Color.shade_of_strings [ base ] with
+            match Color.shade_of_strings ~theme [ base ] with
             | Ok (color, shade) ->
                 Ok (Text_shadow_color_opacity (color, shade, op))
             | Error e -> Error e))
@@ -809,7 +809,7 @@ module Handler = struct
             Ok (Text_shadow_color_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "text" :: "shadow" :: color_parts -> (
-        match Color.shade_of_strings color_parts with
+        match Color.shade_of_strings ~theme color_parts with
         | Ok (color, shade) -> Ok (Text_shadow_color (color, shade))
         | Error e -> Error e)
     | _ -> err_not_utility

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -961,9 +961,30 @@ let test_theme_named_family_declaration_order () =
   check bool "--font-zeta declared before --font-alpha, as in the @theme block"
     true (zeta < alpha)
 
+(* [--default-font-family] is derived from [--font-sans]: a project that took
+   the family out of its theme leaves the derived token naming nothing, and
+   Tailwind drops it rather than emitting a reference that never resolves. *)
+let test_removed_family_drops_derived_default () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("font-sans", "initial") ]
+  in
+  let default_decls =
+    Tw.Typography.default_font_declarations
+    @ Tw.Typography.default_font_family_declarations
+  in
+  let theme_layer = Tw.Build.theme_layer_of ~theme ~default_decls [] in
+  let vars = vars_in_layer "theme" theme_layer in
+  check bool "--font-sans is gone" false (List.mem "--font-sans" vars);
+  check bool "--default-font-family goes with it" false
+    (List.mem "--default-font-family" vars);
+  check bool "--default-mono-font-family stays" true
+    (List.mem "--default-mono-font-family" vars)
+
 let tests =
   [
     test_case "starting-style blocks merge" `Quick test_starting_style_merges;
+    test_case "removed family drops its derived default" `Quick
+      test_removed_family_drops_derived_default;
     test_case "theme-named family keeps @theme declaration order" `Quick
       test_theme_named_family_declaration_order;
     test_case "referenced theme token emitted" `Quick

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -665,6 +665,51 @@ let test_undeclared_theme_colour_rejected () =
       "bg-brand-primary";
     ]
 
+(* A [@theme] block that removes a palette token takes the utilities reading it
+   with it: [text-red-500] would otherwise paint [var(--color-red-500)] with
+   nothing left to declare the variable. A shade the block kept, and a colour it
+   never touched, still resolve. *)
+let test_removed_palette_colour_rejected () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-red-500", "initial") ]
+  in
+  List.iter
+    (fun cls ->
+      match Tw.of_string ~theme cls with
+      | Error _ -> ()
+      | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u))
+    [
+      "text-red-500";
+      "bg-red-500";
+      "border-red-500";
+      "bg-red-500/50";
+      "divide-red-500";
+      "shadow-red-500";
+    ];
+  List.iter
+    (fun cls ->
+      match Tw.of_string ~theme cls with
+      | Ok _ -> ()
+      | Error (`Msg m) -> Alcotest.failf "%s was rejected: %s" cls m)
+    [ "text-red-600"; "text-blue-500" ]
+
+(* The whole-namespace form takes every palette colour, so nothing keyed on
+   [--color-*] resolves, while a colour the block declared for itself does. *)
+let test_removed_palette_namespace_rejected () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-*", "initial"); ("color-brand", "#123456") ]
+  in
+  List.iter
+    (fun cls ->
+      match Tw.of_string ~theme cls with
+      | Error _ -> ()
+      | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u))
+    [ "text-red-500"; "bg-blue-200" ];
+  match Tw.of_string ~theme "text-brand" with
+  | Ok _ -> ()
+  | Error (`Msg m) -> Alcotest.failf "text-brand was rejected: %s" m
+
 (* Test suite *)
 (* An achromatic palette colour must keep a [none] hue. A numeric hue renders
    the same but folds to a plain hex, which pins the hue that interpolation is
@@ -875,6 +920,12 @@ let tests =
     ( "Undeclared theme colour rejected",
       `Quick,
       test_undeclared_theme_colour_rejected );
+    ( "Removed palette colour rejected",
+      `Quick,
+      test_removed_palette_colour_rejected );
+    ( "Removed palette namespace rejected",
+      `Quick,
+      test_removed_palette_namespace_rejected );
     ("RGB to OKLCH roundtrip", `Quick, test_rgb_to_oklch_roundtrip);
     ("Hex parsing", `Quick, test_hex_parsing);
     ("RGB to hex", `Quick, test_rgb_to_hex);

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -394,6 +394,26 @@ let test_container_variant_is_theme_local () =
   check bool "a second theme does not see it" true
     (Result.is_error (Tw.of_string ~theme:Tw.Scheme.default "has-a:flex"))
 
+(* A [@theme] block that clears [--breakpoint-*] takes the built-in responsive
+   variants with it: [md:] then names a breakpoint the project no longer has,
+   and the candidate stops resolving the way an unknown variant does. The
+   [min-], [max-] and [not-] spellings read the same breakpoint, so they go too,
+   while a breakpoint the block declared for itself still resolves. *)
+let test_removed_breakpoint_drops_its_variants () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("breakpoint-*", "initial"); ("breakpoint-tablet", "40rem") ]
+  in
+  List.iter
+    (fun cls ->
+      check bool
+        (cls ^ " names a breakpoint the theme removed")
+        true
+        (Result.is_error (Tw.of_string ~theme cls)))
+    [ "md:flex"; "min-md:flex"; "max-md:flex"; "not-md:flex" ];
+  check bool "the theme's own breakpoint still resolves" true
+    (Result.is_ok (Tw.of_string ~theme "tablet:flex"))
+
 (* Test suite *)
 (* The [!] prefix marks the utility's own declarations !important, leaves theme
    tokens (--spacing) normal, preserves the class name, and nests under a
@@ -1124,6 +1144,8 @@ let tests =
         test_custom_variant_is_theme_local;
       test_case "container variant is theme-local" `Quick
         test_container_variant_is_theme_local;
+      test_case "removed breakpoint drops its variants" `Quick
+        test_removed_breakpoint_drops_its_variants;
     ]
 
 let suite = ("modifiers", tests)

--- a/test/test_scheme.ml
+++ b/test/test_scheme.ml
@@ -37,12 +37,31 @@ let test_namespace_reset_spares_nested_scales () =
     "the text shadows stay" true
     (Tw.Scheme.token s "text-shadow-2xs" <> None)
 
+(* Tailwind reads [--*: initial] as a reset of the whole theme, not just of one
+   namespace: every registered token goes, and only what the block declares in
+   its own right stands. *)
+let test_whole_theme_reset () =
+  let s =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("*", "initial"); ("spacing", "2px") ]
+  in
+  Alcotest.(check bool)
+    "the breakpoints go" true
+    (Tw.Scheme.token s "breakpoint-md" = None);
+  Alcotest.(check bool)
+    "the font sizes go" true
+    (Tw.Scheme.token s "text-sm" = None);
+  Alcotest.(check (option string))
+    "the block's own token stays" (Some "2px")
+    (Tw.Scheme.token s "spacing")
+
 let tests =
   Alcotest.
     [
       test_case "default scheme" `Quick test_default;
       test_case "namespace reset spares nested scales" `Quick
         test_namespace_reset_spares_nested_scales;
+      test_case "whole theme reset" `Quick test_whole_theme_reset;
       test_case "find color" `Quick test_find_color;
       test_case "breakpoint override" `Quick test_breakpoint_override;
     ]


### PR DESCRIPTION
A `@theme` that removes a token left the utilities reading it behind, emitting `var(--color-red-500)` with nothing declaring it.

Four cases, each with its own test. `--*: initial`, Tailwind's whole-theme reset, reached tw as a namespace key too short for `clears_namespace` to act on, so it was inert. `--font-sans: initial` left `--default-font-family` behind, which Tailwind drops. `--breakpoint-*: initial` left `md:` resolving, because the variant was a fixed enum rather than a question asked of the theme. And the palette itself was ungated: a removed `--color-*` still produced its utility.