### PR TITLE
color, divide, svg, typography: give a bracket alpha one reader

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -239,6 +239,20 @@ let hex_to_oklab_alpha hex alpha : Css.color =
       Css.oklaba l a b alpha
   | None -> Css.hex hex
 
+(* A custom colour (a hex or an rgb() the author wrote) with an alpha folded in.
+   Tailwind writes the oklab form, with [none] for a channel that is zero. *)
+let custom_color_with_alpha (c : color) alpha =
+  let ok_l, ok_a, ok_b =
+    match c with
+    | Hex h -> (
+        match hex_to_rgb h with
+        | Some rgb -> rgb_to_oklab rgb
+        | None -> (0.0, 0.0, 0.0))
+    | Rgb { red; green; blue } -> rgb_to_oklab { r = red; g = green; b = blue }
+    | _ -> (0.0, 0.0, 0.0)
+  in
+  Css.oklaba_none_zeros ok_l ok_a ok_b alpha
+
 module Tailwind = struct
   let gray =
     [
@@ -2673,19 +2687,8 @@ module Handler = struct
     | None when is_custom_color c ->
         (* Custom/arbitrary colors (hex, rgb): output oklab() directly. No theme
            variables, no @supports, no hex+alpha fallback. *)
-        let ok_l, ok_a, ok_b =
-          match c with
-          | Hex h -> (
-              match hex_to_rgb h with
-              | Some rgb -> rgb_to_oklab rgb
-              | None -> (0.0, 0.0, 0.0))
-          | Rgb { red; green; blue } ->
-              rgb_to_oklab { r = red; g = green; b = blue }
-          | _ -> (0.0, 0.0, 0.0)
-        in
-        let alpha = percent /. 100.0 in
-        let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
-        style ?merge_key (property_decls oklab_value)
+        style ?merge_key
+          (property_decls (custom_color_with_alpha c (percent /. 100.0)))
     | None -> (
         let scheme = resolve_scheme theme in
         let color_name = scheme_color_name c shade in
@@ -2854,16 +2857,51 @@ module Handler = struct
         Some (mk_color_hex (hex_string_of_rgb (r, g, b)))
     | _ -> None
 
+  (* What an opacity modifier makes of a bracket colour. [Folded] is the single
+     value a colour with a hex spelling and a literal alpha resolves to.
+     [Guarded] is the pair every other case needs: the colour itself, for a
+     browser with no [color-mix()], and the mix behind an [\@supports] guard.
+     The properties the two land on are the caller's, which is why this answers
+     values rather than declarations - a decoration colour writes a vendor
+     prefix alongside, and a divide colour hangs both on its child selector. *)
+  type bracket_opacity =
+    | Folded of Css.color
+    | Guarded of { fallback : Css.color; mixed : Css.color }
+
   (* A bracket colour arrives already parsed into a typed [Css.color], and an
      opacity modifier applies to that value. Reading the bracket text back
      through the palette parser answered black for every colour the palette does
      not name. *)
+  let bracket_color_opacity css_color opacity =
+    match bracket_color_to_custom css_color with
+    | Some c when opacity_var_name opacity = None ->
+        Folded (custom_color_with_alpha c (opacity_to_percent opacity /. 100.0))
+    | _ ->
+        let fallback = resolve_bracket_css_color css_color in
+        Guarded { fallback; mixed = mix_alpha opacity fallback }
+
   let bracket_color_opacity_style ?merge_key ~property css_color opacity =
     match bracket_color_to_custom css_color with
     | Some c -> color_with_opacity_style ~property ?merge_key c 500 opacity
-    | None ->
+    | None -> (
         let base = resolve_bracket_css_color css_color in
-        style ?merge_key [ property (apply_alpha opacity base) ]
+        match css_color with
+        | Css.Current | Css.Var _ ->
+            (* The browser resolves these at use time, so the alpha cannot be
+               folded in ahead of it the way a concrete colour's can - an
+               [oklch()] mix folds to a hex with its alpha, [currentcolor] has
+               nothing to fold. Tailwind writes the plain colour and puts the
+               mix behind the [color-mix()] guard; emitting the mix alone leaves
+               a browser without [color-mix()] no colour at all. *)
+            let supports_block =
+              Css.supports ~condition:color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_")
+                    [ property (apply_alpha opacity base) ];
+                ]
+            in
+            style ?merge_key ~rules:(Some [ supports_block ]) [ property base ]
+        | _ -> style ?merge_key [ property (apply_alpha opacity base) ])
 
   let outline_bracket_color_opacity_style inner css_color opacity =
     let merge_key =
@@ -3397,6 +3435,12 @@ let opacity_var_bare = Handler.opacity_var_bare
 let opacity_var_bare_of = Handler.opacity_var_name
 let shorten_hex_str = shorten_hex_str
 let bracket_color_opacity_style = Handler.bracket_color_opacity_style
+
+type bracket_opacity = Handler.bracket_opacity =
+  | Folded of Css.color
+  | Guarded of { fallback : Css.color; mixed : Css.color }
+
+let bracket_color_opacity = Handler.bracket_color_opacity
 let css_color_to_hex = Handler.css_color_to_hex
 let parse_bracket_color = Handler.parse_bracket_color
 

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -553,6 +553,21 @@ val bracket_color_opacity_style :
     bracket was parsed into, so a CSS keyword or colour function keeps its own
     value rather than being read back through the palette. *)
 
