### PR TITLE
sort, theme: put the late colour block and the theme tail where Tailwind puts them

### DIFF
--- a/docs/adding-a-new-utility.md
+++ b/docs/adding-a-new-utility.md
@@ -222,9 +222,9 @@ conflict resolve in Tailwind's order:
 - **Lookup**: `Build.conflict_order` resolves the pair for a selector, and
   `Sort.compare_indexed_rules` sorts on it with the source index as a stable
   tiebreaker.
-- **Pseudo-elements**: `adjust_pseudo` in `lib/build.ml` adds 5000 to the suborder
-  of a `before:`/`after:` rule, so it trails the base utility rather than
-  interleaving with it.
+- **Variants**: a rule carrying a modifier prefix does not sort on the pair at
+  all until every variant key it holds has tied; `Sort.compare_indexed_rules`
+  reads `variant_orders` first, and `lib/sort.mli` describes the key.
 
 **CSS Minification Considerations**:
 - Minification is cascade's; `Css.Selector.to_string ~minify:true` is what tw calls

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -145,7 +145,7 @@ module Handler = struct
        animation: none directly. *)
     match Scheme.theme_value theme "animate-none" with
     | Some _ ->
-        let tv = Var.theme Css.Animation "animate-none" ~order:(7, 12) in
+        let tv = Var.theme Css.Animation "animate-none" ~order:(7, 40) in
         let none_animation : Css.animation =
           Css.Shorthand
             {
@@ -164,9 +164,9 @@ module Handler = struct
         style [ theme_decl; Css.animation (Css.Var none_var) ]
     | None -> style [ Css.animation None ]
 
-  (* Theme variable for animate-spin - order (7, 13) places it after ease (7,
-     9-11) *)
-  let animate_spin_var = Var.theme Css.Animation "animate-spin" ~order:(7, 13)
+  (* Theme variable for animate-spin - slot (7, 41) places it after ease (7,
+     30-34) *)
+  let animate_spin_var = Var.theme Css.Animation "animate-spin" ~order:(7, 41)
 
   let animate_spin ?theme () =
     let spin_animation : Css.animation =
@@ -187,9 +187,9 @@ module Handler = struct
     let rules = theme_keyframes ?theme ~token:"animate-spin" spin_animation in
     style ~rules [ theme_decl; Css.animation (Css.Var spin_var) ]
 
-  (* Theme variable for animate-ping - order (7, 14) places it after
-     animate-spin (7, 13) *)
-  let animate_ping_var = Var.theme Css.Animation "animate-ping" ~order:(7, 14)
+  (* Theme variable for animate-ping - slot (7, 42) places it after animate-spin
+     (7, 41) *)
+  let animate_ping_var = Var.theme Css.Animation "animate-ping" ~order:(7, 42)
 
   let animate_ping ?theme () =
     let ping_animation : Css.animation =
@@ -210,9 +210,9 @@ module Handler = struct
     let rules = theme_keyframes ?theme ~token:"animate-ping" ping_animation in
     style ~rules [ theme_decl; Css.animation (Css.Var ping_var) ]
 
-  (* Theme variable for animate-pulse - order (7, 15) places it after
-     animate-ping (7, 14) *)
-  let animate_pulse_var = Var.theme Css.Animation "animate-pulse" ~order:(7, 15)
+  (* Theme variable for animate-pulse - slot (7, 43) places it after
+     animate-ping (7, 42) *)
+  let animate_pulse_var = Var.theme Css.Animation "animate-pulse" ~order:(7, 43)
 
   let animate_pulse ?theme () =
     let pulse_animation : Css.animation =
@@ -233,10 +233,10 @@ module Handler = struct
     let rules = theme_keyframes ?theme ~token:"animate-pulse" pulse_animation in
     style ~rules [ theme_decl; Css.animation (Css.Var pulse_var) ]
 
-  (* Theme variable for animate-bounce - order (7, 16) places it after
-     animate-pulse (7, 15) *)
+  (* Theme variable for animate-bounce - slot (7, 44) places it after
+     animate-pulse (7, 43) *)
   let animate_bounce_var =
-    Var.theme Css.Animation "animate-bounce" ~order:(7, 16)
+    Var.theme Css.Animation "animate-bounce" ~order:(7, 44)
 
   let animate_bounce ?theme () =
     let bounce_animation : Css.animation =
@@ -285,7 +285,7 @@ module Handler = struct
 
   let animate_named ?theme name =
     let var_name = "animate-" ^ name in
-    let tv = Var.theme Css.Animation var_name ~order:(7, 16) in
+    let tv = Var.theme Css.Animation var_name ~order:(7, 45) in
     let animation : Css.animation =
       Shorthand
         {

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -283,8 +283,7 @@ let indexed_rule_to_statement ?(verbatim = fun _ -> false)
 let deduplicate_typed_triples triples =
   let seen = Hashtbl.create (List.length triples) in
   List.filter
-    (fun (typ, sel, props, _order, nested, _base_class, _merge_key, _not_order)
-       ->
+    (fun (typ, sel, props, _order, nested, _base_class, _merge_key) ->
       let bucket = (typ, Css.Selector.hash sel, props, nested) in
       if List.exists (Css.Selector.equal sel) (Hashtbl.find_all seen bucket)
       then false
@@ -293,47 +292,29 @@ let deduplicate_typed_triples triples =
         true))
     triples
 
-(* Get utility order from base class, with fallback to conflict order. Note:
-   base_class may contain modifier prefixes (e.g., "md:grid-cols-2"), so we need
-   to strip those before looking up the utility. Pseudo-element modifiers
-   (before:, after:) use a fixed high suborder to preserve source order. *)
-(* Pseudo-element modifiers add 5000 to the base utility's suborder, keeping
-   them near their base utility but after all regular utilities (matching
-   Tailwind v4, where pseudo-elements appear late). *)
-let adjust_pseudo class_name (prio, suborder) =
-  if
-    String.starts_with ~prefix:"before:" class_name
-    || String.starts_with ~prefix:"after:" class_name
-  then (prio, suborder + 5000)
-  else (prio, suborder)
-
 (* The base utility's order is [Utility.order] on its value, recovered here from
    the class string by re-parsing it through the handlers - the expensive part.
-   [order_map] is populated by [Rule.outputs ~order_tbl] from the class strings
-   it already builds, so the common case is a lookup; an unknown class (not in
-   the input set) falls back to the parse, or to a selector-based conflict order
-   when even that fails. *)
+   A base class carries its modifier prefixes ([md:grid-cols-2]), so those are
+   stripped before the lookup. [order_map] is populated by [Rule.outputs
+   ~order_tbl] from the class strings it already builds, so the common case is a
+   lookup; an unknown class (not in the input set) falls back to the parse, or
+   to a selector-based conflict order when even that fails. *)
 
 let order_of_base order_map base_class selector =
   match base_class with
   | Some class_name -> (
       let base_utility = extract_base_utility class_name in
       match Hashtbl.find_opt order_map base_utility with
-      | Some order -> adjust_pseudo class_name order
+      | Some order -> order
       | None -> (
           match Utility.base_of_class Scheme.default base_utility with
-          | Ok u -> adjust_pseudo class_name (Utility.order u)
+          | Ok u -> Utility.order u
           | Error _ -> conflict_order (Css.Selector.to_string selector)))
   | None -> conflict_order (Css.Selector.to_string selector)
 
-(* Adjust order with not-variant offset *)
-let apply_not_order (prio, sub) not_order =
-  if not_order = 0 then (prio, sub) else (prio, sub + not_order)
-
 (* Convert each rule type to typed triple *)
-let triple typ ~selector ~props ~order ~nested ~base_class ~merge_key ~not_order
-    =
-  Some (typ, selector, props, order, nested, base_class, merge_key, not_order)
+let triple typ ~selector ~props ~order ~nested ~base_class ~merge_key =
+  Some (typ, selector, props, order, nested, base_class, merge_key)
 
 (* The [(hover: hover)] media condition is the same for every hover rule. *)
 let hover_media : Css.Media.t =
@@ -342,37 +323,27 @@ let hover_media : Css.Media.t =
        (Css.Media.Plain (Css.Media.Hover, Css.Media.Ident Css.Media.Hover)))
 
 let rule_to_triple order_map = function
-  | Regular
-      { selector; props; base_class; nested; has_hover; merge_key; not_order }
-    ->
-      let order =
-        apply_not_order (order_of_base order_map base_class selector) not_order
-      in
+  | Regular { selector; props; base_class; nested; has_hover; merge_key } ->
+      let order = order_of_base order_map base_class selector in
       let typ = if has_hover then `Media hover_media else `Regular in
       triple typ ~selector ~props ~order ~nested ~base_class ~merge_key
