### PR TITLE
prose, test: render prose against real markup, not bare divs

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1850,36 +1850,45 @@ let try_bare_data_aria s =
     if names_attribute expr then Some (Aria_bracket expr) else None
   else None
 
-(* Ordering of prose element variants (matches Tailwind v4 typography plugin) *)
+(* The order @tailwindcss/typography registers its element variants in, which is
+   the order it emits their rules in. A variant missing from here sorts before
+   every other, so its utility loses to one it should win against. *)
 let prose_element_variant_order = function
   | "headings" -> 96001
   | "h1" -> 96002
   | "h2" -> 96003
   | "h3" -> 96004
   | "h4" -> 96005
-  | "p" -> 96006
-  | "a" -> 96007
-  | "blockquote" -> 96008
-  | "figure" -> 96009
-  | "figcaption" -> 96010
-  | "strong" -> 96011
-  | "em" -> 96012
-  | "kbd" -> 96013
-  | "code" -> 96014
-  | "pre" -> 96015
-  | "ol" -> 96016
-  | "ul" -> 96017
-  | "li" -> 96018
-  | "thead" -> 96019
-  | "th" -> 96020
-  | "td" -> 96021
-  | "img" -> 96022
-  | "video" -> 96023
-  | "hr" -> 96024
-  | "lead" -> 96025
+  | "h5" -> 96006
+  | "h6" -> 96007
+  | "p" -> 96008
+  | "a" -> 96009
+  | "blockquote" -> 96010
+  | "figure" -> 96011
+  | "figcaption" -> 96012
+  | "strong" -> 96013
+  | "em" -> 96014
+  | "kbd" -> 96015
+  | "code" -> 96016
+  | "pre" -> 96017
+  | "ol" -> 96018
+  | "ul" -> 96019
+  | "li" -> 96020
+  | "dl" -> 96021
+  | "dt" -> 96022
+  | "dd" -> 96023
+  | "table" -> 96024
+  | "thead" -> 96025
+  | "tr" -> 96026
+  | "th" -> 96027
+  | "td" -> 96028
+  | "img" -> 96029
+  | "picture" -> 96030
+  | "video" -> 96031
+  | "hr" -> 96032
+  | "lead" -> 96033
   | _ -> 96000
 
-(* Known prose element variant names (matches Tailwind v4 typography plugin) *)
 (* One name per variant @tailwindcss/typography registers. A name outside this
    set is not a variant there either, so the class is rejected rather than
    compiled into a selector Tailwind never produces. *)

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -572,8 +572,16 @@ let to_selector (modifier : modifier) cls =
   | Hocus -> compound [ Class ("hocus:" ^ cls); is_ [ Hover; Focus ] ]
   | Device_hocus ->
       compound [ Class ("device-hocus:" ^ cls); is_ [ Hover; Focus ] ]
-  (* Prose element variants — outer selector is just the class *)
-  | Prose_element name -> Class ("prose-" ^ name ^ ":" ^ cls)
+  (* Prose element variants — the class, then the elements it targets inside it.
+     Returning the class alone loses the descendant part wherever the selector
+     is built from here rather than in the routing, which is every rule that is
+     already a query: [prose-p:md:text-lg] styled the container instead of its
+     paragraphs. *)
+  | Prose_element name ->
+      combine
+        (Class ("prose-" ^ name ^ ":" ^ cls))
+        Descendant
+        (prose_element_inner_selector name)
   (* Pseudo-elements, aria/data, structural, media, peer, form state *)
   | _ -> pseudo_element_selector cls modifier
 

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -876,6 +876,14 @@ let prose_h1 styles = wrap (Prose_element "h1") styles
 let prose_h2 styles = wrap (Prose_element "h2") styles
 let prose_h3 styles = wrap (Prose_element "h3") styles
 let prose_h4 styles = wrap (Prose_element "h4") styles
+let prose_h5 styles = wrap (Prose_element "h5") styles
+let prose_h6 styles = wrap (Prose_element "h6") styles
+let prose_dl styles = wrap (Prose_element "dl") styles
+let prose_dt styles = wrap (Prose_element "dt") styles
+let prose_dd styles = wrap (Prose_element "dd") styles
+let prose_table styles = wrap (Prose_element "table") styles
+let prose_tr styles = wrap (Prose_element "tr") styles
+let prose_picture styles = wrap (Prose_element "picture") styles
 let prose_img styles = wrap (Prose_element "img") styles
 let prose_video styles = wrap (Prose_element "video") styles
 let prose_figure styles = wrap (Prose_element "figure") styles
