### PR TITLE
color, animations, tw, utilities: close four type-safety residuals

### DIFF
--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -319,14 +319,13 @@ module Handler = struct
     | Bracket (_, anim) -> animate_bracket anim
     | Named name -> animate_named ~theme name
 
-  let suborder = function
-    | Bracket _ -> 0
-    | Bounce -> 1
-    | Named _ -> 2
-    | No_animation -> 3
-    | Ping -> 4
-    | Pulse -> 5
-    | Spin -> 6
+  (* Tailwind emits the animate-* rules in class-name order, with no family
+     structure above it: a project animation sits among the built-ins wherever
+     its own name falls, and an arbitrary one leads because the backslash its
+     bracket is escaped with precedes every letter. One shared slot hands the
+     whole family to the alphabetical tie-break, which is that order; numbering
+     the built-ins apart pins every theme-declared name to one gap instead. *)
+  let suborder _ = 0
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1402,20 +1402,13 @@ let color_var color shade =
   | Some var -> var
   | None ->
       let base = pp color in
-      (* Escape brackets in variable names - CSS variable names can't have
-         unescaped []. Almost no colour name contains brackets, so keep a
-         zero-allocation fast path and only build a buffer when needed. *)
-      let escaped_base =
-        if String.contains base '[' || String.contains base ']' then (
-          let buf = Buffer.create (String.length base + 4) in
-          String.iter
-            (fun c ->
-              (match c with '[' | ']' -> Buffer.add_char buf '\\' | _ -> ());
-              Buffer.add_char buf c)
-            base;
-          Buffer.contents buf)
-        else base
-      in
+      (* The name goes after the [--] this module does not write itself, so it
+         is a CSS name rather than a whole ident: [escape_name] is the exact
+         serialisation for that position. A palette colour is already all name
+         code points and comes back unchanged; an arbitrary one carries
+         brackets, a [#] or parens, and every one of those has to be escaped for
+         the result to lex as a single dashed ident. *)
+      let escaped_base = Cascade.Parser.escape_name base in
       let name =
         if shadeless then "color-" ^ escaped_base
         else Pp.str [ "color-"; escaped_base; "-"; string_of_int shade ]

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -8,111 +8,149 @@ module Css = Cascade.Css
 module Handler = struct
   open Style
 
-  type t = Keyword of Css.cursor | Bracket_var of string | Theme of string
+  (* The keywords a [cursor-*] class names, spelled as this module's own type
+     rather than as a [Css.cursor]. A [url()], a CSS-wide keyword and a [var()]
+     are all cursor values and none of them is a utility, so carrying the CSS
+     type here would leave [data] partial and [to_class] raising on a value it
+     was handed. *)
+  type keyword =
+    | Alias
+    | All_scroll
+    | Auto
+    | Cell
+    | Col_resize
+    | Context_menu
+    | Copy
+    | Crosshair
+    | Default
+    | E_resize
+    | Ew_resize
+    | Grab
+    | Grabbing
+    | Help
+    | Move
+    | N_resize
+    | Ne_resize
+    | Nesw_resize
+    | No_drop
+    | No_cursor
+    | Not_allowed
+    | Ns_resize
+    | Nw_resize
+    | Nwse_resize
+    | Pointer
+    | Progress
+    | Row_resize
+    | S_resize
+    | Se_resize
+    | Sw_resize
+    | Text
+    | Vertical_text
+    | W_resize
+    | Wait
+    | Zoom_in
+    | Zoom_out
+
+  type t = Keyword of keyword | Bracket_var of string | Theme of string
   type Utility.base += Self of t
 
   let name = "cursor"
   let priority _ = 11
 
-  (* Class suffix and cascade suborder of one cursor keyword, alphabetical by
-     suffix. Written as a match rather than a lookup table: a constructor added
-     to [Css.cursor] without an entry here is a compile error, not a [Not_found]
-     raised out of [to_class] partway through rendering a sheet. The [url()]
-     form, the CSS-wide keywords and [var()] are spelled out for the same
-     reason. *)
-  let data : Css.cursor -> string * int = function
-    | Css.Alias -> ("alias", 10)
-    | Css.All_scroll -> ("all-scroll", 20)
-    | Css.Auto -> ("auto", 30)
-    | Css.Cell -> ("cell", 40)
-    | Css.Col_resize -> ("col-resize", 50)
-    | Css.Context_menu -> ("context-menu", 60)
-    | Css.Copy -> ("copy", 70)
-    | Css.Crosshair -> ("crosshair", 80)
-    | Css.Default -> ("default", 90)
-    | Css.E_resize -> ("e-resize", 100)
-    | Css.Ew_resize -> ("ew-resize", 110)
-    | Css.Grab -> ("grab", 120)
-    | Css.Grabbing -> ("grabbing", 130)
-    | Css.Help -> ("help", 140)
-    | Css.Move -> ("move", 150)
-    | Css.N_resize -> ("n-resize", 160)
-    | Css.Ne_resize -> ("ne-resize", 170)
-    | Css.Nesw_resize -> ("nesw-resize", 180)
-    | Css.No_drop -> ("no-drop", 190)
-    | Css.None -> ("none", 200)
-    | Css.Not_allowed -> ("not-allowed", 210)
-    | Css.Ns_resize -> ("ns-resize", 220)
-    | Css.Nw_resize -> ("nw-resize", 230)
-    | Css.Nwse_resize -> ("nwse-resize", 240)
-    | Css.Pointer -> ("pointer", 250)
-    | Css.Progress -> ("progress", 260)
-    | Css.Row_resize -> ("row-resize", 270)
-    | Css.S_resize -> ("s-resize", 280)
-    | Css.Se_resize -> ("se-resize", 290)
-    | Css.Sw_resize -> ("sw-resize", 300)
-    | Css.Text -> ("text", 310)
-    | Css.Vertical_text -> ("vertical-text", 320)
-    | Css.W_resize -> ("w-resize", 330)
-    | Css.Wait -> ("wait", 340)
-    | Css.Zoom_in -> ("zoom-in", 350)
-    | Css.Zoom_out -> ("zoom-out", 360)
-    | Css.Url _ | Css.Inherit | Css.Initial | Css.Unset | Css.Revert
-    | Css.Revert_layer | Css.Var _ ->
-        (* No cursor class names a url(), a CSS-wide keyword or a var(), so
-           [of_class] never builds one: the bracket and theme forms have their
-           own constructors. *)
-        invalid_arg "cursor: value has no class name"
+  (* Class suffix, cursor value and cascade suborder of one keyword,
+     alphabetical by suffix. One match covers all three, so a constructor added
+     to [keyword] without an entry here is a compile error. *)
+  let data : keyword -> string * Css.cursor * int = function
+    | Alias -> ("alias", Css.Alias, 10)
+    | All_scroll -> ("all-scroll", Css.All_scroll, 20)
+    | Auto -> ("auto", Css.Auto, 30)
+    | Cell -> ("cell", Css.Cell, 40)
+    | Col_resize -> ("col-resize", Css.Col_resize, 50)
+    | Context_menu -> ("context-menu", Css.Context_menu, 60)
+    | Copy -> ("copy", Css.Copy, 70)
+    | Crosshair -> ("crosshair", Css.Crosshair, 80)
+    | Default -> ("default", Css.Default, 90)
+    | E_resize -> ("e-resize", Css.E_resize, 100)
+    | Ew_resize -> ("ew-resize", Css.Ew_resize, 110)
+    | Grab -> ("grab", Css.Grab, 120)
+    | Grabbing -> ("grabbing", Css.Grabbing, 130)
+    | Help -> ("help", Css.Help, 140)
+    | Move -> ("move", Css.Move, 150)
+    | N_resize -> ("n-resize", Css.N_resize, 160)
+    | Ne_resize -> ("ne-resize", Css.Ne_resize, 170)
+    | Nesw_resize -> ("nesw-resize", Css.Nesw_resize, 180)
+    | No_drop -> ("no-drop", Css.No_drop, 190)
+    | No_cursor -> ("none", Css.None, 200)
+    | Not_allowed -> ("not-allowed", Css.Not_allowed, 210)
+    | Ns_resize -> ("ns-resize", Css.Ns_resize, 220)
+    | Nw_resize -> ("nw-resize", Css.Nw_resize, 230)
+    | Nwse_resize -> ("nwse-resize", Css.Nwse_resize, 240)
+    | Pointer -> ("pointer", Css.Pointer, 250)
+    | Progress -> ("progress", Css.Progress, 260)
+    | Row_resize -> ("row-resize", Css.Row_resize, 270)
+    | S_resize -> ("s-resize", Css.S_resize, 280)
+    | Se_resize -> ("se-resize", Css.Se_resize, 290)
+    | Sw_resize -> ("sw-resize", Css.Sw_resize, 300)
+    | Text -> ("text", Css.Text, 310)
+    | Vertical_text -> ("vertical-text", Css.Vertical_text, 320)
+    | W_resize -> ("w-resize", Css.W_resize, 330)
+    | Wait -> ("wait", Css.Wait, 340)
+    | Zoom_in -> ("zoom-in", Css.Zoom_in, 350)
+    | Zoom_out -> ("zoom-out", Css.Zoom_out, 360)
 
   (* Every keyword a class names, in suffix order, for the class-name lookup and
      for placing a theme cursor among them. *)
-  let all : Css.cursor list =
+  let all =
     [
-      Css.Alias;
-      Css.All_scroll;
-      Css.Auto;
-      Css.Cell;
-      Css.Col_resize;
-      Css.Context_menu;
-      Css.Copy;
-      Css.Crosshair;
-      Css.Default;
-      Css.E_resize;
-      Css.Ew_resize;
-      Css.Grab;
-      Css.Grabbing;
-      Css.Help;
-      Css.Move;
-      Css.N_resize;
-      Css.Ne_resize;
-      Css.Nesw_resize;
-      Css.No_drop;
-      Css.None;
-      Css.Not_allowed;
-      Css.Ns_resize;
-      Css.Nw_resize;
-      Css.Nwse_resize;
-      Css.Pointer;
-      Css.Progress;
-      Css.Row_resize;
-      Css.S_resize;
-      Css.Se_resize;
-      Css.Sw_resize;
-      Css.Text;
-      Css.Vertical_text;
-      Css.W_resize;
-      Css.Wait;
-      Css.Zoom_in;
-      Css.Zoom_out;
+      Alias;
+      All_scroll;
+      Auto;
+      Cell;
+      Col_resize;
+      Context_menu;
+      Copy;
+      Crosshair;
+      Default;
+      E_resize;
+      Ew_resize;
+      Grab;
+      Grabbing;
+      Help;
+      Move;
+      N_resize;
+      Ne_resize;
+      Nesw_resize;
+      No_drop;
+      No_cursor;
+      Not_allowed;
+      Ns_resize;
+      Nw_resize;
+      Nwse_resize;
+      Pointer;
+      Progress;
+      Row_resize;
+      S_resize;
+      Se_resize;
+      Sw_resize;
+      Text;
+      Vertical_text;
+      W_resize;
+      Wait;
+      Zoom_in;
+      Zoom_out;
     ]
 
+  let keyword_suffix v =
+    let suffix, _, _ = data v in
+    suffix
+
   let of_class_map =
-    List.map (fun v -> ("cursor-" ^ fst (data v), Keyword v)) all
+    List.map (fun v -> ("cursor-" ^ keyword_suffix v, Keyword v)) all
 
   let to_class = function
     | Bracket_var s -> "cursor-[" ^ s ^ "]"
     | Theme name -> "cursor-" ^ name
-    | Keyword v -> "cursor-" ^ fst (data v)
+    | Keyword v -> "cursor-" ^ keyword_suffix v
 
   let to_style theme = function
     | Bracket_var s ->
@@ -133,11 +171,18 @@ module Handler = struct
             in
             style [ theme_decl; Css.cursor (Css.Var ref) ]
         | None -> style [ Css.cursor (Css.Var ref) ])
