### PR TITLE
typography, borders, divide, effects: retire the entries cascade unblocked

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -815,6 +815,7 @@ module Handler = struct
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' || c = '-' in
         let is_width =
           (String.length inner > 0 && is_numeric_start inner.[0])
+          || Parse.starts_with_math_function inner
           || is_line_width_keyword inner
         in
         if is_width then
@@ -829,6 +830,7 @@ module Handler = struct
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' in
         let is_width =
           (String.length inner > 0 && is_numeric_start inner.[0])
+          || Parse.starts_with_math_function inner
           || is_line_width_keyword inner
         in
         if is_width then
@@ -891,7 +893,10 @@ module Handler = struct
           let is_numeric_start c =
             (c >= '0' && c <= '9') || c = '.' || c = '-'
           in
-          if String.length inner > 0 && is_numeric_start inner.[0] then
+          if
+            (String.length inner > 0 && is_numeric_start inner.[0])
+            || Parse.starts_with_math_function inner
+          then
             match parse_outline_width inner with
             | Some len -> Ok (Outline_width_bracket (inner, len))
             | None -> err_not_utility

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -269,63 +269,6 @@ module Handler = struct
     Css.parse_length
       (Parse.normalize_css_math_operators (Parse.decode_arbitrary_value str))
 
-  (* [Css.length] and [Css.border_width] are distinct types over overlapping
-     unit sets, so an arbitrary width is read as a length and transposed one
-     unit at a time. The units only [length] has (the dynamic-viewport and
-     container-query families) are not border widths. *)
-  let border_width_of_unit value : string -> Css.border_width option = function
-    | "px" -> Some (Px value)
-    | "cm" -> Some (Cm value)
-    | "mm" -> Some (Mm value)
-    | "q" -> Some (Q value)
-    | "in" -> Some (In value)
-    | "pt" -> Some (Pt value)
-    | "pc" -> Some (Pc value)
-    | "rem" -> Some (Rem value)
-    | "em" -> Some (Em value)
-    | "ex" -> Some (Ex value)
-    | "cap" -> Some (Cap value)
-    | "ic" -> Some (Ic value)
-    | "ric" -> Some (Ric value)
-    | "rlh" -> Some (Rlh value)
-    | "ch" -> Some (Ch value)
-    | "lh" -> Some (Lh value)
-    | "vh" -> Some (Vh value)
-    | "vw" -> Some (Vw value)
-    | "vmin" -> Some (Vmin value)
-    | "vmax" -> Some (Vmax value)
-    | "%" -> Some (Pct value)
-    | _ -> None
-
-  let border_width_of_length : Css.length -> Css.border_width option = function
-    | Px f -> border_width_of_unit f "px"
-    | Cm f -> border_width_of_unit f "cm"
-    | Mm f -> border_width_of_unit f "mm"
-    | Q f -> border_width_of_unit f "q"
-    | In f -> border_width_of_unit f "in"
-    | Pt f -> border_width_of_unit f "pt"
-    | Pc f -> border_width_of_unit f "pc"
-    | Rem f -> border_width_of_unit f "rem"
-    | Em f -> border_width_of_unit f "em"
-    | Ex f -> border_width_of_unit f "ex"
-    | Cap f -> border_width_of_unit f "cap"
-    | Ic f -> border_width_of_unit f "ic"
-    | Ric f -> border_width_of_unit f "ric"
-    | Rlh f -> border_width_of_unit f "rlh"
-    | Ch f -> border_width_of_unit f "ch"
-    | Lh f -> border_width_of_unit f "lh"
-    | Vh f -> border_width_of_unit f "vh"
-    | Vw f -> border_width_of_unit f "vw"
-    | Vmin f -> border_width_of_unit f "vmin"
-    | Vmax f -> border_width_of_unit f "vmax"
-    | Pct f -> border_width_of_unit f "%"
-    (* [Dimension] carries a value whose authored spelling differs from the
-       canonical float ([0.5rem]); its unit names the constructor. *)
-    | Dimension { value; unit; _ } ->
-        border_width_of_unit value (String.lowercase_ascii unit)
-    | Zero -> Some Zero
-    | _ -> None
-
   (* A bare number is not a CSS length, but Tailwind admits [border-[3]] and
      emits it as a width, so it keeps the px reading it has always had. *)
   let parse_bare_number str =
@@ -334,25 +277,31 @@ module Handler = struct
       float_of_string_opt str
     else None
 
