### PR TITLE
color, margin, backgrounds: pin the chroma search and close two raises

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -62,21 +62,22 @@ module Handler = struct
 
   (* Gradient color source - shared by from/via/to *)
   module Color_source = struct
-    type t =
-      | Named of Color.color * int
-      | Named_opacity of Color.color * int * Color.opacity_modifier
+    (* A colour that spells itself out, with no palette behind it. *)
+    type plain =
       | Current
-      | Current_opacity of Color.opacity_modifier
       | Inherit
       | Transparent
       | Bracket_hex of string
-      | Bracket_hex_opacity of string * Color.opacity_modifier
       | Bracket_color_var of string
-      | Bracket_color_var_opacity of string * Color.opacity_modifier
       | Bracket_var of string
-      | Bracket_var_opacity of string * Color.opacity_modifier
       | Bracket_color of string
-      | Bracket_color_opacity of string * Color.opacity_modifier
+
+    (* A palette colour reads its value out of the scheme, so it has no plain
+       CSS spelling. Keeping the two apart is what lets the conversion to a
+       [Css.color] cover every source it is handed. *)
+    type t =
+      | Palette of Color.color * int * Color.opacity_modifier option
+      | Plain of plain * Color.opacity_modifier option
   end
 
   (* Gradient position source *)
@@ -231,33 +232,28 @@ module Handler = struct
         let prefix =
           match target with From -> "from-" | Via -> "via-" | To -> "to-"
         in
-        let color_class = function
-          | Color_source.Named (color, shade) ->
-              if Color.is_shadeless color then Color.pp color
-              else Color.pp color ^ "-" ^ string_of_int shade
-          | Color_source.Named_opacity (color, shade, opacity) ->
+        let plain_class : Color_source.plain -> string = function
+          | Color_source.Current -> "current"
+          | Color_source.Inherit -> "inherit"
+          | Color_source.Transparent -> "transparent"
+          | Color_source.Bracket_hex h -> "[#" ^ h ^ "]"
+          | Color_source.Bracket_color_var v -> "[color:" ^ v ^ "]"
+          | Color_source.Bracket_var v | Color_source.Bracket_color v ->
+              "[" ^ v ^ "]"
+        in
+        let opacity_class = function
+          | None -> ""
+          | Some opacity -> Color.opacity_suffix opacity
+        in
+        let color_class : Color_source.t -> string = function
+          | Color_source.Palette (color, shade, opacity) ->
               let base =
                 if Color.is_shadeless color then Color.pp color
                 else Color.pp color ^ "-" ^ string_of_int shade
               in