-    | Keyword v -> style [ Css.cursor v ]
+    | Keyword v ->
+        let _, cursor, _ = data v in
+        style [ Css.cursor cursor ]
 
   (* The keyword suffixes with their suborders, for placing a theme cursor among
      them. *)
-  let sorted_suffixes = List.map data all
+  let sorted_suffixes =
+    List.map
+      (fun v ->
+        let suffix, _, order = data v in
+        (suffix, order))
+      all
 
   let theme_suborder name =
     (* Find alphabetical position among known cursors *)
@@ -151,7 +196,9 @@ module Handler = struct
   let suborder = function
     | Bracket_var _ -> -1
     | Theme name -> theme_suborder name
-    | Keyword v -> snd (data v)
+    | Keyword v ->
+        let _, _, order = data v in
+        order
 
   let of_class _theme cls =
     let parts = Parse.split_class cls in
@@ -169,7 +216,7 @@ module Handler = struct
         | Some t -> Ok t
         | None -> Error (`Msg "Not a cursor utility"))
 
-  let examples = [ Keyword Css.Auto ]
+  let examples = [ Keyword Auto ]
 end
 
 open Handler
@@ -180,39 +227,39 @@ let () = Utility.register (module Handler)
 (** Public API returning Utility.t *)
 let utility x = Utility.base (Self x)
 
-let cursor_alias = utility (Keyword Css.Alias)
-let cursor_all_scroll = utility (Keyword Css.All_scroll)
-let cursor_auto = utility (Keyword Css.Auto)
-let cursor_cell = utility (Keyword Css.Cell)
-let cursor_col_resize = utility (Keyword Css.Col_resize)
-let cursor_context_menu = utility (Keyword Css.Context_menu)
-let cursor_copy = utility (Keyword Css.Copy)
-let cursor_crosshair = utility (Keyword Css.Crosshair)
-let cursor_default = utility (Keyword Css.Default)
-let cursor_e_resize = utility (Keyword Css.E_resize)
-let cursor_ew_resize = utility (Keyword Css.Ew_resize)
-let cursor_grab = utility (Keyword Css.Grab)
-let cursor_grabbing = utility (Keyword Css.Grabbing)
-let cursor_help = utility (Keyword Css.Help)
-let cursor_move = utility (Keyword Css.Move)
-let cursor_n_resize = utility (Keyword Css.N_resize)
-let cursor_ne_resize = utility (Keyword Css.Ne_resize)
-let cursor_nesw_resize = utility (Keyword Css.Nesw_resize)
-let cursor_no_drop = utility (Keyword Css.No_drop)
-let cursor_none = utility (Keyword Css.None)
-let cursor_not_allowed = utility (Keyword Css.Not_allowed)
-let cursor_ns_resize = utility (Keyword Css.Ns_resize)
-let cursor_nw_resize = utility (Keyword Css.Nw_resize)
-let cursor_nwse_resize = utility (Keyword Css.Nwse_resize)
-let cursor_pointer = utility (Keyword Css.Pointer)
-let cursor_progress = utility (Keyword Css.Progress)
-let cursor_row_resize = utility (Keyword Css.Row_resize)
-let cursor_s_resize = utility (Keyword Css.S_resize)
-let cursor_se_resize = utility (Keyword Css.Se_resize)
-let cursor_sw_resize = utility (Keyword Css.Sw_resize)
-let cursor_text = utility (Keyword Css.Text)
-let cursor_vertical_text = utility (Keyword Css.Vertical_text)
-let cursor_w_resize = utility (Keyword Css.W_resize)
-let cursor_wait = utility (Keyword Css.Wait)
-let cursor_zoom_in = utility (Keyword Css.Zoom_in)
-let cursor_zoom_out = utility (Keyword Css.Zoom_out)
+let cursor_alias = utility (Keyword Alias)
+let cursor_all_scroll = utility (Keyword All_scroll)
+let cursor_auto = utility (Keyword Auto)
+let cursor_cell = utility (Keyword Cell)
+let cursor_col_resize = utility (Keyword Col_resize)
+let cursor_context_menu = utility (Keyword Context_menu)
+let cursor_copy = utility (Keyword Copy)
+let cursor_crosshair = utility (Keyword Crosshair)
+let cursor_default = utility (Keyword Default)
+let cursor_e_resize = utility (Keyword E_resize)
+let cursor_ew_resize = utility (Keyword Ew_resize)
+let cursor_grab = utility (Keyword Grab)
+let cursor_grabbing = utility (Keyword Grabbing)
+let cursor_help = utility (Keyword Help)
+let cursor_move = utility (Keyword Move)
+let cursor_n_resize = utility (Keyword N_resize)
+let cursor_ne_resize = utility (Keyword Ne_resize)
+let cursor_nesw_resize = utility (Keyword Nesw_resize)
+let cursor_no_drop = utility (Keyword No_drop)
+let cursor_none = utility (Keyword No_cursor)
+let cursor_not_allowed = utility (Keyword Not_allowed)
+let cursor_ns_resize = utility (Keyword Ns_resize)
+let cursor_nw_resize = utility (Keyword Nw_resize)
+let cursor_nwse_resize = utility (Keyword Nwse_resize)
+let cursor_pointer = utility (Keyword Pointer)
+let cursor_progress = utility (Keyword Progress)
+let cursor_row_resize = utility (Keyword Row_resize)
+let cursor_s_resize = utility (Keyword S_resize)
+let cursor_se_resize = utility (Keyword Se_resize)
+let cursor_sw_resize = utility (Keyword Sw_resize)
+let cursor_text = utility (Keyword Text)
+let cursor_vertical_text = utility (Keyword Vertical_text)
+let cursor_w_resize = utility (Keyword W_resize)
+let cursor_wait = utility (Keyword Wait)
+let cursor_zoom_in = utility (Keyword Zoom_in)
+let cursor_zoom_out = utility (Keyword Zoom_out)

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -8,58 +8,51 @@ module Css = Cascade.Css
 module Handler = struct
   open Style
 
-  type t = Direction of Css.flex_direction | Wrap of Css.flex_wrap
+  (* The seven values a [flex-*] class names, spelled as the utility's own type
+     rather than as a pair of CSS value types. A CSS-wide keyword and a [var()]
+     are both a [Css.flex_direction] and neither is a utility, so carrying the
+     CSS type here would leave [data] partial and [to_class] raising on a value
+     it was handed. *)
+  type t =
+    | Col
+    | Col_reverse
+    | Row
+    | Row_reverse
+    | Nowrap
+    | Wrap
+    | Wrap_reverse
+
   type Utility.base += Self of t
 
   let name = "flex_layout"
   let priority _ = 16
 
-  (* Class suffix and cascade suborder of one utility, as a match rather than a
-     lookup table: a constructor added to either CSS value type without an entry
-     here is a compile error, not a [Not_found] raised out of [to_class] partway
-     through rendering a sheet. The CSS-wide keywords and the [var()] forms are
-     spelled out rather than swept up by a catch-all, for the same reason. *)
-  let data : t -> string * int = function
-    | Direction Css.Column -> ("col", 0)
-    | Direction Css.Column_reverse -> ("col-reverse", 1)
-    | Direction Css.Row -> ("row", 2)
-    | Direction Css.Row_reverse -> ("row-reverse", 3)
-    | Wrap Css.Nowrap -> ("nowrap", 10)
-    | Wrap Css.Wrap -> ("wrap", 11)
-    | Wrap Css.Wrap_reverse -> ("wrap-reverse", 12)
-    | Direction
-        ( Css.Inherit | Css.Initial | Css.Unset | Css.Revert | Css.Revert_layer
-        | Css.Var _ )
-    | Wrap
-        ( Css.Inherit | Css.Initial | Css.Unset | Css.Revert | Css.Revert_layer
-        | Css.Var _ ) ->
-        (* No flex class names a CSS-wide keyword or a var(), so [of_class]
-           never builds one. *)
-        invalid_arg "flex_layout: value has no class name"
+  (* Class suffix, declaration and cascade suborder of one utility, in one
+     match, so a constructor added above without an entry here is a compile
+     error. *)
+  let data : t -> string * Css.declaration * int = function
+    | Col -> ("col", Css.flex_direction Css.Column, 0)
+    | Col_reverse -> ("col-reverse", Css.flex_direction Css.Column_reverse, 1)
+    | Row -> ("row", Css.flex_direction Css.Row, 2)
+    | Row_reverse -> ("row-reverse", Css.flex_direction Css.Row_reverse, 3)
+    | Nowrap -> ("nowrap", Css.flex_wrap Css.Nowrap, 10)
+    | Wrap -> ("wrap", Css.flex_wrap Css.Wrap, 11)
+    | Wrap_reverse -> ("wrap-reverse", Css.flex_wrap Css.Wrap_reverse, 12)
 
   (* Every constructor a class names, for the class-name lookup. *)
-  let all =
-    [
-      Direction Css.Column;
-      Direction Css.Column_reverse;
-      Direction Css.Row;
-      Direction Css.Row_reverse;
-      Wrap Css.Nowrap;
-      Wrap Css.Wrap;
-      Wrap Css.Wrap_reverse;
-    ]
+  let all = [ Col; Col_reverse; Row; Row_reverse; Nowrap; Wrap; Wrap_reverse ]
 
   let to_class t =
-    let suffix, _ = data t in
+    let suffix, _, _ = data t in
     "flex-" ^ suffix
 
   let suborder t =
-    let _, o = data t in
+    let _, _, o = data t in
     o
 
-  let to_style _theme = function
-    | Direction d -> style [ Css.flex_direction d ]
-    | Wrap w -> style [ Css.flex_wrap w ]
+  let to_style _theme t =
+    let _, decl, _ = data t in
+    style [ decl ]
 
   let of_class_map = List.map (fun t -> (to_class t, t)) all
 
@@ -68,7 +61,7 @@ module Handler = struct
     | Some t -> Ok t
     | None -> Error (`Msg "Not a flex layout utility")
 