@@ -1872,10 +1880,14 @@ let prose_element_variant_order = function
   | _ -> 96000
 
 (* Known prose element variant names (matches Tailwind v4 typography plugin) *)
+(* One name per variant @tailwindcss/typography registers. A name outside this
+   set is not a variant there either, so the class is rejected rather than
+   compiled into a selector Tailwind never produces. *)
 let is_prose_element_name = function
   | "headings" | "p" | "a" | "strong" | "em" | "code" | "pre" | "ol" | "ul"
-  | "li" | "blockquote" | "h1" | "h2" | "h3" | "h4" | "img" | "video" | "figure"
-  | "figcaption" | "hr" | "th" | "td" | "thead" | "kbd" | "lead" ->
+  | "li" | "dl" | "dt" | "dd" | "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5"
+  | "h6" | "img" | "picture" | "video" | "figure" | "figcaption" | "hr"
+  | "table" | "tr" | "th" | "td" | "thead" | "kbd" | "lead" ->
       true
   | _ -> false
 

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -624,6 +624,30 @@ val prose_h3 : t list -> t
 val prose_h4 : t list -> t
 (** [prose_h4 styles] applies [styles] to h4 elements within prose. *)
 
+val prose_h5 : t list -> t
+(** [prose_h5 styles] applies [styles] to h5 elements within prose. *)
+
+val prose_h6 : t list -> t
+(** [prose_h6 styles] applies [styles] to h6 elements within prose. *)
+
+val prose_dl : t list -> t
+(** [prose_dl styles] applies [styles] to dl elements within prose. *)
+
+val prose_dt : t list -> t
+(** [prose_dt styles] applies [styles] to dt elements within prose. *)
+
+val prose_dd : t list -> t
+(** [prose_dd styles] applies [styles] to dd elements within prose. *)
+
+val prose_table : t list -> t
+(** [prose_table styles] applies [styles] to table elements within prose. *)
+
+val prose_tr : t list -> t
+(** [prose_tr styles] applies [styles] to tr elements within prose. *)
+
+val prose_picture : t list -> t
+(** [prose_picture styles] applies [styles] to picture elements within prose. *)
+
 val prose_img : t list -> t
 (** [prose_img styles] applies [styles] to img elements within prose. *)
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1638,6 +1638,22 @@ let route_has_variant inner ~selector base_class props =
   route_regular ~selector ~base_class ~modified_class ~modified ~not_order:10
     props
 
+(* A prose element variant puts the elements it targets under the utility's own
+   class. Substituting for that class rather than rebuilding the selector from
+   it keeps what an inner variant already put there: [prose-a:hover:] wants its
+   [:hover] on the link, [prose-li:marker:] its [::marker] on the item. *)
+let prose_element_rule name ~base_class ~selector props =
+  let replacement =
+    Modifiers.to_selector (Style.Prose_element name) base_class
+  in
+  let combined_sel =
+    Rules_selector.replace_class_with ~old_class:base_class ~replacement
+      selector
+  in
+  regular ~selector:combined_sel ~props
+    ~base_class:("prose-" ^ name ^ ":" ^ base_class)
+    ()
+
 let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
     selector props =
   match modifier with
@@ -1746,13 +1762,7 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
         ~base_class:modified_class ()
   (* Prose element variants — descendant selector with element filter *)
   | Style.Prose_element name ->
-      let modified_class = "prose-" ^ name ^ ":" ^ base_class in
-      let outer_sel = Css.Selector.Class modified_class in
-      let inner_sel = Modifiers.prose_element_inner_selector name in
-      let combined_sel =
-        Css.Selector.combine outer_sel Css.Selector.Descendant inner_sel
-      in
-      regular ~selector:combined_sel ~props ~base_class:modified_class ()
+      prose_element_rule name ~base_class ~selector props
   (* Fallback for other modifiers *)
   | _ ->
       handle_fallback_modifier ~inner_has_hover modifier base_class selector

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -4283,6 +4283,30 @@ val prose_h3 : t list -> t
 val prose_h4 : t list -> t
 (** [prose_h4 styles] applies [styles] to h4 elements within prose. *)
 
