### PR TITLE
backgrounds, borders, color: one owner per colour family

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1971,6 +1971,8 @@ let bg ?opacity ?(shade = 500) color =
   | None -> utility (Bg (color, shade))
   | Some pct -> utility (Bg_opacity (color, shade, Color.opacity_of_int pct))
 
+let bg_transparent = utility Bg_transparent
+let bg_current = utility Bg_current
 let bg_gradient_to dir = utility (Bg_gradient_to dir)
 
 let from_color ?(shade = 500) color =

--- a/lib/backgrounds.mli
+++ b/lib/backgrounds.mli
@@ -22,6 +22,12 @@ val bg : ?opacity:int -> ?shade:int -> Color.color -> t
 (** [bg color] sets the background color. [shade] defaults to 500. [opacity]
     sets the alpha modifier (0-100). *)
 
+val bg_transparent : t
+(** [bg_transparent] makes the background fully transparent. *)
+
+val bg_current : t
+(** [bg_current] uses [currentColor] for the background. *)
+
 val bg_gradient_to : direction -> t
 (** [bg_gradient_to dir] sets gradient direction. Prefer this typed variant over
     the fixed functions when composing logic. *)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -104,10 +104,6 @@ module Handler = struct
     | Border_double
     | Border_hidden
     | Border_none
-    | (* Border color utilities *)
-      Border_color of Color.color * int
-    | Border_transparent
-    | Border_current
     | (* Border radius utilities. One parametric variant over (position, size);
          the bare [rounded] is [Rounded (Corner.All, Rsz_default)] and arbitrary
          brackets are [Rounded (pos, Rsz_arbitrary inner)]. *)
@@ -266,22 +262,6 @@ module Handler = struct
   let border_double = border_style_util Double
   let border_hidden = border_style_util Hidden
   let border_none = border_style_util None
-
-  (* Border color utilities *)
-  let border_color' color shade =
-    if Color.is_custom_color color then
-      let css_color = Color.to_css color shade in
-      style [ Css.border_color css_color ]
-    else
-      let color_var = Color.color_var color shade in
-      let color_value =
-        Color.to_css color (if Color.is_base_color color then 500 else shade)
-      in
-      let decl, color_ref = Var.binding color_var color_value in
-      style (decl :: [ Css.border_color (Var color_ref) ])
-
-  let border_transparent' = style [ Css.border_color (Css.hex "#0000") ]
-  let border_current' = style [ Css.border_color Current ]
 
   (* Arbitrary radii go through the same normalisation as the other arbitrary
      length utilities, so calc() and var() references parse. *)
@@ -687,10 +667,6 @@ module Handler = struct
     | Border_double -> border_double
     | Border_hidden -> border_hidden
     | Border_none -> border_none
-    (* Border color utilities *)
-    | Border_color (color, shade) -> border_color' color shade
-    | Border_transparent -> border_transparent'
-    | Border_current -> border_current'
     (* Border radius utilities (parametric) *)
     | Rounded (pos, size) -> rounded_style ~theme pos size
     (* Outline utilities *)
@@ -821,14 +797,6 @@ module Handler = struct
     | Border_hidden -> 1403
     | Border_none -> 1404
     | Border_solid -> 1405
-    (* Border color utilities (1500-1999) All border colors use the same
-       suborder (1500) to allow alphabetical sorting, matching Tailwind v4
-       behavior. *)
-    | Border_color (color, shade) ->
-        let _ = (color, shade) in
-        1500
-    | Border_transparent -> 1500
-    | Border_current -> 1500
     (* Outline utilities — hidden first, then width, then offset. The colors
        (color.ml, 3000-28000) and the styles (Outline_style_handler,
        30000-30004) close the family. *)
@@ -893,8 +861,6 @@ module Handler = struct
     | [ "border"; "double" ] -> Ok Border_double
     | [ "border"; "hidden" ] -> Ok Border_hidden
     | [ "border"; "none" ] -> Ok Border_none