-  let examples = [ Direction Css.Row; Wrap Css.Wrap ]
+  let examples = [ Row; Wrap ]
 end
 
 open Handler
@@ -77,10 +70,10 @@ open Handler
 let () = Utility.register (module Handler)
 
 let utility x = Utility.base (Self x)
-let flex_row = utility (Direction Css.Row)
-let flex_row_reverse = utility (Direction Css.Row_reverse)
-let flex_col = utility (Direction Css.Column)
-let flex_col_reverse = utility (Direction Css.Column_reverse)
-let flex_wrap = utility (Wrap Css.Wrap)
-let flex_wrap_reverse = utility (Wrap Css.Wrap_reverse)
-let flex_nowrap = utility (Wrap Css.Nowrap)
+let flex_row = utility Row
+let flex_row_reverse = utility Row_reverse
+let flex_col = utility Col
+let flex_col_reverse = utility Col_reverse
+let flex_wrap = utility Wrap
+let flex_wrap_reverse = utility Wrap_reverse
+let flex_nowrap = utility Nowrap

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -30,15 +30,19 @@ module Handler = struct
   let err_invalid_cols = Error (`Msg "Invalid grid-cols value")
   let err_invalid_rows = Error (`Msg "Invalid grid-rows value")
 
+  (* The four arbitrary forms carry the parse beside the text an author wrote:
+     the text spells the class name back and the parse renders it. Keeping only
+     the text left [to_style] re-parsing on every render, with nothing but a
+     comment to say it could not fail. *)
   type t =
     | Grid_cols of int
     | Grid_cols_none
     | Grid_cols_subgrid
