### PR TITLE
modifiers, sort: derive the variant cascade from one table

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -426,7 +426,8 @@ let add_index ?(declared = fun _ -> false) triples =
          not_order;
          variant_order;
          variant_key = Sort.variant_sort_key base_class nested;
-         variant_orders = Sort.variant_order_list base_class variant_order;
+         variant_orders =
+           Sort.variant_order_list base_class variant_order responsive_media_key;
          base_class_key = Option.value ~default:"" base_class;
          media_key;
          nested_media_key;

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2125,6 +2125,7 @@ module Slot = struct
   type t =
     | Child  (** [*:]: every direct child. *)
     | Descendant  (** [**:]: every descendant. *)
+    | Negation  (** [not-X:], ordered inside the slot by the X it negates. *)
     | Group
     | Peer
     | Pseudo_first_letter
@@ -2212,6 +2213,7 @@ module Slot = struct
   let rank = function
     | Child -> 100
     | Descendant -> 200
+    | Negation -> 300
     | Group -> 500
     | Peer -> 600
     | Pseudo_first_letter -> 1000
@@ -2420,6 +2422,8 @@ let slot_of_prefix prefix : Slot.t option =
   match prefix with
   (* [peer-hover] shares [group-hover]'s position rather than the one every
      other [peer-] spelling takes. *)
+  | "*" -> Some Slot.Child
+  | "**" -> Some Slot.Descendant
   | "group-hover" | "peer-hover" -> Some Slot.Group
   | "first-letter" -> Some Slot.Pseudo_first_letter
   | "first-line" -> Some Slot.Pseudo_first_line
@@ -2510,6 +2514,9 @@ let slot_of_prefix prefix : Slot.t option =
      pseudo-classes that merely start with the same letters ([in-range],
      [inert], [invalid]) are matched by name above. *)
   | _ when starts_with "in-" -> Some Slot.Ancestor
+  (* Every [not-X] sorts together, ahead of the variants it can negate;
+     [variant_inner_order] puts the X back inside the slot. *)
+  | _ when starts_with "not-" -> Some Slot.Negation
   | _ when starts_with "prose-" ->
       Some (Slot.Prose (String.sub prefix 6 (String.length prefix - 6)))
   | _ when prefix <> "" && prefix.[0] = '[' -> Some Slot.Arbitrary
@@ -2541,6 +2548,22 @@ let slot_of_media_cond (cond : Css.Media.t) : Slot.t option =
   | Cond (Feature (Plain (Inverted_colors, Ident Inverted))) ->
       Some Slot.Inverted_colors
   | _ -> None
+
+(* What separates two tokens that share a slot: a [group-]/[peer-] token sorts
+   by the state it wraps and a [not-] token by the variant it negates, both read
+   off the same table as the slot itself. *)
+let variant_inner_order token =
+  let after n = String.sub token n (String.length token - n) in
+  let inner =
+    if String.starts_with ~prefix:"group-" token then Some (after 6)
+    else if String.starts_with ~prefix:"peer-" token then Some (after 5)
+    else if String.starts_with ~prefix:"not-" token then Some (after 4)
+    else None
+  in
+  match inner with
+  | Some inner -> (
+      match slot_of_prefix inner with Some slot -> Slot.rank slot | None -> 0)
+  | None -> 0
 
 let not_variant_order m = Slot.rank (slot_of_modifier m)
 

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2558,7 +2558,12 @@ let variant_inner_order token =
     if String.starts_with ~prefix:"group-" token then Some (after 6)
     else if String.starts_with ~prefix:"peer-" token then Some (after 5)
     else if String.starts_with ~prefix:"not-" token then Some (after 4)
