### PR TITLE
entrypoint, build: fold layers and merge starting-style through cascade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,12 +299,14 @@ and the fields it keys on.
        + Block at position 27: .contrast-more\:border-4, .contrast-more\:text-black
      ```
      **Fix**: Media query merging is cascade's. `merge_consecutive_media` lives in
-     `cascade/lib/block.ml`, but `block` is one of cascade's `private_modules` and
-     `optimize.mli` does not re-export it, so tw cannot call it: `lib/build.ml` runs no
-     merge of its own, and `bin/main.ml` reaches cascade's optimizer only under
-     `--optimize`. A plain `--minify` sheet therefore gets no merging at all. The ask is
-     filed in cascade's TODO; until it lands, a rule sorting between two blocks is still
-     the usual cause worth checking first.
+     `cascade/lib/block.ml`, and `cascade/lib/optimize.mli` re-exports it, so tw can call
+     it the way `lib/build.ml` already calls
+     `Css.Optimize.merge_consecutive_starting_style` over the sorted utilities.
+     `lib/build.ml` runs no media merge yet, and `bin/main.ml` reaches the rest of
+     cascade's optimizer only under `--optimize`, so a plain `--minify` sheet gets none.
+     Check first whether a rule sorting between the two blocks is what keeps them apart:
+     `merge_consecutive_media` joins adjacent blocks only, and `merge_distant_media` is
+     the pass that reaches past an intervening rule.
 
   2. **"blocks at different positions"** - Media query appears at wrong location:
      ```

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -485,37 +485,11 @@ let utilities_layer ~layers ~statements =
   else Css.v statements
 
 (* [@starting-style] carries no condition, so a run of [starting:] utilities is
-   one block in Tailwind's output. Each is wrapped on its own here, and the
-   optimizer's merging covers [@media] and [@supports] but not this, so collapse
-   a run before the statements are handed over. *)
+   one block in Tailwind's output. Each rule is wrapped on its own here, and
+   cascade collapses the run. *)
 let statements_of_sorted_rules ?verbatim sorted_rules =