+type bracket_opacity =
+  | Folded of Css.color
+      (** the single value a colour with a hex spelling and a literal alpha
+          resolves to *)
+  | Guarded of { fallback : Css.color; mixed : Css.color }
+      (** the colour itself, for a browser with no [color-mix()], and the mix
+          that goes behind an [@supports] guard *)
+
+val bracket_color_opacity : Css.color -> opacity_modifier -> bracket_opacity
+(** [bracket_color_opacity c opacity] is what [opacity] makes of the bracket
+    colour [c]. It answers values rather than declarations because the
+    properties they land on differ by family: a decoration colour writes a
+    vendor prefix alongside, and a divide colour hangs both on its child
+    selector. *)
+
 val parse_bracket_color : string -> Css.color option
 (** [parse_bracket_color inner] parses a bracket color value into a typed
     {!Css.color}. Handles hex, CSS color functions (rgba, hsl, oklch, ...), and

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -212,50 +212,23 @@ module Handler = struct
     let rule = Css.rule ~selector [ Css.border_color color ] in
     style ~rules:(Some [ rule ]) []
 
-  let divide_bracket_color_opacity_style class_name inner _c opacity =
+  (* An opacity modifier applies to the colour the bracket was parsed into. The
+     modifier read the bracket text back through the CSS colour parser and
+     answered black whenever that failed, and it hung the [@supports] rule on
+     the bare class rather than on the children the utility borders. *)
+  let divide_bracket_color_opacity_style class_name c opacity =
     let selector = divide_children_selector class_name in
-    let percent = Color.opacity_to_percent opacity in
-    let alpha = percent /. 100.0 in
-    if String.length inner > 0 && inner.[0] = '#' then
-      match Color.hex_to_rgb (String.sub inner 1 (String.length inner - 1)) with
-      | Some rgb ->
-          let value =
-            if Color.opacity_var_bare_of opacity <> None then
-              Color.mix_alpha opacity (Css.hex inner)
-            else
-              let ok_l, ok_a, ok_b = Color.rgb_to_oklab rgb in
-              Css.oklaba_none_zeros ok_l ok_a ok_b alpha
-          in
-          let rule = Css.rule ~selector [ Css.border_color value ] in
-          style ~rules:(Some [ rule ]) []
-      | None ->
-          let rule = Css.rule ~selector [ Css.border_color (Css.hex "#000") ] in
-          style ~rules:(Some [ rule ]) []
-    else
-      let normalized = String.map (fun c -> if c = '_' then ' ' else c) inner in
-      let css_color =
-        match Css.parse_color normalized with
-        | Some c -> c
-        | None -> Css.hex "#000"
-      in
-      let hex_color =
-        match Color.css_color_to_hex css_color with
-        | Some h -> h
-        | None -> css_color
-      in
-      let _ = alpha in
-      let fallback_decl = Css.border_color hex_color in
-      let oklab_color =
-        Css.color_mix ~in_space:Oklab hex_color Css.Transparent
-          ~percent1:percent
-      in
-      let oklab_decl = Css.border_color oklab_color in
-      let supports_block =
-        Css.supports ~condition:Color.color_mix_supports_condition
-          [ Css.rule ~selector:(Css.Selector.class_ "_") [ oklab_decl ] ]
-      in
-      let rule = Css.rule ~selector [ fallback_decl ] in
-      style ~rules:(Some [ rule; supports_block ]) []
+    match Color.bracket_color_opacity c opacity with
+    | Color.Folded value ->
+        let rule = Css.rule ~selector [ Css.border_color value ] in
+        style ~rules:(Some [ rule ]) []
+    | Color.Guarded { fallback; mixed } ->
+        let rule = Css.rule ~selector [ Css.border_color fallback ] in
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ Css.rule ~selector [ Css.border_color mixed ] ]
+        in
+        style ~rules:(Some [ rule; supports_block ]) []
 
   let divide_style_of_string (s : string) =
     let open Css in