-    else None
+    else
+      (* [in-focus] names a state on an ancestor; [in-range] names one on the
+         element itself, and the table matches that by name. *)
+      match slot_of_prefix token with
+      | Some Slot.Ancestor -> Some (after 3)
+      | Some _ | None -> None
   in
   match inner with
   | Some inner -> (

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2277,23 +2277,23 @@ module Slot = struct
     | Motion_reduce -> 50100
     | Contrast_more -> 50200
     | Contrast_less -> 50300
-    | Pointer -> 50400
-    | Any_pointer -> 50500
     | Breakpoint -> 60000
+    | Container_query -> 65000
     | Portrait -> 70000
     | Landscape -> 70100
     | Ltr -> 80000
     | Rtl -> 80100
     | Dark -> 90000
+    | Starting -> 90500
     | Print -> 91000
     | Forced_colors -> 92000
-    | Noscript -> 93000
     | Inverted_colors -> 93100
-    | Starting -> 95000
+    | Pointer -> 93200
+    | Any_pointer -> 93300
+    | Noscript -> 93400
     | Custom -> 95500
     | Prose element -> prose_element_variant_order element
     | Arbitrary -> 100000
-    | Container_query -> 110000
 end
 
 (* The slot a modifier constructor sorts in. Exhaustive on purpose: a new

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2111,228 +2111,441 @@ let apply ?(theme = Scheme.default) modifiers base_utility =
 
 (** {1 Variant Ordering}
 
-    These functions define the canonical Tailwind v4 cascade order for
-    modifiers. Ordering lives here — in the module that owns modifier semantics
-    — rather than in the assembly pipeline. *)
+    The Tailwind v4 cascade order of variants, written once. A {!Slot.t} names
+    one position in that order and {!Slot.rank} is the only place a number
+    appears; the three readings below - a modifier constructor, a class-name
+    token, a media condition a rule is nested in - each land on a slot rather
+    than on a scale of their own. Ordering lives here, in the module that owns
+    modifier semantics, rather than in the assembly pipeline. *)
 
-(** [not_variant_order m] returns the sort key for a [not-*] inner modifier.
-    Used when building [:not()] selectors to preserve cascade ordering. *)
-let not_variant_order = function
-  (* Block 1: structural pseudo-classes *)
-  | First -> 100
-  | Last -> 200
-  | Only -> 300
-  | Odd -> 400
-  | Even -> 500
-  | First_of_type -> 600
-  | Last_of_type -> 700
-  | Only_of_type -> 800
-  (* Block 1: state pseudo-classes *)
-  | Visited -> 900
-  | Target -> 1000
-  | Open -> 1100
-  | Default -> 1200
-  | Checked -> 1300
-  | Indeterminate -> 1400
-  | Placeholder_shown -> 1500
-  | Autofill -> 1600
-  | Optional -> 1700
-  | Required -> 1800
-  | Valid -> 1900
-  | Invalid -> 2000
-  | In_range -> 2100
-  | Out_of_range -> 2200
-  | Read_only -> 2300
-  (* Block 1: misc before hover *)
-  | Empty -> 2400
-  | Focus_within -> 2500
-  | Hover -> 2600
-  (* Block 2: interactive pseudo-classes (after hover media) *)
-  | Focus -> 2700
-  | Focus_visible -> 2800
-  | Active -> 2900
-  | Enabled -> 3000
-  | Disabled -> 3100
-  | Inert -> 3200
-  (* Block 2: complex selectors *)
-  | Has _ | Has_variant _ -> 3300
-  | Aria_selected -> 3340
-  | Aria_checked -> 3350
-  | Aria_expanded -> 3360
-  | Aria_disabled -> 3370
-  | Aria_bracket _ -> 3380
-  | Group_aria _ -> 3385
-  | Peer_aria _ -> 3390
-  | Data_custom _ -> 3400
-  | Data_bracket _ -> 3401
-  | Group_data _ -> 3402
-  | Peer_data _ -> 3403
-  | Data_state _ -> 3410
-  | Data_variant _ -> 3420
-  | Data_active -> 3430
-  | Data_inactive -> 3440
-  | Nth _ -> 3500
-  | Nth_last _ -> 3550
-  | Nth_of_type _ -> 3600
-  | Nth_last_of_type _ -> 3650
-  (* @supports *)
-  | Supports_property _ | Supports_condition _ -> 4000
-  (* Media: accessibility preferences *)
-  | Motion_safe -> 5000
-  | Motion_reduce -> 5100
-  | Contrast_more -> 5200
-  | Contrast_less -> 5300
-  (* Media: responsive — max first (descending), then min (ascending) *)
-  | Max_responsive _ -> 6000
-  | Max_arbitrary _ -> 6100
-  | Max_arbitrary_length _ -> 6150
-  | Min_arbitrary _ -> 6200
-  | Min_arbitrary_length _ -> 6250
-  | Min_responsive _ -> 6300
-  | Responsive _ -> 6400
-  (* Media: other *)
-  | Portrait -> 7000
-  | Landscape -> 7100
-  (* Selector: directionality *)
-  | Ltr -> 8000
-  | Rtl -> 8100
-  (* Media: appearance *)
-  | Dark -> 9000
-  | Print -> 9100
-  | Forced_colors -> 9200
-  | Noscript -> 9300
-  (* Custom: hocus/device-hocus *)
-  | Hocus -> 10000
-  | Device_hocus -> 10100
-  (* Bracket patterns *)
-  | Not_bracket _ -> 11000
-  (* Group/peer-not *)
-  | Group_not _ -> 12000
-  | Peer_not _ -> 12100
-  (* Fallback *)
-  | _ -> 5500
+module Slot = struct
+  (* One position in the variant cascade. Named separately from [Style.modifier]
+     because several modifiers share a position: every [group-*] spelling sorts
+     where [group-] sorts, and a [not-X] sorts where X does. *)
+  type t =
+    | Child  (** [*:]: every direct child. *)
+    | Descendant  (** [**:]: every descendant. *)
+    | Group
+    | Peer
+    | Pseudo_first_letter
+    | Pseudo_first_line
+    | Pseudo_marker
+    | Pseudo_selection
+    | Pseudo_file
+    | Pseudo_placeholder
+    | Pseudo_backdrop
+    | Pseudo_details_content
+    | Pseudo_before
+    | Pseudo_after
+    | First
+    | Last
+    | Only
+    | Odd
+    | Even
+    | First_of_type
+    | Last_of_type
+    | Only_of_type
+    | Visited
+    | Target
+    | Open
+    | Default
+    | Checked
+    | Indeterminate
+    | Placeholder_shown
+    | Autofill
+    | Optional
+    | Required
+    | Valid
+    | Invalid
+    | User_valid
+    | User_invalid
+    | In_range
+    | Out_of_range
+    | Read_only
+    | Read_write
+    | Empty
+    | Focus_within
+    | Hover
+    | Focus
+    | Focus_visible
+    | Active
+    | Enabled
+    | Disabled
+    | Inert
+    | Ancestor  (** [in-*]: a state on an ancestor. *)
+    | Has
+    | Aria_named
+    | Aria_arbitrary
+    | Data_named
+    | Data_arbitrary
+    | Nth
+    | Nth_last
+    | Nth_of_type
+    | Nth_last_of_type
+    | Hocus
+    | Supports
+    | Motion_safe
+    | Motion_reduce
+    | Contrast_more
+    | Contrast_less
+    | Pointer
+    | Any_pointer
+    | Breakpoint  (** Every [sm:]/[max-lg:]/[min-[32rem]:] spelling. *)
+    | Portrait
+    | Landscape
+    | Ltr
+    | Rtl
+    | Dark
+    | Print
+    | Forced_colors
+    | Noscript
+    | Inverted_colors
+    | Starting
+    | Custom  (** A [\@custom-variant] the theme registers. *)
+    | Prose of string  (** [prose-X:], ordered by the element X names. *)
+    | Arbitrary  (** [[&>*]:], [not-[...]:] and the other bracket variants. *)
+    | Container_query
 
-(** [variant_order_of_prefix prefix] returns the position of a modifier prefix
-    string in the Tailwind v4 variant cascade. The prefix is the part before the
-    last ":" in a class name (e.g., "hover" in "hover:bg-blue-500", or
-    "dark:group-hover" in "dark:group-hover:text-white"). Returns 0 for unknown
-    or non-variant prefixes. *)
-let variant_order_of_prefix prefix =
+  (* The cascade order itself. Every other function in this section maps onto a
+     slot; this is the only place a position is a number. The gaps leave room to
+     insert a slot without renumbering its neighbours. *)
+  let rank = function
+    | Child -> 100
+    | Descendant -> 200
+    | Group -> 500
+    | Peer -> 600
+    | Pseudo_first_letter -> 1000
+    | Pseudo_first_line -> 1000
+    | Pseudo_marker -> 1100
+    | Pseudo_selection -> 1200
+    | Pseudo_file -> 1300
+    | Pseudo_placeholder -> 1400
+    | Pseudo_backdrop -> 1401
+    | Pseudo_details_content -> 1500
+    | Pseudo_before -> 1600
+    | Pseudo_after -> 1601
+    | First -> 10100
+    | Last -> 10200
+    | Only -> 10300
+    | Odd -> 10400
+    | Even -> 10500
+    | First_of_type -> 10600
+    | Last_of_type -> 10700
+    | Only_of_type -> 10800
+    | Visited -> 10900
+    | Target -> 11000
+    | Open -> 11100
+    | Default -> 11200
+    | Checked -> 11300
+    | Indeterminate -> 11400
+    | Placeholder_shown -> 11500
+    | Autofill -> 11600
+    | Optional -> 11700
+    | Required -> 11800
+    | Valid -> 11900
+    | Invalid -> 12000
+    | User_valid -> 12010
+    | User_invalid -> 12020
+    | In_range -> 12100
+    | Out_of_range -> 12200
+    | Read_only -> 12300
+    | Read_write -> 12310
+    | Empty -> 12400
+    | Focus_within -> 12500
+    | Hover -> 20000
+    | Focus -> 30100
+    | Focus_visible -> 30200
+    | Active -> 30300
+    | Enabled -> 30400
+    | Disabled -> 30500
+    | Inert -> 30550
+    | Ancestor -> 30560
+    | Has -> 30600
+    | Aria_named -> 30700
+    | Aria_arbitrary -> 30790
+    | Data_named -> 30800
+    | Data_arbitrary -> 30810
+    | Nth -> 30900
+    | Nth_last -> 30910
+    | Nth_of_type -> 30920
+    | Nth_last_of_type -> 30930
+    | Hocus -> 35000
+    | Supports -> 40000
+    | Motion_safe -> 50000
+    | Motion_reduce -> 50100
+    | Contrast_more -> 50200
+    | Contrast_less -> 50300
+    | Pointer -> 50400
+    | Any_pointer -> 50500
+    | Breakpoint -> 60000
+    | Portrait -> 70000
+    | Landscape -> 70100
+    | Ltr -> 80000
+    | Rtl -> 80100
+    | Dark -> 90000
+    | Print -> 91000
+    | Forced_colors -> 92000
+    | Noscript -> 93000
+    | Inverted_colors -> 93100
+    | Starting -> 95000
+    | Custom -> 95500
+    | Prose element -> prose_element_variant_order element
+    | Arbitrary -> 100000
+    | Container_query -> 110000
+end
+
+(* The slot a modifier constructor sorts in. Exhaustive on purpose: a new
+   variant has to be given a position here rather than falling into a catch-all
+   that would drop it in the middle of the table. *)
+let rec slot_of_modifier : modifier -> Slot.t = function
+  (* Every group-/peer- spelling sorts where its wrapper does, whatever state it
+     carries. *)
+  | Group_hover | Group_focus | Group_active | Group_visited | Group_disabled
+  | Group_checked | Group_empty | Group_required | Group_valid | Group_invalid
+  | Group_indeterminate | Group_default | Group_open | Group_target
+  | Group_optional | Group_read_only | Group_read_write | Group_inert
+  | Group_user_valid | Group_user_invalid | Group_placeholder_shown
+  | Group_autofill | Group_in_range | Group_out_of_range | Group_focus_within
+  | Group_focus_visible | Group_enabled | Group_first | Group_last | Group_only
+  | Group_odd | Group_even | Group_first_of_type | Group_last_of_type
+  | Group_only_of_type | Group_hocus | Group_has _ | Group_arbitrary _
+  | Group_not _ | Group_data _ | Group_aria _ | Named_group _
+  | Not_named_group _ | Group_peer_named _ ->
+      Slot.Group
+  | Peer_hover | Peer_focus | Peer_checked | Peer_active | Peer_visited
+  | Peer_disabled | Peer_empty | Peer_required | Peer_valid | Peer_invalid
+  | Peer_indeterminate | Peer_default | Peer_open | Peer_target | Peer_optional
+  | Peer_read_only | Peer_read_write | Peer_inert | Peer_user_valid
+  | Peer_user_invalid | Peer_placeholder_shown | Peer_autofill | Peer_in_range
+  | Peer_out_of_range | Peer_focus_within | Peer_focus_visible | Peer_enabled
+  | Peer_first | Peer_last | Peer_only | Peer_odd | Peer_even
+  | Peer_first_of_type | Peer_last_of_type | Peer_only_of_type | Peer_hocus
+  | Peer_has _ | Peer_arbitrary _ | Peer_not _ | Peer_data _ | Peer_aria _
+  | Named_peer _ ->
+      Slot.Peer
+  | Children -> Slot.Child
+  | Descendants -> Slot.Descendant
+  | Pseudo_first_letter -> Slot.Pseudo_first_letter
+  | Pseudo_first_line -> Slot.Pseudo_first_line
+  | Pseudo_marker -> Slot.Pseudo_marker
+  | Pseudo_selection -> Slot.Pseudo_selection
+  | Pseudo_file -> Slot.Pseudo_file
+  | Pseudo_placeholder -> Slot.Pseudo_placeholder
+  | Pseudo_backdrop -> Slot.Pseudo_backdrop
+  | Pseudo_details_content -> Slot.Pseudo_details_content
+  | Pseudo_before -> Slot.Pseudo_before
+  | Pseudo_after -> Slot.Pseudo_after
+  | First -> Slot.First
+  | Last -> Slot.Last
+  | Only -> Slot.Only
+  | Odd -> Slot.Odd
+  | Even -> Slot.Even
+  | First_of_type -> Slot.First_of_type
+  | Last_of_type -> Slot.Last_of_type
+  | Only_of_type -> Slot.Only_of_type
+  | Visited -> Slot.Visited
+  | Target -> Slot.Target
+  | Open -> Slot.Open
+  | Default -> Slot.Default
+  | Checked -> Slot.Checked
+  | Indeterminate -> Slot.Indeterminate
+  | Placeholder_shown -> Slot.Placeholder_shown
+  | Autofill -> Slot.Autofill
+  | Optional -> Slot.Optional
+  | Required -> Slot.Required
+  | Valid -> Slot.Valid
+  | Invalid -> Slot.Invalid
+  | User_valid -> Slot.User_valid
+  | User_invalid -> Slot.User_invalid
+  | In_range -> Slot.In_range
+  | Out_of_range -> Slot.Out_of_range
+  | Read_only -> Slot.Read_only
+  | Read_write -> Slot.Read_write
+  | Empty -> Slot.Empty
+  | Focus_within -> Slot.Focus_within
+  | Hover -> Slot.Hover
+  | Focus -> Slot.Focus
+  | Focus_visible -> Slot.Focus_visible
+  | Active -> Slot.Active
+  | Enabled -> Slot.Enabled
+  | Disabled -> Slot.Disabled
+  | Inert -> Slot.Inert
+  | In_bracket _ | In_data _ | In_state _ | In_named_group _ -> Slot.Ancestor
+  | Has _ | Has_variant _ | Has_named_group _ -> Slot.Has
+  | Aria_checked | Aria_expanded | Aria_selected | Aria_disabled ->
+      Slot.Aria_named
+  | Aria_bracket _ -> Slot.Aria_arbitrary
+  | Data_state _ | Data_variant _ | Data_active | Data_inactive | Data_custom _
+    ->
+      Slot.Data_named
+  | Data_bracket _ -> Slot.Data_arbitrary
+  | Nth _ -> Slot.Nth
+  | Nth_last _ -> Slot.Nth_last
+  | Nth_of_type _ -> Slot.Nth_of_type
+  | Nth_last_of_type _ -> Slot.Nth_last_of_type
+  | Hocus | Device_hocus -> Slot.Hocus
+  | Supports_property _ | Supports_condition _ -> Slot.Supports
+  | Motion_safe -> Slot.Motion_safe
+  | Motion_reduce -> Slot.Motion_reduce
+  | Contrast_more -> Slot.Contrast_more
+  | Contrast_less -> Slot.Contrast_less
+  | Pointer_none | Pointer_coarse | Pointer_fine -> Slot.Pointer
+  | Any_pointer_none | Any_pointer_coarse | Any_pointer_fine -> Slot.Any_pointer
+  | Responsive _ | Min_responsive _ | Max_responsive _ | Min_arbitrary _
+  | Max_arbitrary _ | Min_arbitrary_length _ | Max_arbitrary_length _
+  | Custom_responsive _ | Min_custom _ | Max_custom _ ->
+      Slot.Breakpoint
+  | Portrait -> Slot.Portrait
+  | Landscape -> Slot.Landscape
+  | Ltr -> Slot.Ltr
+  | Rtl -> Slot.Rtl
+  | Dark -> Slot.Dark
+  | Print -> Slot.Print
+  | Forced_colors -> Slot.Forced_colors
+  | Noscript -> Slot.Noscript
+  | Inverted_colors -> Slot.Inverted_colors
+  | Starting -> Slot.Starting
+  | Custom_variant _ -> Slot.Custom
+  | Prose_element element -> Slot.Prose element
+  | Not_bracket _ | Arbitrary_selector _ | At_rule _ -> Slot.Arbitrary
+  | Container _ | Container_style _ -> Slot.Container_query
+  (* A negation sorts where the variant it negates sorts. *)
+  | Not inner -> slot_of_modifier inner
+
+(* The slot a class-name token sorts in, or [None] when the token names no
+   variant this table knows. The token is one modifier of a class name, the part
+   between two ":" (["hover"], ["group-has-checked"], ["@min-[64rem]"]). *)
+let slot_of_prefix prefix : Slot.t option =
+  let starts_with prefix' = String.starts_with ~prefix:prefix' prefix in
   match prefix with
-  (* Pseudo-elements *)
-  | "group-hover" | "peer-hover" -> 500
-  | "first-letter" | "first-line" -> 1000
-  | "marker" -> 1100
-  | "selection" -> 1200
-  | "file" -> 1300
-  | "placeholder" -> 1400
-  | "backdrop" -> 1401
-  | "details-content" -> 1500
-  | "before" -> 1600
-  | "after" -> 1601
-  (* Block 1: structural pseudo-classes *)
-  | "first" -> 10100
-  | "last" -> 10200
-  | "only" -> 10300
-  | "odd" -> 10400
-  | "even" -> 10500
-  | "first-of-type" -> 10600
-  | "last-of-type" -> 10700
-  | "only-of-type" -> 10800
-  | "visited" -> 10900
-  | "target" -> 11000
-  | "open" -> 11100
-  | "default" -> 11200
-  | "checked" -> 11300
-  | "indeterminate" -> 11400
-  | "placeholder-shown" -> 11500
-  | "autofill" -> 11600
-  | "optional" -> 11700
-  | "required" -> 11800
-  | "valid" -> 11900
-  | "invalid" -> 12000
-  | "user-valid" -> 12010
-  | "user-invalid" -> 12020
-  | "in-range" -> 12100
-  | "out-of-range" -> 12200
-  | "read-only" -> 12300
-  | "empty" -> 12400
-  | "focus-within" -> 12500
-  (* Hover — in @media(hover:hover) but between block 1 and block 2 *)
-  | "hover" -> 20000
-  (* Block 2: interactive pseudo-classes *)
-  | "focus" -> 30100
-  | "focus-visible" -> 30200
-  | "active" -> 30300
-  | "enabled" -> 30400
-  | "disabled" -> 30500
-  | "inert" -> 30550
-  | "data-custom" | "data-active" | "data-inactive" -> 30800
-  (* Hocus *)
-  | "hocus" | "device-hocus" -> 35000
-  | "portrait" -> 70000
-  | "landscape" -> 70100
-  (* Directionality *)
-  | "ltr" -> 80000
-  | "rtl" -> 80100
-  (* Appearance media *)
-  | "dark" -> 90000
-  | "print" -> 91000
-  | "forced-colors" -> 92000
-  | "noscript" -> 93000
-  | "inverted-colors" -> 93100
-  (* @starting-style: comes after all media queries including dark:hover *)
-  | "starting" -> 95000
-  | _ ->
-      if String.starts_with ~prefix:"group-" prefix then 500
-      else if String.starts_with ~prefix:"peer-" prefix then 600
-      else if String.starts_with ~prefix:"has-" prefix then 30600
-      else if String.starts_with ~prefix:"aria-" prefix then
-        if String.length prefix > 5 && prefix.[5] <> '[' then 30700 else 30790
-      else if String.starts_with ~prefix:"data-" prefix then
-        if String.length prefix > 5 && prefix.[5] = '[' then 30810 else 30800
-      else if
-        String.starts_with ~prefix:"supports-" prefix
-        || String.starts_with ~prefix:"supports" prefix
-      then 40000
-      else if prefix = "motion-safe" then 50000
-      else if prefix = "motion-reduce" then 50100
-      else if prefix = "contrast-more" then 50200
-      else if prefix = "contrast-less" then 50300
-      else if String.starts_with ~prefix:"pointer-" prefix then 50400
-      else if String.starts_with ~prefix:"any-pointer-" prefix then 50500
-      else if
-        prefix = "sm" || prefix = "md" || prefix = "lg" || prefix = "xl"
-        || prefix = "2xl"
-        || String.starts_with ~prefix:"min-" prefix
-        || String.starts_with ~prefix:"max-" prefix
-      then 60000
-      else if String.starts_with ~prefix:"prose-" prefix then
-        let name = String.sub prefix 6 (String.length prefix - 6) in
-        prose_element_variant_order name
-      else if String.length prefix > 0 && prefix.[0] = '[' then 100000
-      else if String.length prefix > 0 && prefix.[0] = '@' then 110000
-      else 0
+  (* [peer-hover] shares [group-hover]'s position rather than the one every
+     other [peer-] spelling takes. *)
+  | "group-hover" | "peer-hover" -> Some Slot.Group
+  | "first-letter" -> Some Slot.Pseudo_first_letter
+  | "first-line" -> Some Slot.Pseudo_first_line
+  | "marker" -> Some Slot.Pseudo_marker
+  | "selection" -> Some Slot.Pseudo_selection
+  | "file" -> Some Slot.Pseudo_file
+  | "placeholder" -> Some Slot.Pseudo_placeholder
+  | "backdrop" -> Some Slot.Pseudo_backdrop
+  | "details-content" -> Some Slot.Pseudo_details_content
+  | "before" -> Some Slot.Pseudo_before
+  | "after" -> Some Slot.Pseudo_after
+  | "first" -> Some Slot.First
+  | "last" -> Some Slot.Last
+  | "only" -> Some Slot.Only
+  | "odd" -> Some Slot.Odd
+  | "even" -> Some Slot.Even
+  | "first-of-type" -> Some Slot.First_of_type
+  | "last-of-type" -> Some Slot.Last_of_type
+  | "only-of-type" -> Some Slot.Only_of_type
+  | "visited" -> Some Slot.Visited
+  | "target" -> Some Slot.Target
+  | "open" -> Some Slot.Open
+  | "default" -> Some Slot.Default
+  | "checked" -> Some Slot.Checked
+  | "indeterminate" -> Some Slot.Indeterminate
+  | "placeholder-shown" -> Some Slot.Placeholder_shown
+  | "autofill" -> Some Slot.Autofill
+  | "optional" -> Some Slot.Optional
+  | "required" -> Some Slot.Required
+  | "valid" -> Some Slot.Valid
+  | "invalid" -> Some Slot.Invalid
+  | "user-valid" -> Some Slot.User_valid
+  | "user-invalid" -> Some Slot.User_invalid
+  | "in-range" -> Some Slot.In_range
+  | "out-of-range" -> Some Slot.Out_of_range
+  | "read-only" -> Some Slot.Read_only
+  | "read-write" -> Some Slot.Read_write
+  | "empty" -> Some Slot.Empty
+  | "focus-within" -> Some Slot.Focus_within
+  | "hover" -> Some Slot.Hover
+  | "focus" -> Some Slot.Focus
+  | "focus-visible" -> Some Slot.Focus_visible
+  | "active" -> Some Slot.Active
+  | "enabled" -> Some Slot.Enabled
+  | "disabled" -> Some Slot.Disabled
+  | "inert" -> Some Slot.Inert
+  | "data-custom" | "data-active" | "data-inactive" -> Some Slot.Data_named
+  | "hocus" | "device-hocus" -> Some Slot.Hocus
+  | "motion-safe" -> Some Slot.Motion_safe
+  | "motion-reduce" -> Some Slot.Motion_reduce
+  | "contrast-more" -> Some Slot.Contrast_more
+  | "contrast-less" -> Some Slot.Contrast_less
+  | "portrait" -> Some Slot.Portrait
+  | "landscape" -> Some Slot.Landscape
+  | "ltr" -> Some Slot.Ltr
+  | "rtl" -> Some Slot.Rtl
+  | "dark" -> Some Slot.Dark
+  | "print" -> Some Slot.Print
+  | "forced-colors" -> Some Slot.Forced_colors
+  | "noscript" -> Some Slot.Noscript
+  | "inverted-colors" -> Some Slot.Inverted_colors
+  | "starting" -> Some Slot.Starting
+  | "sm" | "md" | "lg" | "xl" | "2xl" -> Some Slot.Breakpoint
+  | _ when starts_with "group-" -> Some Slot.Group
+  | _ when starts_with "peer-" -> Some Slot.Peer
+  | _ when starts_with "has-" -> Some Slot.Has
+  | _ when starts_with "aria-" ->
+      (* [aria-] with nothing after it, and [aria-[expr]], take the arbitrary
+         position; the shorthand names take the named one. *)
+      if String.length prefix > 5 && prefix.[5] <> '[' then Some Slot.Aria_named
+      else Some Slot.Aria_arbitrary
+  | _ when starts_with "data-" ->
+      if String.length prefix > 5 && prefix.[5] = '[' then
+        Some Slot.Data_arbitrary
+      else Some Slot.Data_named
+  | _ when starts_with "supports" -> Some Slot.Supports
+  | _ when starts_with "pointer-" -> Some Slot.Pointer
+  | _ when starts_with "any-pointer-" -> Some Slot.Any_pointer
+  | _ when starts_with "min-" || starts_with "max-" -> Some Slot.Breakpoint
+  (* [nth-3], [nth-last-of-type-2]: the count is the argument, not part of the
+     variant name. Longest spelling first, so [nth-last-of-type-] is not read as
+     an [nth-last-] with a strange argument. *)
+  | _ when starts_with "nth-last-of-type-" -> Some Slot.Nth_last_of_type
+  | _ when starts_with "nth-of-type-" -> Some Slot.Nth_of_type
+  | _ when starts_with "nth-last-" -> Some Slot.Nth_last
+  | _ when starts_with "nth-" -> Some Slot.Nth
+  (* [in-focus], [in-data-open], [in-[.foo]]: a state on an ancestor. The
+     pseudo-classes that merely start with the same letters ([in-range],
+     [inert], [invalid]) are matched by name above. *)
+  | _ when starts_with "in-" -> Some Slot.Ancestor
+  | _ when starts_with "prose-" ->
+      Some (Slot.Prose (String.sub prefix 6 (String.length prefix - 6)))
+  | _ when prefix <> "" && prefix.[0] = '[' -> Some Slot.Arbitrary
+  | _ when prefix <> "" && prefix.[0] = '@' -> Some Slot.Container_query
+  | _ -> None
 
-(* [variant_order_of_media_cond cond] returns the same sort key as
-   [variant_order_of_prefix] for the corresponding CSS media condition. Used to
-   determine the cascade position of rules with nested media queries (e.g.,
-   dark:group-hover has a nested @media(hover:hover), so its effective inner
-   order is 20000, matching standalone hover). *)
-let variant_order_of_media_cond (cond : Css.Media.t) =
+(* The slot a media condition sorts in. A rule can take its position from the
+   query it is nested in rather than from its class name: [dark:group-hover]
+   writes a [(hover: hover)] query, and sorts where a bare [hover] sorts. *)
+let slot_of_media_cond (cond : Css.Media.t) : Slot.t option =
   let open Css.Media in
   match cond with
-  | Cond (Feature (Plain (Hover, Ident Hover))) -> 20000
+  | Cond (Feature (Plain (Hover, Ident Hover))) -> Some Slot.Hover
   | Cond (Feature (Plain (Prefers_reduced_motion, Ident No_preference))) ->
-      50000
-  | Cond (Feature (Plain (Prefers_reduced_motion, Ident Reduce))) -> 50100
-  | Cond (Feature (Plain (Prefers_contrast, Ident More))) -> 50200
-  | Cond (Feature (Plain (Prefers_contrast, Ident Less))) -> 50300
-  | Cond (Feature (Plain (Orientation, Ident Portrait))) -> 70000
-  | Cond (Feature (Plain (Orientation, Ident Landscape))) -> 70100
-  | Cond (Feature (Plain (Prefers_color_scheme, Ident Dark))) -> 90000
-  | Cond (Feature (Plain (Prefers_color_scheme, Ident Light))) -> 90000
-  | Type { prefix = None; type_ = Print; trailing = None } -> 91000
-  | Cond (Feature (Plain (Forced_colors, Ident Active))) -> 92000
-  | Cond (Feature (Plain (Inverted_colors, Ident Inverted))) -> 93100
-  | _ -> 0
+      Some Slot.Motion_safe
+  | Cond (Feature (Plain (Prefers_reduced_motion, Ident Reduce))) ->
+      Some Slot.Motion_reduce
+  | Cond (Feature (Plain (Prefers_contrast, Ident More))) ->
+      Some Slot.Contrast_more
+  | Cond (Feature (Plain (Prefers_contrast, Ident Less))) ->
+      Some Slot.Contrast_less
+  | Cond (Feature (Plain (Orientation, Ident Portrait))) -> Some Slot.Portrait
+  | Cond (Feature (Plain (Orientation, Ident Landscape))) -> Some Slot.Landscape
+  | Cond (Feature (Plain (Prefers_color_scheme, (Ident Dark | Ident Light)))) ->
+      Some Slot.Dark
+  | Type { prefix = None; type_ = Print; trailing = None } -> Some Slot.Print
+  | Cond (Feature (Plain (Forced_colors, Ident Active))) ->
+      Some Slot.Forced_colors
+  | Cond (Feature (Plain (Inverted_colors, Ident Inverted))) ->
+      Some Slot.Inverted_colors
+  | _ -> None
+
+let not_variant_order m = Slot.rank (slot_of_modifier m)
+
+let variant_order_of_prefix prefix =
+  match slot_of_prefix prefix with Some slot -> Slot.rank slot | None -> 0
+
+let variant_order_of_media_cond cond =
+  match slot_of_media_cond cond with Some slot -> Slot.rank slot | None -> 0

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -726,18 +726,24 @@ val parse_data_expr :
     the selector at render time and, via {!Css.Selector.attribute}'s own
     identifier check, to validate the expression at parse time. *)
 