-        ~not_order
-  | Media_query { condition; selector; props; base_class; nested; not_order } ->
-      let order =
-        apply_not_order (order_of_base order_map base_class selector) not_order
-      in
-      triple (`Media condition) ~selector ~props ~order ~nested ~base_class
-        ~merge_key:None ~not_order
+  | Media_query { condition; selector; props; base_class; nested } ->
+      triple (`Media condition) ~selector ~props
+        ~order:(order_of_base order_map base_class selector)
+        ~nested ~base_class ~merge_key:None
   | Container_query { condition; selector; props; base_class; nested } ->
       triple (`Container condition) ~selector ~props
         ~order:(order_of_base order_map base_class selector)
-        ~nested ~base_class ~merge_key:None ~not_order:0
+        ~nested ~base_class ~merge_key:None
   | Starting_style { selector; props; base_class; nested } ->
       triple `Starting ~selector ~props
         ~order:(order_of_base order_map base_class selector)
-        ~nested ~base_class ~merge_key:None ~not_order:0
-  | Supports_query
-      { condition; selector; props; base_class; merge_key; not_order; nested }
+        ~nested ~base_class ~merge_key:None
+  | Supports_query { condition; selector; props; base_class; merge_key; nested }
     ->
-      let order =
-        apply_not_order (order_of_base order_map base_class selector) not_order
-      in
-      triple (`Supports condition) ~selector ~props ~order ~nested ~base_class
-        ~merge_key ~not_order
+      triple (`Supports condition) ~selector ~props
+        ~order:(order_of_base order_map base_class selector)
+        ~nested ~base_class ~merge_key
 
 (* Add index to each triple for stable sorting *)
 (* What [indexed_rule_to_statement] will emit, counted: the theme declarations
@@ -401,7 +372,7 @@ let rec declaration_count props nested =
 let add_index ?(declared = fun _ -> false) triples =
   let buf = Buffer.create 256 in
   List.mapi
-    (fun i (typ, sel, props, order, nested, base_class, merge_key, not_order) ->
+    (fun i (typ, sel, props, order, nested, base_class, merge_key) ->
       Buffer.clear buf;
       Css.Selector.to_buffer buf sel;
       let selector_str = Buffer.contents buf in
@@ -423,7 +394,6 @@ let add_index ?(declared = fun _ -> false) triples =
          nested;
          base_class;
          merge_key;
-         not_order;
          variant_order;
          variant_key = Sort.variant_sort_key base_class nested;
          variant_orders =

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -691,24 +691,6 @@ let compare_orders order_a order_b =
   | None, Some _ -> 1
   | None, None -> 0
 
-(* Tailwind's independently-numbered priority-7 namespaces overlap. Their
-   declaration order at a shared slot follows namespace registration order,
-   rather than the spelling of the complete token name. *)
-let priority_seven_namespace = function
-  | Some name ->
-      let name =
-        if String.starts_with ~prefix:"--" name then
-          String.sub name 2 (String.length name - 2)
-        else name
-      in
-      if String.starts_with ~prefix:"radius-" name then 0
-      else if String.starts_with ~prefix:"drop-shadow-" name then 1
-      else if String.starts_with ~prefix:"ease-" name then 2
-      else if String.starts_with ~prefix:"animate-" name then 3
-      else if String.starts_with ~prefix:"perspective-" name then 4
-      else 5
-  | None -> 5
-
 (* The position of a theme token within the project's [@theme] declaration list,
    keyed by its bare name. [Scheme.token_overrides] preserves the source order
    the CSS entrypoint (or [Scheme.with_overrides] caller) declared them in. *)
@@ -729,12 +711,12 @@ let declared_order declared name =
       in
       List.assoc_opt bare declared
 
-(* Sort declarations by their Var order metadata, namespace at a shared slot,
-   declaration order within that slot, then alphabetical fallback. A project-
-   named family (--font-<name>, --text-<name>, --leading-<name>, ...) funnels
-   every member into one shared (priority, suborder) slot (see [Var.mli]), so
-   two project tokens tie there; Tailwind keeps the order the [@theme] block
-   wrote them in rather than sorting by name. *)
+(* Sort declarations by their Var order metadata, then declaration order within
+   a shared slot, then alphabetical fallback. A project-named family
+   (--font-<name>, --text-<name>, --leading-<name>, ...) funnels every member
+   into one shared (priority, suborder) slot (see [Var.mli]), so two project
+   tokens tie there; Tailwind keeps the order the [@theme] block wrote them in
+   rather than sorting by name. *)
 let sort_by_var_order ~theme decls =
   let declared = declared_index theme in
   decls
@@ -750,19 +732,9 @@ let sort_by_var_order ~theme decls =
       let c = compare_orders a b in
       if c <> 0 then c
       else
-        let namespace_cmp =
-          match (a, b) with
-          | Some (7, _), Some (7, _) ->
-              Int.compare
-                (priority_seven_namespace na)
-                (priority_seven_namespace nb)
-          | _ -> 0
-        in
-        if namespace_cmp <> 0 then namespace_cmp
-        else
-          match (ia, ib) with
-          | Some ia, Some ib -> Int.compare ia ib
-          | _ -> compare na nb)
+        match (ia, ib) with
+        | Some ia, Some ib -> Int.compare ia ib
+        | _ -> compare na nb)
   |> List.map (fun (d, _, _, _) -> d)
 
 (* Build theme layer rule from declarations *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1954,14 +1954,14 @@ module Handler = struct
   let name = "color"
 
   (* Color families sort at their property's canonical rank, not together:
-     border-color (rank ~65) joins border-width/style at priority 19; text-color
-     (the `color` property, rank ~86) interleaves inside the late-typography
-     block, after text-transform and before font-style, at priority 26;
-     outline-color (rank ~92) joins the outline width, offset and style
-     utilities at priority 28. The rest (accent, caret, ...) stay at 25.
-     [_opacity] variants lead each group so the type resolves to the color [t]
-     rather than the shadowed [Css.Border] / [Css.user_select] [Text]
-     constructors. *)
+     border-color (rank ~65) joins border-width/style at priority 19; the
+     [color] property (rank ~86) opens the late-typography block at priority 26,
+     just before text-transform, and the placeholder, caret and accent colours
+     close the same block after the underline offset; outline-color (rank ~92)
+     joins the outline width, offset and style utilities at priority 28. The
+     rest (background, ...) stay at 25. [_opacity] variants lead each group so
+     the type resolves to the color [t] rather than the shadowed [Css.Border] /
+     [Css.user_select] [Text] constructors. *)
   let priority = function
     | Border_opacity _ | Border _ | Border_transparent | Border_current
     | Border_current_opacity _ | Border_bracket_color _ | Border_side_color _
@@ -1971,7 +1971,16 @@ module Handler = struct
     | Text_current_opacity _ | Text_inherit | Text_bracket_color _
     | Text_bracket_color_opacity _ | Text_bracket_var _
     | Text_bracket_var_opacity _ | Text_bracket_typed_var _
-    | Text_bracket_typed_var_opacity _ ->
+    | Text_bracket_typed_var_opacity _ | Placeholder_opacity _ | Placeholder _
+    | Placeholder_transparent | Placeholder_current
+    | Placeholder_current_opacity _ | Placeholder_inherit
+    | Placeholder_bracket_color _ | Placeholder_bracket_color_opacity _
+    | Caret_opacity _ | Caret _ | Caret_transparent | Caret_current
+    | Caret_current_opacity _ | Caret_inherit | Caret_bracket_color _
+    | Caret_bracket_color_opacity _ | Accent_opacity _ | Accent _
+    | Accent_transparent | Accent_current | Accent_current_opacity _
+    | Accent_inherit | Accent_bracket_color _ | Accent_bracket_color_opacity _
+      ->
         26
     | Outline_opacity _ | Outline _ | Outline_current
     | Outline_current_opacity _ | Outline_inherit | Outline_transparent
@@ -3068,24 +3077,24 @@ module Handler = struct
   let suborder = function
     (* [Text_opacity] leads so the match resolves to the colour [t] rather than
        to the [Text] constructor [open Css] brings into scope. All text colors
-       share suborder 8370 (priority 26, after text-transform and before
-       font-style) so they sort alphabetically, matching Tailwind. *)
+       share suborder 8350 (priority 26, after white-space and before
+       text-transform) so they sort alphabetically, matching Tailwind. *)
     | Text_opacity (color, shade, _) ->
         let _ = (color, shade) in
-        8370
+        8350
     | Text (color, shade) ->
         let _ = (color, shade) in
-        8370
-    | Text_transparent -> 8370
-    | Text_current -> 8370
-    | Text_current_opacity _ -> 8370
-    | Text_inherit -> 8370
-    | Text_bracket_color _ -> 8370
-    | Text_bracket_color_opacity _ -> 8370
-    | Text_bracket_var _ -> 8370
-    | Text_bracket_var_opacity _ -> 8370
-    | Text_bracket_typed_var _ -> 8370
-    | Text_bracket_typed_var_opacity _ -> 8370
+        8350
+    | Text_transparent -> 8350
+    | Text_current -> 8350
+    | Text_current_opacity _ -> 8350
+    | Text_inherit -> 8350
+    | Text_bracket_color _ -> 8350
+    | Text_bracket_color_opacity _ -> 8350
+    | Text_bracket_var _ -> 8350
+    | Text_bracket_var_opacity _ -> 8350
+    | Text_bracket_typed_var _ -> 8350
+    | Text_bracket_typed_var_opacity _ -> 8350
     | Border (color, shade) ->
         (* Border colors share suborder 1500 with borders.ml's named border
            colors (Border_color), at priority 19, so named and arbitrary tie and
@@ -3102,46 +3111,46 @@ module Handler = struct
     | Border_bracket_color_opacity _ -> 1500
     (* Per-side border colors sort after the all-sides colors. *)
     | Border_side_color _ -> 1600
-    | Accent (color, shade) ->
-        (* All accent colors use the same suborder (50000) to allow alphabetical
-           sorting, matching Tailwind v4 behavior. *)
-        let _ = (color, shade) in
-        50000
-    | Accent_opacity (color, shade, _) ->
-        let _ = (color, shade) in
-        50000
-    | Accent_transparent -> 50000
-    | Accent_current -> 50000
-    | Accent_current_opacity _ -> 50000
-    | Accent_inherit -> 50000
-    | Accent_bracket_color _ -> 50000
-    | Accent_bracket_color_opacity _ -> 50000
-    (* Caret comes after accent. Alphabetical: current, inherit, [colors],
-       transparent We use: - current: 60000 (c comes before colors, except
-       blue=60003) - inherit: 60000 + 9*1000 = 69000 (i comes after h, before
-       l=lime) - colors: 60000 + color_order * 1000 + shade (blue=3*1000,
-       red=15*1000) - transparent: 60000 + 25*1000 = 85000 (t comes after all
-       colors) Actually simpler: just use character-based ordering for special
-       keywords *)
+    (* The three colour families that close the late-typography block, in
+       Tailwind's order: placeholder, then caret, then accent, all after the
+       underline offset (max 69999). Each family shares one suborder so its
+       members tie and sort alphabetically by class name. *)
+    | Placeholder _ -> 80000
+    | Placeholder_opacity _ -> 80000
+    | Placeholder_transparent -> 80000
+    | Placeholder_current -> 80000
+    | Placeholder_current_opacity _ -> 80000
+    | Placeholder_inherit -> 80000
+    | Placeholder_bracket_color _ -> 80000
+    | Placeholder_bracket_color_opacity _ -> 80000
     | Caret (color, shade) ->
-        (* All caret colors use the same suborder (60000) to allow alphabetical
-           sorting, matching Tailwind v4 behavior. *)
         let _ = (color, shade) in
-        60000
+        81000
     | Caret_opacity (color, shade, _) ->
         let _ = (color, shade) in
-        60000
-    | Caret_current -> 60000
-    | Caret_current_opacity _ -> 60000
-    | Caret_inherit -> 60000
-    | Caret_transparent -> 60000
-    | Caret_bracket_color _ -> 60000
-    | Caret_bracket_color_opacity _ -> 60000
-    (* t -> after all colors (max=24) *)
+        81000
+    | Caret_current -> 81000
+    | Caret_current_opacity _ -> 81000
+    | Caret_inherit -> 81000
+    | Caret_transparent -> 81000
+    | Caret_bracket_color _ -> 81000
+    | Caret_bracket_color_opacity _ -> 81000
+    | Accent (color, shade) ->
+        let _ = (color, shade) in
+        82000
+    | Accent_opacity (color, shade, _) ->
+        let _ = (color, shade) in
+        82000
+    | Accent_transparent -> 82000
+    | Accent_current -> 82000
+    | Accent_current_opacity _ -> 82000
+    | Accent_inherit -> 82000
+    | Accent_bracket_color _ -> 82000
+    | Accent_bracket_color_opacity _ -> 82000
     (* Outline colors run at priority 28 with the rest of the outline family
        (see [priority]): the 3000 base puts them after borders.ml's outline
-       width (1999-2010) and offset (2200-2299) and before its outline
-       styles (30000-30004). *)
+       width (1999-2010) and offset (2200-2299) and before its outline styles
+       (30000-30004). *)
     | Outline (color, shade) ->
         let base =
           if is_base_color color then
@@ -3173,15 +3182,6 @@ module Handler = struct
     | Outline_bracket_var_opacity _ -> 3000
     | Outline_bracket_typed_var _ -> 3000
     | Outline_bracket_typed_var_opacity _ -> 3000
-    (* Placeholder colors: 80000 base *)
-    | Placeholder _ -> 80000
-    | Placeholder_opacity _ -> 80000
-    | Placeholder_transparent -> 80000
-    | Placeholder_current -> 80000
-    | Placeholder_current_opacity _ -> 80000
-    | Placeholder_inherit -> 80000
-    | Placeholder_bracket_color _ -> 80000
-    | Placeholder_bracket_color_opacity _ -> 80000
 
   let to_class = function
     (* [Text_opacity] leads so the match resolves to the colour [t] rather than

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1988,7 +1988,6 @@ module Handler = struct
     | Outline_bracket_var _ | Outline_bracket_var_opacity _
     | Outline_bracket_typed_var _ | Outline_bracket_typed_var_opacity _ ->
         28
-    | _ -> 25
 
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -500,16 +500,16 @@ module Handler = struct
 
   (* Theme tokens for the sized drop-shadow utilities. Tailwind v4 defines a
      [--drop-shadow-<size>] design token in the theme layer and references it
-     from [--tw-drop-shadow]. These tokens sort after border-radius (order 7)
-     and before blur (order 8). Bound via [Var.binding] so the theme declaration
-     is always emitted with its default value and stays overridable through an
-     [@theme] token override threaded via [Scheme.t]. *)
-  let drop_shadow_xs_var = Var.theme Css.Shadow "drop-shadow-xs" ~order:(7, 8)
-  let drop_shadow_sm_var = Var.theme Css.Shadow "drop-shadow-sm" ~order:(7, 9)
-  let drop_shadow_md_var = Var.theme Css.Shadow "drop-shadow-md" ~order:(7, 10)
-  let drop_shadow_lg_var = Var.theme Css.Shadow "drop-shadow-lg" ~order:(7, 11)
-  let drop_shadow_xl_var = Var.theme Css.Shadow "drop-shadow-xl" ~order:(7, 12)
-  let drop_shadow_2xl_var = Var.theme Css.Shadow "drop-shadow-2xl" ~order:(7, 13)
+     from [--tw-drop-shadow]. The family owns slots (7, 20-25), after radius (7,
+     0-11) and before ease (7, 30-34). Bound via [Var.binding] so the theme
+     declaration is always emitted with its default value and stays overridable
+     through an [@theme] token override threaded via [Scheme.t]. *)
+  let drop_shadow_xs_var = Var.theme Css.Shadow "drop-shadow-xs" ~order:(7, 20)
+  let drop_shadow_sm_var = Var.theme Css.Shadow "drop-shadow-sm" ~order:(7, 21)
+  let drop_shadow_md_var = Var.theme Css.Shadow "drop-shadow-md" ~order:(7, 22)
+  let drop_shadow_lg_var = Var.theme Css.Shadow "drop-shadow-lg" ~order:(7, 23)
+  let drop_shadow_xl_var = Var.theme Css.Shadow "drop-shadow-xl" ~order:(7, 24)
+  let drop_shadow_2xl_var = Var.theme Css.Shadow "drop-shadow-2xl" ~order:(7, 25)
 
   let drop_shadow_color_ref fallback =
     Var.reference_with_fallback drop_shadow_color_var fallback

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -10,16 +10,13 @@ type t =
       has_hover : bool; (* Track if this rule has hover modifier *)
       nested : Css.statement list; (* Nested statements (e.g., @media) *)
       merge_key : string option;
-      not_order : int; (* Variant order for not-* rules, 0 for normal rules *)
     }
   | Media_query of {
       condition : Css.Media.t;
       selector : Css.Selector.t;
       props : Css.declaration list;
       base_class : string option;
-      nested : Css.statement list;
-          (* Nested statements for compound modifiers *)
-      not_order : int;
+      nested : Css.statement list; (* Nested statements for compound modifiers *)
     }
   | Container_query of {
       condition : Css.Container.t;
@@ -40,7 +37,6 @@ type t =
       props : Css.declaration list;
       base_class : string option;
       merge_key : string option;
-      not_order : int;
       nested : Css.statement list;
     }
 