-              base ^ Color.opacity_suffix opacity
-          | Color_source.Current -> "current"
-          | Color_source.Current_opacity opacity ->
-              "current" ^ Color.opacity_suffix opacity
-          | Color_source.Inherit -> "inherit"
-          | Color_source.Transparent -> "transparent"
-          | Color_source.Bracket_hex h -> "[#" ^ h ^ "]"
-          | Color_source.Bracket_hex_opacity (h, opacity) ->
-              "[#" ^ h ^ "]" ^ Color.opacity_suffix opacity
-          | Color_source.Bracket_color_var v -> "[color:" ^ v ^ "]"
-          | Color_source.Bracket_color_var_opacity (v, opacity) ->
-              "[color:" ^ v ^ "]" ^ Color.opacity_suffix opacity
-          | Color_source.Bracket_var v -> "[" ^ v ^ "]"
-          | Color_source.Bracket_var_opacity (v, opacity) ->
-              "[" ^ v ^ "]" ^ Color.opacity_suffix opacity
-          | Color_source.Bracket_color v -> "[" ^ v ^ "]"
-          | Color_source.Bracket_color_opacity (v, opacity) ->
-              "[" ^ v ^ "]" ^ Color.opacity_suffix opacity
+              base ^ opacity_class opacity
+          | Color_source.Plain (source, opacity) ->
+              plain_class source ^ opacity_class opacity
         in
         prefix ^ color_class src
     | Gradient_stop_position (target, src) -> (
@@ -1345,42 +1341,18 @@ module Handler = struct
     let vr : Css.color Css.var = Var.bracket bare in
     Var vr
 
-  (** Convert a non-named Color_source.t to a Css.color *)
-  let css_color_of_source : Color_source.t -> Css.color = function
-    | Color_source.Current | Color_source.Current_opacity _ -> Css.Current
+  (** Convert a plain colour source to a Css.color *)
+  let css_color_of_plain : Color_source.plain -> Css.color = function
+    | Color_source.Current -> Css.Current
     | Color_source.Inherit -> Css.Inherit
     | Color_source.Transparent -> Css.Transparent
-    | Color_source.Bracket_hex h | Color_source.Bracket_hex_opacity (h, _) ->
-        Css.hex h
-    | Color_source.Bracket_color_var v
-    | Color_source.Bracket_color_var_opacity (v, _) ->
+    | Color_source.Bracket_hex h -> Css.hex h
+    | Color_source.Bracket_color_var v | Color_source.Bracket_var v ->
         color_var_ref v
-    | Color_source.Bracket_var v | Color_source.Bracket_var_opacity (v, _) ->
-        color_var_ref v
-    | Color_source.Bracket_color v | Color_source.Bracket_color_opacity (v, _)
-      -> (
+    | Color_source.Bracket_color v -> (
         match Color.parse_bracket_color v with
         | Some c -> c
         | None -> Css.Transparent)
-    | Color_source.Named _ | Color_source.Named_opacity _ ->
-        (* A palette colour resolves through the scheme, not into a plain CSS
-           colour; [to_style] answers those before it reaches here. *)
-        invalid_arg "backgrounds: a palette colour has no plain CSS colour"
-
-  (** Extract opacity from a Color_source.t, if present *)
-  let opacity_of_source : Color_source.t -> Color.opacity_modifier option =
-    function
-    | Color_source.Current_opacity o
-    | Color_source.Bracket_hex_opacity (_, o)
-    | Color_source.Bracket_color_var_opacity (_, o)
-    | Color_source.Bracket_var_opacity (_, o)
-    | Color_source.Bracket_color_opacity (_, o) ->
-        Some o
-    | Color_source.Named _ | Color_source.Named_opacity _ | Color_source.Current
-    | Color_source.Inherit | Color_source.Transparent
-    | Color_source.Bracket_hex _ | Color_source.Bracket_color_var _
-    | Color_source.Bracket_var _ | Color_source.Bracket_color _ ->
-        None
 
   let to_style theme =
     let gradient_color_opacity ~prefix ~set_var ?(shade = 500) color opacity =
@@ -1395,28 +1367,23 @@ module Handler = struct
     | Bg_gradient_to dir -> bg_gradient_to' dir
     | Gradient_color (target, src) -> (
         let prefix, set_var, _pos_var = gradient_target_info target in
-        (* Named colors use the scheme system with theme variables *)
+        (* A palette colour goes through the scheme, which gives it a theme
+           variable to read. *)
         match src with
-        | Color_source.Named (color, shade) ->
+        | Color_source.Palette (color, shade, None) ->
             gradient_color ~prefix ~set_var ~shade color
-        | Color_source.Named_opacity (color, shade, opacity) ->
+        | Color_source.Palette (color, shade, Some opacity) ->
             gradient_color_opacity ~prefix ~set_var ~shade color opacity
-        | Color_source.Bracket_hex_opacity (h, opacity) ->
+        | Color_source.Plain (Color_source.Bracket_hex h, Some opacity) ->
             (* Hex is known at compile time: compute oklab directly *)
             let alpha = Color.opacity_to_percent opacity /. 100.0 in
             let color = Color.hex_to_oklab_alpha h alpha in
             gradient_simple ~prefix ~set_var color []
-        | Color_source.Current | Color_source.Current_opacity _
-        | Color_source.Inherit | Color_source.Transparent
-        | Color_source.Bracket_hex _ | Color_source.Bracket_color_var _
-        | Color_source.Bracket_color_var_opacity _ | Color_source.Bracket_var _
-        | Color_source.Bracket_var_opacity _ | Color_source.Bracket_color _
-        | Color_source.Bracket_color_opacity _ -> (
+        | Color_source.Plain (source, opacity) -> (
             (* A keyword or a bracket value: the colour is known without the
-               scheme. Spelled out rather than swept up, so a source added to
-               [Color_source.t] is a compile error here. *)
-            let color = css_color_of_source src in
-            match opacity_of_source src with
+               scheme. *)
+            let color = css_color_of_plain source in
+            match opacity with
             | None -> gradient_simple ~prefix ~set_var color []
             | Some opacity ->
                 let percent = Color.opacity_to_percent opacity in
@@ -1573,15 +1540,19 @@ module Handler = struct
 
   let parse_gradient_color ?theme target rest =
     let gc src = Ok (Gradient_color (target, src)) in
+    let plain ?opacity source = gc (Color_source.Plain (source, opacity)) in
+    let palette ?opacity color shade =
+      gc (Color_source.Palette (color, shade, opacity))
+    in
     let gp src = Ok (Gradient_stop_position (target, src)) in
     match rest with
     (* Keywords *)
-    | [ "current" ] -> gc Color_source.Current
+    | [ "current" ] -> plain Color_source.Current
     | [ current_str ] when String.starts_with ~prefix:"current/" current_str ->
         let _, opacity = Color.parse_opacity_modifier ?theme current_str in
-        gc (Color_source.Current_opacity opacity)
-    | [ "inherit" ] -> gc Color_source.Inherit
-    | [ "transparent" ] -> gc Color_source.Transparent
+        plain ~opacity Color_source.Current
+    | [ "inherit" ] -> plain Color_source.Inherit
+    | [ "transparent" ] -> plain Color_source.Transparent
     (* Percentage positions: from-0%, from-100% (integer only) *)
     | [ pct_str ] when String.ends_with ~suffix:"%" pct_str -> (
         let num_s = String.sub pct_str 0 (String.length pct_str - 1) in
@@ -1599,12 +1570,13 @@ module Handler = struct
             let inner = Parse.bracket_inner bracket_opacity in
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
-              gc (Color_source.Bracket_color_var var_str)
+              plain (Color_source.Bracket_color_var var_str)
             else if is_bracket_hex inner then
-              gc
+              plain
                 (Color_source.Bracket_hex
                    (String.sub inner 1 (String.length inner - 1)))
-            else if Parse.is_var inner then gc (Color_source.Bracket_var inner)
+            else if Parse.is_var inner then
+              plain (Color_source.Bracket_var inner)
             else
               match parse_bracket_position_value inner with
               | Some value -> gp (Bracket (inner, value))
@@ -1615,35 +1587,34 @@ module Handler = struct
             let inner = Parse.bracket_inner base in
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
-              gc (Color_source.Bracket_color_var_opacity (var_str, opacity))
+              plain ~opacity (Color_source.Bracket_color_var var_str)
             else if is_bracket_hex inner then
-              gc
-                (Color_source.Bracket_hex_opacity
-                   (String.sub inner 1 (String.length inner - 1), opacity))
+              plain ~opacity
+                (Color_source.Bracket_hex
+                   (String.sub inner 1 (String.length inner - 1)))
             else if Parse.is_var inner then
-              gc (Color_source.Bracket_var_opacity (inner, opacity))
+              plain ~opacity (Color_source.Bracket_var inner)
             else if Color.parse_bracket_color inner <> None then
-              gc (Color_source.Bracket_color_opacity (inner, opacity))
+              plain ~opacity (Color_source.Bracket_color inner)
             else Error (`Msg "Invalid gradient bracket with opacity")
         | _ -> (
             (* Named color with opacity *)
             match Color.shade_and_opacity_of_strings ?theme rest with
-            | Ok (color, shade, opacity) ->
-                gc (Color_source.Named_opacity (color, shade, opacity))
+            | Ok (color, shade, opacity) -> palette ~opacity color shade
             | Error e -> Error e))
     (* Bracket notation without opacity *)
     | [ bracket ] when Parse.is_bracket_value bracket -> (
         let inner = Parse.bracket_inner bracket in
         if String.length inner > 6 && String.sub inner 0 6 = "color:" then
           let var_str = String.sub inner 6 (String.length inner - 6) in
-          gc (Color_source.Bracket_color_var var_str)
+          plain (Color_source.Bracket_color_var var_str)
         else if is_bracket_hex inner then
-          gc
+          plain
             (Color_source.Bracket_hex
                (String.sub inner 1 (String.length inner - 1)))
-        else if Parse.is_var inner then gc (Color_source.Bracket_var inner)
+        else if Parse.is_var inner then plain (Color_source.Bracket_var inner)
         else if Color.parse_bracket_color inner <> None then
-          gc (Color_source.Bracket_color inner)
+          plain (Color_source.Bracket_color inner)
         else
           match parse_bracket_position_value inner with
           | Some value -> gp (Bracket (inner, value))
@@ -1651,13 +1622,12 @@ module Handler = struct
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (
         match Color.shade_and_opacity_of_strings ?theme rest with
-        | Ok (color, shade, opacity) ->
-            gc (Color_source.Named_opacity (color, shade, opacity))
+        | Ok (color, shade, opacity) -> palette ~opacity color shade
         | Error e -> Error e)
     (* Named color *)
     | _ -> (
         match Color.shade_of_strings ?theme rest with
-        | Ok (color, shade) -> gc (Color_source.Named (color, shade))
+        | Ok (color, shade) -> palette color shade
         | Error _ -> Error (`Msg "Invalid gradient color"))
 
   let of_class theme class_name =
@@ -1977,12 +1947,12 @@ let bg_gradient_to dir = utility (Bg_gradient_to dir)
 
 let from_color ?(shade = 500) color =
   Color.check_shade ~utility:"from_color" color shade;
-  utility (Gradient_color (From, Color_source.Named (color, shade)))
+  utility (Gradient_color (From, Color_source.Palette (color, shade, None)))
 
 let via_color ?(shade = 500) color =
   Color.check_shade ~utility:"via_color" color shade;
-  utility (Gradient_color (Via, Color_source.Named (color, shade)))
+  utility (Gradient_color (Via, Color_source.Palette (color, shade, None)))
 
 let to_color ?(shade = 500) color =
   Color.check_shade ~utility:"to_color" color shade;
-  utility (Gradient_color (To, Color_source.Named (color, shade)))
+  utility (Gradient_color (To, Color_source.Palette (color, shade, None)))

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -50,18 +50,20 @@ type color =
   | Theme_named of string
 
 (* The colour-space arithmetic (linearisation, OKLab, the polar OKLCh form) is
-   cascade's: tw used to carry its own copies, and its forward matrix went
-   straight to LMS while its inverse went via XYZ, so the two were not exact
-   inverses and [#0088cc] came back as [#0288cc]. Only [linearize_channel] and
-   [gamma_correct] stay private, because they are byte <-> [0,1] float
-   conversions that cascade's float-only API has no reason to own.
+   cascade's: a second copy drifts, since a forward matrix straight to LMS and
+   an inverse routed via XYZ are not exact inverses, and [#0088cc] then comes
+   back as [#0288cc]. Only [linearize_channel] and [gamma_correct] stay private,
+   because they are byte <-> [0, 1] float conversions that cascade's float-only
+   API has no reason to own.
 
-   The one algorithm cascade genuinely lacks is below: [gamut_map_chroma]'s
-   binary search for the widest in-gamut chroma. Cascade's
-   [srgb_bytes_of_linear] answers a narrower question - "is this exact colour
-   representable" - and returns [None] out of gamut instead of hunting for the
-   nearest one, which is what an out-of-gamut OKLCh colour (e.g.
-   [oklch(0.7_0.35_150)]) needs to render at all. *)
+   [gamut_map_chroma] below stays private for a different reason. Cascade has a
+   chroma search of its own, [Color_space.gamut_mapped_srgb_of_oklch], but it
+   answers CSS Color 4 sec. 14.2.2 and keeps the largest chroma whose clipped
+   result is within a just noticeable difference. Tailwind's published CSS
+   carries the fallback lightningcss folds out of its sRGB [color-mix], and that
+   one stops at the first such chroma: for [--color-blue-500] the spec answers
+   [#2b7fff] and Tailwind ships [#3080ff]. Parity is with what Tailwind ships,
+   so the search below is the one that runs. *)
 let linearize_channel c =
   Cascade.Color_space.linear_of_srgb (float_of_int c /. 255.0)
 
@@ -91,7 +93,9 @@ let clip (r, g, b) = (clip_val r, clip_val g, clip_val b)
 let in_gamut (r, g, b) =
   r >= 0.0 && r <= 1.0 && g >= 0.0 && g <= 1.0 && b >= 0.0 && b <= 1.0
 
-(* Binary search to find maximum chroma that stays in sRGB gamut *)
+(* Halve the chroma at constant lightness and hue until the clipped colour is
+   within one just noticeable difference of the colour searched, and take that
+   first one. *)
 let gamut_map_chroma ~ok_l ~cos_h ~sin_h chroma =
   let jnd = 0.02 in
   let epsilon = 0.00001 in

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -6,14 +6,19 @@ module Handler = struct
   open Style
   open Css
 
-  type margin_value =
-    | Standard of margin (* auto, spacing values *)
+  type signed =
+    | Spacing of Style.spacing
     | Arbitrary of string * Css.length (* mx-[4px], raw kept for round-trip *)
     | Arbitrary_var of string (* mx-[var(--value)] *)
     | Named of string (* mx-big - custom spacing *)
 
+  (* [Auto] sits outside [signed] because there is no [-m-auto] and negating
+     [auto] means nothing. Carrying the sign in the value rather than beside it
+     is what makes that pair unrepresentable instead of a case [to_style] has to
+     turn away. *)
+  type margin_value = Auto | Positive of signed | Negative of signed
+
   type t = {
-    negative : bool;
     axis : [ `All | `X | `Y | `T | `R | `B | `L | `S | `E | `Bs | `Be ];
     value : margin_value;
   }
@@ -26,20 +31,6 @@ module Handler = struct
   let priority _ = 2
 
   (** {2 Typed Margin Utilities} *)
-
-  let v ?theme (prop : length -> declaration) (m : margin) =
-    match m with
-    | `Auto -> style [ prop Auto ]
-    | #Style.spacing as s ->
-        let decl, len = Spacing.to_decl_len ?theme ~negative:false s in
-        style (Option.to_list decl @ [ prop len ])
-
-  let vs ?theme (prop : length list -> declaration) (m : margin) =
-    match m with
-    | `Auto -> style [ prop [ Auto ] ]
-    | #Style.spacing as s ->
-        let decl, len = Spacing.to_decl_len ?theme ~negative:false s in
-        style (Option.to_list decl @ [ prop [ len ] ])
 
   let named_margin_value ?theme name : Css.declaration option * Css.length =
     let prop_name = "spacing-" ^ name in
@@ -60,16 +51,6 @@ module Handler = struct
 
   (** {1 Conversion Functions} *)
 
-  let margin_util_neg ?theme (prop : length -> declaration) (s : Style.spacing)
-      =
-    let decl, len = Spacing.to_decl_len ?theme ~negative:true s in
-    style (Option.to_list decl @ [ prop len ])
-
-  let margin_list_util_neg ?theme (prop : length list -> declaration)
-      (s : Style.spacing) =
-    let decl, len = Spacing.to_decl_len ?theme ~negative:true s in
-    style (Option.to_list decl @ [ prop [ len ] ])
-
   (* Spacing keywords sort by their suffix's first character, matching
      Tailwind's raw order after the numeric rem values: auto ('a') < a named
      spacing like big ('b') < full ('f') < px ('p'). *)
@@ -82,10 +63,6 @@ module Handler = struct
     | `Named s -> keyword_order (if String.length s > 0 then s.[0] else '~')
     | `Full -> keyword_order 'f'
     | `Px -> keyword_order 'p'
-
-  let margin_value_order = function
-    | `Auto -> keyword_order 'a'
-    | #spacing as s -> spacing_value_order s
 
   (* Get the CSS property function for an axis *)
   let prop_for_axis axis =
@@ -103,82 +80,56 @@ module Handler = struct
     | `Be -> margin_block_end
 
   (** Convert margin utility to style *)
-  let to_style theme { negative; axis; value } =
-    let m_fn m = vs ~theme margin m in
-    let mx m = v ~theme margin_inline m in
-    let my m = v ~theme margin_block m in
-    let mt m = v ~theme margin_top m in
-    let mr m = v ~theme margin_right m in
-    let mb m = v ~theme margin_bottom m in
-    let ml m = v ~theme margin_left m in
-    let ms m = v ~theme margin_inline_start m in
-    let me m = v ~theme margin_inline_end m in
-    let mbs m = v ~theme margin_block_start m in
-    let mbe m = v ~theme margin_block_end m in
-    let margin_util_neg prop s = margin_util_neg ~theme prop s in
-    let margin_list_util_neg prop s = margin_list_util_neg ~theme prop s in
-    let named_margin_value name = named_margin_value ~theme name in
+  let to_style theme { axis; value } =
     let prop = prop_for_axis axis in
-    match value with
-    | Arbitrary (_, len) ->
-        if negative then
-          (* For simple values, use direct negation: -4px instead of calc(4px *
-             -1) *)
-          let neg_len : Css.length =
-            match len with
-            | Px f -> Px (-.f)
-            | Rem f -> Rem (-.f)
-            | Pct f -> Pct (-.f)
-            | _ -> Calc (Calc.mul (Calc.length len) (Calc.float (-1.)))
-          in
-          style [ prop neg_len ]
-        else style [ prop len ]
-    | Arbitrary_var var_str ->
-        let bare_name = Parse.extract_var_name var_str in
-        let len : Css.length =
+    let named_margin_value name = named_margin_value ~theme name in
+    let spacing_style ~negative s =
+      (* The typed constructors keep the scale they were handed, so [m (-4)]
+         stores a negative rem while [-m-4] parses to a positive one. Both spell
+         the same class, so the sign comes from [Negative] alone. *)
+      let s = match s with `Rem f -> `Rem (Float.abs f) | other -> other in
+      let decl, len = Spacing.to_decl_len ~theme ~negative s in
+      style (Option.to_list decl @ [ prop len ])
+    in
+    let of_signed ~negative = function
+      | Spacing s -> spacing_style ~negative s
+      | Arbitrary (_, len) ->
           if negative then
-            Calc (Calc.mul (Calc.var bare_name) (Calc.float (-1.)))
-          else Var (Var.bracket bare_name)
-        in
-        style [ prop len ]
-    | Named name ->
-        let decl_opt, len = named_margin_value name in
-        let decls = Option.to_list decl_opt in
-        if negative then
-          style
-            (decls
-            @ [ prop (Calc (Calc.mul (Calc.length len) (Calc.float (-1.)))) ])
-        else style (decls @ [ prop len ])
-    | Standard m -> (
-        let abs_value =
-          match m with `Rem f -> `Rem (Float.abs f) | other -> other
-        in
-        match (negative, axis, abs_value) with
-        | false, `All, _ -> m_fn abs_value
-        | false, `X, _ -> mx abs_value
-        | false, `Y, _ -> my abs_value
-        | false, `T, _ -> mt abs_value
-        | false, `R, _ -> mr abs_value
-        | false, `B, _ -> mb abs_value
-        | false, `L, _ -> ml abs_value
-        | false, `S, _ -> ms abs_value
-        | false, `E, _ -> me abs_value
-        | false, `Bs, _ -> mbs abs_value
-        | false, `Be, _ -> mbe abs_value
-        | true, `All, (#spacing as s) -> margin_list_util_neg margin s
-        | true, `X, (#spacing as s) -> margin_util_neg margin_inline s
-        | true, `Y, (#spacing as s) -> margin_util_neg margin_block s
-        | true, `T, (#spacing as s) -> margin_util_neg margin_top s
-        | true, `R, (#spacing as s) -> margin_util_neg margin_right s
-        | true, `B, (#spacing as s) -> margin_util_neg margin_bottom s
-        | true, `L, (#spacing as s) -> margin_util_neg margin_left s
-        | true, `S, (#spacing as s) -> margin_util_neg margin_inline_start s
-        | true, `E, (#spacing as s) -> margin_util_neg margin_inline_end s
-        | true, `Bs, (#spacing as s) -> margin_util_neg margin_block_start s
-        | true, `Be, (#spacing as s) -> margin_util_neg margin_block_end s
-        | true, _, `Auto -> failwith "Negative auto margin not supported")
+            (* A plain unit negates directly, [-4px] rather than a calc with a
+               factor of -1. *)
+            let neg_len : Css.length =
+              match len with
+              | Px f -> Px (-.f)
+              | Rem f -> Rem (-.f)
+              | Pct f -> Pct (-.f)
+              | _ -> Calc (Calc.mul (Calc.length len) (Calc.float (-1.)))
+            in
+            style [ prop neg_len ]
+          else style [ prop len ]
+      | Arbitrary_var var_str ->
+          let bare_name = Parse.extract_var_name var_str in
+          let len : Css.length =
+            if negative then
+              Calc (Calc.mul (Calc.var bare_name) (Calc.float (-1.)))
+            else Var (Var.bracket bare_name)
+          in
+          style [ prop len ]
+      | Named name ->
+          let decl_opt, len = named_margin_value name in
+          let decls = Option.to_list decl_opt in
+          if negative then
+            style
+              (decls
+              @ [ prop (Calc (Calc.mul (Calc.length len) (Calc.float (-1.)))) ]
+              )
+          else style (decls @ [ prop len ])
+    in
+    match value with
+    | Auto -> style [ prop Auto ]
+    | Positive v -> of_signed ~negative:false v
+    | Negative v -> of_signed ~negative:true v
 
-  let suborder { negative; axis; value } =
+  let suborder { axis; value } =
     (* Tailwind orders margins by side first, then sign (negatives before
        positives within a side), then value. Side spacing (1_000_000) exceeds
        the sign+value range so the tiers never cross. *)
@@ -196,17 +147,21 @@ module Handler = struct
       | `Bs -> 9
       | `Be -> 10
     in
-    let sign_offset = if negative then 0 else 200000 in
+    let sign_offset =
+      match value with Negative _ -> 0 | Auto | Positive _ -> 200000
+    in
     let value_order =
       match value with
-      | Standard m -> margin_value_order m
-      | Arbitrary _ -> 50000 (* after numbered, before auto *)
-      | Arbitrary_var _ -> 55000
-      | Named _ -> 60000 (* after arbitrary *)
+      | Auto -> keyword_order 'a'
+      | Positive (Spacing s) | Negative (Spacing s) -> spacing_value_order s
+      | Positive (Arbitrary _) | Negative (Arbitrary _) ->
+          50000 (* after numbered, before auto *)
+      | Positive (Arbitrary_var _) | Negative (Arbitrary_var _) -> 55000
+      | Positive (Named _) | Negative (Named _) -> 60000 (* after arbitrary *)
     in
     (side_index * 1000000) + sign_offset + value_order
 
-  let to_class { negative; axis; value } =
+  let to_class { axis; value } =
     let prefix =
       match axis with
       | `All -> "m-"
@@ -221,17 +176,22 @@ module Handler = struct
       | `Bs -> "mbs-"
       | `Be -> "mbe-"
     in
-    let neg_prefix = if negative then "-" else "" in
+    let neg_prefix =
+      match value with Negative _ -> "-" | Auto | Positive _ -> ""
+    in
     let value_suffix =
       match value with
-      | Standard m -> Spacing.pp_margin_suffix m
-      | Arbitrary (raw, _) -> "[" ^ raw ^ "]"
-      | Arbitrary_var s -> "[" ^ s ^ "]"
-      | Named name -> name
+      | Auto -> Spacing.pp_margin_suffix `Auto
+      | Positive (Spacing s) | Negative (Spacing s) ->
+          Spacing.pp_margin_suffix (s :> margin)
+      | Positive (Arbitrary (raw, _)) | Negative (Arbitrary (raw, _)) ->
+          "[" ^ raw ^ "]"
+      | Positive (Arbitrary_var s) | Negative (Arbitrary_var s) -> "[" ^ s ^ "]"
+      | Positive (Named name) | Negative (Named name) -> name
     in
     neg_prefix ^ prefix ^ value_suffix
 
-  let parse_arbitrary s : margin_value option =
+  let parse_arbitrary s : signed option =
     (* Parse [4px], [1rem], [50%], [-5cqw], [calc(...)], or [var(--value)]. The
        raw inner is kept verbatim for the class name; the value goes through the
        full length grammar so any unit or calc() is accepted. *)
@@ -270,25 +230,21 @@ module Handler = struct
   let is_named_spacing theme name =
     Scheme.theme_value theme ("spacing-" ^ name) <> None
 
+  let sign ~is_negative v = if is_negative then Negative v else Positive v
+
   (** Parse value to standard or named margin *)
   let parse_value ?theme ~is_negative value =
     let allow_auto = not is_negative in
     match Spacing.parse_value_string ?theme ~allow_auto value with
     | Some (#spacing as spacing_val) ->
-        Some
-          {
-            negative = is_negative;
-            axis = `All;
-            value = Standard (spacing_val :> margin);
-          }
-    | Some `Auto when not is_negative ->
-        Some { negative = false; axis = `All; value = Standard `Auto }
+        Some { axis = `All; value = sign ~is_negative (Spacing spacing_val) }
+    | Some `Auto when not is_negative -> Some { axis = `All; value = Auto }
     | None
       when (not is_negative)
            && Parse.is_valid_theme_name value
            && is_named_spacing theme value ->
         (* Try as a named spacing: mx-big *)
-        Some { negative = false; axis = `All; value = Named value }
+        Some { axis = `All; value = Positive (Named value) }
     | _ -> None
 
   (** Parse string parts to margin utility using shared logic *)
@@ -298,12 +254,12 @@ module Handler = struct
     (* Handle arbitrary values: mx-[4px], mx-[var(--value)] *)
     | [ prefix; arb ] when String.length arb > 0 && arb.[0] = '[' -> (
         match (axis_of_prefix_ext prefix, parse_arbitrary arb) with
-        | Some axis, Some value -> Ok { negative = false; axis; value }
+        | Some axis, Some value -> Ok { axis; value = Positive value }
         | _ -> Error (`Msg "Not a margin utility"))
     (* Handle negative arbitrary: -mx-[4px], -mx-[var(--value)] *)
     | [ ""; prefix; arb ] when String.length arb > 0 && arb.[0] = '[' -> (
         match (axis_of_prefix_ext prefix, parse_arbitrary arb) with
-        | Some axis, Some value -> Ok { negative = true; axis; value }
+        | Some axis, Some value -> Ok { axis; value = Negative value }
         | _ -> Error (`Msg "Not a margin utility"))
     (* Handle extended axes (ms, me, mbs, mbe) with values *)
     | [ prefix; value ] when is_extended_margin_prefix prefix -> (
@@ -351,52 +307,37 @@ module Handler = struct
                       if
                         Parse.is_valid_theme_name value
                         && is_named_spacing (Some theme) value
-                      then
-                        Ok { negative = is_negative; axis; value = Named value }
+                      then Ok { axis; value = sign ~is_negative (Named value) }
                       else Error (`Msg "Not a margin utility")
                   | Some (#spacing as spacing_val) ->
                       Ok
                         {
-                          negative = is_negative;
                           axis;
-                          value = Standard (spacing_val :> margin);
+                          value = sign ~is_negative (Spacing spacing_val);
                         }
                   | Some `Auto ->
                       if is_negative then Error (`Msg "Not a margin utility")
-                      else Ok { negative = false; axis; value = Standard `Auto }
-                  ))
+                      else Ok { axis; value = Auto }))
         | None -> Error (`Msg "Not a margin utility"))
 
   let examples =
-    [
-      { negative = false; axis = `All; value = Standard `Auto };
-      { negative = false; axis = `X; value = Standard `Auto };
-      { negative = false; axis = `Y; value = Standard `Auto };
-      { negative = false; axis = `T; value = Standard `Auto };
-      { negative = false; axis = `R; value = Standard `Auto };
-      { negative = false; axis = `B; value = Standard `Auto };
-      { negative = false; axis = `L; value = Standard `Auto };
-      { negative = false; axis = `S; value = Standard `Auto };
-      { negative = false; axis = `E; value = Standard `Auto };
-      { negative = false; axis = `Bs; value = Standard `Auto };
-      { negative = false; axis = `Be; value = Standard `Auto };
-    ]
+    List.map
+      (fun axis -> { axis; value = Auto })
+      [ `All; `X; `Y; `T; `R; `B; `L; `S; `E; `Bs; `Be ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
-let utility negative axis value = Utility.base (Self { negative; axis; value })
+let utility axis value = Utility.base (Self { axis; value })
 
 let v d n =
-  let s = (Spacing.int n :> Style.margin) in
-  let neg = n < 0 in
-  utility neg d (Handler.Standard s)
+  let s = Handler.Spacing (Spacing.int n :> Style.spacing) in
+  utility d (if n < 0 then Handler.Negative s else Handler.Positive s)
 
 let v' d n =
-  let s = (Spacing.float n :> Style.margin) in
-  let neg = n < 0.0 in
-  utility neg d (Handler.Standard s)
+  let s = Handler.Spacing (Spacing.float n :> Style.spacing) in
+  utility d (if n < 0.0 then Handler.Negative s else Handler.Positive s)
 
 let m n = v `All n
 let mx n = v `X n
@@ -412,10 +353,10 @@ let mt' n = v' `T n
 let mr' n = v' `R n
 let mb' n = v' `B n
 let ml' n = v' `L n
-let m_auto = utility false `All (Handler.Standard `Auto)
-let mx_auto = utility false `X (Handler.Standard `Auto)
-let my_auto = utility false `Y (Handler.Standard `Auto)
-let mt_auto = utility false `T (Handler.Standard `Auto)
-let mr_auto = utility false `R (Handler.Standard `Auto)
-let mb_auto = utility false `B (Handler.Standard `Auto)
-let ml_auto = utility false `L (Handler.Standard `Auto)
+let m_auto = utility `All Handler.Auto
+let mx_auto = utility `X Handler.Auto
+let my_auto = utility `Y Handler.Auto
+let mt_auto = utility `T Handler.Auto
+let mr_auto = utility `R Handler.Auto
+let mb_auto = utility `B Handler.Auto
+let ml_auto = utility `L Handler.Auto

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -923,6 +923,46 @@ let test_color_var_name_is_one_ident () =
       Css (Css.hex "#0088cc");
     ]
 
+(* [oklch(0.7 0.35 150)] is outside the sRGB gamut, so it has to be mapped onto
+   a colour a display can show, and there is more than one answer. CSS Color 4
+   sec. 14.2.2 halves the chroma at constant lightness and hue and keeps the
+   largest one whose clipped result is within a just noticeable difference of
+   the colour searched; [oklch_to_rgb] takes the first such chroma instead, and
+   that is the answer Tailwind ships, because lightningcss folds the
+   [color-mix(in srgb, oklch(...) ...)] fallback in Tailwind's own output the
+   same way. Cascade's [Color_space.gamut_mapped_srgb_of_oklch] answers the
+   spec's question, so it is not interchangeable with this one: [bg-blue-500/50]
+   is where the two part company, and Tailwind's byte there is the one pinned
+   below. *)
+let test_out_of_gamut_oklch () =
+  let requested = { l = 70.0; c = 0.35; h = 150.0 } in
+  let rgb = oklch_to_rgb requested in
+  Alcotest.(check string)
+    "out-of-gamut oklch maps onto a colour sRGB can show" "#00c14b"
+    (rgb_to_hex rgb);
+  let mapped = rgb_to_oklch rgb in
+  Alcotest.(check bool) "chroma is what gave way" true (mapped.c < requested.c);
+  (* The search only moves along the constant-lightness, constant-hue ray, so
+     the rendered colour lands within one just noticeable difference (0.02 in
+     OKLab) of a point on that ray. That bounds the lightness drift directly,
+     and bounds the hue drift by the angle a chord that long subtends at the
+     mapped radius. *)
+  let jnd = 0.02 in
+  let hue_cone = Float.asin (jnd /. mapped.c) *. 180.0 /. Float.pi in
+  Alcotest.(check bool)
+    "lightness stays within one JND" true
+    (Float.abs (mapped.l -. requested.l) /. 100.0 <= jnd);
+  Alcotest.(check bool)
+    "hue stays inside the JND cone" true
+    (Float.abs (mapped.h -. requested.h) <= hue_cone);
+  (* blue-500 is a palette colour just outside the gamut, so the choice of
+     mapping shows up in a shipped utility: Tailwind's minified
+     [.bg-blue-500/50] carries [#3080ff80]. *)
+  let blue_500 = { l = 62.3; c = 0.214; h = 259.815 } in
+  Alcotest.(check string)
+    "blue-500 maps to the fallback Tailwind publishes" "#3080ff"
+    (rgb_to_hex (oklch_to_rgb blue_500))
+
 let tests =
   [
     ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
@@ -981,6 +1021,7 @@ let tests =
       `Quick,
       test_opacity_modifier_rejects_non_numeric );
     ("Shorthand hex with alpha", `Quick, test_shorthand_hex_alpha);
+    ("Out-of-gamut OKLCH", `Quick, test_out_of_gamut_oklch);
   ]
 
 let suite = ("color", tests)

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -93,6 +93,20 @@ let check_escape_class_name () =
   check string "escapes slash" "w-1\\/2" (Tw.Rule.escape_class_name "w-1/2");
   check string "escapes dot" "text-1\\.5" (Tw.Rule.escape_class_name "text-1.5")
 
+(* [escape_class_name] strips the dot off cascade's selector printer, so what it
+   returns is the spelling that lands in the sheet. Cascade's ident escaper,
+   [Parser.escape_ident], is not interchangeable with it. Both spell a name that
+   decodes back to the source, so markup matches either, but they pick different
+   escapes: above U+007F the printer hex-escapes where the ident escaper keeps
+   the source bytes, which is the spelling Tailwind prints, and on a leading
+   dash-digit, which has to be broken up or the selector re-tokenises as a
+   number, the printer escapes the dash and the ident escaper the digit. *)
+let check_escape_class_name_hex_escapes () =
+  check string "breaks up a leading dash-digit" "\\2d 4xl"
+    (Tw.Rule.escape_class_name "-4xl");
+  check string "hex-escapes above U+007F" "aria-\\[\\e9 tat\\]\\:flex"
+    (Tw.Rule.escape_class_name "aria-[état]:flex")
+
 let test_modifier_to_rule () =
   let rule =
     Tw.Rule.modifier_to_rule Tw.Style.Hover "bg-blue-500"
@@ -524,6 +538,8 @@ let tests =
     test_case "extract selector props - responsive 2xl" `Quick
       check_extract_responsive_2xl;
     test_case "escape class name" `Quick check_escape_class_name;
+    test_case "escape class name hex escapes" `Quick
+      check_escape_class_name_hex_escapes;
     test_case "modifier_to_rule" `Quick test_modifier_to_rule;
   ]
 


### PR DESCRIPTION
cascade #591 landed CSS Color 4 gamut mapping, and the obvious move is to delete tw's private `gamut_map_chroma` and call it. That breaks parity, so this pins why instead.

Tailwind emits `color-mix(in srgb, oklch(...) 50%, transparent)` for `bg-blue-500/50`, and lightningcss folds it to `#3080ff80` in the minified sheet tw is compared against. tw's search reproduces lightningcss on every palette colour checked. cascade answers `#2b7fff80`, and cascade is right: CSS Color 4 sec. 14.2.2 keeps the largest chroma within one JND where tw's copy takes the first. Two functions, two questions. The comment claiming cascade lacks the algorithm is replaced, since that claim is what invites the swap.

`escape_class_name` stays for the same shape of reason. cascade fixed the dash-digit escape, but its selector printer and `Parser.escape_ident` still escape different characters (`\\2d 4xl` against `-\\34 xl`, `aria-\\[\\e9 tat\\]` against `aria-\\[état\\]`), and the printer is what writes tw's sheet. Both spellings are pinned so the next reader sees it.

Two partial functions become total: `margin` folds the sign into the value, so a negative `auto` is unrepresentable rather than a `failwith`, and `backgrounds` splits `Color_source.t` into palette and plain-CSS variants, retiring its `invalid_arg`. Both behaviour-preserving, 258 lines lighter.