-    | Grid_cols_arbitrary of string
+    | Grid_cols_arbitrary of string * Css.grid_template
     | Grid_rows of int
     | Grid_rows_none
     | Grid_rows_subgrid
-    | Grid_rows_arbitrary of string
+    | Grid_rows_arbitrary of string * Css.grid_template
     | Grid_flow_row
     | Grid_flow_col
     | Grid_flow_dense
@@ -49,13 +53,13 @@ module Handler = struct
     | Auto_cols_max
     | Auto_cols_fr
     | Auto_cols_spacing of float  (** [auto-cols-<n>]: spacing-scaled track. *)
-    | Auto_cols_arbitrary of string
+    | Auto_cols_arbitrary of string * Css.grid_template
     | Auto_rows_auto
     | Auto_rows_min
     | Auto_rows_max
     | Auto_rows_fr
     | Auto_rows_spacing of float  (** [auto-rows-<n>]: spacing-scaled track. *)
-    | Auto_rows_arbitrary of string
+    | Auto_rows_arbitrary of string * Css.grid_template
 
   type Utility.base += Self of t
 
@@ -256,13 +260,6 @@ module Handler = struct
         | Some ts -> Some (Tracks ts)
         | None -> None)
 
-  (* Should never fail: of_class validates arbitrary values before constructing
-     [Grid_cols_arbitrary]/[Grid_rows_arbitrary]. *)
-  let parse_arbitrary_grid_template_exn s =
-    match parse_arbitrary_grid_template s with
-    | Some v -> v
-    | None -> invalid_arg ("Unparseable grid template: " ^ s)
-
   (* A track written with the [--spacing()] shorthand reads the scale, so the
      token has to be declared alongside it. *)
   let spacing_decls s =
