### PR TITLE
changes, docs: record 1.1.0 and state the release bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,19 @@
   mask stops and images, mask gradients, and typed divide utilities
   (#148, #161, #162, #163, #165, #182, #222, #239, #265, #296).
 
+- Accept a value the project named in its own `@theme` wherever Tailwind does:
+  shadows, blur radii, timing functions, font weights, line heights, letter
+  spacing, corner radii, font sizes, perspectives, aspect ratios and max-widths
+  (#447, #450, #457, #458, #459, #460, #461, #462, #463, #464).
+- Honour a `@theme` that REMOVES a token. A namespace reset (`--color-*:
+  initial`) now reaches tw at all, `--spacing: initial` drops the multiplier,
+  a removed breakpoint stops resolving its variant, and a removed palette
+  entry no longer leaves a utility referencing a variable nothing declares
+  (#507, #515).
+- Keep `@keyframes` when a `@theme` redefines an animation. The keyframes
+  follow the animation the value names, so retiming `--animate-ping` no longer
+  emitted an animation that never ran (#510).
+
 ### Arbitrary values and validation
 
 - Parse arbitrary lengths, calculations, theme and spacing functions, grid
@@ -55,6 +68,19 @@
   channels, unitless decoration colours, and non-canonical numeric spellings
   (#127, #234, #237, #257, #282, #284, #285, #307, #309).
 
+- Read an arbitrary value through cascade's own grammar rather than a private
+  unit table, so a length, angle, colour, shadow, ease, blur, tracking,
+  line-height, stroke width, border-spacing or gradient stop takes every unit
+  and math function CSS allows (#371, #372, #373, #375, #376, #377, #378,
+  #404, #417, #418, #420, #465, #503, #504, #509, #522).
+- Refuse an unreadable arbitrary value at parse time, with the reason, instead
+  of accepting the class and emitting nothing usable: animations, order,
+  z-index, grid lines, the `not-has` shorthand, data expressions, gradient
+  interpolation, and a bracket carrying two brackets (#405, #406, #407, #408,
+  #410, #421, #422, #496).
+- Spell an arbitrary value in the class name the way the author wrote it, so a
+  class the parser produced reads back (#412, #413, #415, #489, #490).
+
 ### Colours and effects
 
 - Apply alpha modifiers consistently to theme variables, borders, rings,
@@ -63,6 +89,20 @@
   (#169, #185, #201, #202, #209, #214, #225, #231, #244, #254, #281, #308,
   #322, #323).
 
+- A bracket colour carrying an opacity modifier no longer renders black.
+  `text-[rebeccapurple]/50` and its siblings kept the parsed colour rather than
+  re-reading the bracket text through the palette, whose failure arm answered
+  black; `bg-[red]/50` separately read the palette red-500 instead of CSS red.
+  `decoration-`, `divide-` and `stroke-` accept the modifier at all now, and a
+  colour the browser resolves at use time keeps the `@supports` fallback
+  Tailwind writes (#508, #517).
+- A `theme()` alpha survives a hex-bound palette entry. It was applied by
+  chopping the colour's closing paren, so it vanished whenever the entry was a
+  hex rather than an `oklch()` (#508).
+- Each colour family has one owning handler. Five classes were accepted by two,
+  and which answered was decided by dune link order, so `bg-red-500` could sort
+  before or after its neighbours depending on an unrelated build edit (#518).
+
 ### Variants and selectors
 
 - Compose arbitrary, compound, negated, group, peer, `has`, `in`, container,
@@ -70,6 +110,14 @@
   content structurally and support custom-variant selector shorthand
   (#135, #167, #173, #196, #197, #198, #199, #200, #203, #204, #211, #213,
   #215, #219, #220, #224, #231, #232, #233, #235, #238, #280, #314).
+
+- `[attr~=value]` attribute selectors work in arbitrary variants. The gate
+  rejected any bracket containing `~`, reading the whitespace-list operator as
+  a sibling combinator (#509).
+- `supports-*` emits the test the author wrote, as a typed condition rather
+  than a string reparsed after assembly (#389, #484).
+- A container query is refused as a `not-*` inner, and a media inner is refused
+  inside a group or peer negation, matching what Tailwind accepts (#488, #493).
 
 ### CSS ordering and structure
 
@@ -83,11 +131,42 @@
   implement (#194, #220, #226, #228, #255, #256, #271, #313, #316, #319,
   #324).
 
+- A declared `@utility` sorts after the built-ins of its family, as Tailwind
+  puts it, so on an element carrying both the declared one wins; and a
+  multi-rule one keeps its nesting rather than being flattened and scattered
+  (#516).
+- The variant cascade comes from one table instead of four copies on three
+  numeric scales. An unrecognised prefix used to return 0, which put the rule
+  in a different sort bucket entirely rather than merely out of order (#520).
+- The late typography colour block and the priority-7 theme tail emit in
+  Tailwind's order; `divide-x-reverse`, container queries and column values
+  sort where Tailwind puts them (#429, #443, #494, #523).
+- One malformed declared `@utility` costs only its own class. The re-parse
+  answered an error for the whole buffer, so a single unclosed brace silently
+  dropped every routed utility in the sheet (#526).
+
 ### Public OCaml API
 
 - Add the typed `divide` constructors, from `divide_x` to `divide_style`: only
   the two reverse utilities were exposed, so the rest of the family was
   reachable from a class string but not from OCaml (#239, closes #5).
+- An unrecognised class has one behaviour everywhere. `Tw.str` raised,
+  `Tw_html` copied the name in silently, and `Tw_dom.use_str` crashed the
+  browser render. Unknown names now pass through everywhere, never raise from a
+  rendering path, and are reportable: `Tw.of_classes` returns them alongside
+  the utilities, and `Tw_html.unknown_classes` and `Tw_dom.unknown_classes`
+  expose the same list. `Tw.of_string` is unchanged, so the CLI still reports a
+  deliberately typed class as an error (#514).
+- **Breaking:** `bg_transparent`, `bg_current` and the background colour
+  constructors move to `Backgrounds`; `border_color`, `border_transparent` and
+  `border_current` move to `Color`. Building one from OCaml and parsing the
+  same class name used to reach different handlers with different sort slots
+  (#518).
+- Every spacing utility takes an `int`, with a primed variant for a float, so
+  the common call needs no conversion (#492).
+- `divide_x_length` accepts a line-width keyword. Tailwind renders
+  `divide-x-[thin]`, and the parser already did, but the typed constructor
+  raised on it (#522).
 
 ### Documentation, compatibility, and release quality
 
@@ -98,6 +177,16 @@
   (#158, #258, #259, #270, #286, #301).
 - Require Cascade 1.1.0 and its released comparison API, removing the moving
   CI dependency (#297, #302).
+- The browser rendering comparison actually runs in CI. `npm ci` installs
+  Playwright but not the browser it drives, and the check skipped silently
+  without one, so eight suites reported no rendering difference because they
+  never looked. CI installs Chromium now, and a missing browser fails rather
+  than skips (#513).
+- The upstream parity suite no longer takes its expected values from Tailwind's
+  own output. Breaking four built-in defaults used to leave it passing every
+  case; the same breakage now fails it (#512).
+- The typography plugin's descendant rules are exercised against real markup
+  rather than bare divs, which is most of the largest plugin (#519).
 
 ## 1.0.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,59 @@
+# tw release criteria
+
+The bar a tagged release must clear. tw's contract is byte-parity with the
+Tailwind CSS v4 compiler for the utilities and plugins it claims, so most gates
+compare against the real tool rather than against a fixture we wrote.
+
+Reproduce every measurement from a worktree with the freshly built binaries.
+An installed `tw` on `PATH` can be months old and will invent differences that
+do not exist.
+
+## Correctness (hard gates - all must pass)
+
+1. **Suites.** `dune exec test/test.exe`, `dune exec test/upstream/test.exe`,
+   and `dune exec test/tools/test.exe` all green. The upstream suite is strict
+   by default; there is no tolerance switch to forget.
+2. **Rendering.** `TW_BROWSER_TESTS=1` set, so a missing Chromium fails rather
+   than skips. Without it the eight suites calling `check_rendering_matches`
+   report no difference because they never looked - which is what CI did until
+   #513.
+3. **Doc examples and cram.** `dune build @runtest`. It compiles the MDX
+   examples in the `.mli` files and the README, and runs `test/cli/*.t`, which
+   covers entrypoint behaviour no Alcotest suite reaches. Read the HEAD of its
+   output: a cram diff prints first and `| tail` hides it.
+4. **Sort fuzzer.** Clean across several seeds
+   (`TEST_SEED=<n> dune exec test/test.exe -- test sort`). It is authoritative;
+   a case it reports is a real ordering bug, never something to skip.
+5. **Gates.** `dune build`, `dune build @fmt`, and `merlint` clean.
+
+## Parity (the contract)
+
+6. **Upstream corpus.** `test/upstream/` replays Tailwind's own fixtures and
+   must pass without an allowlist. The suite may not take an expected value
+   from Tailwind's output and hand it back to tw - breaking a built-in default
+   has to fail it (see #512).
+7. **Whole-site measurement.** `sh test/parity/measure.sh` runs tw against
+   Tailwind over the class list of tailwindcss.com. Quote the differ's summary
+   line together with the top-level entries under it; the summary counts
+   containers rather than their contents, so one `@layer` entry can hide a
+   thousand rules. Last measured 2026-08-28: 0.5% diff, 1 removed rule,
+   8 modified, 20 reordered, 5 changed containers.
+
+## Quality (target, non-blocking)
+
+8. **No partial function reachable from a class.** `lib/` still holds
+   `failwith`/`invalid_arg` sites; none is reachable from ordinary input
+   (the corpus runs `of_string` then `to_css` over 6491 classes and raises on
+   none). Track the count down rather than gate on it.
+9. **No private cascade module.** tw must compile against cascade as an
+   *installed* library, not only against the source tree beside it. A name from
+   a module in `cascade/lib/dune`'s `private_modules` resolves locally and fails
+   CI; check the public `.mli` before using one.
+
+## Hygiene
+
+10. **Changelog + version.** A `CHANGES.md` entry for the version, every `#N`
+    resolving to a merged PR, and the tag on the current `main` lineage.
+11. **Cascade bound.** `dune-project` and `tw.opam` name a cascade version CI
+    can resolve. CI pins cascade to its `main`; a local build compiles it from
+    source, so green locally is not green on CI.


### PR DESCRIPTION
The unreleased `1.1.0` block stopped at #361 while `main` ran 139 merged PRs and 295 commits past it, so nothing since has been described to a reader deciding whether to upgrade. Written as user-visible changes with the PRs sharing a reference, not one bullet per PR: the theme-reset handling, the bracket colours that rendered black, the unrecognised-class API, the ordering fixes, and the two suites that were reporting success without looking.

tw also had no release criteria while cascade has had them for a while, so "are we ready" had no document to answer against, 802 commits after the 1.0.0 tag. `RELEASE.md` states the bar from what the gates now actually are, and records the two traps that cost time this week: a cram diff prints at the HEAD of a `@runtest` run so piping it through `tail` hides it, and a name from a module in cascade's `private_modules` resolves against a source checkout and fails CI against the installed library.