-    | [ "border"; "transparent" ] -> Ok Border_transparent
-    | [ "border"; "current" ] -> Ok Border_current
     | [ "border"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' || c = '-' in
@@ -921,10 +887,6 @@ module Handler = struct
           | Some w -> Ok (Border_side_width_bracket (side, inner, w))
           | None -> err_not_utility
         else err_not_utility
-    | "border" :: color_parts -> (
-        match Color.shade_of_strings ~theme color_parts with
-        | Ok (color, shade) -> Ok (Border_color (color, shade))
-        | Error _ -> err_not_utility)
     (* Border radius utilities (parametric). [rounded] / [rounded-<size>] target
        all corners; [rounded-<pos>] / [rounded-<pos>-<size>] target a side or
        corner. Sizes and positions are disjoint token sets. *)
@@ -1045,11 +1007,6 @@ module Handler = struct
     | Border_double -> "border-double"
     | Border_hidden -> "border-hidden"
     | Border_none -> "border-none"
-    | Border_color (c, shade) ->
-        if Color.is_shadeless c then "border-" ^ Color.color_to_string c
-        else "border-" ^ Color.color_to_string c ^ "-" ^ string_of_int shade
-    | Border_transparent -> "border-transparent"
-    | Border_current -> "border-current"
     | Rounded (pos, size) ->
         let pos_str =
           match pos with
@@ -1104,7 +1061,6 @@ module Handler = struct
       Border_x;
       Border_y;
       Border_solid;
-      Border_current;
       Outline_width 2;
       Outline_offset 2;
       Rounded (Corner.All, Rsz_sm);
@@ -1205,15 +1161,6 @@ let border_hidden = utility Border_hidden
 let border_none = utility Border_none
 
 (** {1 Border Color Utilities} *)
-
-let border_color ?opacity ?(shade = 500) color =
-  Color.check_shade ~utility:"border_color" color shade;
-  match opacity with
-  | None -> utility (Border_color (color, shade))
-  | Some pct -> Color.border_color ~opacity:pct ~shade color
-
-let border_transparent = utility Border_transparent
-let border_current = utility Border_current
 
 (* Border width utilities with semantic names matching tw.mli *)
 let border_xs = border (* 1px *)

--- a/lib/borders.mli
+++ b/lib/borders.mli
@@ -67,18 +67,6 @@ val border_none : t
 (** [border_none] sets [--tw-border-style] to [none] and applies
     [border-style: none]. *)
 
-(** {1 Border Color Utilities} *)
-
-val border_color : ?opacity:int -> ?shade:int -> Color.color -> t
-(** [border_color color] sets the border color. [shade] defaults to 500.
-    [opacity] sets the alpha modifier (0-100). *)
-
-val border_transparent : t
-(** [border_transparent] sets the border color to transparent. *)
-
-val border_current : t
-(** [border_current] sets the border color to currentColor. *)
-
 val border_xs : t
 (** [border_xs] is a semantic width alias – 1px. *)
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1737,12 +1737,6 @@ module Handler = struct
 
   (** Local color utility type *)
   type t =
-    (* Background colors *)
-    | Bg of color * int
-    | Bg_opacity of color * int * opacity_modifier
-    | Bg_transparent
-    | Bg_current
-    | Bg_current_opacity of opacity_modifier
     (* Text colors *)
     | Text of color * int
     | Text_opacity of color * int * opacity_modifier
@@ -2093,22 +2087,6 @@ module Handler = struct
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "bg"; "transparent" ] -> Ok Bg_transparent
-    | [ "bg"; current_str ]
-      when String.starts_with ~prefix:"current" current_str -> (
-        let base, opacity = parse_opacity_modifier ~theme current_str in
-        match opacity with
-        | No_opacity when base = "current" -> Ok Bg_current
-        | No_opacity -> Error (`Msg ("Invalid bg: " ^ current_str))
-        | _ -> Ok (Bg_current_opacity opacity))
-    | "bg" :: color_parts when List.exists has_opacity color_parts -> (
-        match shade_and_opacity_of_strings ~theme color_parts with
-        | Ok (color, shade, opacity) -> Ok (Bg_opacity (color, shade, opacity))
-        | Error e -> Error e)
-    | "bg" :: color_parts -> (
-        match shade_of_strings ~theme color_parts with
-        | Ok (color, shade) -> Ok (Bg (color, shade))
-        | Error e -> Error e)
     | [ "text"; "transparent" ] -> Ok Text_transparent
     | [ "text"; "inherit" ] -> Ok Text_inherit
     | [ "text"; current_str ]
@@ -2374,20 +2352,6 @@ module Handler = struct
         | Ok (color, shade) -> Ok (Placeholder (color, shade))
         | Error e -> Error e)
     | _ -> Error (`Msg "Not a color utility")
-
-  let bg' ?theme c shade =
-    if is_custom_color c then
-      let css_color = to_css c shade in
-      style [ Css.background_color css_color ]
-    else
-      (* Use shared color variable to match tailwindcss output exactly. *)
-      let cv = color_var c shade in
-      let color_value = get_color_value ?theme c shade in
-      let decl, color_ref = Var.binding cv color_value in
-      style (decl :: [ Css.background_color (Css.Var color_ref) ])
-
-  let bg_transparent = style [ Css.background_color (Css.hex "#0000") ]
-  let bg_current = style [ Css.background_color Css.Current ]
 
   (** Text color utilities *)
 
@@ -2769,11 +2733,6 @@ module Handler = struct
     colors_with_opacity_style ?theme ~properties:[ property ] ?property_prefix
       ?merge_key c shade opacity
 
-  (** Background color with opacity *)
-  let bg_with_opacity ?theme c shade opacity =
-    color_with_opacity_style ?theme ~property:Css.background_color
-      ~property_prefix:"background-color" c shade opacity
-
   (** Text color with opacity *)
   let text_with_opacity ?theme c shade opacity =
     let property_prefix =
@@ -2956,15 +2915,11 @@ module Handler = struct
   let to_style theme =
     (* Shadow the scheme-reading colour helpers with theme-applied versions so
        the match arms below read from the explicitly threaded scheme. *)
-    let bg' color shade = bg' ~theme color shade in
     let text' color shade = text' ~theme color shade in
     let border_color' color shade = border_color' ~theme color shade in
     let accent' color shade = accent' ~theme color shade in
     let caret' color shade = caret' ~theme color shade in
     let outline' color shade = outline' ~theme color shade in
-    let bg_with_opacity color shade opacity =
-      bg_with_opacity ~theme color shade opacity
-    in
     let text_with_opacity color shade opacity =
       text_with_opacity ~theme color shade opacity
     in
@@ -2981,19 +2936,11 @@ module Handler = struct
       outline_with_opacity ~theme color shade opacity
     in
     function
-    | Bg (color, shade) -> bg' color shade
-    | Bg_opacity (color, shade, opacity) ->
-        (* 100% opacity: same as base color, no @supports needed *)
-        if is_fully_opaque opacity && not (is_custom_color color) then
-          bg' color shade
-        else bg_with_opacity color shade opacity
-    | Bg_transparent -> bg_transparent
-    | Bg_current -> bg_current
-    | Bg_current_opacity opacity ->
-        current_color_with_opacity ~property:Css.background_color opacity
-    | Text (color, shade) -> text' color shade
+    (* [Text_opacity] leads so the match resolves to the colour [t] rather than
+       to the [Text] constructor [open Css] brings into scope. *)
     | Text_opacity (color, shade, opacity) ->
         text_with_opacity color shade opacity
+    | Text (color, shade) -> text' color shade
     | Text_transparent -> text_transparent
     | Text_current -> text_current
     | Text_current_opacity opacity ->
@@ -3123,29 +3070,18 @@ module Handler = struct
         with_pseudo Css.Selector.Placeholder
           (bracket_color_opacity_style ~property:Css.color css_color opacity)
 
-  (* Suborder for the non-text color families: border (0-9999) then bg
-     (10000-19999). text-color runs at priority 26 (see [priority]) with a fixed
-     suborder inside the late-typography block. NOTE: Bg must be first pattern
-     to infer local type t vs shadowed Css.Border. *)
+  (* Suborder for the non-text color families: border first (0-9999), then the
+     rest. text-color runs at priority 26 (see [priority]) with a fixed suborder
+     inside the late-typography block. *)
   let suborder = function
-    | Bg (color, shade) ->
-        (* All background colors use the same suborder (10000) to allow
-           alphabetical sorting, matching Tailwind v4 behavior. *)
-        let _ = (color, shade) in
-        10000
-    | Bg_opacity (color, shade, _) ->
-        let _ = (color, shade) in
-        10000
-    | Bg_transparent -> 10000
-    | Bg_current -> 10000
-    | Bg_current_opacity _ -> 10000
-    | Text (color, shade) ->
-        (* All text colors share suborder 8370 (priority 26, after
-           text-transform and before font-style) so they sort alphabetically,
-           matching Tailwind. *)
+    (* [Text_opacity] leads so the match resolves to the colour [t] rather than
+       to the [Text] constructor [open Css] brings into scope. All text colors
+       share suborder 8370 (priority 26, after text-transform and before
+       font-style) so they sort alphabetically, matching Tailwind. *)
+    | Text_opacity (color, shade, _) ->
         let _ = (color, shade) in
         8370
-    | Text_opacity (color, shade, _) ->
+    | Text (color, shade) ->
         let _ = (color, shade) in
         8370
     | Text_transparent -> 8370
@@ -3256,27 +3192,17 @@ module Handler = struct
     | Placeholder_bracket_color_opacity _ -> 80000
 
   let to_class = function
-    | Bg (c, shade) ->
-        if is_shadeless c then "bg-" ^ color_to_string c
-        else "bg-" ^ color_to_string c ^ "-" ^ string_of_int shade
-    | Bg_opacity (c, shade, opacity) ->
-        if is_shadeless c then
-          "bg-" ^ color_to_string c ^ opacity_suffix opacity
-        else
-          "bg-" ^ color_to_string c ^ "-" ^ string_of_int shade
-          ^ opacity_suffix opacity
-    | Bg_transparent -> "bg-transparent"
-    | Bg_current -> "bg-current"
-    | Bg_current_opacity opacity -> "bg-current" ^ opacity_suffix opacity
-    | Text (c, shade) ->
-        if is_shadeless c then "text-" ^ color_to_string c
-        else "text-" ^ color_to_string c ^ "-" ^ string_of_int shade
+    (* [Text_opacity] leads so the match resolves to the colour [t] rather than
+       to the [Text] constructor [open Css] brings into scope. *)
     | Text_opacity (c, shade, opacity) ->
         if is_shadeless c then
           "text-" ^ color_to_string c ^ opacity_suffix opacity
         else
           "text-" ^ color_to_string c ^ "-" ^ string_of_int shade
           ^ opacity_suffix opacity
+    | Text (c, shade) ->
+        if is_shadeless c then "text-" ^ color_to_string c
+        else "text-" ^ color_to_string c ^ "-" ^ string_of_int shade
     | Text_transparent -> "text-transparent"
     | Text_current -> "text-current"
     | Text_current_opacity opacity -> "text-current" ^ opacity_suffix opacity
@@ -3410,7 +3336,6 @@ module Handler = struct
 
   let examples =
     [
-      Bg_transparent;
       Text_transparent;
       Border_transparent;
       Outline_transparent;
@@ -3794,12 +3719,6 @@ let bg_current_with_opacity ?theme opacity =
 (** Public API *)
 let utility x = Utility.base (Self x)
 
-let bg ?opacity ?(shade = 500) color =
-  check_shade ~utility:"bg" color shade;
-  match opacity with
-  | None -> utility (Bg (color, shade))
-  | Some pct -> utility (Bg_opacity (color, shade, opacity_of_int pct))
-
 let text ?opacity ?(shade = 500) color =
   check_shade ~utility:"text" color shade;
   match opacity with
@@ -3812,8 +3731,6 @@ let border_color ?opacity ?(shade = 500) color =
   | None -> utility (Border (color, shade))
   | Some pct -> utility (Border_opacity (color, shade, opacity_of_int pct))
 
-let bg_transparent = utility Bg_transparent
-let bg_current = utility Bg_current
 let text_transparent = utility Text_transparent
 let text_current = utility Text_current
 let text_inherit = utility Text_inherit

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -281,16 +281,6 @@ end
 
 (** {1 Color Application Utilities} *)
 
-val bg : ?opacity:int -> ?shade:int -> color -> t
-(** [bg color] sets the background color. [shade] defaults to 500. [opacity]
-    sets the alpha modifier (0-100), e.g. [bg ~opacity:50 white]. *)
-
-val bg_transparent : t
-(** [bg_transparent] makes the background fully transparent. *)
-
-val bg_current : t
-(** [bg_current] uses [currentColor] for the background. *)
-
 val text : ?opacity:int -> ?shade:int -> color -> t
 (** [text color] sets the text color. [shade] defaults to 500. [opacity] sets
     the alpha modifier (0-100), e.g. [text ~opacity:50 red]. *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -1,6 +1,7 @@
 module Css = Cascade.Css
 open Alcotest
 open Tw.Color
+open Tw.Backgrounds
 open Tw.Padding
 open Tw.Margin
 open Tw.Modifiers

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -5,6 +5,7 @@ open Tw.Modifiers
 open Tw.Padding
 open Tw.Margin
 open Tw.Color
+open Tw.Backgrounds
 open Tw.Grid_template
 open Tw.Animations
 open Tw.Transitions

--- a/test/test_output.ml
+++ b/test/test_output.ml
@@ -2,6 +2,7 @@ module Css = Cascade.Css
 open Alcotest
 open Tw.Output
 open Tw.Color
+open Tw.Backgrounds
 open Tw.Padding
 open Tw.Margin
 open Tw.Modifiers

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -2,6 +2,7 @@ module Css = Cascade.Css
 open Alcotest
 open Tw.Output
 open Tw.Color
+open Tw.Backgrounds
 open Tw.Padding
 open Tw.Modifiers
 

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1,6 +1,7 @@
 module Css = Cascade.Css
 open Alcotest
 open Tw.Color
+open Tw.Backgrounds
 open Tw.Padding
 
 (* OCaml 4.14 compat *)

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -293,6 +293,11 @@ let test_no_class_claimed_twice () =
         "ring-offset-2";
         "inset-ring-2";
         "bg-red-500";
+        "bg-current";
+        "bg-transparent";
+        "border-red-500";
+        "border-current";
+        "border-transparent";
         "bg-linear-45";
         "from-red-500";
         "via-red-500";
@@ -339,18 +344,15 @@ let test_no_class_claimed_twice () =
         | names -> Some (cls ^ " -> " ^ String.concat ", " names))
       (List.sort_uniq String.compare corpus)
   in
-  (* These five are claimed twice today: [backgrounds] and [color] both accept
-     [bg-<colour>], and [borders] and [color] both accept [border-current] and
-     [border-transparent]. Which one answers is decided by dune link order. The
-     output is right today, so this pins the set rather than the emptiness: a
-     sixth overlap fails here, and so does resolving one of these, which is the
-     prompt to update the list. *)
+  (* The border colours are still claimed twice: [borders] and [color] both
+     accept them, and which one answers is decided by dune link order. Both
+     spell the same rule at the same (priority, suborder), so the output is
+     right today; this pins the set rather than the emptiness, so that a new
+     overlap fails here and so does resolving one of these. *)
   let known_doubled =
     [
-      "bg-current -> backgrounds, color";
-      "bg-red-500 -> backgrounds, color";
-      "bg-transparent -> backgrounds, color";
       "border-current -> borders, color";
+      "border-red-500 -> borders, color";
       "border-transparent -> borders, color";
     ]
   in

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -269,10 +269,10 @@ let test_order_of_property_covers_named_families () =
 (* [base_of_class] takes the FIRST handler that accepts a class, and handlers
    are tried in dune link order, so a class two handlers both accept would
    resolve on an unrelated build detail rather than on anything declared - and
-   would change silently when someone edits a dune file. No such class was ever
-   demonstrated; this asserts there is none, over the utilities every handler
-   offers as its own examples plus the families whose prefixes overlap most
-   (border/divide, text/font, shadow/inset-shadow, bg gradients, ring). *)
+   would change silently when someone edits a dune file. This asserts there is
+   no such class, over the utilities every handler offers as its own examples
+   plus the families whose prefixes overlap most (border/divide, text/font,
+   shadow/inset-shadow, bg colours and gradients, ring). *)
 let test_no_class_claimed_twice () =
   let corpus =
     Tw.Utility.examples_classes ()
@@ -344,20 +344,7 @@ let test_no_class_claimed_twice () =
         | names -> Some (cls ^ " -> " ^ String.concat ", " names))
       (List.sort_uniq String.compare corpus)
   in