-(** {1 Variant Ordering} *)
+(** {1 Variant Ordering}
+
+    The three functions below read one table of cascade positions, so they
+    cannot put a variant in one place as a [not-*] inner and another place as a
+    class-name token. All three return a key on the same scale, comparable with
+    each other. *)
 
 val not_variant_order : modifier -> int
-(** [not_variant_order m] returns the cascade sort key for a [not-*] inner
-    modifier. Matches the ordering of {!val-variant_order_of_prefix} for the
-    corresponding pseudo-class/media prefix. *)
+(** [not_variant_order m] returns the cascade sort key of the variant [m]. Used
+    for the inner modifier of a [not-*], which sorts where the variant it
+    negates sorts. Never 0: every modifier has a position. *)
 
 val variant_order_of_prefix : string -> int
 (** [variant_order_of_prefix prefix] returns the position of a modifier prefix
-    string in the Tailwind v4 variant cascade. The prefix is the part before the
-    last ":" in a base class name (e.g. ["hover"], ["dark:group-hover"]).
-    Returns 0 for unknown prefixes. *)
+    string in the Tailwind v4 variant cascade. The prefix is one modifier of a
+    class name, the part between two ":" (e.g. ["hover"], ["group-has-checked"],
+    ["@min-[64rem]"]). Returns 0 for a token that names no variant, which
+    {!Sort.compare_indexed_rules} reads as "this rule carries no variant". *)
 
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -745,6 +745,12 @@ val variant_order_of_prefix : string -> int
     ["@min-[64rem]"]). Returns 0 for a token that names no variant, which
     {!Sort.compare_indexed_rules} reads as "this rule carries no variant". *)
 