@@ -279,15 +276,11 @@ module Handler = struct
       [ decl ]
     else []
 
-  let grid_cols_arbitrary s =
-    style
-      (spacing_decls s
-      @ [ Css.grid_template_columns (parse_arbitrary_grid_template_exn s) ])
+  let grid_cols_arbitrary s template =
+    style (spacing_decls s @ [ Css.grid_template_columns template ])
 
-  let grid_rows_arbitrary s =
-    style
-      (spacing_decls s
-      @ [ Css.grid_template_rows (parse_arbitrary_grid_template_exn s) ])
+  let grid_rows_arbitrary s template =
+    style (spacing_decls s @ [ Css.grid_template_rows template ])
 
   let grid_rows n =
     if n < 1 || n > 999 then
@@ -322,9 +315,7 @@ module Handler = struct
   let auto_cols_min = style [ Css.grid_auto_columns Min_content ]
   let auto_cols_max = style [ Css.grid_auto_columns Max_content ]
   let auto_cols_fr = style [ Css.grid_auto_columns (Min_max (Zero, Fr 1.0)) ]
-
-  let auto_cols_arbitrary s =
-    style [ Css.grid_auto_columns (parse_arbitrary_grid_template_exn s) ]
+  let auto_cols_arbitrary template = style [ Css.grid_auto_columns template ]
 
   (* [auto-cols-<n>] sizes implicit columns to a spacing-scaled track,
      [grid-auto-columns: calc(var(--spacing) * n)]. *)
@@ -343,9 +334,7 @@ module Handler = struct
   let auto_rows_min = style [ Css.grid_auto_rows Min_content ]
   let auto_rows_max = style [ Css.grid_auto_rows Max_content ]
   let auto_rows_fr = style [ Css.grid_auto_rows (Min_max (Zero, Fr 1.0)) ]
-
-  let auto_rows_arbitrary s =
-    style [ Css.grid_auto_rows (parse_arbitrary_grid_template_exn s) ]
+  let auto_rows_arbitrary template = style [ Css.grid_auto_rows template ]
 
   let auto_rows_spacing ?theme n =
     let decl, len = Theme.spacing_calc_float ?theme n in
@@ -363,11 +352,11 @@ module Handler = struct
     | Grid_cols n -> grid_cols n
     | Grid_cols_none -> grid_cols_none ()
     | Grid_cols_subgrid -> grid_cols_subgrid
-    | Grid_cols_arbitrary s -> grid_cols_arbitrary s
+    | Grid_cols_arbitrary (s, template) -> grid_cols_arbitrary s template
     | Grid_rows n -> grid_rows n
     | Grid_rows_none -> grid_rows_none ()
     | Grid_rows_subgrid -> grid_rows_subgrid
-    | Grid_rows_arbitrary s -> grid_rows_arbitrary s
+    | Grid_rows_arbitrary (s, template) -> grid_rows_arbitrary s template
     | Grid_flow_row -> grid_flow_row
     | Grid_flow_col -> grid_flow_col
     | Grid_flow_dense -> grid_flow_dense
@@ -378,13 +367,13 @@ module Handler = struct
     | Auto_cols_max -> auto_cols_max
     | Auto_cols_fr -> auto_cols_fr
     | Auto_cols_spacing n -> auto_cols_spacing n
-    | Auto_cols_arbitrary s -> auto_cols_arbitrary s
+    | Auto_cols_arbitrary (_, template) -> auto_cols_arbitrary template
     | Auto_rows_auto -> auto_rows_auto ()
     | Auto_rows_min -> auto_rows_min
     | Auto_rows_max -> auto_rows_max
     | Auto_rows_fr -> auto_rows_fr
     | Auto_rows_spacing n -> auto_rows_spacing n