-  let is_starting (r : Sort.indexed_rule) = r.rule_type = `Starting in
-  let rec take_run taken = function
-    | (x : Sort.indexed_rule) :: tl when is_starting x ->
-        take_run (x :: taken) tl
-    | tl -> (List.rev taken, tl)
-  in
-  let rec go acc = function
-    | [] -> List.rev acc
-    | (r : Sort.indexed_rule) :: rest when is_starting r ->
-        let run, rest = take_run [ r ] rest in
-        let inner =
-          List.concat_map
-            (fun (x : Sort.indexed_rule) ->
-              (* A variant stacked under [starting:] carries its query in
-                 [nested] and has no declarations of its own. *)
-              if x.nested <> [] then filter_theme_from_statements x.nested
-              else
-                [
-                  Css.rule ~selector:x.selector
-                    (filter_utility_properties x.props);
-                ])
-            run
-        in
-        go (Css.starting_style inner :: acc) rest
-    | r :: rest -> go (indexed_rule_to_statement ?verbatim r :: acc) rest
-  in
-  go [] sorted_rules
+  List.map (indexed_rule_to_statement ?verbatim) sorted_rules
+  |> Css.Optimize.merge_consecutive_starting_style
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1448,13 +1448,23 @@ let flattened_statement stmt =
       [ stmt ]
   | _ -> Css.statements (Css.flatten_nesting (Css.v [ stmt ]))
 
-let parse_routed_blocks ~block_count ~own_order css =
+(* The statements of one generated block, or none when it will not parse at all.
+   A malformed body has to cost its own class and nothing else: read as one
+   assembled sheet, an unclosed brace nests every block written after it inside
+   the broken one, and a parse the recovery cannot save loses the lot. *)
+let parse_routed_block css =
   match Css.of_string css with
-  | Error _ -> (0, [], [])
+  | Error _ -> None
   | Ok parsed ->
-      Css.statements parsed.Css.stylesheet
-      |> List.concat_map flattened_statement
-      |> routed_statements ~block_count ~own_order
+      Some
+        (Css.statements parsed.Css.stylesheet
+        |> List.concat_map flattened_statement)
+
+let parse_routed_blocks ~own_order ~hoisted blocks =
+  let parsed = List.filter_map parse_routed_block blocks in
+  let hoisted = Option.value ~default:[] (parse_routed_block hoisted) in
+  List.concat parsed @ hoisted
+  |> routed_statements ~block_count:(List.length parsed) ~own_order
 
 let custom_routed_utilities ~theme ~defs ~udefs candidates =
   let hoisted = Buffer.create 0 in
@@ -1472,7 +1482,9 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
       collect_routed_templates ~theme derived udefs;
       let extra_defs = routed_variant_defs defs derived in
       (* A [@utility] body is author CSS: it may hold [@apply], [@variant] and
-         the [--spacing()]/[theme()] shorthands. *)
-      String.concat "" (blocks @ [ Buffer.contents hoisted ])
-      |> apply_variants ~extra_defs ~udefs ~theme
-      |> parse_routed_blocks ~block_count:(List.length blocks) ~own_order
+         the [--spacing()]/[theme()] shorthands. Each block is expanded and read
+         on its own so one unparseable body cannot take the others down. *)
+      let expand = apply_variants ~extra_defs ~udefs ~theme in
+      parse_routed_blocks ~own_order
+        ~hoisted:(expand (Buffer.contents hoisted))
+        (List.map expand blocks)

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1031,60 +1031,33 @@ let preload_imports ~transform ~base_url stylesheet =
    author's own rules and shift every one of them. *)
 let equal_layer = Css.Stylesheet.equal_layer_name
 
-(* A named layer appears once in Tailwind's output. The generated sheet and the
-   [@layer properties] blocks each applied utility hoists arrive separately, so
-   fold every repeat of a name into the first, dropping content the first
-   already has. *)
-let named_layer stmt =
-  match Css.as_layer stmt with Some (Some name, _) -> Some name | _ -> None
-
-let layer_statements stmt =
-  match Css.as_layer stmt with Some (_, inner) -> inner | None -> []
-
-let repeated_layer_names stmts =
-  let counts = Hashtbl.create 8 in
-  List.iter
+let dedup_statements stmts =
+  let seen = Hashtbl.create 8 in
+  List.filter
     (fun stmt ->
-      match named_layer stmt with
-      | Some name ->
-          Hashtbl.replace counts name
-            (1 + Option.value ~default:0 (Hashtbl.find_opt counts name))
-      | None -> ())
-    stmts;
-  Hashtbl.fold
-    (fun name count acc -> if count > 1 then name :: acc else acc)
-    counts []
+      let key = Css.to_string ~minify:true (Css.v [ stmt ]) in
+      if Hashtbl.mem seen key then false
+      else begin
+        Hashtbl.add seen key ();
+        true
+      end)
+    stmts
 
+(* A named layer appears once in Tailwind's output, so fold every repeat of a
+   name into the first. The generated sheet and the [@layer properties] block
+   each applied utility hoists say the same thing, and the fold takes no hook to
+   re-optimize the body it joins the way the [merge_consecutive_*] passes do, so
+   drop what the joined body now holds twice. *)
 let merge_named_layers stmts =
-  let repeated = repeated_layer_names stmts in
-  if repeated = [] then stmts
+  let merged = Css.Optimize.merge_named_layers_by_name stmts in
+  if List.compare_lengths merged stmts = 0 then stmts
   else
-    let merged = Hashtbl.create 8 in
-    List.iter
-      (fun n ->
-        let body =
-          List.concat_map
-            (fun stmt ->
-              match named_layer stmt with
-              | Some m when equal_layer m n -> layer_statements stmt
-              | _ -> [])
-            stmts
-          |> dedup_statements
-        in
-        Hashtbl.add merged n body)
-      repeated;
-    let emitted = Hashtbl.create 8 in
-    List.filter_map
+    List.map
       (fun stmt ->
-        match named_layer stmt with
-        | Some n when List.exists (equal_layer n) repeated ->
-            if Hashtbl.mem emitted n then None
-            else begin
-              Hashtbl.add emitted n ();
-              Some (Css.layer ~name:n (Hashtbl.find merged n))
-            end
-        | _ -> Some stmt)
-      stmts
+        match Css.as_layer stmt with
+        | Some (Some name, inner) -> Css.layer ~name (dedup_statements inner)
+        | _ -> stmt)
+      merged
 
 let layer_block_name stmt =
   match Css.layer_block_name stmt with Some [] | None -> None | name -> name

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1031,16 +1031,27 @@ let preload_imports ~transform ~base_url stylesheet =
    author's own rules and shift every one of them. *)
 let equal_layer = Css.Stylesheet.equal_layer_name
 
-let dedup_statements stmts =
-  let seen = Hashtbl.create 8 in
-  List.filter
-    (fun stmt ->
-      let key = Css.to_string ~minify:true (Css.v [ stmt ]) in
-      if Hashtbl.mem seen key then false
-      else begin
-        Hashtbl.add seen key ();
-        true
-      end)
+(* An empty [@layer name] block says only that the name has a slot, and with
+   nothing in it the fold below reads it as no occurrence at all and leaves it
+   standing. The generated sheet writes an empty utilities layer whenever every
+   utility in the sheet is a declared one, and [hoist_layer_blocks] fills a slot
+   from the first block of its name, so an empty block in front of the real one
+   hides the rules. Write what it means, a slot, and both passes then see the
+   block that has them. Tailwind emits the same [@layer name;] for it. *)
+let declare_empty_layers stmts =
+  let has_content name =
+    List.exists
+      (fun st ->
+        match Css.as_layer st with
+        | Some (Some n, _ :: _) -> equal_layer n name
+        | _ -> false)
+      stmts
+  in
+  List.map
+    (fun st ->
+      match Css.as_layer st with
+      | Some (Some n, []) when has_content n -> Css.layer_decl [ n ]
+      | _ -> st)
     stmts
 
 (* A named layer appears once in Tailwind's output, so fold every repeat of a
@@ -1049,6 +1060,7 @@ let dedup_statements stmts =
    re-optimize the body it joins the way the [merge_consecutive_*] passes do, so
    drop what the joined body now holds twice. *)
 let merge_named_layers stmts =
+  let stmts = declare_empty_layers stmts in
   let merged = Css.Optimize.merge_named_layers_by_name stmts in
   if List.compare_lengths merged stmts = 0 then stmts
   else

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -224,6 +224,31 @@ let test_declared_utility_keeps_its_nesting () =
         (Cascade.Css.to_string ~minify:true (Cascade.Css.v statements))
   | _ -> Alcotest.failf "expected one entry, got %d" (List.length entries)
 
+(* A [@utility] body is author text tw does not validate. An unclosed brace in
+   one must cost that class alone: assembled into a single sheet, the block
+   swallows every utility written after it, and the sheet as a whole no longer
+   parses, which dropped the lot. *)
+let test_malformed_utility_spares_the_others () =
+  let udefs =
+    [
+      ("line-bad", " color: red; &::before { content: \"x\" ");
+      ("line-ok", " padding: 5px ");
+    ]
+  in
+  let _, entries, _ =
+    custom_routed_utilities ~theme:Tw.Scheme.default ~defs:[] ~udefs
+      [ "line-bad"; "line-ok" ]
+  in
+  let is_ok (cls, _, _) = String.equal cls "line-ok" in
+  let name (cls, _, _) = cls in
+  match List.find_opt is_ok entries with
+  | None ->
+      Alcotest.failf "line-ok dropped, entries: %s"
+        (String.concat ", " (List.map name entries))
+  | Some (_, _, statements) ->
+      check string "the good utility stands on its own" ".line-ok{padding:5px}"
+        (Cascade.Css.to_string ~minify:true (Cascade.Css.v statements))
+
 let tests =
   [
     test_case "variant segments" `Quick test_variant_segments;