-  (* The CSS line-width keywords are border widths, not lengths, so
-     [Css.parse_length] never sees them. They are the only idents a width
-     bracket takes: anything else there is a colour or a mistake. *)
-  let line_width_keyword : string -> Css.border_width option = function
-    | "thin" -> Some Thin
-    | "medium" -> Some Medium
-    | "thick" -> Some Thick
-    | _ -> None
+  (* [border-[X]] is a width or a colour, and the class grammar has to say which
+     before the value is read. The three CSS line-width keywords are the only
+     idents on the width side. *)
+  let is_line_width_keyword = function
+    | "thin" | "medium" | "thick" -> true
+    | _ -> false
 
+  (* cascade's own border-width reader answers the line-width keywords, every
+     unit [Css.border_width] names, [calc()] and [var()]. The units only
+     [Css.length] has (the dynamic-viewport and container-query families) are
+     not border widths there either, so such a bracket is still refused. *)
   let parse_border_width inner : Css.border_width option =
-    match line_width_keyword inner with
-    | Some _ as w -> w
-    | None -> (
-        match parse_length inner with
-        | Some len -> border_width_of_length len
-        | None -> (
-            match parse_bare_number inner with
-            | Some f -> Some (Px f)
-            | None -> None))
+    let cursor =
+      Cascade.Cursor.of_string
+        (Parse.normalize_css_math_operators
+           (Parse.decode_arbitrary_value inner))
+    in
+    match
+      Cascade.Cursor.try_parse_full_err Css.Properties.read_border_width cursor
+    with
+    | Ok w -> Some w
+    | Error _ -> (
+        match parse_bare_number inner with
+        | Some f -> Some (Px f)
+        | None -> None)
 
   let parse_outline_width inner : Css.length option =
     match parse_length inner with
@@ -866,7 +815,7 @@ module Handler = struct
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' || c = '-' in
         let is_width =
           (String.length inner > 0 && is_numeric_start inner.[0])
-          || line_width_keyword inner <> None
+          || is_line_width_keyword inner
         in
         if is_width then
           match parse_border_width inner with
@@ -880,7 +829,7 @@ module Handler = struct
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' in
         let is_width =
           (String.length inner > 0 && is_numeric_start inner.[0])
-          || line_width_keyword inner <> None
+          || is_line_width_keyword inner
         in
         if is_width then
           match parse_border_width inner with
@@ -1392,4 +1341,4 @@ let outline_offset_2 = utility (Outline_offset 2)
 let outline_offset_4 = utility (Outline_offset 4)
 let outline_offset_8 = utility (Outline_offset 8)
 let border_style_var = Handler.border_style_var
-let border_width_of_length = Handler.border_width_of_length
+let parse_border_width = Handler.parse_border_width

--- a/lib/borders.mli
+++ b/lib/borders.mli
@@ -625,12 +625,13 @@ val border_style_var : Cascade.Css.border_style Var.property_default
     utilities that read the same property cannot register a second, disagreeing
     slot for it. *)
 
-val border_width_of_length :
-  Cascade.Css.length -> Cascade.Css.border_width option
-(** [border_width_of_length len] transposes a length read from an arbitrary
-    value into the [Css.border_width] type a border/divide width sets;
-    [Css.length] and [Css.border_width] cover overlapping unit sets but are
-    distinct types. [None] for units the length grammar has that a border width
-    does not (the dynamic-viewport and container-query units). *)
+val parse_border_width : string -> Cascade.Css.border_width option
+(** [parse_border_width text] reads the inside of an arbitrary width bracket
+    with cascade's border-width reader: a line-width keyword, a length in a unit
+    [Css.border_width] names, [calc()] or [var()]. A bare number reads as
+    pixels, which is what Tailwind emits for [border-[3]]. [None] for anything
+    else, including the units the length grammar has that a border width does
+    not (the dynamic-viewport and container-query families). Shared with the
+    divide utilities, which set the same property. *)
 
 module Handler : Utility.Handler

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2513,8 +2513,7 @@ module Handler = struct
            the same value. It leaves a colour whose channels are not all static
            alone, and that one has no hex form. *)
         match
-          Cascade.Values.nonkeyword_color
-            (Cascade.Values.normalize_color ~in_feature_query:false c)
+          Cascade.Values.nonkeyword_color (Cascade.Values.normalize_color c)
         with
         | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
             let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -377,10 +377,11 @@ module Handler = struct
      the CSS functions have no bracket spelling at all. *)
   let bracket_spelling (width : Css.border_width) : string option =
     match width with