-    | Auto_rows_arbitrary s -> auto_rows_arbitrary s
+    | Auto_rows_arbitrary (_, template) -> auto_rows_arbitrary template
 
   let suborder = function
     (* Grid template columns (10000-10999) *)
@@ -430,7 +419,7 @@ module Handler = struct
         if len > 2 && n.[0] = '[' && n.[len - 1] = ']' then
           let inner = String.sub n 1 (len - 2) in
           match parse_arbitrary_grid_template inner with
-          | Some _ -> Ok (Grid_cols_arbitrary inner)
+          | Some template -> Ok (Grid_cols_arbitrary (inner, template))
           | None -> err_invalid_cols
         else
           match Parse.decimal_int n with
@@ -443,7 +432,7 @@ module Handler = struct
         if len > 2 && n.[0] = '[' && n.[len - 1] = ']' then
           let inner = String.sub n 1 (len - 2) in
           match parse_arbitrary_grid_template inner with
-          | Some _ -> Ok (Grid_rows_arbitrary inner)
+          | Some template -> Ok (Grid_rows_arbitrary (inner, template))
           | None -> err_invalid_rows
         else
           match Parse.decimal_int n with
@@ -466,7 +455,7 @@ module Handler = struct
             if len > 2 && n.[0] = '[' && n.[len - 1] = ']' then
               let inner = String.sub n 1 (len - 2) in
               match parse_arbitrary_grid_template inner with
-              | Some _ -> Ok (Auto_cols_arbitrary inner)
+              | Some template -> Ok (Auto_cols_arbitrary (inner, template))
               | None -> err_not_utility
             else err_not_utility)
     | [ "auto"; "rows"; "auto" ] -> Ok Auto_rows_auto
@@ -481,7 +470,7 @@ module Handler = struct
             if len > 2 && n.[0] = '[' && n.[len - 1] = ']' then
               let inner = String.sub n 1 (len - 2) in
               match parse_arbitrary_grid_template inner with
-              | Some _ -> Ok (Auto_rows_arbitrary inner)
+              | Some template -> Ok (Auto_rows_arbitrary (inner, template))
               | None -> err_not_utility
             else err_not_utility)
     | _ -> err_not_utility
@@ -490,11 +479,11 @@ module Handler = struct
     | Grid_cols n -> "grid-cols-" ^ string_of_int n
     | Grid_cols_none -> "grid-cols-none"
     | Grid_cols_subgrid -> "grid-cols-subgrid"
-    | Grid_cols_arbitrary s -> "grid-cols-[" ^ s ^ "]"
+    | Grid_cols_arbitrary (s, _) -> "grid-cols-[" ^ s ^ "]"
     | Grid_rows n -> "grid-rows-" ^ string_of_int n
     | Grid_rows_none -> "grid-rows-none"
     | Grid_rows_subgrid -> "grid-rows-subgrid"
-    | Grid_rows_arbitrary s -> "grid-rows-[" ^ s ^ "]"
+    | Grid_rows_arbitrary (s, _) -> "grid-rows-[" ^ s ^ "]"
     | Grid_flow_row -> "grid-flow-row"
     | Grid_flow_col -> "grid-flow-col"
     | Grid_flow_dense -> "grid-flow-dense"
@@ -505,13 +494,13 @@ module Handler = struct
     | Auto_cols_max -> "auto-cols-max"
     | Auto_cols_fr -> "auto-cols-fr"
     | Auto_cols_spacing n -> "auto-cols-" ^ pp_float n
-    | Auto_cols_arbitrary s -> "auto-cols-[" ^ s ^ "]"
+    | Auto_cols_arbitrary (s, _) -> "auto-cols-[" ^ s ^ "]"
     | Auto_rows_auto -> "auto-rows-auto"
     | Auto_rows_min -> "auto-rows-min"
     | Auto_rows_max -> "auto-rows-max"
     | Auto_rows_fr -> "auto-rows-fr"
     | Auto_rows_spacing n -> "auto-rows-" ^ pp_float n
-    | Auto_rows_arbitrary s -> "auto-rows-[" ^ s ^ "]"
+    | Auto_rows_arbitrary (s, _) -> "auto-rows-[" ^ s ^ "]"
 
   let examples =
     [

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -9,7 +9,23 @@ module Handler = struct
   open Style
   open Css
 
-  type t = Action of Css.touch_action
+  (* The ten values a [touch-*] class names, spelled as the utility's own type
+     rather than as a [Css.touch_action]. A composed list, a CSS-wide keyword
+     and a [var()] are all touch-action values and none of them is a utility, so
+     carrying the CSS type here would leave [data] partial and [to_class]
+     raising on a value it was handed. *)
+  type t =
+    | Auto
+    | Manipulation
+    | No_action
+    | Pan_left
+    | Pan_right
+    | Pan_x
+    | Pan_down
+    | Pan_up
+    | Pan_y
+    | Pinch_zoom
+
   type Utility.base += Self of t
 
   let name = "touch"
@@ -45,79 +61,71 @@ module Handler = struct
     style ~property_rules:touch_props [ decl; composable_touch_action () ]
 
   (* Class suffix, style and cascade suborder of one utility, alphabetical
-     except that the x-axis pans come before the y-axis ones. Written as a match
-     rather than a lookup table: a constructor added to [Css.touch_action]
-     without an entry here is a compile error, not a [Not_found] raised out of
-     [to_class] partway through rendering a sheet. The CSS-wide keywords and the
-     composed and var() forms are spelled out for the same reason. *)
-  let data : Css.touch_action -> string * Style.t * int = function
-    | Css.Auto -> ("auto", style [ touch_action Css.Auto ], 0)
-    | Css.Manipulation ->
+     except that the x-axis pans come before the y-axis ones. One match covers
+     all three, so a constructor added to [t] without an entry here is a compile
+     error. *)
+  let data : t -> string * Style.t * int = function
+    | Auto -> ("auto", style [ touch_action Css.Auto ], 0)
+    | Manipulation ->
         ("manipulation", style [ touch_action Css.Manipulation ], 1)