@@ -53,13 +49,11 @@ type by_type = {
 }
 
 let regular ~selector ~props ?base_class ?(has_hover = false) ?(nested = [])
-    ?merge_key ?(not_order = 0) () =
-  Regular
-    { selector; props; base_class; has_hover; nested; merge_key; not_order }
+    ?merge_key () =
+  Regular { selector; props; base_class; has_hover; nested; merge_key }
 
-let media_query ~condition ~selector ~props ?base_class ?(nested = [])
-    ?(not_order = 0) () =
-  Media_query { condition; selector; props; base_class; nested; not_order }
+let media_query ~condition ~selector ~props ?base_class ?(nested = []) () =
+  Media_query { condition; selector; props; base_class; nested }
 
 let container_query ~condition ~selector ~props ?base_class ?(nested = []) () =
   Container_query { condition; selector; props; base_class; nested }
@@ -68,9 +62,8 @@ let starting_style ~selector ~props ?base_class ?(nested = []) () =
   Starting_style { selector; props; base_class; nested }
 
 let supports_query ~condition ~selector ~props ?base_class ?merge_key
-    ?(not_order = 0) ?(nested = []) () =
-  Supports_query
-    { condition; selector; props; base_class; merge_key; not_order; nested }
+    ?(nested = []) () =
+  Supports_query { condition; selector; props; base_class; merge_key; nested }
 
 let base_class = function
   | Regular { base_class; _ }

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -28,8 +28,6 @@ type t =
           *)
       merge_key : string option;
           (** Override key for the CSS optimizer's merge heuristic. *)
-      not_order : int;
-          (** Sort key for [not-*] variant rules; 0 for normal rules. *)
     }
   | Media_query of {
       condition : Css.Media.t;
@@ -37,7 +35,6 @@ type t =
       props : Css.declaration list;
       base_class : string option;
       nested : Css.statement list;
-      not_order : int;
     }
   | Container_query of {
       condition : Css.Container.t;
@@ -58,14 +55,13 @@ type t =
       props : Css.declaration list;
       base_class : string option;
       merge_key : string option;
-      not_order : int;
       nested : Css.statement list;
     }
 
 (** {1 Smart constructors}
 
     All arguments except [selector] and [props] are optional and default to
-    sensible values ([false], [[]], [None], [0]). *)
+    sensible values ([false], [[]], [None]). *)
 
 val regular :
   selector:Css.Selector.t ->