@@ -370,7 +343,7 @@ module Handler = struct
         divide_bracket_color_style class_name inner c
     | Bracket_color_opacity (inner, c, opacity) ->
         let class_name = to_class (Bracket_color_opacity (inner, c, opacity)) in
-        divide_bracket_color_opacity_style class_name inner c opacity
+        divide_bracket_color_opacity_style class_name c opacity
     | Line_style bs -> divide_style_style bs
 
   (* Tailwind's order across the family, read off its own output: divide-x,
@@ -486,30 +459,17 @@ module Handler = struct
         | _ -> Ok (Current_opacity opacity))
     | [ "divide"; v ]
       when Parse.is_bracket_value (fst (Color.parse_opacity_modifier ~theme v))
-      ->
+      -> (
         let base_str, opacity = Color.parse_opacity_modifier ~theme v in
         let inner = Parse.bracket_inner base_str in
-        let normalized =
-          String.map (fun c -> if c = '_' then ' ' else c) inner
-        in
-        if
-          (String.length inner > 0 && inner.[0] = '#')
-          || Parse.is_css_color_fn normalized
-        then
-          let css_color =
-            (* A [#] prefix only names a colour when what follows is a hex
-               spelling; [Css.hex] raises on anything else, and this runs inside
-               [of_class]. *)
-            if String.length inner > 0 && inner.[0] = '#' then Css.hex_opt inner
-            else Css.parse_color normalized
-          in
-          match css_color with
-          | Some c -> (
-              match opacity with
-              | Color.No_opacity -> Ok (Bracket_color (inner, c))
-              | _ -> Ok (Bracket_color_opacity (inner, c, opacity)))
-          | None -> Error (`Msg ("Invalid divide bracket color: " ^ inner))
-        else Error (`Msg ("Invalid divide bracket value: " ^ inner))
+        (* Every colour spelling CSS knows, not only a [#] hex and a colour
+           function: a named colour and a keyword name a divide colour too. *)
+        match Color.parse_bracket_color inner with
+        | Some c -> (
+            match opacity with
+            | Color.No_opacity -> Ok (Bracket_color (inner, c))
+            | _ -> Ok (Bracket_color_opacity (inner, c, opacity)))
+        | None -> Error (`Msg ("Invalid divide bracket color: " ^ inner)))
     | "divide" :: color_parts when List.exists has_opacity color_parts -> (
         match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -95,30 +95,13 @@ module Handler = struct
     style ~merge_key
       [ property (Css.Color (Css.Var (Var.bracket bare_name)) : Css.svg_paint) ]
 
-  (* Extract a hex string (with leading #) from a Css.color, for oklab
-     conversion *)
-  let extract_hex_string css_color =
-    let hex_byte = Pp.hex_byte in
-    let rgba_hex r g b a =
-      let rgb = hex_byte r ^ hex_byte g ^ hex_byte b in
-      if a = 255 then rgb else rgb ^ hex_byte a
-    in
-    match Color.css_color_to_hex css_color with
-    | Some (Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ }) ->
-        "#" ^ rgba_hex r g b a
-    | _ -> (
-        match css_color with
-        | Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ } ->
-            "#" ^ rgba_hex r g b a
-        | _ -> "#000000")
-
-  (* Bracket color with opacity: convert to hex first, then apply oklab alpha *)
+  (* Bracket colour with opacity. The paint the modifier applies to is the
+     colour the bracket was parsed into: reading the bracket text back as a hex
+     answered black for every colour with no hex spelling. *)
   let bracket_color_opacity_style ~property css_color opacity =
-    let percent = Color.opacity_to_percent opacity in
-    let alpha = percent /. 100.0 in
-    let hex = extract_hex_string css_color in
-    let oklab_value = Color.hex_to_oklab_alpha hex alpha in
-    style [ property (Css.Color oklab_value : Css.svg_paint) ]
+    Color.bracket_color_opacity_style
+      ~property:(fun c -> property (Css.Color c : Css.svg_paint))
+      css_color opacity
 
   (* Bracket var with opacity: var fallback + @supports color-mix *)
   let bracket_var_opacity_style ~property ~merge_key v opacity =
@@ -410,13 +393,14 @@ module Handler = struct
         (* Bracket value: could be color or width *)
         let base_str, _ = Color.parse_opacity_modifier ~theme v in
         let base_inner = Parse.bracket_inner base_str in
-        let normalized =
-          String.map (fun c -> if c = '_' then ' ' else c) base_inner
-        in
+        (* Every colour spelling CSS knows, not only a [#] hex and a colour
+           function: a named colour and a keyword are stroke colours too, and
+           the width reader would refuse them. A [#] that spells no hex stays a
+           colour so it is refused as one rather than read as a width. *)
         if
           starts "color:" base_inner || starts "var(" base_inner
           || starts "#" base_inner
-          || Parse.is_css_color_fn normalized
+          || Stdlib.Option.is_some (Color.parse_bracket_color base_inner)
         then parse_bracket_stroke_color v
         else parse_bracket_stroke_width base_inner
     | [ "stroke"; "0" ] -> Ok Stroke_0

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1876,24 +1876,12 @@ module Typography_late = struct
               else if String.starts_with ~prefix:"percentage:" inner then
                 let var_part = String.sub inner 11 (String.length inner - 11) in
                 Ok (Decoration_bracket_pct_var var_part)
-              else if
-                String.length inner > 0
-                && (inner.[0] = '#'
-                   || Parse.is_css_color_fn
-                        (String.map (fun c -> if c = '_' then ' ' else c) inner)
-                   )
-              then
-                let normalized =
-                  String.map (fun c -> if c = '_' then ' ' else c) inner
-                in
-                let css_color =
-                  (* A [#] prefix only names a colour when what follows is a hex
-                     spelling; [Css.hex] raises on anything else, and this runs
-                     inside [of_class]. *)
-                  if inner.[0] = '#' then Css.hex_opt inner
-                  else Css.parse_color normalized
-                in
-                match css_color with
+              else
+                (* Every colour spelling CSS knows, not only a [#] hex and a
+                   colour function: a named colour and a keyword name a
+                   decoration colour too. The colour reader runs before the
+                   percentage one because [hsl(200_50%_50%)] ends in a [%]. *)
+                match Color.parse_bracket_color inner with
                 | Some c -> (
                     match opacity with
                     | Color.No_opacity ->
@@ -1903,25 +1891,25 @@ module Typography_late = struct
                           (Decoration_bracket_color_opacity (inner, c, opacity))
                     )
                 | None -> (
-                    match parse_decoration_thickness inner with
-                    | Some len -> Ok (Decoration_bracket_thickness (inner, len))
-                    | None -> err_not_utility)
-              else if
-                String.length inner > 0 && inner.[String.length inner - 1] = '%'
-              then
-                match parse_decoration_pct inner with
-                | Some len -> Ok (Decoration_bracket_pct (inner, len))
-                | None -> err_not_utility
-              else if is_bare_number inner then
-                (* Tailwind resolves the ambiguous unitless spelling through the
-                   colour candidate path. Its declaration is invalid CSS and
-                   browsers discard it; accepting an inert candidate is
-                   therefore equivalent, while treating it as px is not. *)
-                Ok (Decoration_bracket_invalid_color inner)
-              else
-                match parse_decoration_thickness inner with
-                | Some len -> Ok (Decoration_bracket_thickness (inner, len))
-                | None -> err_not_utility
+                    if
+                      String.length inner > 0
+                      && inner.[String.length inner - 1] = '%'
+                    then
+                      match parse_decoration_pct inner with
+                      | Some len -> Ok (Decoration_bracket_pct (inner, len))
+                      | None -> err_not_utility
+                    else if is_bare_number inner then
+                      (* Tailwind resolves the ambiguous unitless spelling
+                         through the colour candidate path. Its declaration is
+                         invalid CSS and browsers discard it; accepting an inert
+                         candidate is therefore equivalent, while treating it as
+                         px is not. *)
+                      Ok (Decoration_bracket_invalid_color inner)
+                    else
+                      match parse_decoration_thickness inner with
+                      | Some len ->
+                          Ok (Decoration_bracket_thickness (inner, len))
+                      | None -> err_not_utility)
             else
               (* Try parsing as number (decoration thickness) *)
               match Parse.int_any base_str with
@@ -2652,36 +2640,27 @@ module Typography_late = struct
     in
     style ~merge_key:"decoration-" [ text_decoration_color color ]
 
-  let decoration_bracket_color_with_opacity inner c opacity =
-    let percent = Color.opacity_to_percent opacity in
-    let alpha = percent /. 100.0 in
-    if String.length inner > 0 && inner.[0] = '#' then
-      match Color.hex_to_rgb (String.sub inner 1 (String.length inner - 1)) with
-      | Some rgb ->
-          let ok_l, ok_a, ok_b = Color.rgb_to_oklab rgb in
-          let oklab_value = Css.oklaba_none_zeros ok_l ok_a ok_b alpha in
-          style ~merge_key:"decoration-" [ text_decoration_color oklab_value ]
-      | None -> style [ text_decoration_color (Css.hex "#000") ]
-    else
-      let hex_color =
-        match Color.css_color_to_hex c with Some h -> h | None -> c
-      in
-      let _ = alpha in
-      let fallback_decl = text_decoration_color hex_color in
-      let oklab_color =
-        Css.color_mix ~in_space:Oklab hex_color Css.Transparent
-          ~percent1:percent
-      in
-      let oklab_decl = text_decoration_color oklab_color in
-      let supports_block =
-        Css.supports ~condition:Color.color_mix_supports_condition
-          [
-            Css.rule ~selector:(Css.Selector.class_ "_")
-              [ webkit_text_decoration_color oklab_color; oklab_decl ];
-          ]
-      in
-      style ~merge_key:"decoration-" ~rules:(Some [ supports_block ])
-        [ fallback_decl ]
+  (* An opacity modifier applies to the colour the bracket was parsed into. The
+     modifier read the bracket text back as a hex and answered black whenever
+     that failed, and it wrote the mix in place of the colour for every spelling
+     that is not a [#] hex, where Tailwind folds the alpha in. *)
+  let decoration_bracket_color_with_opacity c opacity =
+    match Color.bracket_color_opacity c opacity with
+    | Color.Folded value ->
+        style ~merge_key:"decoration-" [ text_decoration_color value ]
+    | Color.Guarded { fallback; mixed } ->
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [
+              Css.rule ~selector:(Css.Selector.class_ "_")
+                [
+                  webkit_text_decoration_color mixed;
+                  text_decoration_color mixed;
+                ];
+            ]
+        in
+        style ~merge_key:"decoration-" ~rules:(Some [ supports_block ])
+          [ text_decoration_color fallback ]
 
   let decoration_bracket_var_style v =
     let bare_name = Parse.extract_var_name v in
@@ -3195,8 +3174,8 @@ module Typography_late = struct
     | Decoration_bracket_color (inner, c) ->
         decoration_bracket_color_style inner c
     | Decoration_bracket_invalid_color _ -> style []
-    | Decoration_bracket_color_opacity (inner, c, opacity) ->
-        decoration_bracket_color_with_opacity inner c opacity
+    | Decoration_bracket_color_opacity (_, c, opacity) ->
+        decoration_bracket_color_with_opacity c opacity
     | Decoration_bracket_var v -> decoration_bracket_var_style v
     | Decoration_bracket_var_opacity (v, opacity) ->
         decoration_bracket_var_with_opacity v opacity

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -179,6 +179,43 @@ let test_invalid_bracket_hex () =
     "divide-[#ff0000] still emits the colour" true
     (Astring.String.is_infix ~affix:"border-color:#f00" (css "divide-[#ff0000]"))
 
+(* A bracket colour CSS names without spelling it as a function - a named
+   colour, a keyword - is a divide colour too. The reader admitted only a [#]
+   hex and a colour function, so [divide-[rebeccapurple]] was an unknown class,
+   with or without an opacity modifier. *)
+let test_bracket_named_color () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  (* the value a class sets for [border-color], so two spellings of one colour
+     compare without their class names *)
+  let value cls =
+    let sheet = css cls in
+    let key = "border-color:" in
+    match Astring.String.find_sub ~sub:key sheet with
+    | None -> Alcotest.failf "%s sets no border colour: %s" cls sheet
+    | Some i ->
+        let first = i + String.length key in
+        Astring.String.with_range ~first sheet
+        |> Astring.String.take ~sat:(fun c -> c <> ';' && c <> '}')
+  in
+  emits "border-color:rebeccapurple" "divide-[rebeccapurple]";
+  emits "border-color:currentColor" "divide-[currentColor]";
+  (* the modifier folds into the colour the bracket named, not into black *)
+  Alcotest.(check string)
+    "divide-[rebeccapurple]/50 is divide-[#663399]/50"
+    (value "divide-[#663399]/50")
+    (value "divide-[rebeccapurple]/50");
+  (* a bracket naming no colour is still not a class *)
+  Alcotest.(check bool)
+    "divide-[notacolour] is not a class" true
+    (Result.is_error (Tw.of_string "divide-[notacolour]"))
+
 (* The divide width suffix is a plain decimal integer. [divide-x-0x10] was read
    as 16 and emitted a rule selecting [.divide-x-16], a class the author never
    wrote; Tailwind emits nothing for it. *)
@@ -211,6 +248,7 @@ let tests =
         rendering_matches_tailwind;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
       Alcotest.test_case "non-decimal widths" `Quick test_non_decimal_widths;
+      Alcotest.test_case "bracket named colour" `Quick test_bracket_named_color;
     ]
 
 let suite = ("divide", tests)

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -82,9 +82,52 @@ let stroke_arbitrary_width_invalid () =
   rejected "stroke-[.]";
   rejected "stroke-[-]"
 
+(* A bracket colour CSS names without spelling it as a function - a named
+   colour, a keyword - is a stroke colour too. The stroke reader told colours
+   from widths by looking for a [#] or a colour function, so
+   [stroke-[rebeccapurple]] fell through to the width reader and was refused. An
+   opacity modifier then folds into the colour the bracket named: fill and
+   stroke read the bracket text back as a hex and answered black for every
+   colour with no hex spelling. *)
+let bracket_named_color () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  (* the value a class sets for [prop], so two spellings of one colour compare
+     without their class names *)
+  let value prop cls =
+    let sheet = css cls in
+    let key = prop ^ ":" in
+    match Astring.String.find_sub ~sub:key sheet with
+    | None -> Alcotest.failf "%s sets no %s: %s" cls prop sheet
+    | Some i ->
+        let first = i + String.length key in
+        Astring.String.with_range ~first sheet
+        |> Astring.String.take ~sat:(fun c -> c <> ';' && c <> '}')
+  in
+  let same prop cls other =
+    Alcotest.(check string)
+      (cls ^ " is " ^ other)
+      (value prop other) (value prop cls)
+  in
+  emits "stroke:rebeccapurple" "stroke-[rebeccapurple]";
+  emits "stroke:currentColor" "stroke-[currentColor]";
+  same "stroke" "stroke-[rebeccapurple]/50" "stroke-[#663399]/50";
+  same "fill" "fill-[rebeccapurple]/50" "fill-[#663399]/50";
+  (* a bracket naming neither a colour nor a width is still not a class *)
+  Alcotest.(check bool)
+    "stroke-[notacolour] is not a class" true
+    (Result.is_error (Tw.of_string "stroke-[notacolour]"))
+
 let tests =
   [
     test_case "basic svg" `Quick basic_svg;
+    test_case "bracket named colour" `Quick bracket_named_color;
     test_case "stroke shadeless colors" `Quick stroke_shadeless_colors;
     test_case "stroke light-dark color" `Quick stroke_light_dark_color;
     test_case "stroke arbitrary width units" `Quick stroke_arbitrary_width_units;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -948,6 +948,43 @@ let test_decoration_opacity_fallback () =
   emits "color-mix(in oklab,var(--color-brand) var(--a),transparent)"
     "decoration-brand/(--a)"
 
+(* A bracket colour CSS names without spelling it as a function - a named
+   colour, a keyword - is a decoration colour too. The reader admitted only a
+   [#] hex and a colour function, so [decoration-[rebeccapurple]] was an unknown
+   class, with or without an opacity modifier. *)
+let test_decoration_bracket_named_color () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  (* the value a class sets for [text-decoration-color], so two spellings of one
+     colour compare without their class names *)
+  let value cls =
+    let sheet = css cls in
+    let key = "text-decoration-color:" in
+    match Astring.String.find_sub ~sub:key sheet with
+    | None -> Alcotest.failf "%s sets no decoration colour: %s" cls sheet
+    | Some i ->
+        let first = i + String.length key in
+        Astring.String.with_range ~first sheet
+        |> Astring.String.take ~sat:(fun c -> c <> ';' && c <> '}')
+  in
+  emits "text-decoration-color:rebeccapurple" "decoration-[rebeccapurple]";
+  emits "text-decoration-color:currentColor" "decoration-[currentColor]";
+  (* the modifier folds into the colour the bracket named, not into black *)
+  Alcotest.(check string)
+    "decoration-[rebeccapurple]/50 is decoration-[#663399]/50"
+    (value "decoration-[#663399]/50")
+    (value "decoration-[rebeccapurple]/50");
+  (* a bracket naming no colour and no thickness is still not a class *)
+  Alcotest.(check bool)
+    "decoration-[notacolour] is not a class" true
+    (Result.is_error (Tw.of_string "decoration-[notacolour]"))
+
 (* A [#] bracket is only a decoration colour when what follows is a hex
    spelling. The decoration reader handed everything after the [#] to the
    raising constructor from inside [of_class], so a malformed hex escaped the
@@ -1111,6 +1148,8 @@ let tests =
       line_clamp_sorts_with_box_sizing;
     test_case "decoration opacity fallback" `Quick
       test_decoration_opacity_fallback;
+    test_case "decoration bracket named colour" `Quick
+      test_decoration_bracket_named_color;
     test_case "typography renders like Tailwind" `Slow
       rendering_matches_tailwind;
   ]


### PR DESCRIPTION
`decoration-[<colour>]/<alpha>`, `divide-[...]` and `stroke-[...]` had no arm for a bracket colour with an opacity modifier at all, so each was an unknown class. They now share one reader with the families that had one.

A colour the browser resolves at use time - `currentcolor`, a `var()` - cannot have its alpha folded in ahead of it, so Tailwind writes the plain colour and puts the mix behind the `color-mix()` guard. tw emitted the mix alone, which leaves a browser without `color-mix()` no colour at all for that property. A concrete colour still folds: an `oklch()` mix resolves to a hex carrying its alpha, and keying the guard on hex-ability rather than on the colour kind regressed exactly that case before the test caught it.