-  (* The border colours are still claimed twice: [borders] and [color] both
-     accept them, and which one answers is decided by dune link order. Both
-     spell the same rule at the same (priority, suborder), so the output is
-     right today; this pins the set rather than the emptiness, so that a new
-     overlap fails here and so does resolving one of these. *)
-  let known_doubled =
-    [
-      "border-current -> borders, color";
-      "border-red-500 -> borders, color";
-      "border-transparent -> borders, color";
-    ]
-  in
-  Alcotest.(check (list string))
-    "no class is claimed twice beyond the known set" known_doubled doubled
+  Alcotest.(check (list string)) "no class is claimed twice" [] doubled
 
 let tests =
   [


### PR DESCRIPTION
Five classes were accepted by two handlers each, and `register` conses onto the handler list, so which one answered was decided by the dune link order.

They were not equivalent. `backgrounds` gave `bg-red-500` priority 20 with a suborder from the `background-color` property rank; `color` gave it priority 25 from its catch-all and a flat suborder, which sorts it after `.bg-none`, `.bg-cover` and `.p-4`. Canonical `--diff` calls that no difference, correctly - it is cascade-neutral reordering, the blind spot the docs record - so it took `--diff-mode=tree` to see. The border pair agreed exactly, and went to `color` because it already owns the sides, the brackets and the opacity spellings, leaving `borders` with a strict subset.

That disagreement reached the public API: `Tw.bg_transparent` resolved through `Color` at priority 20's expense while the same class name parsed from a string resolved through `Backgrounds`, so one rule could land in two places depending on how it was built. The pinned `known_doubled` list is gone and the test now asserts the set is empty.