@@ -74,7 +70,6 @@ val regular :
   ?has_hover:bool ->
   ?nested:Css.statement list ->
   ?merge_key:string ->
-  ?not_order:int ->
   unit ->
   t
 (** [regular ~selector ~props ()] constructs a plain (non-media,
@@ -86,7 +81,6 @@ val media_query :
   props:Css.declaration list ->
   ?base_class:string ->
   ?nested:Css.statement list ->
-  ?not_order:int ->
   unit ->
   t
 (** [media_query ~condition ~selector ~props ()] constructs a
@@ -119,7 +113,6 @@ val supports_query :
   props:Css.declaration list ->
   ?base_class:string ->
   ?merge_key:string ->
-  ?not_order:int ->
   ?nested:Css.statement list ->
   unit ->
   t

--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -55,23 +55,23 @@ let box_resets () =
       ];
   ]
 
-(* Font feature/variation settings variables Order (8, 10+) to come after
-   default-transition-* (8, 0-1) *)
+(* Font feature/variation settings variables Order (8, 40+) to come after
+   default-transition-* (8, 30-31) *)
 let font_feature =
   Var.theme Css.Font_feature_settings "default-font-feature-settings"
-    ~order:(8, 10)
+    ~order:(8, 40)
 
 let font_variation =
   Var.theme Css.Font_variation_settings "default-font-variation-settings"
-    ~order:(8, 11)
+    ~order:(8, 41)
 
 let mono_font_feature =
   Var.theme Css.Font_feature_settings "default-mono-font-feature-settings"
-    ~order:(8, 12)
+    ~order:(8, 42)
 
 let mono_font_variation =
   Var.theme Css.Font_variation_settings "default-mono-font-variation-settings"
-    ~order:(8, 13)
+    ~order:(8, 43)
 
 (** Helper for creating variable references in preflight context
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -503,16 +503,15 @@ let has_anchor_rel ~anchor ~combinator ?name inner =
    its [:hover]. With no inner variant [selector] is the bare class and the
    result is [modified] itself. *)
 let route_regular ~selector ~base_class ~modified_class ~modified ?has_hover
-    ~not_order props =
+    props =
   let sel =
     Rules_selector.transform_selector_with_modifier modified base_class
       modified_class selector
   in
-  regular ~selector:sel ~props ~base_class:modified_class ?has_hover ~not_order
-    ()
+  regular ~selector:sel ~props ~base_class:modified_class ?has_hover ()
 
-let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
-    ~selector selector_str base_class props =
+let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~selector
+    selector_str base_class props =
   let open Css.Selector in
   let parsed_selector =
     match has_relative_selector selector_str with
@@ -529,7 +528,7 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
       let class_name = "has-" ^ has_part selector_str ^ ":" ^ base_class in
       let modified = compound [ class_ class_name; has [ parsed_selector ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~has_hover ~not_order props
+        ~has_hover props
   | `Group_has ->
       let name_suffix = match name with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -541,7 +540,7 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
       in
       let modified = compound [ Class class_name; is_ [ rel ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~has_hover ~not_order props
+        ~has_hover props
   | `Peer_has ->
       let name_suffix = match name with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -553,7 +552,7 @@ let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~not_order
       in
       let modified = compound [ Class class_name; is_ [ rel ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~has_hover ~not_order props
+        ~has_hover props
 
 (* Pseudo-class modifiers: transform the base selector and mark hover when
    needed. *)
@@ -661,7 +660,6 @@ let route_data_bracket_modifier modifier ~selector base_class props =
   let attr_name, attr_match, attr_flag = Modifiers.parse_data_expr expr in
   let open Css.Selector in
   let class_part = raw_str in
-  let not_order = 20 in
   match kind with
   | `Data ->
       let class_name = "data-" ^ class_part ^ ":" ^ base_class in
@@ -670,7 +668,7 @@ let route_data_bracket_modifier modifier ~selector base_class props =
           [ class_ class_name; attribute ?flag:attr_flag attr_name attr_match ]
       in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~not_order props
+        props
   | `Group_data ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -690,7 +688,7 @@ let route_data_bracket_modifier modifier ~selector base_class props =
       in
       let modified = compound [ Class class_name; is_ [ rel ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~not_order props
+        props
   | `Peer_data ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -710,7 +708,7 @@ let route_data_bracket_modifier modifier ~selector base_class props =
       in
       let modified = compound [ Class class_name; is_ [ rel ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~not_order props
+        props
 
 (* Route :has() variants to appropriate handler *)
 let route_has_modifier modifier ~selector base_class props =
@@ -732,17 +730,8 @@ let route_has_modifier modifier ~selector base_class props =
   let shorthand = if is_shorthand then Some raw_str else None in
   (* [has-hover] gates on the pointer just like [hover] itself does. *)
   let has_hover = is_shorthand && raw_str = "hover" in
-  (* Ordering: shorthands before brackets; pseudo-class brackets before
-     combinator brackets. Named vs unnamed ordering handled by
-     normalize_for_sort since '/' maps to '|' which sorts after ':' → '!'. *)
-  let base_order =
-    if is_shorthand then 10
-    else if raw_str <> "" && raw_str.[0] = ':' then 20
-    else 30
-  in
-  let not_order = base_order in
-  has_like_selector kind ?name ?shorthand ~has_hover ~not_order ~selector
-    selector_str base_class props
+  has_like_selector kind ?name ?shorthand ~has_hover ~selector selector_str
+    base_class props
 
 (* Parse an aria expression string into an attribute name and match. "modal" →
    ("aria-modal", Presence) "valuenow=1" → ("aria-valuenow", Exact "1")
@@ -783,7 +772,6 @@ let route_aria_modifier modifier ~selector base_class props =
     else parse_aria_expr raw_str
   in
   let class_part = if is_shorthand then raw_str else "[" ^ raw_str ^ "]" in
-  let not_order = if is_shorthand then 10 else 20 in
   match kind with
   | `Aria ->
       let class_name = "aria-" ^ class_part ^ ":" ^ base_class in
@@ -791,7 +779,7 @@ let route_aria_modifier modifier ~selector base_class props =
         compound [ class_ class_name; attribute aria_attr aria_match ]
       in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~not_order props
+        props
   | `Group_aria ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -808,7 +796,7 @@ let route_aria_modifier modifier ~selector base_class props =
       in
       let modified = compound [ Class class_name; is_ [ rel ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~not_order props
+        props
   | `Peer_aria ->
       let name_suffix = match name_opt with Some n -> "/" ^ n | None -> "" in
       let class_name =
@@ -825,7 +813,7 @@ let route_aria_modifier modifier ~selector base_class props =
       in
       let modified = compound [ Class class_name; is_ [ rel ] ] in
       route_regular ~selector ~base_class ~modified_class:class_name ~modified
-        ~not_order props
+        props
 
 (* Handle fallback for unmatched modifiers. Must extract modified_class so that
    outer modifiers like dark: can properly transform the selector. *)
@@ -1081,20 +1069,18 @@ and extract_not_conditions inner_modifier base_class =
       | _ -> [ sel ])
 
 (** Build a regular rule with :not() selector for a not-* modifier. *)
-let not_selector_rule ?(not_order = 0) inner_modifier modified_class base_class
-    ~selector props =
+let not_selector_rule inner_modifier modified_class base_class ~selector props =
   let conditions = extract_not_conditions inner_modifier base_class in
   let not_sel = Css.Selector.Not conditions in
   let modified =
     Css.Selector.compound [ Css.Selector.Class modified_class; not_sel ]
   in
-  route_regular ~selector ~base_class ~modified_class ~modified ~not_order props
+  route_regular ~selector ~base_class ~modified_class ~modified props
 
 (* Create a single not-media rule *)
-let not_media_rule ~nvo ~condition modified_class props =
+let not_media_rule ~condition modified_class props =
   [
-    media_query ~not_order:nvo ~condition
-      ~selector:(Css.Selector.Class modified_class) ~props
+    media_query ~condition ~selector:(Css.Selector.Class modified_class) ~props
       ~base_class:modified_class ();
   ]
 
@@ -1105,14 +1091,11 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
   let modified_class =
     "not-" ^ not_class_prefix inner_modifier ^ ":" ^ base_class
   in
-  let nvo = Modifiers.not_variant_order inner_modifier in
   let sel_rule () =
-    not_selector_rule ~not_order:nvo inner_modifier modified_class base_class
-      ~selector props
+    not_selector_rule inner_modifier modified_class base_class ~selector props
   in
   let not_hover_media () =
-    not_media_rule ~nvo ~condition:(negate_media hover_media) modified_class
-      props
+    not_media_rule ~condition:(negate_media hover_media) modified_class props
   in
   match inner_modifier with
   | Style.Hover -> [ sel_rule () ] @ not_hover_media ()
@@ -1120,11 +1103,10 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
   | Style.Hocus -> [ sel_rule () ]
   | _ when Option.is_some (media_condition_of_modifier inner_modifier) ->
       let condition = Option.get (media_condition_of_modifier inner_modifier) in
-      not_media_rule ~nvo ~condition:(negate_media condition) modified_class
-        props
+      not_media_rule ~condition:(negate_media condition) modified_class props
   | Style.Supports_property prop ->
       [
-        supports_query ~not_order:nvo
+        supports_query
           ~condition:(Css.Supports.Not (Css.Supports.property prop "var(--tw)"))
           ~selector:(Css.Selector.Class modified_class) ~props
           ~base_class:modified_class ();
@@ -1132,32 +1114,30 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
   | Style.Supports_condition condition_str ->
       let inner_condition = normalize_supports_condition condition_str in
       [
-        supports_query ~not_order:nvo
-          ~condition:(Css.Supports.Not inner_condition)
+        supports_query ~condition:(Css.Supports.Not inner_condition)
           ~selector:(Css.Selector.Class modified_class) ~props
           ~base_class:modified_class ();
       ]
   | Style.Responsive bp | Style.Min_responsive bp ->
-      not_media_rule ~nvo
+      not_media_rule
         ~condition:(breakpoint_not_condition ?theme bp)
         modified_class props
   | Style.Max_responsive bp ->
-      not_media_rule ~nvo
+      not_media_rule
         ~condition:(breakpoint_condition ?theme bp)
         modified_class props
   | Style.Min_arbitrary w ->
-      not_media_rule ~nvo
+      not_media_rule
         ~condition:(media_not_min_width_px w.px)
         modified_class props
   | Style.Max_arbitrary w ->
-      not_media_rule ~nvo ~condition:(media_min_width_px w.px) modified_class
-        props
+      not_media_rule ~condition:(media_min_width_px w.px) modified_class props
   | Style.Min_arbitrary_length l ->
-      not_media_rule ~nvo
+      not_media_rule
         ~condition:(Css.media_not_min_width_length l)
         modified_class props
   | Style.Max_arbitrary_length l ->
-      not_media_rule ~nvo
+      not_media_rule
         ~condition:(Css.media_min_width_length l)
         modified_class props
   | _ -> [ sel_rule () ]
@@ -1231,10 +1211,7 @@ let handle_in_bracket content base_class props =
     Css.Selector.combine (Css.Selector.Where [ ancestor ])
       Css.Selector.Descendant (Css.Selector.Class modified_class)
   in
-  [
-    regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in"
-      ~not_order:300 ();
-  ]
+  [ regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in" () ]
 
 (** Handle in-data-X modifier. Returns a list of rules. *)
 let handle_in_data attr base_class props =
@@ -1247,10 +1224,7 @@ let handle_in_data attr base_class props =
          ])
       Css.Selector.Descendant (Css.Selector.Class modified_class)
   in
-  [
-    regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in"
-      ~not_order:200 ();
-  ]
+  [ regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in" () ]
 
 (* [not-in-*] negates the ancestor relation rather than the class, so the
    class's own position in the negated selector is a universal. *)
@@ -1266,10 +1240,7 @@ let not_in_rule ~modified_class ~ancestor props =
           ];
       ]
   in
-  [
-    regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in"
-      ~not_order:100 ();
-  ]
+  [ regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in" () ]
 
 (** Handle not-in-[...] bracket modifier. Returns a list of rules. *)
 let handle_not_in_bracket content base_class props =
@@ -1289,7 +1260,6 @@ let handle_not_in_data attr base_class props =
 (** Handle not-[...] bracket modifier. Returns a list of rules. *)
 let handle_not_bracket content base_class props =
   let modified_class = "not-[" ^ content ^ "]:" ^ base_class in
-  let nvo = Modifiers.not_variant_order (Style.Not_bracket content) in
   if
     (String.length content > 6 && String.sub content 0 6 = "@media")
     || (String.length content > 7 && String.sub content 0 7 = "@media_")
@@ -1297,15 +1267,14 @@ let handle_not_bracket content base_class props =
     (* Media bracket pattern: not-[@media...] → negated media query *)
     let condition = parse_bracket_media content in
     [
-      media_query ~not_order:nvo ~condition
-        ~selector:(Css.Selector.Class modified_class) ~props
-        ~base_class:modified_class ();
+      media_query ~condition ~selector:(Css.Selector.Class modified_class)
+        ~props ~base_class:modified_class ();
     ]
   else if content <> "" && content.[0] = ':' then
     (* Pseudo-class bracket: not-[:checked] → :not(:checked) *)
     let pseudo = parse_bracket_pseudo content in
     [
-      regular ~not_order:nvo
+      regular
         ~selector:
           (Css.Selector.compound
              [ Css.Selector.Class modified_class; Css.Selector.Not [ pseudo ] ])
@@ -1324,7 +1293,7 @@ let handle_not_bracket content base_class props =
         (Css.Selector.read (Cascade.Cursor.of_string sel_str))
     in
     [
-      regular ~not_order:nvo
+      regular
         ~selector:
           (Css.Selector.compound
              [ Css.Selector.Class modified_class; Css.Selector.Not [ inner ] ])
@@ -1343,14 +1312,13 @@ let is_media_inner_modifier = function
   | Style.Hover | Style.Device_hocus -> true
   | inner -> Option.is_some (media_condition_of_modifier inner)
 
-let handle_named_not ~prefix ~base_marker_class ~combinator ~variant inner
-    name_opt base_class props =
+let handle_named_not ~prefix ~base_marker_class ~combinator inner name_opt
+    base_class props =
   let inner_str = not_modifier_inner_string inner in
   let name_suffix = named_modifier_suffix name_opt in
   let modified_class =
     prefix ^ "-not-" ^ inner_str ^ name_suffix ^ ":" ^ base_class
   in
-  let nvo = Modifiers.not_variant_order (variant inner name_opt) in
   if is_media_inner_modifier inner then []
   else
     let not_conditions =
@@ -1365,24 +1333,20 @@ let handle_named_not ~prefix ~base_marker_class ~combinator ~variant inner
         not_conditions
     in
     [
-      regular ~not_order:nvo
+      regular
         ~selector:(compound [ Class modified_class; is_ [ rel ] ])
         ~props ~base_class:modified_class ();
     ]
 
 let handle_group_not_modifier inner name_opt base_class props =
   handle_named_not ~prefix:"group" ~base_marker_class:"group"
-    ~combinator:Descendant
-    ~variant:(fun inner name_opt -> Style.Group_not (inner, name_opt))
-    inner name_opt base_class props
+    ~combinator:Descendant inner name_opt base_class props
 
 (** Handle peer-not-X modifier. Produces selector with
     :is(:where(.peer):not(...) sibling) pattern. *)
 let handle_peer_not_modifier inner name_opt base_class props =
   handle_named_not ~prefix:"peer" ~base_marker_class:"peer"
-    ~combinator:Subsequent_sibling
-    ~variant:(fun inner name_opt -> Style.Peer_not (inner, name_opt))
-    inner name_opt base_class props
+    ~combinator:Subsequent_sibling inner name_opt base_class props
 
 (** Convert a base modifier to its CSS pseudo-class selector. *)
 let pseudo_selector_of_modifier = function
@@ -1474,7 +1438,7 @@ let handle_in_state inner name base_class props =
   [
     (* [in-hover] gates on the pointer just as [hover] itself does. *)
     regular ~selector:sel ~props ~base_class:modified_class ~merge_key:"in"
-      ~has_hover:(Modifiers.is_hover inner) ~not_order:250 ();
+      ~has_hover:(Modifiers.is_hover inner) ();
   ]
 
 (** Handle not-group-STATE/name compound variant *)
@@ -1637,8 +1601,7 @@ let route_has_variant inner ~selector base_class props =
         Css.Selector.Has (extract_not_conditions inner base_class);
       ]
   in
-  route_regular ~selector ~base_class ~modified_class ~modified ~not_order:10
-    props
+  route_regular ~selector ~base_class ~modified_class ~modified props
 
 (* A prose element variant puts the elements it targets under the utility's own
    class. Substituting for that class rather than rebuilding the selector from
@@ -2087,7 +2050,7 @@ and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
   in
   apply_modifier_to_rule ?theme modifier inner
   |> List.map (function
-    | Regular { selector; props; base_class; has_hover; not_order; _ } ->
+    | Regular { selector; props; base_class; has_hover; _ } ->
         (* A bare hover: rule carries [has_hover] instead of an outer media;
            wrap the @supports in @media (hover:hover) to match. *)
         if has_hover then
@@ -2095,8 +2058,7 @@ and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
         else
           (* Keep the variant's own order: without it the block sorts before the
              rule it enhances, and the plain fallback wins instead. *)
-          supports_query ~condition ~selector ~props ?base_class ?merge_key
-            ~not_order ()
+          supports_query ~condition ~selector ~props ?base_class ?merge_key ()
     | Media_query { condition = outer; selector; props; base_class; nested; _ }
       ->
         wrap_supports_in_media outer selector props base_class nested

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -613,7 +613,9 @@ module Handler = struct
   let aspect_auto' = style [ Css.aspect_ratio Auto ]
 
   (* Theme variables for aspect ratios *)
-  let aspect_video_var = Var.theme Css.Aspect_ratio "aspect-video" ~order:(4, 1)
+  (* Tailwind's [@theme] declares [--aspect-video] after the perspective scale
+     (8, 10-16) and before the [--default-*] tokens (8, 30+). *)
+  let aspect_video_var = Var.theme Css.Aspect_ratio "aspect-video" ~order:(8, 20)
 
   (* aspect-square inlines the 1/1 ratio in v4 (no --aspect-square theme token),
      unlike aspect-video which references the --aspect-video token. *)
@@ -635,7 +637,9 @@ module Handler = struct
     match Hashtbl.find_opt aspect_named_cache name with
     | Some var -> var
     | None ->
-        let var = Var.theme Css.Aspect_ratio ("aspect-" ^ name) ~order:(4, 2) in
+        let var =
+          Var.theme Css.Aspect_ratio ("aspect-" ^ name) ~order:(8, 21)
+        in
         Hashtbl.add aspect_named_cache name var;
         var
 

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -70,7 +70,6 @@ type indexed_rule = {
   nested : Css.statement list;
   base_class : string option;
   merge_key : string option;
-  not_order : int;
   variant_order : int;
   variant_key : string * int;
       (* Precomputed (variant prefix, effective inner order) - see
@@ -878,13 +877,6 @@ let compare_starting_rules = compare_by_order_then_index
 (* Main Rule Comparison *)
 (* ======================================================================== *)
 
-(* Compare by base class (precomputed in [add_index]), then index. Tailwind
-   sorts same-family variants by the raw class name (ASCII), so compare
-   as-is. *)
-let compare_by_base_class r1 r2 =
-  let class_cmp = String.compare r1.base_class_key r2.base_class_key in
-  if class_cmp <> 0 then class_cmp else Int.compare r1.index r2.index
-
 let supports_suffix s =
   if String.starts_with ~prefix:"supports-" s then
     Some (String.sub s 9 (String.length s - 9))
@@ -1287,19 +1279,6 @@ let compare_indexed_rules r1 r2 =
     compare_variant_ordered r1 r2
   else if r1.variant_order > 0 then 1
   else if r2.variant_order > 0 then -1
-  else if r1.not_order > 0 || r2.not_order > 0 then
-    if r1.not_order = 0 then -1
-    else if r2.not_order = 0 then 1
-    else
-      let not_cmp = Int.compare r1.not_order r2.not_order in
-      if not_cmp <> 0 then not_cmp
-      else
-        match (r1.rule_type, r2.rule_type) with
-        | `Supports _, `Supports _
-          when is_modifier_supports r1.base_class
-               && is_modifier_supports r2.base_class ->
-            compare_supports_by_key r1 r2
-        | _ -> compare_by_base_class r1 r2
   else
     let type_cmp =
       Int.compare (rule_type_order r1.rule_type) (rule_type_order r2.rule_type)

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -59,7 +59,6 @@ type indexed_rule = {
   nested : Css.statement list;
   base_class : string option;
   merge_key : string option;
-  not_order : int;
   variant_order : int;
       (** Non-zero for modifier-prefixed rules; they sort after base rules. *)
   variant_key : string * int;

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -207,21 +207,22 @@ module Handler = struct
     Var.channel ~needs_property:true ~property_order:4 ~family:`Skew
       Css.Transform "tw-skew-y"
 
-  (* Perspective theme variables, ordered by value to match Tailwind's theme *)
+  (* Perspective theme variables, ordered by value to match Tailwind's theme.
+     The family owns slots (8, 10-16), after blur (8, 0-8). *)
   let perspective_dramatic_var =
-    Var.theme Css.Length "perspective-dramatic" ~order:(7, 13)
+    Var.theme Css.Length "perspective-dramatic" ~order:(8, 10)
 
   let perspective_near_var =
-    Var.theme Css.Length "perspective-near" ~order:(7, 14)
+    Var.theme Css.Length "perspective-near" ~order:(8, 11)
 
   let perspective_normal_var =
-    Var.theme Css.Length "perspective-normal" ~order:(7, 15)
+    Var.theme Css.Length "perspective-normal" ~order:(8, 12)
 
   let perspective_midrange_var =
-    Var.theme Css.Length "perspective-midrange" ~order:(7, 16)
+    Var.theme Css.Length "perspective-midrange" ~order:(8, 13)
 
   let perspective_distant_var =
-    Var.theme Css.Length "perspective-distant" ~order:(7, 17)
+    Var.theme Css.Length "perspective-distant" ~order:(8, 14)
 
   (* A [--perspective-*] token the project declared names a depth the built-in
      scale has no slot for; they share the slot after the scale. *)
@@ -232,12 +233,12 @@ module Handler = struct
     match Hashtbl.find_opt perspective_named_cache name with
     | Some var -> var
     | None ->
-        let var = Var.theme Css.Length ("perspective-" ^ name) ~order:(7, 19) in
+        let var = Var.theme Css.Length ("perspective-" ^ name) ~order:(8, 16) in
         Hashtbl.add perspective_named_cache name var;
         var
 
   let perspective_none_var =
-    Var.theme Css.Length "perspective-none" ~order:(7, 18)
+    Var.theme Css.Length "perspective-none" ~order:(8, 15)
 
   (** {1 Helpers} *)
 

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -53,11 +53,11 @@ module Handler = struct
      (8,0) so it appears before timing-function (8,1) in the theme layer output,
      matching Tailwind's order. *)
   let default_transition_duration_var =
-    Var.theme Css.Duration "default-transition-duration" ~order:(8, 0)
+    Var.theme Css.Duration "default-transition-duration" ~order:(8, 30)
 
   let default_transition_timing_function_var =
     Var.theme Css.Timing_function "default-transition-timing-function"
-      ~order:(8, 1)
+      ~order:(8, 31)
 
   (* Variable for transition duration with @property *)
   let tw_duration_var =
@@ -332,10 +332,10 @@ module Handler = struct
     in
     style ~property_rules [ Var.binding_initial tw_ease_var ]
 
-  (* Theme variables for easing functions - order (7, 9-12) places them after
-     radius (7, 0-8) but before animate (7, 13-17) *)
-  let ease_in_var = Var.theme Css.Timing_function "ease-in" ~order:(7, 9)
-  let ease_out_var = Var.theme Css.Timing_function "ease-out" ~order:(7, 10)
+  (* Theme variables for easing functions - slots (7, 30-34) place them after
+     drop-shadow (7, 20-25) and before animate (7, 40-45). *)
+  let ease_in_var = Var.theme Css.Timing_function "ease-in" ~order:(7, 30)
+  let ease_out_var = Var.theme Css.Timing_function "ease-out" ~order:(7, 31)
 
   (* An [--ease-*] token the project declared names a timing function the
      built-in scale has no slot for; they share the slot after the scale. *)
@@ -347,16 +347,16 @@ module Handler = struct
     | Some var -> var
     | None ->
         let var =
-          Var.theme Css.Timing_function ("ease-" ^ name) ~order:(7, 12)
+          Var.theme Css.Timing_function ("ease-" ^ name) ~order:(7, 34)
         in
         Hashtbl.add ease_named_cache name var;
         var
 
   let ease_in_out_var =
-    Var.theme Css.Timing_function "ease-in-out" ~order:(7, 11)
+    Var.theme Css.Timing_function "ease-in-out" ~order:(7, 32)
 
   let ease_linear_var =
-    Var.theme Css.Timing_function "ease-linear" ~order:(7, 12)
+    Var.theme Css.Timing_function "ease-linear" ~order:(7, 33)
 
   let ease_linear ?theme () =
     (* Tailwind uses the raw 'linear' keyword by default, but uses

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2271,42 +2271,44 @@ module Typography_late = struct
   (** {1 Ordering Support} *)
 
   let suborder = function
-    (* Decoration color - comes first in late typography. All color variants use
-       the same suborder so the optimizer sorts them alphabetically by class
-       name. *)
-    | Decoration_color _ -> 5000
-    | Decoration_color_opacity _ -> 5000
-    | Decoration_transparent -> 5000
-    | Decoration_current -> 5000
-    | Decoration_current_opacity _ -> 5000
-    | Decoration_inherit -> 5000
-    | Decoration_bracket_color _ -> 4000
-    | Decoration_bracket_invalid_color _ -> 4000
-    | Decoration_bracket_color_opacity _ -> 4000
-    | Decoration_bracket_color_var _ -> 4100
-    | Decoration_bracket_color_var_opacity _ -> 4100
-    | Decoration_bracket_var _ -> 4200
-    | Decoration_bracket_var_opacity _ -> 4200
     (* Text decoration lines - suborder >= 8000 (alphabetical) *)
     | Line_through -> 8400
     | No_underline -> 8401
     | Overline -> 8402
     | Underline -> 8403
+    (* The decoration properties follow the line, in Tailwind's own order:
+       colour, then style, then thickness. All the colour variants share a
+       suborder so the tie is broken alphabetically by class name. *)
+    | Decoration_bracket_color _ -> 8410
+    | Decoration_bracket_invalid_color _ -> 8410
+    | Decoration_bracket_color_opacity _ -> 8410
+    | Decoration_bracket_color_var _ -> 8411
+    | Decoration_bracket_color_var_opacity _ -> 8411
+    | Decoration_bracket_var _ -> 8412
+    | Decoration_bracket_var_opacity _ -> 8412
+    | Decoration_color _ -> 8413
+    | Decoration_color_opacity _ -> 8413
+    | Decoration_transparent -> 8413
+    | Decoration_current -> 8413
+    | Decoration_current_opacity _ -> 8413
+    | Decoration_inherit -> 8413
     (* Decoration styles - same suborder, sorted by class name *)
-    | Decoration_solid -> 8100
-    | Decoration_double -> 8100
-    | Decoration_dotted -> 8100
-    | Decoration_dashed -> 8100
-    | Decoration_wavy -> 8100
+    | Decoration_solid -> 8420
+    | Decoration_double -> 8420
+    | Decoration_dotted -> 8420
+    | Decoration_dashed -> 8420
+    | Decoration_wavy -> 8420
     (* Decoration thickness - numeric values by n, then brackets, then
-       auto/from-font *)
-    | Decoration_thickness n -> 8200 + n
-    | Decoration_bracket_thickness _ -> 8400
-    | Decoration_bracket_pct _ -> 8400
-    | Decoration_bracket_length_var _ -> 8400
-    | Decoration_bracket_pct_var _ -> 8400
-    | Decoration_auto -> 8500
-    | Decoration_from_font -> 8500
+       auto/from-font. The numeric band is open-ended (the class carries any
+       integer), so the brackets sit far enough above it that no thickness a
+       stylesheet would ask for reaches them, and below the underline offset. *)
+    | Decoration_thickness n -> 8430 + n
+    | Decoration_bracket_thickness _ -> 30000
+    | Decoration_bracket_pct _ -> 30000
+    | Decoration_bracket_length_var _ -> 30000
+    | Decoration_bracket_pct_var _ -> 30000
+    | Decoration_auto -> 30010
+    | Decoration_from_font -> 30010
     (* Tracking — negative first, then arbitrary, then named *)
     | Neg_tracking_arbitrary _ -> 8245
     | Neg_tracking_var _ -> 8250

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -467,6 +467,66 @@ let test_resolve_deps_dedup_queue () =
   check bool "has text-xl line-height var" true
     (List.mem "--text-xl-line-height" vars)
 
+(* Where [sheet] declares each of [vars], in the order the sheet declares them.
+   The theme layer is the only place a [--name:] declaration appears; every
+   other mention is a [var()] reference with no colon after the name. *)
+let theme_var_order sheet vars =
+  let position v =
+    let needle = v ^ ":" in
+    let n = String.length needle and len = String.length sheet in
+    let rec scan i =
+      if i + n > len then failf "%s is missing from the sheet" v
+      else if String.sub sheet i n = needle then i
+      else scan (i + 1)
+    in
+    scan 0
+  in
+  List.map (fun v -> (position v, v)) vars |> List.sort compare |> List.map snd
+
+(* Several theme families number their slots from a base of their own, so tokens
+   from different families land on one slot and the tie falls to the variable
+   name, which interleaves them. Nothing rendered changes and the canonical
+   differ reads the two sheets as equal, so the CLI's own emission order is the
+   oracle. *)
+let check_theme_layer_family_order () =
+  let classes =
+    [
+      "rounded-4xl";
+      "drop-shadow-md";
+      "ease-out";
+      "animate-spin";
+      "animate-pulse";
+      "blur-md";
+      "perspective-dramatic";
+      "perspective-near";
+      "aspect-video";
+    ]
+  in
+  let vars =
+    [
+      "--radius-4xl";
+      "--drop-shadow-md";
+      "--ease-out";
+      "--animate-spin";
+      "--animate-pulse";
+      "--blur-md";
+      "--perspective-dramatic";
+      "--perspective-near";
+      "--aspect-video";
+    ]
+  in
+  let utilities =
+    List.map
+      (fun c ->
+        match Tw.of_string c with
+        | Ok u -> u
+        | Error (`Msg m) -> failf "%s: %s" c m)
+      classes
+  in
+  let expected = theme_var_order (tailwind_css classes) vars in
+  check (list string) "theme layer family order" expected
+    (theme_var_order (our_css utilities) vars)
+
 let test_theme_layer_media_refs () =
   (* Vars referenced only under media queries should still end up in theme. *)
   let theme_layer =
@@ -1026,6 +1086,7 @@ let tests =
     test_case "inline_vs_variables_diff" `Quick test_inline_vs_variables_diff;
     test_case "resolve_dependencies_dedup_and_queue" `Quick
       test_resolve_deps_dedup_queue;
+    test_case "theme layer family order" `Quick check_theme_layer_family_order;
     test_case "theme_layer_collects_media_refs" `Quick
       test_theme_layer_media_refs;
     test_case "theme_layer_collects_media_refs (md)" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -972,6 +972,33 @@ let test_container_query_call_order () =
       "@min-[theme(--breakpoint-sm)]:flex";
     ]
 
+(* The suborder a rule sorts on carries more than the utility's own number: a
+   [before:]/[after:] class has 5000 added to it, and a rule built by one of the
+   negation, ancestor, has-, aria- or data- handlers has that handler's offset
+   added. Both offsets are common to every rule the comparator can reach them
+   with - it only reads the suborder for two rules whose whole variant prefix is
+   equal - so they cancel, and this pins the order they were meant to produce
+   across the families that carry them. *)
+let test_variant_family_order () =
+  Test_helpers.check_class_order ~test_name:"variant families sort as Tailwind"
+    [
+      "underline";
+      "before:underline";
+      "after:underline";
+      "has-checked:underline";
+      "has-[>img]:underline";
+      "aria-checked:underline";
+      "aria-[sort=none]:underline";
+      "data-open:underline";
+      "in-data-open:underline";
+      "in-[.foo]:underline";
+      "not-hover:underline";
+      "not-first:underline";
+      "not-in-data-open:underline";
+      "group-not-[:checked]:underline";
+      "peer-not-checked:underline";
+    ]
+
 let test_arbitrary_vs_named_order () =
   (* Within a variant block, arbitrary values sort by their raw class name ('['
      = 0x5b, before lowercase letters), so dark:bg-[#...] precedes
@@ -1853,6 +1880,8 @@ let tests =
     test_case "suborder within group" `Slow test_suborder_within_group;
     test_case "random utilities with minimization" `Slow
       test_random_utilities_with_minimization;
+    test_case "variant families sort as Tailwind" `Quick
+      test_variant_family_order;
     test_case "comparator is antisymmetric" `Quick test_comparator_antisymmetry;
     test_case "comparator is transitive" `Quick test_comparator_transitivity;
   ]

--- a/test/test_theme.ml
+++ b/test/test_theme.ml
@@ -48,28 +48,32 @@ let theme_cross_module_vars () =
         ]
         (List.sort String.compare custom_props)
 
-let priority_seven_namespace_order () =
+(* Tailwind's [@theme] writes each token family as one block: the whole radius
+   scale, then drop-shadow, then ease, then animate, with perspective after
+   blur. A token a project [@theme] renames keeps the slot its name already
+   owns, so an override does not move it out of its family's block. *)
+let theme_family_block_order () =
   let expected =
     [
       "--radius-3xl";
-      "--drop-shadow-sm";
-      "--ease-in";
       "--radius-4xl";
+      "--drop-shadow-sm";
       "--drop-shadow-md";
-      "--ease-out";
       "--drop-shadow-lg";
-      "--ease-in-out";
       "--drop-shadow-xl";
+      "--drop-shadow-2xl";
+      "--ease-in";
+      "--ease-out";
+      "--ease-in-out";
       "--ease-linear";
       "--animate-none";
-      "--drop-shadow-2xl";
       "--animate-spin";
-      "--perspective-dramatic";
       "--animate-ping";
-      "--perspective-near";
       "--animate-pulse";
-      "--perspective-normal";
       "--animate-bounce";
+      "--perspective-dramatic";
+      "--perspective-near";
+      "--perspective-normal";
       "--perspective-midrange";
     ]
   in
@@ -115,7 +119,7 @@ let priority_seven_namespace_order () =
         |> Css.custom_props_of_rules
         |> List.filter (fun name -> List.mem name expected)
   in
-  check (list string) "Tailwind namespace order at shared slots" expected actual
+  check (list string) "Tailwind family block order" expected actual
 
 (* Utilities across ten modules bind [--spacing] as they emit, each supplying
    the value the theme layer declares. Each has to bind it to
@@ -172,7 +176,7 @@ let tests =
   [
     test_case "theme layer stable order" `Quick theme_layer_stable_order;
     test_case "theme cross-module vars" `Quick theme_cross_module_vars;
-    test_case "priority-7 namespace order" `Quick priority_seven_namespace_order;
+    test_case "theme family block order" `Quick theme_family_block_order;
     test_case "one spacing declaration" `Quick one_spacing_declaration;
   ]
 

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -597,6 +597,30 @@ let line_clamp_sorts_with_box_sizing () =
   let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
   Test_helpers.check_ordering_matches ~test_name:"line-clamp order" utilities
 
+(* Tailwind's tail runs the [color] property, then text-transform, font-style
+   and text-decoration-line, then the decoration colour, style and thickness,
+   the underline offset, and last the placeholder, caret and accent colours.
+   Every one of those writes a different property, so a reorder among them is
+   cascade-neutral and the canonical differ reads the two sheets as equal;
+   reading each class's position back out of the sheet is what sees it. *)
+let late_typography_colour_block_order () =
+  Test_helpers.check_class_order ~test_name:"late typography colour block"
+    [
+      "tracking-wide";
+      "whitespace-nowrap";
+      "text-red-500";
+      "uppercase";
+      "italic";
+      "underline";
+      "decoration-red-500";
+      "decoration-solid";
+      "decoration-2";
+      "underline-offset-2";
+      "placeholder-red-500";
+      "caret-red-500";
+      "accent-red-500";
+    ]
+
 let suborder_matches_tailwind () =
   let open Tw in
   let utilities =
@@ -1149,6 +1173,8 @@ let tests =
     test_case "decoration undefined colour shade" `Quick
       test_decoration_undefined_shade;
     test_case "typography of_string - invalid values" `Quick of_string_invalid;
+    test_case "late typography colour block order" `Quick
+      late_typography_colour_block_order;
     test_case "typography suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "line-clamp sorts with box-sizing" `Quick

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -108,16 +108,20 @@ let order_of_shared_slot () =
   check order "first" (Some (990, 0)) (Tw.Var.order "test-shared-first");
   check order "second" (Some (990, 0)) (Tw.Var.order "test-shared-second")
 
-(* The in-tree tokens whose slot another family also claims. *)
-let order_of_shared_slot_tokens () =
+(* Each family in the theme layer's tail owns a band no other family reaches
+   into, so the emission order is the family order Tailwind's [@theme] writes
+   rather than the spelling of the token names. *)
+let order_of_family_bands () =
   let expect name o = check order name (Some o) (Tw.Var.order name) in
-  expect "ease-linear" (7, 12);
-  expect "drop-shadow-xl" (7, 12);
-  expect "animate-spin" (7, 13);
-  expect "drop-shadow-2xl" (7, 13);
-  expect "perspective-dramatic" (7, 13);
-  expect "default-transition-duration" (8, 0);
-  expect "blur-xs" (8, 0)
+  expect "radius-4xl" (7, 10);
+  expect "drop-shadow-xl" (7, 24);
+  expect "drop-shadow-2xl" (7, 25);
+  expect "ease-linear" (7, 33);
+  expect "animate-spin" (7, 41);
+  expect "blur-xs" (8, 0);
+  expect "perspective-dramatic" (8, 10);
+  expect "aspect-video" (8, 20);
+  expect "default-transition-duration" (8, 30)
 
 (* A project [@theme] may name font families of its own; they all sit at (1,
    100). Rendering one must not decide the answer for the others. *)
@@ -227,7 +231,7 @@ let tests =
     test_case "arbitrary var fallbacks" `Quick arbitrary_var_fallbacks;
     test_case "var in theme layer" `Quick var_in_theme_layer;
     test_case "order of shared slot" `Quick order_of_shared_slot;
-    test_case "order of shared slot tokens" `Quick order_of_shared_slot_tokens;
+    test_case "order of family bands" `Quick order_of_family_bands;
     test_case "order of theme-named tokens" `Quick order_of_theme_named_tokens;
     test_case "order of redefined name" `Quick order_of_redefined_name;
     test_case "order of theme-renamed builtin" `Quick


### PR DESCRIPTION
Two orderings were cascade-neutral, so canonical `--diff` called them equal and only `--diff-mode=tree` showed them. Both now match `--tailwind` exactly.

The late-typography block emitted `accent, caret, decoration, decoration-2, uppercase, text-red-500, italic, underline` against Tailwind's `text-red-500, uppercase, italic, underline, decoration-red-500, decoration-2, caret, accent`. `placeholder-*` was out of band too and is measured against the CLI alongside them. In the theme layer, the families at priority 7 overlapped, interleaving animate into perspective and putting perspective ahead of blur; each family owns a disjoint band now, shared slots drop from 13 to 3, and the tie-break that existed only to separate them is gone.

The third item was a reported collision in the multiplexed suborder channel, and it does not reproduce. The comparator reads a variant suborder only once the whole variant prefix has tied, which means both rules came through the same handler and the offset cancels. Neutralising the code leaves the emitted CSS byte-identical over a 1898-class variant corpus and the 4825-class parity list, and an instrumented branch fired zero times across both plus the upstream fixtures. The dead field and its 33 call sites are deleted, 104 lines, compiler-guided.