### PR TITLE
sort, entrypoint: put a declared @utility where Tailwind puts it

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -375,7 +375,30 @@ let rule_to_triple order_map = function
         ~merge_key ~not_order
 
 (* Add index to each triple for stable sorting *)
-let add_index triples =
+(* What [indexed_rule_to_statement] will emit, counted: the theme declarations
+   the utilities layer drops are not part of the rule Tailwind orders. A
+   declared utility's rules arrive as finished CSS and carry none. *)
+let rec declaration_count props nested =
+  List.length (filter_utility_properties props)
+  + List.fold_left
+      (fun acc stmt ->
+        acc
+        +
+        match Css.as_rule stmt with
+        | Some (_, decls, inner) -> declaration_count decls inner
+        | None -> (
+            match Css.as_declarations stmt with
+            | Some decls -> declaration_count decls []
+            | None -> (
+                match Css.as_media stmt with
+                | Some (_, inner) -> declaration_count [] inner
+                | None -> (
+                    match Css.as_supports stmt with
+                    | Some (_, inner) -> declaration_count [] inner
+                    | None -> 0))))
+      0 nested
+
+let add_index ?(declared = fun _ -> false) triples =
   let buf = Buffer.create 256 in
   List.mapi
     (fun i (typ, sel, props, order, nested, base_class, merge_key, not_order) ->
@@ -393,6 +416,9 @@ let add_index triples =
          selector_kind = Sort.classify_selector sel;
          has_modifier_colon = Css.Selector.contains_modifier_colon sel;
          props;
+         declared =
+           (match base_class with Some c -> declared c | None -> false);
+         declaration_count = declaration_count props nested;
          order;
          nested;
          base_class;
@@ -486,10 +512,10 @@ let statements_of_sorted_rules ?verbatim sorted_rules =
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)
-let sorted_indexed_rules order_map all_rules =
+let sorted_indexed_rules ?declared order_map all_rules =
   all_rules
   |> List.filter_map (rule_to_triple order_map)
-  |> deduplicate_typed_triples |> add_index
+  |> deduplicate_typed_triples |> add_index ?declared
   |> List.sort Sort.compare_indexed_rules
 
 (* Sort var names by property_order. Names include -- prefix. *)
@@ -1668,11 +1694,13 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
   (* [sorted_rules] (the filter_map/dedup/index/sort pass) feeds both the
      utilities-layer statements and the variable first-usage order, so compute
      it once and share it rather than recomputing inside [layers]. *)
-  let sorted_rules = sorted_indexed_rules order_map selector_props in
   let verbatim =
     let names = Hashtbl.create 8 in
     List.iter (fun (cls, _, _) -> Hashtbl.replace names cls ()) extra;
     fun cls -> Hashtbl.mem names cls
+  in
+  let sorted_rules =
+    sorted_indexed_rules ~declared:verbatim order_map selector_props
   in
   let statements = statements_of_sorted_rules ~verbatim sorted_rules in
   let layer_results =

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -45,6 +45,16 @@ type indexed_rule = {
   selector_kind : selector_kind;
   has_modifier_colon : bool;
   props : Css.declaration list;
+  declared : bool;
+      (* The rule came in as finished CSS from a project's own [@utility]. *)
+  declaration_count : int;
+      (* How many declarations the rule emits, those of its nested rules
+         included. Tailwind breaks a tie between two rules that write the same
+         property by this, widest first, so the narrower one wins the cascade.
+         Read only when one side is [declared]: the built-ins of a family are
+         already separated by their suborders, and tw writes vendor-prefixed
+         spellings Tailwind leaves to its optimizer, so counting them against
+         each other would move rules the corpus pins. *)
   order : int * int;
   nested : Css.statement list;
   base_class : string option;
@@ -733,6 +743,16 @@ let compare_focus_modifier_ordering r1 r2 kind1 kind2 =
   else if f1 && f2 then Some (compare_by_priority_index r1 r2)
   else None
 
+(* A project's [@utility] borrows the slot of the property it writes, so it
+   lands among the built-ins of that family and the two orders decide which
+   wins. Tailwind puts the rule carrying more declarations first: [select-none]
+   writes the prefixed spelling of [user-select] as well as the plain one, so it
+   comes before a declared utility writing [user-select] alone whatever that
+   utility is called. *)
+let compare_declared_width r1 r2 =
+  if not (r1.declared || r2.declared) then 0
+  else Int.compare r2.declaration_count r1.declaration_count
+
 (** Compare by priority, suborder, late modifiers, then natural selector sort.
     Used as the final comparison when focus-visible/state/focus modifiers don't
     apply. *)
@@ -750,7 +770,15 @@ let compare_by_prio_sub_late r1 r2 kind1 kind2 =
       if late1 && not late2 then 1
       else if late2 && not late1 then -1
       else if late1 && late2 then compare_late_modifiers r1 r2 kind1 kind2
-      else natural_compare r1.selector_str r2.selector_str
+      else
+        (* Two utilities share a slot when they are named for the same property,
+           which is where a project's own [@utility] lands. The wider rule goes
+           first - [select-none] writes the prefixed spelling of [user-select]
+           as well as the plain one - and only rules of equal width fall through
+           to the candidate name. *)
+        let width_cmp = compare_declared_width r1 r2 in
+        if width_cmp <> 0 then width_cmp
+        else natural_compare r1.selector_str r2.selector_str
 
 let compare_cross_utility_regular r1 r2 =
   let p1, s1 = r1.order and p2, s2 = r2.order in

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -36,6 +36,13 @@ type indexed_rule = {
   selector_kind : selector_kind;
   has_modifier_colon : bool;
   props : Css.declaration list;
+  declared : bool;
+      (** The rule came in as finished CSS from a project's own [@utility]. *)
+  declaration_count : int;
+      (** How many declarations the rule emits, those of its nested rules
+          included. A declared utility shares a slot with the built-ins named
+          for the same property, and the wider rule comes first, so the narrower
+          one wins the cascade. Read only when one side is {!field-declared}. *)
   order : int * int;  (** [(priority, suborder)] from the utility definition. *)
   nested : Css.statement list;
   base_class : string option;

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1465,11 +1465,27 @@ let routed_statements ~block_count ~own_order stmts =
   in
   (block_count, ordered, unplaced @ dedup_statements hoisted)
 
+(* Flattening is what turns the wrappers a variant builds around a [@utility]
+   body into selectors: [.focus\:line-y { &:focus { ... } }] has to become
+   [.focus\:line-y:focus]. The body's own nesting is not a wrapper, and Tailwind
+   keeps it - [.line-y { padding: 5px; &::before { color: red } }] is one block
+   in its output. A rule already carrying declarations of its own is the utility
+   rather than a wrapper, so it goes through as written; flattening it would
+   split the utility into a rule per selector, each sorting by the property it
+   writes. *)
+let flattened_statement stmt =
+  match Css.as_rule stmt with
+  | Some (_, _ :: _, nested)
+    when List.for_all (fun st -> Css.as_rule st <> None) nested ->
+      [ stmt ]
+  | _ -> Css.statements (Css.flatten_nesting (Css.v [ stmt ]))
+
 let parse_routed_blocks ~block_count ~own_order css =
   match Css.of_string css with
   | Error _ -> (0, [], [])
   | Ok parsed ->
-      Css.statements (Css.flatten_nesting parsed.Css.stylesheet)
+      Css.statements parsed.Css.stylesheet
+      |> List.concat_map flattened_statement
       |> routed_statements ~block_count ~own_order
 
 let custom_routed_utilities ~theme ~defs ~udefs candidates =

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1389,6 +1389,75 @@ let test_compound_variant_same_multiset () =
   Test_helpers.check_ordering_matches
     ~test_name:"compound variant same multiset" utilities
 
+(* A project's [@utility] takes the slot of the property it writes, so it lands
+   among the built-ins of that family and the two orders decide which wins.
+   Tailwind breaks that tie by how many declarations each rule carries, widest
+   first: [.select-none] writes the prefixed spelling as well as [user-select],
+   so it comes before a declared utility writing [user-select] alone whatever
+   that utility is called. *)
+let declared_user_select name =
+  let order =
+    match Tw.Utility.order_of_property (Key User_select) with
+    | Some order -> order
+    | None -> Alcotest.fail "user-select has no utility slot"
+  in
+  ( name,
+    order,
+    [
+      Css.rule ~selector:(Css.Selector.class_ name)
+        [ Css.user_select (Text : Css.user_select) ];
+    ] )
+
+let builtin cls =
+  match Tw.Utility.base_of_class Tw.Scheme.default cls with
+  | Ok base -> Tw.Utility.base base
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+let utility_selectors sheet =
+  Test_helpers.extract_utilities_layer_rules sheet
+  |> Test_helpers.extract_rule_selectors
+
+let check_before what sheet first second =
+  let selectors = utility_selectors sheet in
+  let position sel =
+    match index (String.equal sel) selectors with
+    | Some i -> i
+    | None -> Alcotest.failf "%s missing from the utilities layer" sel
+  in
+  check bool what true (position first < position second)
+
+let test_declared_utility_after_wider_builtin () =
+  let sheet =
+    Tw.Build.to_css
+      ~extra:[ declared_user_select "aaa-sel" ]
+      [ builtin "select-none" ]
+  in
+  check_before "select-none before the declared utility" sheet ".select-none"
+    ".aaa-sel"
+
+(* The rule is not an unconditional append: two rules writing the same property
+   with as many declarations each still sort by candidate name, so a declared
+   utility can precede the built-in. *)
+let test_declared_utility_ties_by_name () =
+  let sheet =
+    Tw.Build.to_css
+      ~extra:
+        [
+          ( "aaa-pad",
+            (match Tw.Utility.order_of_property (Key Padding) with
+            | Some order -> order
+            | None -> Alcotest.fail "padding has no utility slot"),
+            [
+              Css.rule
+                ~selector:(Css.Selector.class_ "aaa-pad")
+                [ Css.padding [ Css.Px 5.0 ] ];
+            ] );
+        ]
+      [ builtin "p-4" ]
+  in
+  check_before "the declared utility keeps its alphabetical place" sheet
+    ".aaa-pad" ".p-4"
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -1717,6 +1786,10 @@ let tests =
       test_compound_variant_same_multiset;
     test_case "regular before media same priority" `Quick
       test_regular_before_media;
+    test_case "declared utility after a wider built-in" `Quick
+      test_declared_utility_after_wider_builtin;
+    test_case "declared utility ties by candidate name" `Quick
+      test_declared_utility_ties_by_name;
     test_case "rules_of_grouped prose merging bug" `Quick
       rules_of_grouped_prose_bug;
     test_case "suborder within group" `Slow test_suborder_within_group;

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -171,6 +171,27 @@ let test_apply_merges_one_rule () =
     ".btn{margin:calc(var(--spacing)*4);padding:calc(var(--spacing)*4)}"
     (Cascade.Css.to_string ~minify:true out)
 
+(* Tailwind emits a declared utility as one block, its own nesting intact:
+   [.line-y { padding: 5px; &::before { color: red } }]. Flattened into two
+   rules, the second sorts by the property it writes and an unrelated utility
+   can land between them. *)
+let test_declared_utility_keeps_its_nesting () =
+  let udefs = [ ("line-y", " padding: 5px; &::before { color: red } ") ] in
+  let count, entries, _ =
+    custom_routed_utilities ~theme:Tw.Scheme.default ~defs:[] ~udefs
+      [ "line-y" ]
+  in
+  check int "one candidate generated" 1 count;
+  match entries with
+  | [ (cls, _, statements) ] ->
+      check string "the utility's own class" "line-y" cls;
+      check int "one block, not one rule per selector" 1
+        (List.length statements);
+      check string "the nested rule is still nested"
+        ".line-y{padding:5px;&:before{color:red}}"
+        (Cascade.Css.to_string ~minify:true (Cascade.Css.v statements))
+  | _ -> Alcotest.failf "expected one entry, got %d" (List.length entries)
+
 let tests =
   [
     test_case "variant segments" `Quick test_variant_segments;
@@ -187,6 +208,8 @@ let tests =
     test_case "directives dropped" `Quick test_drop_directives;
     test_case "theme keyframes hoisted" `Quick test_hoist_theme_keyframes;
     test_case "@apply merges into one rule" `Quick test_apply_merges_one_rule;
+    test_case "declared utility keeps its nesting" `Quick
+      test_declared_utility_keeps_its_nesting;
   ]
 
 let suite = ("entrypoint", tests)


### PR DESCRIPTION
A declared `@utility` sorted before the built-ins of its family, so on an element carrying both, `sel-mine` lost to `select-none` where Tailwind has it win. Both write the same property, so the order decides the outcome; it is a cascade difference, not byte parity.

A declared multi-rule `@utility` was also flattened, and its `::before` rule then sorted by its own property, letting an unrelated utility land between the two halves of one block. It keeps its nesting now.