### PR TITLE
build, entrypoint: decide statement identity without rendering it

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -277,18 +277,54 @@ let indexed_rule_to_statement ?(verbatim = fun _ -> false)
         Css.supports ~condition
           [ Css.rule ~selector:r.selector ?merge_key filtered_props ]
 
-(* Deduplicate typed triples while preserving first occurrence order. Selectors
-   are compared with cascade's structural equality; the bucket key carries their
-   hash, which cascade keeps consistent with that equality. *)
+(* Two rules of the same kind. A condition is read through the equality its own
+   cascade module states, which answers on the media the query selects rather
+   than on how it is spelled. *)
+let equal_rule_type a b =
+  match (a, b) with
+  | `Regular, `Regular | `Starting, `Starting -> true
+  | `Media a, `Media b -> Css.Media.equal a b
+  | `Container a, `Container b -> Css.Container.equal a b
+  | `Supports a, `Supports b -> Css.Supports.equal a b
+  | _ -> false
+
+(* A rule kind's own identity, all a fingerprint may read of it: [Media] and
+   [Container] answer equality on normalised queries, and no hash agrees with
+   that, so the condition stays unread and two kinds share a bucket. *)
+let rule_type_tag = function
+  | `Regular -> 0
+  | `Media _ -> 1
+  | `Container _ -> 2
+  | `Starting -> 3
+  | `Supports _ -> 4
+
+(* Deduplicate typed triples while preserving first occurrence order. Every part
+   is compared through the equality its own cascade module states, and the
+   bucket key carries the hashes those modules keep consistent with it. *)
+let dedup_key (typ, sel, props, nested) =
+  let combine acc h = (acc * 31) + h in
+  let key = combine (rule_type_tag typ) (Css.Selector.hash sel) in
+  let key =
+    List.fold_left (fun key d -> combine key (Css.Declaration.hash d)) key props
+  in
+  List.fold_left (fun key st -> combine key (Css.hash_statement st)) key nested
+
+let equal_dedup_key (typ, sel, props, nested) (typ', sel', props', nested') =
+  equal_rule_type typ typ'
+  && Css.Selector.equal sel sel'
+  && List.equal Css.Declaration.equal_declaration props props'
+  && List.equal Css.equal_statement nested nested'
+
 let deduplicate_typed_triples triples =
   let seen = Hashtbl.create (List.length triples) in
   List.filter
     (fun (typ, sel, props, _order, nested, _base_class, _merge_key) ->
-      let bucket = (typ, Css.Selector.hash sel, props, nested) in
-      if List.exists (Css.Selector.equal sel) (Hashtbl.find_all seen bucket)
-      then false
+      let key = (typ, sel, props, nested) in
+      let bucket = dedup_key key in
+      if List.exists (equal_dedup_key key) (Hashtbl.find_all seen bucket) then
+        false
       else (
-        Hashtbl.add seen bucket sel;
+        Hashtbl.add seen bucket key;
         true))
     triples
 

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -761,12 +761,13 @@ let dedup_statements stmts =
   let seen = Hashtbl.create 8 in
   List.filter (fun stmt -> not (seen_statement seen stmt)) stmts
 
+(* A utility's selector names a class, the theme block's [:root, :host] does
+   not. Asked of the selector itself rather than of its text, where a '.' also
+   comes from an attribute value or a decimal inside a pseudo argument. *)
 let is_utility_statement stmt =
   match Css.statement_selector stmt with
   | None -> true
-  | Some sel ->
-      let s = Cascade.Selector.to_string ~minify:true sel in
-      String.contains s '.'
+  | Some sel -> Css.Selector.exists_class (fun _ -> true) sel
 
 let rec merge_same_selector = function
   | a :: b :: rest -> (

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -744,6 +744,23 @@ let split_declared_variants defs name =
       in
       (declared, String.concat ":" (builtin @ [ bare ]))
 
+(* Whether [seen] already holds [stmt], recording it when it does not.
+   [Css.hash_statement] buckets a statement and [Css.equal_statement] settles
+   the bucket, so identity is decided on the statement rather than on the CSS
+   text it renders to. *)
+let seen_statement seen stmt =
+  let bucket = Css.hash_statement stmt in
+  if List.exists (Css.equal_statement stmt) (Hashtbl.find_all seen bucket) then
+    true
+  else begin
+    Hashtbl.add seen bucket stmt;
+    false
+  end
+
+let dedup_statements stmts =
+  let seen = Hashtbl.create 8 in
+  List.filter (fun stmt -> not (seen_statement seen stmt)) stmts
+
 let is_utility_statement stmt =
   match Css.statement_selector stmt with
   | None -> true
@@ -800,22 +817,18 @@ let nested_utilities ~theme names =
          They all decorate the same [&], so they belong in one rule, the way
          Tailwind emits them; left apart, each is a rule of the author's
          selector holding one declaration. *)
-      (* One string per hoisted statement, not one for the whole block: two
+      (* The hoisted statements go back one by one, not as one block: two
          utilities bring overlapping [@property] sets, and deduping the blocks
          whole re-emits every property they do not share. *)
-      ( render_nested_utilities ~classes nestable,
-        List.map (fun st -> Css.to_string ~minify:true (Css.v [ st ])) hoisted
-      )
+      (render_nested_utilities ~classes nestable, hoisted)
 
 (* Append each statement unless it is already there: every utility that sets the
    same variable brings back the same hoisted [@property]. *)
 let add_once buf seen items =
   List.iter
-    (fun s ->
-      if s <> "" && not (List.mem s !seen) then begin
-        seen := s :: !seen;
-        Buffer.add_string buf s
-      end)
+    (fun stmt ->
+      if not (seen_statement seen stmt) then
+        Buffer.add_string buf (Css.to_string ~minify:true (Css.v [ stmt ])))
     items
 
 let apply_names css start stop =
@@ -877,7 +890,7 @@ let expand_apply ~theme ~defs ?(udefs = []) css =
   let len = String.length css in
   let buf = Buffer.create len in
   let hoisted = Buffer.create 0 in
-  let seen = ref [] in
+  let seen = Hashtbl.create 64 in
   let rec go i =
     if i >= len then ()
     else
@@ -1048,7 +1061,6 @@ let merge_named_layers stmts =
     let merged = Hashtbl.create 8 in
     List.iter
       (fun n ->
-        let seen = Hashtbl.create 64 in
         let body =
           List.concat_map
             (fun stmt ->
@@ -1056,13 +1068,7 @@ let merge_named_layers stmts =
               | Some m when equal_layer m n -> layer_statements stmt
               | _ -> [])
             stmts
-          |> List.filter (fun st ->
-              let key = Css.to_string ~minify:true (Css.v [ st ]) in
-              if Hashtbl.mem seen key then false
-              else begin
-                Hashtbl.add seen key ();
-                true
-              end)
+          |> dedup_statements
         in
         Hashtbl.add merged n body)
       repeated;
@@ -1381,18 +1387,6 @@ let routed_variant_defs defs derived =
         match template with Some body -> (name, body) :: acc | None -> acc)
       derived []
 
-let dedup_statements stmts =
-  let seen = Hashtbl.create 8 in
-  List.filter
-    (fun stmt ->
-      let key = Css.to_string ~minify:true (Css.v [ stmt ]) in
-      if Hashtbl.mem seen key then false
-      else begin
-        Hashtbl.add seen key ();
-        true
-      end)
-    stmts
-
 let group_routed_rules ~own_order rules =
   let group = Hashtbl.create 8 in
   let order_of = Hashtbl.create 8 in
@@ -1490,7 +1484,7 @@ let parse_routed_blocks ~block_count ~own_order css =
 
 let custom_routed_utilities ~theme ~defs ~udefs candidates =
   let hoisted = Buffer.create 0 in
-  let seen = ref [] in
+  let seen = Hashtbl.create 64 in
   let derived = Hashtbl.create 8 in
   let own_order = Hashtbl.create 8 in
   let blocks =

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -171,6 +171,38 @@ let test_apply_merges_one_rule () =
     ".btn{margin:calc(var(--spacing)*4);padding:calc(var(--spacing)*4)}"
     (Cascade.Css.to_string ~minify:true out)
 
+(* Each utility an [@apply] pulls in hoists an [@property] block for every
+   variable it sets, and the two shadow utilities set the same ones. The hoisted
+   blocks are deduplicated on statement identity, so the sheet declares each
+   property once however many rules applied a utility that sets it. *)
+let test_apply_hoists_each_property_once () =
+  let path = "apply-property-entry.css" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        "@import \"tailwindcss\";\n\
+         .a { @apply shadow-md; }\n\
+         .b { @apply shadow-lg; }\n");
+  let out =
+    Fun.protect
+      ~finally:(fun () -> Sys.remove path)
+      (fun () ->
+        splice_into_entrypoint ~theme:Tw.Scheme.default ~path (Cascade.Css.v []))
+  in
+  let names =
+    Cascade.Css.statements out
+    |> List.filter_map (fun stmt ->
+        match Cascade.Css.as_property stmt with
+        | Some (Cascade.Css.Property_info { name; _ }) -> Some name
+        | None -> None)
+  in
+  check bool "the shadow properties are hoisted" true (names <> []);
+  check string_list "each declared once"
+    (List.sort_uniq String.compare names)
+    (List.sort String.compare names)
+
 (* Tailwind emits a declared utility as one block, its own nesting intact:
    [.line-y { padding: 5px; &::before { color: red } }]. Flattened into two
    rules, the second sorts by the property it writes and an unrelated utility
@@ -208,6 +240,8 @@ let tests =
     test_case "directives dropped" `Quick test_drop_directives;
     test_case "theme keyframes hoisted" `Quick test_hoist_theme_keyframes;
     test_case "@apply merges into one rule" `Quick test_apply_merges_one_rule;
+    test_case "@apply hoists each property once" `Quick
+      test_apply_hoists_each_property_once;
     test_case "declared utility keeps its nesting" `Quick
       test_declared_utility_keeps_its_nesting;
   ]


### PR DESCRIPTION
Four sites keyed on rendered CSS text, one of them quadratic. cascade now publishes statement equality and hashing, so they ask directly.

`deduplicate_typed_triples` keyed on `(typ, Selector.to_string sel, props, nested)` - a stringified selector spliced into a tuple compared by OCaml polymorphic equality over abstract cascade values. Each part is now compared through its own cascade module and bucketed on the matching hash. `add_once` deduped hoisted `@property` blocks with `List.mem` over rendered strings; it uses a hashtable keyed on `Css.hash_statement`, and `nested_utilities` returns statements rather than pre-rendered text.

One further site turned up in the sweep: `is_utility_statement` rendered its selector and searched the text for a `.`, which a selector also spells inside an attribute value or a decimal in a pseudo argument, so the text answered a different question than the call site asks. It uses `Css.Selector.exists_class` now.

The remaining text key, `by_text` over layer names, needs a total order that equality cannot give and is justified in place.