@@ -244,6 +269,8 @@ let tests =
       test_apply_hoists_each_property_once;
     test_case "declared utility keeps its nesting" `Quick
       test_declared_utility_keeps_its_nesting;
+    test_case "malformed utility spares the others" `Quick
+      test_malformed_utility_spares_the_others;
   ]
 
 let suite = ("entrypoint", tests)


### PR DESCRIPTION
cascade now publishes the statement-merging passes, so two hand-rolled copies go: the `@starting-style` run merge in `lib/build.ml`, and about 60 lines of layer folding in `lib/tools/entrypoint.ml`.

The layer fold was filed as a signature-exact drop-in. It is not, in two ways that both produce wrong output. Cascade concatenates bodies without deduplicating, so any entrypoint carrying an `@apply` emitted its `@layer properties` `@supports` block twice. And an empty `@layer name {}` is not an occurrence to cascade, so it stays put - while tw fills a slot from the first block of a name, and the sheet writes an empty utilities layer whenever every utility is a declared one. The empty block took the slot and the block holding the routed rules was dropped, so `@utility line-t { @apply border-t }` produced no `.line-t` at all. A shadowed empty block is rewritten to `@layer name;`, which is what Tailwind emits for one.

Separately, one malformed declared `@utility` used to cost every routed utility in the sheet: the re-parse answered `Error _` for the whole buffer. Each routed block is expanded and parsed on its own now, so an unclosed brace costs only its own class.

Nine entrypoint fixtures diff byte-for-byte against a binary built from `main`.