+val variant_inner_order : string -> int
+(** [variant_inner_order token] returns what separates [token] from another
+    token in the same cascade position: the state a [group-]/[peer-] token
+    wraps, and the variant a [not-] token negates, both on the scale
+    {!val-variant_order_of_prefix} returns. [0] for every other token. *)
+
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as
     {!val-variant_order_of_prefix} for the corresponding CSS media condition.

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -747,9 +747,10 @@ val variant_order_of_prefix : string -> int
 
 val variant_inner_order : string -> int
 (** [variant_inner_order token] returns what separates [token] from another
-    token in the same cascade position: the state a [group-]/[peer-] token
-    wraps, and the variant a [not-] token negates, both on the scale
-    {!val-variant_order_of_prefix} returns. [0] for every other token. *)
+    token in the same cascade position: the state a [group-]/[peer-] or [in-]
+    token names on another element, and the variant a [not-] token negates, all
+    on the scale {!val-variant_order_of_prefix} returns. [0] for every other
+    token. *)
 
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -959,8 +959,10 @@ let compute_variant_order ~selector_str base_class =
      to avoid matching utility-generated pseudo-elements like prose's
      ::before. *)
   if vo > 0 then vo
-  else if has_substring selector_str "before\\:" then 1600
-  else if has_substring selector_str "after\\:" then 1601
+  else if has_substring selector_str "before\\:" then
+    Modifiers.variant_order_of_prefix "before"
+  else if has_substring selector_str "after\\:" then
+    Modifiers.variant_order_of_prefix "after"
   else 0
 
 (** Build the class name prefix for a not-* inner modifier. Handles shorthand

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -1083,13 +1083,7 @@ let compare_variant_components a b =
    group-focus and group-has keep their focus-before-has order. *)
 let token_order_key ~breakpoint token =
   let slot = Modifiers.variant_order_of_prefix token in