-    | Css.None -> ("none", style [ touch_action Css.None ], 2)
-    | Css.Pan_left -> ("pan-left", composable_style tw_pan_x_var Css.Pan_left, 3)
-    | Css.Pan_right ->
-        ("pan-right", composable_style tw_pan_x_var Css.Pan_right, 4)
-    | Css.Pan_x -> ("pan-x", composable_style tw_pan_x_var Css.Pan_x, 5)
-    | Css.Pan_down -> ("pan-down", composable_style tw_pan_y_var Css.Pan_down, 6)
-    | Css.Pan_up -> ("pan-up", composable_style tw_pan_y_var Css.Pan_up, 7)
-    | Css.Pan_y -> ("pan-y", composable_style tw_pan_y_var Css.Pan_y, 8)
-    | Css.Pinch_zoom ->
+    | No_action -> ("none", style [ touch_action Css.None ], 2)
+    | Pan_left -> ("pan-left", composable_style tw_pan_x_var Css.Pan_left, 3)
+    | Pan_right -> ("pan-right", composable_style tw_pan_x_var Css.Pan_right, 4)
+    | Pan_x -> ("pan-x", composable_style tw_pan_x_var Css.Pan_x, 5)
+    | Pan_down -> ("pan-down", composable_style tw_pan_y_var Css.Pan_down, 6)
+    | Pan_up -> ("pan-up", composable_style tw_pan_y_var Css.Pan_up, 7)
+    | Pan_y -> ("pan-y", composable_style tw_pan_y_var Css.Pan_y, 8)
+    | Pinch_zoom ->
         ("pinch-zoom", composable_style tw_pinch_zoom_var Css.Pinch_zoom, 9)
-    | Css.Actions _ | Css.Inherit | Css.Initial | Css.Unset | Css.Revert
-    | Css.Revert_layer | Css.Vars _ | Css.Var _ ->
-        (* No touch class names a composed list, a CSS-wide keyword or a var(),
-           so [of_class] never builds one. *)
-        invalid_arg "touch: value has no class name"
 
   (* Every value a class names, for the class-name lookup. *)
-  let all : Css.touch_action list =
+  let all =
     [
-      Css.Auto;
-      Css.Manipulation;
-      Css.None;
-      Css.Pan_left;
-      Css.Pan_right;
-      Css.Pan_x;
-      Css.Pan_down;
-      Css.Pan_up;
-      Css.Pan_y;
-      Css.Pinch_zoom;
+      Auto;
+      Manipulation;
+      No_action;
+      Pan_left;
+      Pan_right;
+      Pan_x;
+      Pan_down;
+      Pan_up;
+      Pan_y;
+      Pinch_zoom;
     ]
 
-  let to_class (Action v) =
+  let to_class v =
     let suffix, _, _ = data v in
     "touch-" ^ suffix
 
-  let to_style _theme (Action v) =
+  let to_style _theme v =
     let _, s, _ = data v in
     s
 
-  let suborder (Action v) =
+  let suborder v =
     let _, _, o = data v in
     o
 
-  let of_class_map = List.map (fun v -> (to_class (Action v), Action v)) all
+  let of_class_map = List.map (fun v -> (to_class v, v)) all
 
   let of_class _theme cls =
     match List.assoc_opt cls of_class_map with
     | Some t -> Ok t
     | None -> Error (`Msg "Not a touch-action utility")
 
-  let examples = [ Action Css.Auto ]
+  let examples = [ Auto ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let touch_auto = utility (Action Css.Auto)
-let touch_none = utility (Action Css.None)
-let touch_manipulation = utility (Action Css.Manipulation)
-let touch_pan_x = utility (Action Css.Pan_x)
-let touch_pan_y = utility (Action Css.Pan_y)
-let touch_pan_left = utility (Action Css.Pan_left)
-let touch_pan_right = utility (Action Css.Pan_right)
-let touch_pan_up = utility (Action Css.Pan_up)
-let touch_pan_down = utility (Action Css.Pan_down)
-let touch_pinch_zoom = utility (Action Css.Pinch_zoom)
+let touch_auto = utility Auto
+let touch_none = utility No_action
+let touch_manipulation = utility Manipulation
+let touch_pan_x = utility Pan_x
+let touch_pan_y = utility Pan_y
+let touch_pan_left = utility Pan_left
+let touch_pan_right = utility Pan_right
+let touch_pan_up = utility Pan_up
+let touch_pan_down = utility Pan_down
+let touch_pinch_zoom = utility Pinch_zoom

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -181,16 +181,14 @@ let theme_resolve_path ~theme inner =
           | Some a -> theme_color_with_alpha base a
           | None -> Some base)
       | _ -> None)
-  | [ "spacing"; n ] -> (
-      match float_of_string_opt n with
-      | Some nf ->
-          let rem = nf *. 0.25 in
-          let s =
-            if Float.is_integer rem then string_of_int (int_of_float rem)
-            else string_of_float rem
-          in
-          Some (String.concat "" [ s; "rem" ])
-      | None -> None)
+  | [ "spacing"; n ] ->
+      (* The step here is Tailwind's own 0.25rem and not whatever [--spacing]
+         the project set: checked against the CLI with [@theme { --spacing:
+         0.5rem }], both sheets still resolve [theme(spacing.4)] to [1rem], so
+         reading the theme would lose parity rather than gain it.
+         [Theme.spacing_times] is that same fixed product, and going through it
+         is what keeps the two spellings of it in step. *)
+      Stdlib.Option.bind (float_of_string_opt n) Theme.spacing_times
   | _ -> None
 
 (* Replace each theme(<path>) in a class string with its resolved value, spaces

--- a/test/test_animations.ml
+++ b/test/test_animations.ml
@@ -182,6 +182,57 @@ let test_keyframes_for_theme_and_bracket_names () =
     "bracket naming an unknown animation" []
     (animate_keyframes "animate-[wiggle_1s_ease-in-out_infinite]")
 
+(* Tailwind orders the [animate-*] rules alphabetically by class name and a
+   theme-declared animation is just another name in that order. Measured with
+   the pinned CLI over an [@theme] declaring [--animate-aaa], [--animate-mmm]
+   and [--animate-zzz]: aaa, bounce, mmm, none, ping, pulse, spin, zzz. The
+   ordering helpers drive the CLI without a theme, so the expectation is written
+   out rather than compared against a live run. *)
+let test_theme_animation_sorts_by_name () =
+  let theme =
+    {
+      Tw.Scheme.default with
+      token_overrides =
+        [
+          ("animate-aaa", "aaa 1s linear infinite");
+          ("animate-mmm", "mmm 1s linear infinite");
+          ("animate-zzz", "zzz 1s linear infinite");
+        ];
+    }
+  in
+  let utility cls =
+    match Tw.of_string ~theme cls with
+    | Ok u -> u
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let utilities =
+    List.map utility
+      [
+        "animate-pulse";
+        "animate-zzz";
+        "animate-spin";
+        "animate-bounce";
+        "animate-aaa";
+        "animate-mmm";
+        "animate-none";
+        "animate-ping";
+      ]
+  in
+  let css = Tw.to_css ~theme ~base:false utilities in
+  Alcotest.(check (list string))
+    "alphabetical by class name"
+    [
+      ".animate-aaa";
+      ".animate-bounce";
+      ".animate-mmm";
+      ".animate-none";
+      ".animate-ping";
+      ".animate-pulse";
+      ".animate-spin";
+      ".animate-zzz";
+    ]
+    (Test_helpers.selectors_in_layer "utilities" css)
+
 let tests =
   [
     test_case "transitions" `Quick test_transitions;
@@ -197,6 +248,8 @@ let tests =
       test_keyframes_follow_the_animation_name;
     test_case "keyframes for theme and bracket names" `Quick
       test_keyframes_for_theme_and_bracket_names;
+    test_case "theme animation sorts by name" `Quick
+      test_theme_animation_sorts_by_name;
   ]
 
 let suite = ("animations", tests)

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -887,9 +887,48 @@ let test_opacity_modifier_rejects_non_numeric () =
       "shadow-lg/[25px]";
     ]
 