-    | Thin | Medium | Thick | Auto | Max_content | Min_content | Fit_content
-    | From_font | Calc _ | Min _ | Max _ | Clamp _ | Inherit | Initial | Unset
-    | Revert | Revert_layer | Var _ ->
-        None
+    (* [None] is exactly what the bracket reader refuses, so the typed
+       constructor can build every class the parser accepts and no other. A
+       sizing keyword is not a width, and a [var()] has no spelling of its
+       own. *)
+    | Auto | Max_content | Min_content | Fit_content | From_font | Var _ -> None
     (* The bracket is re-read as a width, and a bare [0] is not one, so the
        unitless zero takes the unit back. *)
     | Zero -> Some "0px"

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -407,20 +407,14 @@ module Handler = struct
     Stdlib.Option.map (Css.Pp.to_string (Css.pp_length ~always:true)) length
 
   (* The bracket text and the width it denotes. The text is what [to_class]
-     spells, so a class parsed here is reproduced verbatim. [divide-x-[...]]
-     takes any CSS length, so the bracket is read with the value parser rather
-     than a hand-picked unit table; [Css.border_width] is a distinct type from
-     [Css.length], so the result is transposed through
-     [Borders.border_width_of_length]. *)
+     spells, so a class parsed here is reproduced verbatim. A divide width sets
+     the same property a border width does, so it is read by the same reader. *)
   let parse_bracket_width s : (string * Css.border_width) option =
     let len = String.length s in
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
-      match Parse.arbitrary_length inner with
-      | Some length -> (
-          match Borders.border_width_of_length length with
-          | Some width -> Some (inner, width)
-          | None -> None)
+      match Borders.parse_border_width inner with
+      | Some width -> Some (inner, width)
       | None -> None
     else None
 

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -372,39 +372,19 @@ module Handler = struct
     | X_reverse -> 500000
 
   (* The bracket spelling of an arbitrary width, for the typed constructors,
-     which are handed a width rather than the text an author wrote. Keywords and
-     CSS functions have no bracket spelling. *)
+     which are handed a width rather than the text an author wrote. cascade
+     prints the width, so a unit it learns needs no table here; the keywords and
+     the CSS functions have no bracket spelling at all. *)
   let bracket_spelling (width : Css.border_width) : string option =
-    let length : Css.length option =
-      match width with
-      | Px f -> Some (Px f)
-      | Cm f -> Some (Cm f)
-      | Mm f -> Some (Mm f)
-      | Q f -> Some (Q f)
-      | In f -> Some (In f)
-      | Pt f -> Some (Pt f)
-      | Pc f -> Some (Pc f)
-      | Rem f -> Some (Rem f)
-      | Em f -> Some (Em f)
-      | Ex f -> Some (Ex f)
-      | Cap f -> Some (Cap f)
-      | Ic f -> Some (Ic f)
-      | Ric f -> Some (Ric f)
-      | Rlh f -> Some (Rlh f)
-      | Ch f -> Some (Ch f)
-      | Lh f -> Some (Lh f)
-      | Vh f -> Some (Vh f)
-      | Vw f -> Some (Vw f)
-      | Vmin f -> Some (Vmin f)
-      | Vmax f -> Some (Vmax f)
-      | Pct f -> Some (Pct f)
-      | Zero -> Some (Px 0.)
-      | Thin | Medium | Thick | Auto | Max_content | Min_content | Fit_content
-      | From_font | Calc _ | Min _ | Max _ | Clamp _ | Inherit | Initial | Unset
-      | Revert | Revert_layer | Var _ ->
-          None
-    in
-    Stdlib.Option.map (Css.Pp.to_string (Css.pp_length ~always:true)) length
+    match width with
+    | Thin | Medium | Thick | Auto | Max_content | Min_content | Fit_content
+    | From_font | Calc _ | Min _ | Max _ | Clamp _ | Inherit | Initial | Unset
+    | Revert | Revert_layer | Var _ ->
+        None
+    (* The bracket is re-read as a width, and a bare [0] is not one, so the
+       unitless zero takes the unit back. *)
+    | Zero -> Some "0px"
+    | width -> Some (Css.Pp.to_string Css.Properties.pp_border_width width)
 
   (* The bracket text and the width it denotes. The text is what [to_class]
      spells, so a class parsed here is reproduced verbatim. A divide width sets

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -863,7 +863,15 @@ module Handler = struct
           let hex = "#" ^ rgba_hex_string r g b a in
           ( Css.hex (Color.hex_with_alpha hex percent),
             Color.hex_to_oklab_alpha hex alpha )
-      | _ -> (c, c)
+      (* A colour with no sRGB hex has nothing to carry the alpha byte, so the
+         modifier stays a mix: sRGB for the plain fallback, oklab for the
+         guarded value. A modifier reading a custom property has no percentage a
+         plain fallback can hold, so only the guarded value mixes. *)
+      | _ ->
+          let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
+          if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
+            (c, guarded)
+          else (Color.mix_alpha ~in_space:Srgb opacity c, guarded)
     in
     let base_decl, _ = Var.binding shadow_color_var base_value in
     let enhanced_color =
@@ -1475,14 +1483,19 @@ module Handler = struct
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
     (* As for the outer shadow: the plain fallback is a hex carrying the alpha
-       byte, and the oklab spelling is kept for the guarded [color-mix]. *)
+       byte, the oklab spelling is kept for the guarded [color-mix], and a
+       colour with no hex keeps its alpha as a mix in each space. *)
     let base_value, with_alpha =
       match c with
       | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
           let hex = "#" ^ rgba_hex_string r g b a in
           ( Css.hex (Color.hex_with_alpha hex percent),
             Color.hex_to_oklab_alpha hex alpha )