-  let wrapped =
-    if
-      String.starts_with ~prefix:"group-" token
-      || String.starts_with ~prefix:"peer-" token
-    then strip_group_peer_vo token
-    else 0
-  in
+  let wrapped = Modifiers.variant_inner_order token in
   let breakpoint =
     if slot = responsive_variant_order then breakpoint else None
   in

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -27,6 +27,17 @@ type selector_kind =
       has_aria : bool;
     }  (** Selector with combinators, pseudo-classes, etc. *)
 
+(* One component of a rule's variant sort key: the slot the token sorts in, plus
+   what separates two tokens that share it. A breakpoint token carries the width
+   it names, so [sm] and [md] no longer collapse onto one key; a group-/ peer-
+   token carries the state it wraps, so [group-focus] and [group-has] keep their
+   order. *)
+type variant_component = {
+  slot : int;
+  breakpoint : Css.Media.key option;
+  wrapped : int;
+}
+
 (** Relationship between two rules being compared *)
 type rule_relationship =
   | Same_utility of string  (** Both rules from same base utility *)
@@ -64,7 +75,7 @@ type indexed_rule = {
   variant_key : string * int;
       (* Precomputed (variant prefix, effective inner order) - see
          [variant_sort_key]. Read by [compare_variant_ordered]. *)
-  variant_orders : (int * int) list;
+  variant_orders : variant_component list;
       (* The rule's variant order keys sorted descending - see
          [variant_order_list]. Compared lexicographically by
          [compare_variant_ordered] so a stacked variant sorts into the group of
@@ -1049,19 +1060,40 @@ let variant_sort_key base_class nested =
   let prefix = variant_prefix base_class in
   (prefix, effective_ivo_of nested prefix)
 
-(* One modifier token's sort key: its variant order, paired with the inner
-   pseudo order for group-/peer- wrappers so group-focus and group-has (both
-   order 500) keep their focus-before-has order. Non-wrapper tokens use 0. *)
-let token_order_key token =
-  let primary = Modifiers.variant_order_of_prefix token in
-  let secondary =
+(* Two components in the same slot are separated by the breakpoint first: a rule
+   whose highest-order variant is a breakpoint groups under that breakpoint, so
+   first:sm:m-2 stays beside sm:bg-top instead of falling past md:block. A slot
+   with no width on one side leaves that to the tie-breakers below, as the
+   wrapped state and then the rest of the stack. *)
+let compare_variant_components a b =
+  let slot_cmp = Int.compare a.slot b.slot in
+  if slot_cmp <> 0 then slot_cmp
+  else
+    let bp_cmp =
+      match (a.breakpoint, b.breakpoint) with
+      | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
+      | Some _, None | None, Some _ | None, None -> 0
+    in
+    if bp_cmp <> 0 then bp_cmp else Int.compare a.wrapped b.wrapped
+
+(* One modifier token's sort key. The slot alone leaves every breakpoint on one
+   key and every group-/peer- spelling on another, so the component carries what
+   separates two tokens inside a slot: the width for a breakpoint, read off the
+   media query the rule renders as, and the wrapped state for group-/peer-, so
+   group-focus and group-has keep their focus-before-has order. *)
+let token_order_key ~breakpoint token =
+  let slot = Modifiers.variant_order_of_prefix token in
+  let wrapped =
     if
       String.starts_with ~prefix:"group-" token
       || String.starts_with ~prefix:"peer-" token
     then strip_group_peer_vo token
     else 0
   in
-  (primary, secondary)
+  let breakpoint =
+    if slot = responsive_variant_order then breakpoint else None
+  in
+  { slot; breakpoint; wrapped }
 
 (* The variant order keys of a class's modifier stack, sorted descending.
    Tailwind sorts a candidate by this list compared lexicographically ascending,
@@ -1070,7 +1102,7 @@ let token_order_key token =
    (group:hover vs hover:group) get identical keys. Falls back to the scalar
    [variant_order] for selector-derived variants (before:/after:) that carry no
    order-bearing prefix in the base class. *)
-let variant_order_list base_class variant_order =
+let variant_order_list base_class variant_order breakpoint =
   let from_bc =
     match base_class with
     | None -> []
@@ -1078,13 +1110,14 @@ let variant_order_list base_class variant_order =
         let modifiers, _ = Modifiers.of_string bc in
         List.filter_map
           (fun m ->
-            let ((primary, _) as key) = token_order_key m in
-            if primary > 0 then Some key else None)
+            let key = token_order_key ~breakpoint m in
+            if key.slot > 0 then Some key else None)
           modifiers
-        |> List.sort (fun a b -> compare b a)
+        |> List.sort (fun a b -> compare_variant_components b a)
   in
   match from_bc with
-  | [] when variant_order > 0 -> [ (variant_order, 0) ]
+  | [] when variant_order > 0 ->
+      [ { slot = variant_order; breakpoint = None; wrapped = 0 } ]
   | l -> l
 
 (* Compare two descending variant-order-key lists lexicographically, ascending
@@ -1096,7 +1129,7 @@ let rec compare_variant_order_lists l1 l2 =
   | [], _ -> -1
   | _, [] -> 1
   | a :: r1, b :: r2 ->
-      let c = compare a b in
+      let c = compare_variant_components a b in
       if c <> 0 then c else compare_variant_order_lists r1 r2
 
 (** Classify bracket content: pseudo-class brackets ([:checked]) sort before
@@ -1174,19 +1207,6 @@ let compare_variant_tail r1 r2 =
               if class_cmp <> 0 then class_cmp
               else Int.compare r1.index r2.index)
 
-(* Tailwind groups a rule under its breakpoint before it reads the rest of the
-   variant stack, so first:sm:m-2 stays beside sm:bg-top instead of falling past
-   md:block. Only when the breakpoint is the highest-order component on both
-   sides: dark:sm:flex sorts under dark, not under sm. *)
-let compare_responsive_breakpoint r1 r2 =
-  match (r1.variant_orders, r2.variant_orders) with
-  | (p1, _) :: _, (p2, _) :: _
-    when p1 = responsive_variant_order && p2 = responsive_variant_order -> (
-      match (r1.responsive_media_key, r2.responsive_media_key) with
-      | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
-      | _ -> 0)
-  | _ -> 0
-
 let compare_variant_ordered r1 r2 =
   match (r1.rule_type, r2.rule_type) with
   | `Supports _, `Supports _
@@ -1195,51 +1215,47 @@ let compare_variant_ordered r1 r2 =
          && is_modifier_supports r2.base_class ->
       compare_supports_by_key r1 r2
   | _ ->
-      let breakpoint_cmp = compare_responsive_breakpoint r1 r2 in
-      if breakpoint_cmp <> 0 then breakpoint_cmp
+      let list_cmp =
+        compare_variant_order_lists r1.variant_orders r2.variant_orders
+      in
+      if list_cmp <> 0 then list_cmp
       else
-        let list_cmp =
-          compare_variant_order_lists r1.variant_orders r2.variant_orders
+        let p1_prefix, _ = r1.variant_key in
+        let p2_prefix, _ = r2.variant_key in
+        (* The descending variant-order lists tie (same variant multiset), so
+           hover:sm: and sm:hover: arrive here indistinguishable. The query a
+           rule writes on the outside decides between them, hover before sm and
+           sm before md; a nested breakpoint or hover, the prefix and the
+           utility's own priority order what is left. *)
+        let media_cmp =
+          match compare_container_values r1 r2 p1_prefix p2_prefix with
+          | Some c -> c
+          | None -> (
+              match (r1.media_key, r2.media_key) with
+              | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
+              | _ -> 0)
         in
-        if list_cmp <> 0 then list_cmp
+        if media_cmp <> 0 then media_cmp
         else
-          let p1_prefix, _ = r1.variant_key in
-          let p2_prefix, _ = r2.variant_key in
-          (* The descending variant-order lists tie (same variant multiset), so
-             hover:sm: and sm:hover: arrive here indistinguishable. The query a
-             rule writes on the outside decides between them, hover before sm
-             and sm before md; a nested breakpoint or hover, the prefix and the
-             utility's own priority order what is left. *)
-          let media_cmp =
-            match compare_container_values r1 r2 p1_prefix p2_prefix with
-            | Some c -> c
-            | None -> (
-                match (r1.media_key, r2.media_key) with
-                | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
-                | _ -> 0)
+          let nested_cmp =
+            Int.compare
+              (nested_order r1.rule_type r1.nested)
+              (nested_order r2.rule_type r2.nested)
           in
-          if media_cmp <> 0 then media_cmp
+          if nested_cmp <> 0 then nested_cmp
           else
-            let nested_cmp =
-              Int.compare
-                (nested_order r1.rule_type r1.nested)
-                (nested_order r2.rule_type r2.nested)
-            in
-            if nested_cmp <> 0 then nested_cmp
+            let nested_media_cmp = compare_nested_media r1 r2 in
+            if nested_media_cmp <> 0 then nested_media_cmp
             else
-              let nested_media_cmp = compare_nested_media r1 r2 in
-              if nested_media_cmp <> 0 then nested_media_cmp
-              else
-                (* Two container variants at the same width are already fully
-                   ordered: what remains is the utility's own priority, so the
-                   prefix must not step in and group @sm/main away from @sm. *)
-                let prefix_cmp =
-                  match (r1.rule_type, r2.rule_type) with
-                  | `Container _, `Container _ -> 0
-                  | _ -> compare_bracket_prefixes p1_prefix p2_prefix
-                in
-                if prefix_cmp <> 0 then prefix_cmp
-                else compare_variant_tail r1 r2
+              (* Two container variants at the same width are already fully
+                 ordered: what remains is the utility's own priority, so the
+                 prefix must not step in and group @sm/main away from @sm. *)
+              let prefix_cmp =
+                match (r1.rule_type, r2.rule_type) with
+                | `Container _, `Container _ -> 0
+                | _ -> compare_bracket_prefixes p1_prefix p2_prefix
+              in
+              if prefix_cmp <> 0 then prefix_cmp else compare_variant_tail r1 r2
 
 (* Compare two Supports rules *)
 let compare_supports_rules r1 r2 =

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -23,6 +23,18 @@ type selector_kind =
       has_aria : bool;
     }
 
+type variant_component = {
+  slot : int;  (** The position in the variant cascade the token sorts in. *)
+  breakpoint : Css.Media.key option;
+      (** The width a breakpoint token names, so [sm] and [md] do not collapse
+          onto one key. [None] for every other token. *)
+  wrapped : int;
+      (** The state a [group-]/[peer-] token wraps, so [group-focus] and
+          [group-has] keep their order. [0] for every other token. *)
+}
+(** One component of a rule's variant sort key: the slot a modifier token sorts
+    in, plus what separates two tokens that share that slot. *)
+
 type indexed_rule = {
   index : int;  (** Source position — used as a stable tiebreaker. *)
   rule_type :
@@ -54,7 +66,7 @@ type indexed_rule = {
       (** Precomputed [(variant prefix, effective inner order)], built with
           {!variant_sort_key}, so {!val-compare_indexed_rules} does not
           recompute it per comparison. *)
-  variant_orders : (int * int) list;
+  variant_orders : variant_component list;
       (** The rule's variant order keys sorted descending, built with
           {!variant_order_list}. Compared lexicographically by
           {!val-compare_indexed_rules} so a stacked variant sorts into the group
@@ -85,11 +97,14 @@ val variant_sort_key : string option -> Css.statement list -> string * int
     [(variant prefix, effective inner variant order)] pair stored in
     {!field-variant_key}. *)
 
-val variant_order_list : string option -> int -> (int * int) list
-(** [variant_order_list base_class variant_order] is the descending list of
-    variant order keys stored in {!field-variant_orders}. [variant_order] is the
-    scalar fallback for selector-derived variants with no order-bearing prefix.
-*)
+val variant_order_list :
+  string option -> int -> Css.Media.key option -> variant_component list
+(** [variant_order_list base_class variant_order breakpoint] is the descending
+    list of variant order keys stored in {!field-variant_orders}.
+    [variant_order] is the scalar fallback for selector-derived variants with no
+    order-bearing prefix. [breakpoint] is the rule's {!val-responsive_media_key}
+    and becomes the {!field-variant_component.breakpoint} of whichever token
+    names a breakpoint. *)
 
 val media_sort_keys :
   [ `Regular

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -415,6 +415,134 @@ let test_removed_breakpoint_drops_its_variants () =
   check bool "the theme's own breakpoint still resolves" true
     (Result.is_ok (Tw.of_string ~theme "tablet:flex"))
 
+(* The variant cascade the one table defines, read as a ladder: every token
+   sorts strictly after the one before it. A token the table has no position for
+   returns 0, and the comparator reads 0 as "this rule carries no variant" and
+   puts the rule in another group entirely, so a missing rung is not a small
+   ordering error. *)
+let variant_cascade_ladder =
+  [
+    "*";
+    "**";
+    "not-hover";
+    "group-hover";
+    "peer-focus";
+    "first-letter";
+    "marker";
+    "selection";
+    "file";
+    "placeholder";
+    "backdrop";
+    "details-content";
+    "before";
+    "after";
+    "first";
+    "last";
+    "only";
+    "odd";
+    "even";
+    "first-of-type";
+    "last-of-type";
+    "only-of-type";
+    "visited";
+    "target";
+    "open";
+    "default";
+    "checked";
+    "indeterminate";
+    "placeholder-shown";
+    "autofill";
+    "optional";
+    "required";
+    "valid";
+    "invalid";
+    "user-valid";
+    "user-invalid";
+    "in-range";
+    "out-of-range";
+    "read-only";
+    "read-write";
+    "empty";
+    "focus-within";
+    "hover";
+    "focus";
+    "focus-visible";
+    "active";
+    "enabled";
+    "disabled";
+    "inert";
+    "in-focus";
+    "has-checked";
+    "aria-checked";
+    "aria-[modal]";
+    "data-active";
+    "data-[open]";
+    "nth-3";
+    "nth-last-3";
+    "nth-of-type-3";
+    "nth-last-of-type-3";
+    "hocus";
+    "supports-grid";
+    "motion-safe";
+    "motion-reduce";
+    "contrast-more";
+    "contrast-less";
+    "pointer-fine";
+    "any-pointer-fine";
+    "md";
+    "portrait";
+    "landscape";
+    "ltr";
+    "rtl";
+    "dark";
+    "print";
+    "forced-colors";
+    "noscript";
+    "inverted-colors";
+    "starting";
+    "prose-h1";
+    "[&>*]";
+    "@md";
+  ]
+
+let test_variant_cascade_ladder () =
+  List.iter
+    (fun token ->
+      check bool
+        (token ^ " has a position in the cascade")
+        true
+        (variant_order_of_prefix token > 0))
+    variant_cascade_ladder;
+  List.iteri
+    (fun i token ->
+      match List.nth_opt variant_cascade_ladder (i + 1) with
+      | None -> ()
+      | Some next ->
+          check bool
+            (token ^ " sorts before " ^ next)
+            true
+            (variant_order_of_prefix token < variant_order_of_prefix next))
+    variant_cascade_ladder
+
+(* Two tokens in the same position are separated by what they carry: a [not-]
+   sorts where the variant it negates sorts, a [group-]/[peer-] where the state
+   it wraps sorts. Both read the same table as the position itself. *)
+let test_variant_inner_order () =
+  List.iter
+    (fun (token, inner) ->
+      check int
+        (token ^ " carries " ^ inner)
+        (variant_order_of_prefix inner)
+        (variant_inner_order token))
+    [
+      ("not-hover", "hover");
+      ("not-md", "md");
+      ("not-supports-grid", "supports-grid");
+      ("group-focus", "focus");
+      ("peer-checked", "checked");
+    ];
+  check int "a plain token carries nothing" 0 (variant_inner_order "hover")
+
 (* Test suite *)
 (* The [!] prefix marks the utility's own declarations !important, leaves theme
    tokens (--spacing) normal, preserves the class name, and nests under a
@@ -1216,6 +1344,8 @@ let tests =
       test_case "prose element variants" `Quick test_prose_element_variants;
       test_case "prose element variant invalid" `Quick
         test_prose_element_variant_invalid;
+      test_case "variant cascade ladder" `Quick test_variant_cascade_ladder;
+      test_case "variant inner order" `Quick test_variant_inner_order;
     ]
 
 let suite = ("modifiers", tests)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -487,22 +487,22 @@ let variant_cascade_ladder =
     "motion-reduce";
     "contrast-more";
     "contrast-less";
-    "pointer-fine";
-    "any-pointer-fine";
     "md";
+    "@md";
     "portrait";
     "landscape";
     "ltr";
     "rtl";
     "dark";
+    "starting";
     "print";
     "forced-colors";
-    "noscript";
     "inverted-colors";
-    "starting";
+    "pointer-fine";
+    "any-pointer-fine";
+    "noscript";
     "prose-h1";
     "[&>*]";
-    "@md";
   ]
 
 let test_variant_cascade_ladder () =

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1150,6 +1150,61 @@ let test_breakpoint_groups_stacked_variants () =
     (List.sort Int.compare positions)
     positions
 
+(* The cascade order the variant table gives, end to end. Every token here has a
+   position in it; a token with none returns 0, which the comparator reads as
+   "this rule carries no variant" and sorts into another group, which is what
+   put nth-*, in-* and the child variants ahead of the plain utilities. This
+   list is what tailwindcss emits for the same classes. *)
+let test_variant_table_emission_order () =
+  let classes =
+    [
+      "block";
+      "*:m-1";
+      "**:m-2";
+      "not-hover:m-3";
+      "group-hover:m-4";
+      "hover:m-5";
+      "inert:m-6";
+      "in-focus:m-7";
+      "has-checked:m-8";
+      "data-active:m-9";
+      "nth-3:mt-1";
+      "supports-grid:mt-2";
+      "md:mt-3";
+      "dark:mt-4";
+    ]
+  in
+  let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
+  let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
+  let position needle =
+    match Astring.String.find_sub ~sub:needle css with
+    | Some i -> i
+    | None -> Alcotest.failf "%s not found in %s" needle css
+  in
+  let positions =
+    List.map position
+      [
+        ".block";
+        "m-1";
+        "m-2";
+        "m-3";
+        "m-4";
+        "m-5";
+        "m-6";
+        "m-7";
+        "m-8";
+        "m-9";
+        "mt-1";
+        "mt-2";
+        "mt-3";
+        "mt-4";
+      ]
+  in
+  Alcotest.(check (list int))
+    "emission order"
+    (List.sort Int.compare positions)
+    positions
+
 let test_stacked_media_outer_query_order () =
   (* hover:sm: and sm:hover: carry the same variants, so the stack alone cannot
      separate them. The query each writes on the outside does: hover before sm,
@@ -1766,6 +1821,8 @@ let tests =
     test_case "stacked variant outline order" `Slow
       test_stacked_variant_outline_order;
     test_case "not-supports variant order" `Slow test_not_supports_variant_order;
+    test_case "variant table emission order" `Slow
+      test_variant_table_emission_order;
     test_case "stacked responsive variant order" `Slow
       test_stacked_responsive_variant_order;
     test_case "breakpoint groups stacked variants" `Slow


### PR DESCRIPTION
The variant cascade order was written four times on three numeric scales, and two of the copies were live bugs. A catch-all dropped any new constructor into the middle of the not-* range instead of failing to compile, and an unrecognised prefix returned 0 - not a small ordering error, because `sort.ml` partitions on `variant_order > 0`, so the rule landed in a different bucket entirely. A breakpoint token now carries its width in the variant key, which is what PRs #368 and #369 worked around rather than removed.

The slot order itself was wrong and the ladder test pinned it, because the test was written from the table rather than from the tool. Real Tailwind emits `md`, `@md`, `portrait`, `landscape`, `ltr`, `rtl`, `dark`, `starting`, `print`, `forced-colors`, `inverted-colors`, `pointer`, `any-pointer`, `noscript`; the table had pointer and any-pointer ahead of the breakpoints and container queries last.