+(* A custom property is a dashed ident, so every byte of its name outside the
+   CSS name set has to carry a backslash for the whole thing to lex as one
+   token. Walking the name is the check: a bare [#], [(] or [,] ends the ident
+   and turns the rest into stray tokens. *)
+let check_escaped_name name =
+  let n = String.length name in
+  let is_name_code_point c =
+    match c with
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+    | c -> Char.code c >= 0x80
+  in
+  let rec walk i =
+    if i >= n then ()
+    else if name.[i] = '\\' then walk (i + 2)
+    else if is_name_code_point name.[i] then walk (i + 1)
+    else Alcotest.failf "--%s: %C at offset %d is unescaped" name name.[i] i
+  in
+  walk 0
+
+(* [color_var] is public, so it has to name a variable that a browser can read
+   whatever colour it is handed - the utility API happens to branch on
+   [is_custom_color] before it gets here, but the signature makes no such
+   promise. *)
+let test_color_var_name_is_one_ident () =
+  List.iter
+    (fun color -> check_escaped_name (Tw.Var.name (color_var color 500)))
+    [
+      Red;
+      Black;
+      Theme_named "brand";
+      Hex "0088cc";
+      Rgb { red = 1; green = 2; blue = 3 };
+      Oklch { l = 50.; c = 0.1; h = 20. };
+      Css (Css.hex "#0088cc");
+    ]
+
 let tests =
   [
     ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
+    ( "Colour variable name is one ident",
+      `Quick,
+      test_color_var_name_is_one_ident );
     ("Achromatic colour keeps a none hue", `Quick, test_achromatic_none_hue);
     ("Per-side border colors", `Quick, test_border_side_color);
     ("Border color var", `Quick, test_border_color_var);


### PR DESCRIPTION
`Color.color_var` hand-escaped only brackets, so a `Hex`, `Rgb` or `Oklch` base came out with an unescaped `#` or `(` inside an ident. It now uses `Cascade.Parser.escape_name`. Nothing moves: instrumenting the old and new escaping over the main suite, the upstream corpus and 102 hand-built arbitrary-colour classes gave zero divergences, because arbitrary colours reach the utilities as bracket source variants and every named path branches on `is_custom_color` first. Only the public entry point becomes correct.

A theme-declared `animate-<name>` sorted before the built-ins. Checked against the pinned CLI with `@theme` declaring three names: Tailwind emits the family in plain class-name order with the arbitrary bracket first, so there is no family structure to model and the comparator's existing alphabetical tie-break reproduces it once the suborder collapses to one slot.

`theme(spacing.N)` recomputed the spacing step and re-implemented the rem formatting. It routes through `Theme.spacing_times` now. The step stays fixed on purpose, which is counterintuitive enough that the comment now says why: with `@theme { --spacing: 0.5rem }` both Tailwind and tw still emit `1rem` for `theme(spacing.4)`, so reading the theme here would break parity.

`cursor`, `touch` and `flex_layout` each carried a CSS value type as the utility type, so `url()`, composed lists and `var()` were representable and had to be swept into a raising case; each has its own closed type now. `grid_template` parsed an arbitrary template to validate it, threw the parse away, and re-parsed in `to_style` behind an `invalid_arg`; the constructor carries both spellings. That takes the partial-function count from 45 to 41; the rest are weighed in TODO.md with what each would cost.