+val prose_h5 : t list -> t
+(** [prose_h5 styles] applies [styles] to h5 elements within prose. *)
+
+val prose_h6 : t list -> t
+(** [prose_h6 styles] applies [styles] to h6 elements within prose. *)
+
+val prose_dl : t list -> t
+(** [prose_dl styles] applies [styles] to dl elements within prose. *)
+
+val prose_dt : t list -> t
+(** [prose_dt styles] applies [styles] to dt elements within prose. *)
+
+val prose_dd : t list -> t
+(** [prose_dd styles] applies [styles] to dd elements within prose. *)
+
+val prose_table : t list -> t
+(** [prose_table styles] applies [styles] to table elements within prose. *)
+
+val prose_tr : t list -> t
+(** [prose_tr styles] applies [styles] to tr elements within prose. *)
+
+val prose_picture : t list -> t
+(** [prose_picture styles] applies [styles] to picture elements within prose. *)
+
 val prose_img : t list -> t
 (** [prose_img styles] applies [styles] to img elements within prose. *)
 

--- a/test/helpers/browser/compare.js
+++ b/test/helpers/browser/compare.js
@@ -84,8 +84,8 @@ async function computed(browser, css, names) {
       }
       return parts.join(' > ');
     };
-    const style = (el) => {
-      const cs = getComputedStyle(el);
+    const style = (el, pseudo) => {
+      const cs = getComputedStyle(el, pseudo || null);
       const o = {};
       for (const prop of cs) o[prop] = cs.getPropertyValue(prop);
       for (const n of ns) {
@@ -94,13 +94,20 @@ async function computed(browser, css, names) {
       }
       return o;
     };
+    // The element itself and the pseudo-elements a sheet can reach without the
+    // page being interacted with. Prose puts its list bullets on ::marker and
+    // the before:/after: variants exist to write ::before and ::after, none of
+    // which the element's own computed style shows.
+    const pseudos = ['', '::before', '::after', '::marker'];
     const res = { nodes: [], classes: [] };
+    const record = (id, el, p) => {
+      for (const ps of pseudos)
+        res.nodes.push({ id, path: p + ps, style: style(el, ps) });
+    };
     document.querySelectorAll('body > div[id^=e]').forEach((el) => {
       res.classes.push([...el.classList].join(' '));
-      res.nodes.push({ id: el.id, path: '', style: style(el) });
-      el.querySelectorAll('*').forEach((d) =>
-        res.nodes.push({ id: el.id, path: path(d, el), style: style(d) })
-      );
+      record(el.id, el, '');
+      el.querySelectorAll('*').forEach((d) => record(el.id, d, path(d, el)));
     });
     return res;
   }, names);