-      | _ -> (c, c)
+      | _ ->
+          let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
+          if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
+            (c, guarded)
+          else (Color.mix_alpha ~in_space:Srgb opacity c, guarded)
     in
     let base_decl, _ = Var.binding inset_shadow_color_var base_value in
     let enhanced_color =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -154,6 +154,14 @@ let is_css_non_math_function = function
   | "attr" | "env" | "url" | "var" -> true
   | _ -> false
 
+(* A math function stands for the value it computes, so a bracket opening with
+   one denotes whatever the utility's numeric side takes. Utilities that tell a
+   width from a colour by the bracket's first character need to know. *)
+let starts_with_math_function s =
+  match String.index_opt s '(' with
+  | Some i -> is_css_math_function (String.lowercase_ascii (String.sub s 0 i))
+  | None -> false
+
 let normalize_css_math_operators s =
   let len = String.length s in
   let buf = Buffer.create (len + 8) in

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -92,6 +92,13 @@ val is_ident : string -> bool
 (** [is_ident s] is [true] when [s] is a CSS identifier, as a custom-ident or a
     property name written in an arbitrary value has to be. *)
 
+val starts_with_math_function : string -> bool
+(** [starts_with_math_function s] is [true] when [s] opens with a CSS math
+    function ([calc], [min], [max], [clamp], ...). A utility whose bracket takes
+    either a length or a colour reads this to classify one that starts with a
+    function call: a math function stands for the value it computes, so it is on
+    the numeric side. *)
+
 val is_var : string -> bool
 (** [is_var s] returns [true] if [s] starts with ["var("]. Works on inner
     bracket content (without surrounding brackets). *)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -594,61 +594,6 @@ module Typography_early = struct
     in
     find 0 0
 
-  (* The line-height that says what the length cascade read says. A unit
-     [Css.line_height] has no constructor for, such as [vw] or [ch], has no
-     line-height spelling here, and the caller refuses the utility rather than
-     approximating it. *)
-  let rec line_height_of_length (l : Css.length) : Css.line_height option =
-    match l with
-    | Px f -> Some (Px f)
-    | Rem f -> Some (Rem f)
-    | Em f -> Some (Em f)
-    | Pct f -> Some (Pct f)
-    | Zero -> Some (Num 0.)
-    | Normal -> Some Normal
-    | Inherit -> Some Inherit
-    | Initial -> Some Initial
-    | Unset -> Some Unset
-    | Revert -> Some Revert
-    | Revert_layer -> Some Revert_layer
-    | Var v -> Some (Var (Var.bracket (Css.var_name v)))
-    | Calc c -> (
-        match line_height_of_calc c with
-        | Some c -> Some (Calc c)
-        | None -> None)
-    | _ -> None
-
-  and line_height_of_calc (c : Css.length Css.calc) :
-      Css.line_height Css.calc option =
-    let both left right =
-      match (line_height_of_calc left, line_height_of_calc right) with
-      | Some left, Some right -> Some (left, right)
-      | _ -> None
-    in
-    match c with
-    | Val l -> (
-        match line_height_of_length l with
-        | Some lh -> Some (Val lh)
-        | None -> None)
-    | Var v -> Some (Var (Var.bracket (Css.var_name v)))
-    | Num n -> Some (Num n)
-    | Math_const m -> Some (Math_const m)
-    | Sibling_index -> Some Sibling_index
-    | Sibling_count -> Some Sibling_count
-    | Math_fn f -> Some (Math_fn f)
-    | Nested c -> (
-        match line_height_of_calc c with
-        | Some c -> Some (Nested c)
-        | None -> None)
-    | Parens c -> (
-        match line_height_of_calc c with
-        | Some c -> Some (Parens c)
-        | None -> None)
-    | Expr (left, op, right) -> (
-        match both left right with
-        | Some (left, right) -> Some (Expr (left, op, right))
-        | None -> None)
-
   (* The one reader for an arbitrary line-height, shared by [leading-[...]] and
      by the [/leading] modifier on a text size. The string parsing is cascade's,
      so every unit, [calc()] and [var()] spelling it reads is accepted; a
@@ -656,12 +601,20 @@ module Typography_early = struct
   let parse_bracket_leading raw : Css.line_height option =
     if Parse.is_var raw then Some (Var (Var.bracket raw))
     else
-      match float_of_string_opt (Parse.decode_arbitrary_value raw) with
-      | Some f -> Some (Num f)
-      | None -> (
-          match Parse.arbitrary_length raw with
-          | Some length -> line_height_of_length length
-          | None -> None)
+      let cursor =
+        Cascade.Cursor.of_string (Parse.decode_arbitrary_value raw)
+      in
+      match
+        Cascade.Cursor.try_parse_full_err Css.Properties.read_line_height cursor
+      with
+      (* The reader keeps a dimension whose unit it does not know as verbatim
+         text, so a stray source word reading as one would become a utility. The
+         length grammar is what says whether the unit is a length; asking it
+         keeps the answer out of a unit table here. *)
+      | Ok (Number { repr; unit = Some unit; _ } as lh) ->
+          if Css.parse_length (repr ^ unit) = None then None else Some lh
+      | Ok lh -> Some lh
+      | Error _ -> None
 
   (* [none] is not here: [parse_lh_modifier] answers it with [No_leading] before
      this list is consulted, because Tailwind writes [line-height: 1] for it

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -85,15 +85,20 @@ let rec style_declarations (s : Style.t) =
 
 (* A width utility writes the style property as a bare reference to the style
    utilities' channel, so the declaration says nothing about which family the
-   utility belongs to. No cascade API tells a bare var() carrier from a real
-   value, so the two carriers are named here. *)
+   utility belongs to. The two carriers are named by the channel they read,
+   matched on the typed value rather than on the printed declaration, so a
+   declared [border-style] naming any other variable stays a style utility. *)
 let is_ordering_carrier decl =
-  match Cascade.Css.Declaration.property_key decl with
-  | Key Border_style ->
-      Cascade.Css.declaration_value ~minify:true decl = "var(--tw-border-style)"
-  | Key Outline_style ->
-      Cascade.Css.declaration_value ~minify:true decl
-      = "var(--tw-outline-style)"
+  match decl with
+  | Cascade.Css.Declaration.Declaration { property = Border_style; value; _ }
+    -> (
+      match value with
+      | Var v -> String.equal (Cascade.Css.var_name v) "tw-border-style"
+      | _ -> false)
+  | Declaration { property = Outline_style; value; _ } -> (
+      match value with
+      | Var v -> String.equal (Cascade.Css.var_name v) "tw-outline-style"
+      | _ -> false)
   | _ -> false
 
 (* The property name a vendor-prefixed one stands in for: [-webkit-user-select]

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -88,17 +88,21 @@ let rec style_declarations (s : Style.t) =
    utility belongs to. The two carriers are named by the channel they read,
    matched on the typed value rather than on the printed declaration, so a
    declared [border-style] naming any other variable stays a style utility. *)
+(* A carrier reads its channel and nothing else. There is no public accessor for
+   a declaration's typed value - [Properties_intf] is one of cascade's private
+   modules, so destructuring the record only compiles when cascade is built from
+   source in the same workspace - and the printed form is the surface cascade
+   does expose. Comparing it to the one spelling a carrier can have keeps a
+   declared [border-style] naming any other variable a style utility. *)
+let carries_var decl name =
+  String.equal
+    (Cascade.Css.declaration_value ~minify:true decl)
+    ("var(--" ^ name ^ ")")
+
 let is_ordering_carrier decl =
-  match decl with
-  | Cascade.Css.Declaration.Declaration { property = Border_style; value; _ }
-    -> (
-      match value with
-      | Var v -> String.equal (Cascade.Css.var_name v) "tw-border-style"
-      | _ -> false)
-  | Declaration { property = Outline_style; value; _ } -> (
-      match value with
-      | Var v -> String.equal (Cascade.Css.var_name v) "tw-outline-style"
-      | _ -> false)
+  match Cascade.Css.Declaration.property_key decl with
+  | Key Border_style -> carries_var decl "tw-border-style"
+  | Key Outline_style -> carries_var decl "tw-outline-style"
   | _ -> false
 
 (* The property name a vendor-prefixed one stands in for: [-webkit-user-select]

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -353,6 +353,28 @@ let test_bracket_width_units () =
   emits "border-width: .5rem" "border-[0.5rem]";
   emits "border-top-width: 3vw" "border-t-[3vw]"
 
+(* A math function in a width bracket stands for the width it computes, so it is
+   a width and not a colour. The bracket was classified by its first character,
+   which put [calc(...)] on the colour side and refused the class Tailwind
+   renders. *)
+let test_bracket_math_function_width () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "border-width: calc(1rem + 2px)" "border-[calc(1rem_+_2px)]";
+  emits "border-top-width: calc(1rem + 2px)" "border-t-[calc(1rem_+_2px)]";
+  emits "border-width: min(2px, 1rem)" "border-[min(2px,1rem)]";
+  emits "border-width: clamp(1px, 2px, 3px)" "border-[clamp(1px,2px,3px)]";
+  emits "outline-width: calc(1rem + 2px)" "outline-[calc(1rem_+_2px)]";
+  (* a bare var() is still a colour on both *)
+  emits "border-color: var(--w)" "border-[var(--w)]";
+  emits "outline-color: var(--w)" "outline-[var(--w)]"
+
 (* The three CSS line-width keywords are border widths in their own right, so a
    bracket naming one is a width and not an unknown class: Tailwind emits
    border-width: thin for border-[thin], and the same for medium and thick on
@@ -437,6 +459,8 @@ let tests =
     test_case "invalid bracket widths" `Quick test_invalid_bracket_widths;
     test_case "bracket line-width keywords" `Quick
       test_bracket_line_width_keywords;
+    test_case "bracket math-function width" `Quick
+      test_bracket_math_function_width;
     test_case "project radius token" `Quick test_project_radius_token;
     test_case "border side width order" `Slow test_side_width_order;
     test_case "rounded-sm default radius" `Quick test_rounded_sm_default;

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -369,7 +369,7 @@ let test_bracket_math_function_width () =
   emits "border-width: calc(1rem + 2px)" "border-[calc(1rem_+_2px)]";
   emits "border-top-width: calc(1rem + 2px)" "border-t-[calc(1rem_+_2px)]";
   emits "border-width: min(2px, 1rem)" "border-[min(2px,1rem)]";
-  emits "border-width: clamp(1px, 2px, 3px)" "border-[clamp(1px,2px,3px)]";
+  emits "border-width: clamp(1px, 2vw, 3rem)" "border-[clamp(1px,2vw,3rem)]";
   emits "outline-width: calc(1rem + 2px)" "outline-[calc(1rem_+_2px)]";
   (* a bare var() is still a colour on both *)
   emits "border-color: var(--w)" "border-[var(--w)]";

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -77,6 +77,41 @@ let test_typed_arbitrary_width () =
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected divide_x_length Thin to be refused"
 
+(* Every unit a border width names has a bracket spelling, so a typed
+   constructor handed one produces a class the parser reads back. *)
+let test_typed_width_units () =
+  let open Tw in
+  let spelled (expected, width) =
+    Test_helpers.check_typed_class
+      ("divide-x-[" ^ expected ^ "]")
+      (divide_x_length width)
+  in
+  List.iter spelled
+    [
+      ("4px", (Css.Px 4. : Css.border_width));
+      ("1cm", Css.Cm 1.);
+      ("2mm", Css.Mm 2.);
+      ("3q", Css.Q 3.);
+      ("1in", Css.In 1.);
+      ("12pt", Css.Pt 12.);
+      ("1pc", Css.Pc 1.);
+      ("1.5rem", Css.Rem 1.5);
+      ("2em", Css.Em 2.);
+      ("1ex", Css.Ex 1.);
+      ("1cap", Css.Cap 1.);
+      ("1ic", Css.Ic 1.);
+      ("1ric", Css.Ric 1.);
+      ("1rlh", Css.Rlh 1.);
+      ("2ch", Css.Ch 2.);
+      ("1lh", Css.Lh 1.);
+      ("3vh", Css.Vh 3.);
+      ("3vw", Css.Vw 3.);
+      ("3vmin", Css.Vmin 3.);
+      ("3vmax", Css.Vmax 3.);
+      ("50%", Css.Pct 50.);
+      ("0px", Css.Zero);
+    ]
+
 (* Every divide utility the parser accepts also has a typed constructor, and the
    two agree on the class name (issue #5). *)
 let test_typed () =
@@ -237,6 +272,7 @@ let tests =
         test_arbitrary_width_roundtrip;
       Alcotest.test_case "typed arbitrary width" `Quick
         test_typed_arbitrary_width;
+      Alcotest.test_case "typed width units" `Quick test_typed_width_units;
       Alcotest.test_case "arbitrary width units" `Quick
         test_arbitrary_width_units;
       Alcotest.test_case "order matches Tailwind" `Slow order_matches_tailwind;

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -66,16 +66,20 @@ let test_arbitrary_width_roundtrip () =
     (Astring.String.is_infix ~affix:".divide-x-\\[2rem\\]"
        (selector "divide-x-[2rem]"))
 
-(* The typed constructor spells the width itself, and refuses a width that has
-   no spelling inside a class name. *)
+(* The typed constructor spells the width itself, and builds exactly the classes
+   the bracket reader accepts. Tailwind takes a line-width keyword there -
+   [divide-x-[thin]] emits [calc(thin * var(--tw-divide-x-reverse))] - so
+   refusing [Thin] refused a class the parser already read. A sizing keyword is
+   not a width and stays refused. *)
 let test_typed_arbitrary_width () =
   let open Tw in
   Test_helpers.check_typed_class "divide-x-[4px]" (divide_x_length (Css.Px 4.));
   Test_helpers.check_typed_class "divide-y-[1rem]"
     (divide_y_length (Css.Rem 1.));
-  match divide_x_length Css.Thin with
+  Test_helpers.check_typed_class "divide-x-[thin]" (divide_x_length Css.Thin);
+  match divide_x_length Css.Auto with
   | exception Invalid_argument _ -> ()
-  | _ -> Alcotest.fail "expected divide_x_length Thin to be refused"
+  | _ -> Alcotest.fail "expected divide_x_length Auto to be refused"
 
 (* Every unit a border width names has a bracket spelling, so a typed
    constructor handed one produces a class the parser reads back. *)

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -350,6 +350,29 @@ let test_arbitrary_shadow_colour_opacity () =
     "--tw-inset-shadow-alpha:var(--x)";
   has "inset-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
 
+(* A bracket colour with no sRGB hex - [oklch()] and the other wide-gamut
+   spellings - has no hex to fold the modifier's alpha into, so the alpha has to
+   stay a mix. Tailwind writes the plain fallback in sRGB and the guarded value
+   in oklab; the colour used to fall through untouched, which painted the shadow
+   fully opaque and dropped the modifier. *)
+let test_bracket_colour_opacity_without_hex () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  let lacks cls affix =
+    Alcotest.(check bool) cls false (Astring.String.is_infix ~affix (css cls))
+  in
+  has "shadow-[oklch(0.7_0.1_200)]/50" "--tw-shadow-color:color-mix(in srgb,";
+  lacks "shadow-[oklch(0.7_0.1_200)]/50" "--tw-shadow-color:oklch(";
+  has "inset-shadow-[oklch(0.7_0.1_200)]/50"
+    "--tw-inset-shadow-color:color-mix(in srgb,";
+  lacks "inset-shadow-[oklch(0.7_0.1_200)]/50" "--tw-inset-shadow-color:oklch("
+
 (* A bracket alpha modifier with no [%] sign (shadow-lg/[25]) tracks the
    modifier's own written text in --tw-shadow-alpha, the way Tailwind does,
    rather than scaling it into a percentage: the alpha the shadow paints with
@@ -526,6 +549,8 @@ let tests =
     test_case "arbitrary shadow lengths" `Quick test_arbitrary_shadow_lengths;
     test_case "arbitrary shadow colour opacity" `Quick
       test_arbitrary_shadow_colour_opacity;
+    test_case "bracket colour opacity without a hex" `Quick
+      test_bracket_colour_opacity_without_hex;
     test_case "shadow bracket alpha tracking" `Quick
       test_shadow_bracket_alpha_tracking;
     test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -467,6 +467,13 @@ let test_arbitrary_leading () =
   agree "normal" "normal";
   agree "var(--lh)" "var(--lh)";
   agree "calc(1rem_+_2px)" "calc(1rem + 2px)";
+  (* every unit the length grammar names, not the handful the line-height type
+     happens to have a constructor for *)
+  agree "2vw" "2vw";
+  agree "3ch" "3ch";
+  agree "10dvh" "10dvh";
+  agree "2cqw" "2cqw";
+  agree "4lh" "4lh";
   (* the spellings that already worked keep working *)
   agree "24px" "24px";
   agree "2rem" "2rem";

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -229,6 +229,32 @@ let test_order_of_property_skips_outline_carrier () =
     (Some (order_of "outline-solid"))
     (order_of_property (Key Outline_style))
 
+(* The carrier is the style channel a width utility reads, not the property name
+   on its own: a declared [@utility] writing [border-style] with any other value
+   is a style utility and keeps the style slot. *)
+let test_ordering_property_carrier () =
+  let open Tw.Utility in
+  let key name = Alcotest.testable (fun ppf _ -> Fmt.string ppf name) ( = ) in
+  let carrier : Tw.Css.declaration =
+    Tw.Css.border_style (Var (Tw.Css.var_ref "tw-border-style"))
+  in
+  check
+    (option (key "border-width"))
+    "the channel carrier does not claim the style slot"
+    (Some (Tw.Css.Declaration.Key Border_width))
+    (ordering_property [ carrier; Tw.Css.border_width (Px 2.) ]);
+  check
+    (option (key "border-style"))
+    "a declared border-style keeps the style slot"
+    (Some (Tw.Css.Declaration.Key Border_style))
+    (ordering_property [ Tw.Css.border_style Dashed ]);
+  check
+    (option (key "border-style"))
+    "border-style reading another variable is not a carrier"
+    (Some (Tw.Css.Declaration.Key Border_style))
+    (ordering_property
+       [ Tw.Css.border_style (Var (Tw.Css.var_ref "my-border-style")) ])
+
 (* Tailwind sorts a declared [@utility] by the property it writes, so every
    property a family is named for needs a slot. A family with no example
    covering its property leaves a declared utility at the layer's tail. *)
@@ -362,6 +388,8 @@ let tests =
       test_order_of_property_skips_outline_carrier;
     test_case "order_of_property covers the named families" `Quick
       test_order_of_property_covers_named_families;
+    test_case "ordering property skips the style carrier" `Quick
+      test_ordering_property_carrier;
     test_case "order returns correct priorities" `Quick test_order_priorities;
     test_case "order returns correct suborders" `Quick test_order_suborders;
     test_case "order is consistent" `Quick test_order_consistency;


### PR DESCRIPTION
The "Blocked on cascade API" list rots: entries written days ago outlive the API they were waiting for. Re-checking each against cascade as it stands found several that had landed.

`leading-[2vw]` and `leading-[3ch]` were refused where Tailwind renders them, because the line-height reader existed only privately in cascade; it is exported now. An arbitrary border or outline width was read by a private unit table rather than cascade's reader, so a math function in the bracket was rejected. A bracket divide width was spelled by a private printer. A bracket shadow colour with no hex form dropped its opacity. And a style-channel carrier was matched on the property name rather than on the typed value, which is what put a declared `border-style` on the border-width member of its family.

Two more came out of the same pass. `normalize_color` no longer takes `~in_feature_query`, since cascade keeps a value inside a condition verbatim. And `divide_x_length` refused a line-width keyword the parser already accepted: `divide-x-[thin]` emits `calc(thin * var(--tw-divide-x-reverse))` in both tools, but the typed constructor raised on `Css.Thin`. The test asserted that refusal, so it asserted the wrong contract; it now pins the keyword against Tailwind and keeps a sizing keyword refused.