@@ -142,7 +149,8 @@ async function computed(browser, css, names) {
 
   const label = (n) => {
     const cls = entries[Number(n.id.slice(1))].classes;
-    return n.path ? `${cls} :: ${n.path}` : cls;
+    if (!n.path) return cls;
+    return n.path.startsWith('::') ? `${cls} ${n.path}` : `${cls} :: ${n.path}`;
   };
 
   // A custom property is a token stream: the browser hands back the author's

--- a/test/helpers/browser/compare.js
+++ b/test/helpers/browser/compare.js
@@ -14,7 +14,21 @@ try {
 }
 
 const [, , elementsFile, twCss, tailwindCss] = process.argv;
-const elements = fs.readFileSync(elementsFile, 'utf8').split('\n').filter((l) => l.trim());
+
+// An entry is a class list, optionally followed by a tab and the markup to put
+// inside the element carrying it. A bare element only exercises the rules that
+// match the class itself; a plugin like @tailwindcss/typography spends most of
+// its sheet on descendants, which fire on real children or not at all.
+const entries = fs
+  .readFileSync(elementsFile, 'utf8')
+  .split('\n')
+  .filter((l) => l.trim())
+  .map((l) => {
+    const tab = l.indexOf('\t');
+    return tab < 0
+      ? { classes: l.trim(), inner: '' }
+      : { classes: l.slice(0, tab).trim(), inner: l.slice(tab + 1) };
+  });
 
 // Custom properties are absent from getComputedStyle's enumeration, so collect
 // the names the sheets declare and ask for each by hand.
@@ -30,13 +44,16 @@ const attr = (s) =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-const page = (css, classes) =>
-  `<!doctype html><meta charset="utf-8"><style>${css}</style>` +
-  `<body>${classes.map((c, i) => `<div id="e${i}" class="${attr(c)}"></div>`).join('')}</body>`;
+const page = (css) =>
+  `<!doctype html><meta charset="utf-8"><style>${css}</style><body>` +
+  entries
+    .map((e, i) => `<div id="e${i}" class="${attr(e.classes)}">${e.inner}</div>`)
+    .join('') +
+  `</body>`;
 
 // What each element is meant to carry, whitespace normalised the way classList
 // reports it.
-const wanted = elements.map((e) => e.trim().split(/\s+/).join(' '));
+const wanted = entries.map((e) => e.classes.split(/\s+/).join(' '));
 
 // An element that lost part of its class attribute is styled by neither sheet,
 // and the two then agree on the same bare element - a pass that says nothing.
@@ -52,10 +69,22 @@ const unusable = (got) => {
 
 async function computed(browser, css, names) {
   const p = await browser.newPage({ viewport: { width: 1280, height: 800 } });
-  await p.setContent(page(css, elements));
+  await p.setContent(page(css));
   const out = await p.evaluate((ns) => {
-    const res = { styles: {}, classes: [] };
-    document.querySelectorAll('div[id^=e]').forEach((el) => {
+    // Where a descendant sits inside its element, as tag names with an index
+    // wherever siblings share a tag: enough to find it again in the markup.
+    const path = (el, root) => {
+      const parts = [];
+      for (let n = el; n && n !== root; n = n.parentElement) {
+        const tag = n.tagName.toLowerCase();
+        const sibs = [...n.parentElement.children].filter(
+          (c) => c.tagName === n.tagName
+        );
+        parts.unshift(sibs.length > 1 ? `${tag}(${sibs.indexOf(n) + 1})` : tag);
+      }
+      return parts.join(' > ');
+    };
+    const style = (el) => {
       const cs = getComputedStyle(el);
       const o = {};
       for (const prop of cs) o[prop] = cs.getPropertyValue(prop);
@@ -63,8 +92,15 @@ async function computed(browser, css, names) {
         const v = cs.getPropertyValue(n);
         if (v !== '') o[n] = v;
       }
-      res.styles[el.id] = o;
+      return o;
+    };
+    const res = { nodes: [], classes: [] };
+    document.querySelectorAll('body > div[id^=e]').forEach((el) => {
       res.classes.push([...el.classList].join(' '));
+      res.nodes.push({ id: el.id, path: '', style: style(el) });
+      el.querySelectorAll('*').forEach((d) =>
+        res.nodes.push({ id: el.id, path: path(d, el), style: style(d) })
+      );
     });
     return res;
   }, names);
@@ -92,8 +128,22 @@ async function computed(browser, css, names) {
     console.log(`markup does not carry the intended classes: ${broken}`);
     process.exit(3);
   }
-  const ta = ra.styles;
-  const tb = rb.styles;
+  // Both pages are built from the same entries, so the two node lists are the
+  // same tree walked in the same order. A mismatch means one page parsed the
+  // markup differently, and pairing them up by index would compare unrelated
+  // elements.
+  if (ra.nodes.length !== rb.nodes.length) {
+    console.log(
+      `markup parsed to ${ra.nodes.length} nodes under tw and ` +
+        `${rb.nodes.length} under tailwind`
+    );
+    process.exit(3);
+  }
+
+  const label = (n) => {
+    const cls = entries[Number(n.id.slice(1))].classes;
+    return n.path ? `${cls} :: ${n.path}` : cls;
+  };
 
   // A custom property is a token stream: the browser hands back the author's
   // own whitespace and quoting, so two sheets that minify differently differ on
@@ -103,18 +153,33 @@ async function computed(browser, css, names) {
     k.startsWith('--') && v !== undefined ? v.replace(/["'\s]+/g, '') : v;
 
   const lines = [];
-  for (const [id, pa] of Object.entries(ta)) {
-    const pb = tb[id];
+  for (let i = 0; i < ra.nodes.length; i++) {
+    const na = ra.nodes[i];
+    const nb = rb.nodes[i];
+    if (na.id !== nb.id || na.path !== nb.path) {
+      console.log(
+        `markup walked differently: [${label(na)}] under tw, ` +
+          `[${label(nb)}] under tailwind`
+      );
+      process.exit(3);
+    }
+    const pa = na.style;
+    const pb = nb.style;
     for (const k of new Set([...Object.keys(pa), ...Object.keys(pb)])) {
       // A custom property one sheet declares and the other prunes renders the
       // same unless something reads it, and whatever reads it differs instead.
       if (k.startsWith('--') && (pa[k] === undefined || pb[k] === undefined)) continue;
       if (norm(k, pa[k]) !== norm(k, pb[k]))
-        lines.push(`${elements[Number(id.slice(1))]}: ${k}: ${pa[k]} (tw) vs ${pb[k]} (tailwind)`);
+        lines.push(`${label(na)}: ${k}: ${pa[k]} (tw) vs ${pb[k]} (tailwind)`);
     }
   }
   if (lines.length) {
-    console.log(lines.join('\n'));
+    // Every difference fails the run; a whole descendant tree off by one rule
+    // prints thousands of lines, so the report stops at a readable prefix.
+    const shown = lines.slice(0, 200);
+    console.log(shown.join('\n'));
+    if (lines.length > shown.length)
+      console.log(`... and ${lines.length - shown.length} more differences`);
     process.exit(1);
   }
   process.exit(0);

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -397,7 +397,13 @@ let render_elements classnames =
     (classnames
     @ List.map (fun (a, b) -> a ^ " " ^ b) (interacting_pairs classnames))
 
-let check_rendering_matches ?(forms = false) ~test_name utilities =
+(* The element list is line-oriented, so markup that spans lines in the test
+   source is folded onto one. HTML reads the two the same, and nothing the
+   comparison looks at is computed from the markup's own whitespace. *)
+let one_line s = String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c) s
+
+let check_rendering_matches ?(forms = false) ?(inner = "") ~test_name utilities
+    =
   let root =
     match Lazy.force project_root with Some r -> r | None -> Alcotest.skip ()
   in
@@ -408,9 +414,13 @@ let check_rendering_matches ?(forms = false) ~test_name utilities =
   let tailwind = tailwind_css ~forms classnames in
   let dir = render_dir root test_name in
   let path name = Filename.concat dir name in
+  let entry cls =
+    if String.equal inner "" then cls else cls ^ "\t" ^ one_line inner
+  in
   write_file (path "tw.css") (our_css utilities);
   write_file (path "tailwind.css") tailwind;
-  write_file (path "elements.txt") (String.concat "\n" elements);
+  write_file (path "elements.txt")
+    (String.concat "\n" (List.map entry elements));
   let out = path "diff.txt" and err = path "stderr.txt" in
   let cmd =
     Fmt.str "node %s %s %s %s > %s 2> %s"

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -113,7 +113,12 @@ val check_rendering_matches :
     [inner] is markup put inside every element built, and every descendant of it
     is compared too. Without it the elements are bare, so a rule that only
     matches a child - which is most of what [@tailwindcss/typography] emits -
-    has nothing to match and the comparison passes without reading it. *)
+    has nothing to match and the comparison passes without reading it.
+
+    Every node is read four times: itself, then its [::before], [::after] and
+    [::marker]. A rule on a pseudo-element leaves the element's own computed
+    style untouched, so prose's list bullets and everything the [before:] and
+    [after:] variants write are invisible without it. *)
 
 (** {1 CSS Test Helpers} *)
 

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -101,14 +101,19 @@ val render_elements : string list -> string list
     pair, duplicates dropped and first occurrence kept. *)
 
 val check_rendering_matches :
-  ?forms:bool -> test_name:string -> Tw.t list -> unit
-(** [check_rendering_matches ?forms ~test_name utilities] renders both sheets in
-    headless Chromium and fails on any computed style that differs. Each class
-    gets an element of its own, plus one per {!interacting_pairs} pair, which is
-    where an ordering difference shows. Fails too when an element does not carry
-    the classes it was given, since then the comparison is vacuous. Skips when
-    node or Playwright is absent; [TW_BROWSER_TESTS=0] opts out where they are
-    present. *)
+  ?forms:bool -> ?inner:string -> test_name:string -> Tw.t list -> unit
+(** [check_rendering_matches ?forms ?inner ~test_name utilities] renders both
+    sheets in headless Chromium and fails on any computed style that differs.
+    Each class gets an element of its own, plus one per {!interacting_pairs}
+    pair, which is where an ordering difference shows. Fails too when an element
+    does not carry the classes it was given, since then the comparison is
+    vacuous. Skips when node or Playwright is absent; [TW_BROWSER_TESTS=0] opts
+    out where they are present.
+
+    [inner] is markup put inside every element built, and every descendant of it
+    is compared too. Without it the elements are bare, so a rule that only
+    matches a child - which is most of what [@tailwindcss/typography] emits -
+    has nothing to match and the comparison passes without reading it. *)
 
 (** {1 CSS Test Helpers} *)
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -465,6 +465,72 @@ let test_not_has_shorthand_selector () =
   renders "not-has-checked:flex";
   renders "not-has-hover:flex"
 
+(* @tailwindcss/typography registers one variant per element it styles, and the
+   variant is what puts a utility on that element. Eight of them - h5, h6, dl,
+   dt, dd, table, tr, picture - were not recognised at all, so the class was
+   rejected and the utility never reached the element. *)
+let test_prose_element_variants () =
+  let selector name =
+    let cls = "prose-" ^ name ^ ":underline" in
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+  in
+  let targets name affix =
+    Alcotest.(check bool)
+      ("prose-" ^ name ^ ": targets " ^ affix)
+      true
+      (Astring.String.is_infix ~affix:(":where(" ^ affix ^ ")") (selector name))
+  in
+  List.iter
+    (fun n -> targets n n)
+    [
+      "p";
+      "a";
+      "blockquote";
+      "figure";
+      "figcaption";
+      "strong";
+      "em";
+      "kbd";
+      "code";
+      "pre";
+      "ol";
+      "ul";
+      "li";
+      "dl";
+      "dt";
+      "dd";
+      "table";
+      "thead";
+      "tr";
+      "th";
+      "td";
+      "img";
+      "picture";
+      "video";
+      "hr";
+      "h1";
+      "h2";
+      "h3";
+      "h4";
+      "h5";
+      "h6";
+    ];
+  targets "headings" "h1,h2,h3,h4,h5,h6,th";
+  targets "lead" "[class~=lead]"
+
+(* The plugin has no variant for an element it does not style, and neither has
+   tw: the class is rejected rather than compiled into a selector nothing in
+   Tailwind produces. *)
+let test_prose_element_variant_invalid () =
+  Alcotest.(check bool)
+    "prose-span: is not a variant" true
+    (Result.is_error (Tw.of_string "prose-span:underline"));
+  Alcotest.(check bool)
+    "prose-h7: is not a variant" true
+    (Result.is_error (Tw.of_string "prose-h7:underline"))
+
 let tests =
   [
     test_case "important prefix" `Quick test_important_prefix;
@@ -1147,6 +1213,9 @@ let tests =
         test_container_variant_is_theme_local;
       test_case "removed breakpoint drops its variants" `Quick
         test_removed_breakpoint_drops_its_variants;
+      test_case "prose element variants" `Quick test_prose_element_variants;
+      test_case "prose element variant invalid" `Quick
+        test_prose_element_variant_invalid;
     ]
 
 let suite = ("modifiers", tests)

--- a/test/test_prose.ml
+++ b/test/test_prose.ml
@@ -98,6 +98,91 @@ let test_color_theme_parity () =
       prose_orange;
     ]
 
+(* The markup the typography plugin actually targets. Nearly every rule it emits
+   is a descendant selector - :where(h1), :where(a code), :where(tbody
+   td:first-child), :where(.prose > ul > li p) - so an empty element matches
+   none of them and comparing one says nothing about the plugin beyond its root
+   declarations and --tw-prose-* bindings. Every element named in a typography
+   selector appears here at least once, in a position where the structural parts
+   of the selector (:first-child, + *, first-of-type, nesting) have something to
+   select. *)
+let prose_document =
+  {html|
+<h1>Heading one with <code>code</code> and <strong>strong</strong></h1>
+<p class="lead">A lead paragraph.</p>
+<p>Body copy with <a href="#">a link holding <code>code</code> and
+  <strong>strong</strong></a>, <em>emphasis</em>, <kbd>Ctrl</kbd> and
+  <code>inline code</code>.</p>
+<h2>Heading two with <code>code</code> and <strong>strong</strong></h2>
+<p>The paragraph directly after the h2.</p>
+<h3>Heading three with <code>code</code> and <strong>strong</strong></h3>
+<p>The paragraph directly after the h3.</p>
+<h4>Heading four with <code>code</code> and <strong>strong</strong></h4>
+<p>The paragraph directly after the h4.</p>
+<blockquote>
+  <p>First quoted paragraph with <code>code</code> and <strong>strong</strong>.</p>
+  <p>Last quoted paragraph.</p>
+</blockquote>
+<pre><code>let x = 1</code></pre>
+<ul>
+  <li>
+    <p>First paragraph of the item.</p>
+    <p>Last paragraph of the item.</p>
+  </li>
+  <li>A bare item<ul><li>nested unordered</li></ul></li>
+  <li>Another bare item<ol><li>nested ordered</li></ol></li>
+</ul>
+<ol>
+  <li><p>Ordered item holding a paragraph.</p></li>
+  <li>A bare ordered item</li>
+</ol>
+<ol type="A"><li>Upper alpha</li></ol>
+<ol type="i"><li>Lower roman</li></ol>
+<dl><dt>A term</dt><dd>Its definition.</dd></dl>
+<hr>
+<p>The paragraph directly after the rule.</p>
+<figure><img alt=""><figcaption>A caption.</figcaption></figure>
+<picture><img alt=""></picture>
+<video></video>
+<div class="not-prose"><p>Opted out of the plugin.</p></div>
+<table>
+  <thead>
+    <tr>
+      <th>Head with <code>code</code></th>
+      <th>Head with <strong>strong</strong></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>First row, first cell</td><td>First row, last cell</td></tr>
+    <tr><td>Last row, first cell</td><td>Last row, last cell</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td>Foot, first cell</td><td>Foot, last cell</td></tr>
+  </tfoot>
+</table>
+<p>The last child of the container.</p>
+|html}
+
+(* Bare elements exercise the root declarations and the --tw-prose-* bindings
+   and nothing else, which leaves the bulk of the plugin uncompared. Rendering
+   the document above under both sheets and diffing every computed style of
+   every node in it is what covers the descendant rules; the size variants
+   rescale those rules rather than the root, so they need the same document. *)
+let test_descendant_rendering () =
+  Test_helpers.check_rendering_matches ~inner:prose_document
+    ~test_name:"prose descendants render like Tailwind"
+    [ prose; prose_sm; prose_lg; prose_xl; prose_2xl ]
+
+(* The colour themes only write --tw-prose-* bindings; nothing on the container
+   reads them, so a bare element compares the variables and stops there. What
+   consumes them is the descendant rules - body copy, links, headings, code,
+   quote bars, table borders - so the document is what turns a mis-bound
+   variable into an observable colour. *)
+let test_color_rendering () =
+  Test_helpers.check_rendering_matches ~inner:prose_document
+    ~test_name:"prose colours render like Tailwind"
+    [ prose; prose_gray; prose_slate; prose_invert; prose_orange ]
+
 let suite =
   ( "prose",
     [
@@ -109,4 +194,8 @@ let suite =
       Alcotest.test_case "size parity with Tailwind" `Quick test_size_parity;
       Alcotest.test_case "colour theme parity with Tailwind" `Quick
         test_color_theme_parity;
+      Alcotest.test_case "descendants render like Tailwind" `Quick
+        test_descendant_rendering;
+      Alcotest.test_case "colours render like Tailwind" `Quick
+        test_color_rendering;
     ] )

--- a/test/test_prose.ml
+++ b/test/test_prose.ml
@@ -183,6 +183,73 @@ let test_color_rendering () =
     ~test_name:"prose colours render like Tailwind"
     [ prose; prose_gray; prose_slate; prose_invert; prose_orange ]
 
+(* The element variants are the other half of the plugin: they put a utility on
+   a prose descendant, and a variant stacked under one has to reach the same
+   element. Rendered against the document, prose-li:marker: lands on the bullet
+   and prose-code:before: on the generated box, neither of which shows in the
+   element's own computed style. *)
+let element_variant cls =
+  match Tw.of_string cls with
+  | Ok u -> u
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+let element_variants =
+  List.map element_variant
+    [
+      "prose-h2:text-red-500";
+      "prose-a:underline";
+      "prose-li:marker:text-green-500";
+      "prose-code:before:content-['x']";
+      "prose-td:text-right";
+    ]
+
+let test_element_variant_rendering () =
+  Test_helpers.check_rendering_matches ~inner:prose_document
+    ~test_name:"prose element variants render like Tailwind" element_variants
+
+(* Every variant the plugin registers, against the real CLI. Eight of them were
+   not recognised at all, and the selector the rest built dropped whatever an
+   inner variant had put on it. *)
+let test_element_variant_parity () =
+  Test_helpers.check_ordering_matches
+    ~test_name:"prose element variants match Tailwind"
+    (List.map element_variant
+       [
+         "prose-headings:text-lg";
+         "prose-h1:text-lg";
+         "prose-h2:text-lg";
+         "prose-h3:text-lg";
+         "prose-h4:text-lg";
+         "prose-h5:text-lg";
+         "prose-h6:text-lg";
+         "prose-p:text-lg";
+         "prose-a:underline";
+         "prose-blockquote:italic";
+         "prose-figure:mt-4";
+         "prose-figcaption:text-xs";
+         "prose-strong:font-black";
+         "prose-em:not-italic";
+         "prose-kbd:text-xs";
+         "prose-code:text-xs";
+         "prose-pre:text-xs";
+         "prose-ol:list-decimal";
+         "prose-ul:list-disc";
+         "prose-li:ml-4";
+         "prose-dl:mt-4";
+         "prose-dt:font-bold";
+         "prose-dd:ml-4";
+         "prose-table:w-full";
+         "prose-thead:text-left";
+         "prose-tr:border-b";
+         "prose-th:text-left";
+         "prose-td:text-right";
+         "prose-img:rounded-lg";
+         "prose-picture:block";
+         "prose-video:w-full";
+         "prose-hr:border-dashed";
+         "prose-lead:tracking-wide";
+       ])
+
 let suite =
   ( "prose",
     [
@@ -198,4 +265,8 @@ let suite =
         test_descendant_rendering;
       Alcotest.test_case "colours render like Tailwind" `Quick
         test_color_rendering;
+      Alcotest.test_case "element variant parity with Tailwind" `Quick
+        test_element_variant_parity;
+      Alcotest.test_case "element variants render like Tailwind" `Quick
+        test_element_variant_rendering;
     ] )

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -453,6 +453,16 @@ let test_at_rule_keeps_inner () =
   variant_has "[@starting-style]:open:opacity-0"
     ":is([open],:popover-open,:open)"
 
+(* A prose element variant rebuilt its selector from the bare class, which threw
+   away whatever an inner variant had put on it: [prose-a:hover:text-red-500]
+   lost its [:hover] and coloured every link, [prose-li:marker:text-green-500]
+   lost its [::marker] and coloured the item's own text. *)
+let test_prose_element_keeps_inner () =
+  variant_has "prose-a:hover:text-red-500" "[class~=not-prose] *)):hover";
+  variant_has "prose-li:marker:text-green-500" "[class~=not-prose] *))::marker";
+  variant_has "prose-p:first-line:uppercase" "[class~=not-prose] *)):first-line";
+  variant_has "prose-code:after:content-['y']" "[class~=not-prose] *)):after"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -488,6 +498,8 @@ let tests =
       test_outer_media_renames_nested;
     test_case "at-rule variant keeps the inner selector" `Quick
       test_at_rule_keeps_inner;
+    test_case "prose element variant keeps the inner selector" `Quick
+      test_prose_element_keeps_inner;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -463,6 +463,14 @@ let test_prose_element_keeps_inner () =
   variant_has "prose-p:first-line:uppercase" "[class~=not-prose] *)):first-line";
   variant_has "prose-code:after:content-['y']" "[class~=not-prose] *)):after"
 
+(* The reverse direction: a prose element variant over a rule that is already a
+   media query built its selector from [Modifiers.to_selector], which returned
+   the class alone, so the elements it targets went missing and the utility
+   landed on the container. *)
+let test_prose_element_over_media () =
+  variant_has "prose-p:md:text-lg" ".prose-p\\:md\\:text-lg :where(p)";
+  variant_has "prose-a:dark:text-white" ".prose-a\\:dark\\:text-white :where(a)"
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -500,6 +508,8 @@ let tests =
       test_at_rule_keeps_inner;
     test_case "prose element variant keeps the inner selector" `Quick
       test_prose_element_keeps_inner;
+    test_case "prose element variant over a media query" `Quick
+      test_prose_element_over_media;
     test_case "extract selector props - basic" `Quick
       check_extract_selector_props;
     test_case "extract selector props - hover" `Quick check_extract_hover;


### PR DESCRIPTION
The rendering comparison built prose elements as bare divs, so the typography plugin's `:where(h1)`-style descendant rules were never exercised: only the root declarations and the `--tw-prose-*` variables were covered. That is the bulk of the largest plugin, and it is only worth closing now that the comparison actually runs in CI.

Rendering real markup found three defects. A prose element variant lost part of the selector it sits on; the plugin registers more element variants than tw took; and the ones tw did take sorted differently from the order the plugin emits them in. The check also now compares pseudo-elements, which the element rules rely on.