### PR TITLE
text_shadow, effects, borders: close three bracket gaps

### DIFF
--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -74,7 +74,8 @@ module Handler = struct
     | Border_width of int
     | Border_width_bracket of string * Css.border_width
     | Border_side_width_bracket of string * string * Css.border_width
-      (* side ("t"/"r"/"b"/"l"), arbitrary width inner: border-t-[1px] *)
+      (* a side, physical or logical, and an arbitrary width inner:
+         border-t-[1px], border-x-[3px] *)
     | Border_side_width of string * int
       (* side ("t"/"r"/"b"/"l") with a width Tailwind spells in px: border-t-16.
          The 0/2/4/8 constructors below keep their own names, as Border_0/2/4/8
@@ -192,67 +193,43 @@ module Handler = struct
     in
     style ~property_rules:property_rule (side_props_fn border_ref)
 
-  let border_t =
-    make_side_util (fun border_var ->
-        [ border_top_style (Var border_var); border_top_width (Px 1.) ])
+  (* What one side writes for a width: the border-style variable and the width
+     itself, on the longhands that side names. The axes paint the logical inline
+     and block axes through the border-inline and border-block longhands, not
+     the two physical edges; the logical single sides paint one inline or block
+     edge each. *)
+  let side_width_props side border_var (w : Css.border_width) =
+    match side with
+    | "x" ->
+        [
+          border_inline_style (Var border_var);
+          border_inline_width (logical_border_width w);
+        ]
+    | "y" ->
+        [
+          border_block_style (Var border_var);
+          border_block_width (logical_border_width w);
+        ]
+    | "s" ->
+        [
+          border_inline_start_style (Var border_var);
+          border_inline_start_width w;
+        ]
+    | "e" ->
+        [ border_inline_end_style (Var border_var); border_inline_end_width w ]
+    | "bs" ->
+        [
+          border_block_start_style (Var border_var); border_block_start_width w;
+        ]
+    | "be" ->
+        [ border_block_end_style (Var border_var); border_block_end_width w ]
+    | "t" -> [ border_top_style (Var border_var); border_top_width w ]
+    | "r" -> [ border_right_style (Var border_var); border_right_width w ]
+    | "b" -> [ border_bottom_style (Var border_var); border_bottom_width w ]
+    | _ -> [ border_left_style (Var border_var); border_left_width w ]
 
-  let border_r =
-    make_side_util (fun border_var ->
-        [ border_right_style (Var border_var); border_right_width (Px 1.) ])
-
-  let border_b =
-    make_side_util (fun border_var ->
-        [ border_bottom_style (Var border_var); border_bottom_width (Px 1.) ])
-
-  let border_l =
-    make_side_util (fun border_var ->
-        [ border_left_style (Var border_var); border_left_width (Px 1.) ])
-
-  (* v4 axis borders paint the logical inline and block axes via the
-     border-inline and border-block longhands, not the two physical edges. *)
-  let border_inline_axis border_var w =
-    [
-      border_inline_style (Var border_var);
-      border_inline_width (logical_border_width (Px w));
-    ]
-
-  let border_block_axis border_var w =
-    [
-      border_block_style (Var border_var);
-      border_block_width (logical_border_width (Px w));
-    ]
-
-  let border_x = make_side_util (fun v -> border_inline_axis v 1.)
-  let border_y = make_side_util (fun v -> border_block_axis v 1.)
-  let border_x_width n = make_side_util (fun v -> border_inline_axis v n)
-  let border_y_width n = make_side_util (fun v -> border_block_axis v n)
-
-  (* Logical single-side borders paint one inline/block edge, unlike the axis
-     utilities above which paint both edges of an axis. *)
-  let border_s_of w =
-    make_side_util (fun v ->
-        [ border_inline_start_style (Var v); border_inline_start_width (Px w) ])
-
-  let border_e_of w =
-    make_side_util (fun v ->
-        [ border_inline_end_style (Var v); border_inline_end_width (Px w) ])
-
-  let border_bs_of w =
-    make_side_util (fun v ->
-        [ border_block_start_style (Var v); border_block_start_width (Px w) ])
-
-  let border_be_of w =
-    make_side_util (fun v ->
-        [ border_block_end_style (Var v); border_block_end_width (Px w) ])
-
-  let border_s = border_s_of 1.
-  let border_e = border_e_of 1.
-  let border_bs = border_bs_of 1.
-  let border_be = border_be_of 1.
-  let border_s_width n = border_s_of (float_of_int n)
-  let border_e_width n = border_e_of (float_of_int n)
-  let border_bs_width n = border_bs_of (float_of_int n)
-  let border_be_width n = border_be_of (float_of_int n)
+  let side_width side w = make_side_util (fun v -> side_width_props side v w)
+  let side_width_px side n = side_width side (Px (float_of_int n))
 
   (** Border side utilities with specific widths *)
   let border_solid = border_style_util Solid
@@ -577,38 +554,25 @@ module Handler = struct
     | Border_8 -> border_8
     | Border_width n -> border_n n
     | Border_width_bracket (_, w) -> border_width_bracket_style w
-    | Border_side_width_bracket (side, _, w) ->
-        make_side_util (fun bv ->
-            match side with
-            | "t" -> [ border_top_style (Var bv); border_top_width w ]
-            | "r" -> [ border_right_style (Var bv); border_right_width w ]
-            | "b" -> [ border_bottom_style (Var bv); border_bottom_width w ]
-            | _ -> [ border_left_style (Var bv); border_left_width w ])
-    | Border_side_width (side, n) ->
-        let w : Css.border_width = Px (float_of_int n) in
-        make_side_util (fun bv ->
-            match side with
-            | "t" -> [ border_top_style (Var bv); border_top_width w ]
-            | "r" -> [ border_right_style (Var bv); border_right_width w ]
-            | "b" -> [ border_bottom_style (Var bv); border_bottom_width w ]
-            | _ -> [ border_left_style (Var bv); border_left_width w ])
+    | Border_side_width_bracket (side, _, w) -> side_width side w
+    | Border_side_width (side, n) -> side_width_px side n
     (* Border side/axis utilities *)
-    | Border_t -> border_t
-    | Border_r -> border_r
-    | Border_b -> border_b
-    | Border_l -> border_l
-    | Border_x -> border_x
-    | Border_y -> border_y
-    | Border_x_width n -> border_x_width (float_of_int n)
-    | Border_y_width n -> border_y_width (float_of_int n)
-    | Border_s -> border_s
-    | Border_e -> border_e
-    | Border_bs -> border_bs
-    | Border_be -> border_be
-    | Border_s_width n -> border_s_width n
-    | Border_e_width n -> border_e_width n
-    | Border_bs_width n -> border_bs_width n
-    | Border_be_width n -> border_be_width n
+    | Border_t -> side_width_px "t" 1
+    | Border_r -> side_width_px "r" 1
+    | Border_b -> side_width_px "b" 1
+    | Border_l -> side_width_px "l" 1
+    | Border_x -> side_width_px "x" 1
+    | Border_y -> side_width_px "y" 1
+    | Border_x_width n -> side_width_px "x" n
+    | Border_y_width n -> side_width_px "y" n
+    | Border_s -> side_width_px "s" 1
+    | Border_e -> side_width_px "e" 1
+    | Border_bs -> side_width_px "bs" 1
+    | Border_be -> side_width_px "be" 1
+    | Border_s_width n -> side_width_px "s" n
+    | Border_e_width n -> side_width_px "e" n
+    | Border_bs_width n -> side_width_px "bs" n
+    | Border_be_width n -> side_width_px "be" n
     (* Border style utilities *)
     | Border_solid -> border_solid
     | Border_dashed -> border_dashed
@@ -676,7 +640,29 @@ module Handler = struct
     && Scheme.theme_value (Some theme) ("radius-" ^ n) <> None
 
   (* Forty apart, so a side's widths and its bracket never reach the next. *)
-  let side_band = function "t" -> 1160 | "r" -> 1200 | "b" -> 1240 | _ -> 1280
+  (* Every border width writes a property another one writes too, so their
+     order decides which wins. Tailwind groups them side-major: the all-sides
+     width first, then each axis and logical side, then the physical sides.
+     Each side gets a hundred-wide band, since a width the scale does not name
+     still has to sort between its neighbours. *)
+  let width_band = function
+    | "" -> 300
+    | "x" -> 400
+    | "y" -> 500
+    | "s" -> 600
+    | "e" -> 700
+    | "bs" -> 800
+    | "be" -> 900
+    | "t" -> 1000
+    | "r" -> 1100
+    | "b" -> 1200
+    | _ -> 1300
+
+  (* Within a band the bare utility leads, then the widths in numeric order,
+     then the arbitrary width. A width past what the band holds shares the slot
+     below the arbitrary one. *)
+  let width_slot side n = width_band side + 1 + min n 97
+  let width_bracket_slot side = width_band side + 99
 
   let suborder = function
     (* Border radius utilities - flat suborder per position group for natural
@@ -703,42 +689,33 @@ module Handler = struct
         | Corner.Bottom -> 150
         | Corner.Bottom_right -> 160
         | Corner.Bottom_left -> 170)
-    (* Border width utilities (1000-1099) *)
-    | Border -> 1000
-    | Border_0 -> 1001
-    | Border_2 -> 1002
-    | Border_4 -> 1003
-    | Border_8 -> 1004
-    | Border_width n -> 1001 + n
-    | Border_width_bracket _ -> 1005
-    (* Border sides are side-major (Tailwind groups each side's bare width, its
-       numeric widths and its arbitrary width together), and the axes and
-       logical sides come first: x, y, s, e, bs, be, then t, r, b, l. The order
-       decides the width, since border-y and border-b both write the bottom one.
-       Within a side: bare, 0, 2, 4, 8, arbitrary. *)
-    | Border_x -> 1100
-    | Border_x_width n -> 1100 + n
-    | Border_y -> 1110
-    | Border_y_width n -> 1110 + n
-    | Border_s -> 1120
-    | Border_s_width n -> 1120 + n
-    | Border_e -> 1130
-    | Border_e_width n -> 1130 + n
-    | Border_bs -> 1140
-    | Border_bs_width n -> 1140 + n
-    | Border_be -> 1150
-    | Border_be_width n -> 1150 + n
-    (* Each side gets a band of its own: the bare side leads, then the widths in
-       numeric order, then the bracket. They all write one property, so the
-       order decides which one wins, and the band has to be wide enough for a
-       width the scale does not name - [border-t-6] used to sort past the
-       bracket. *)
-    | Border_side_width_bracket (side, _, _) -> side_band side + 30
-    | Border_side_width (side, n) -> side_band side + 1 + n
-    | Border_t -> side_band "t"
-    | Border_r -> side_band "r"
-    | Border_b -> side_band "b"
-    | Border_l -> side_band "l"
+    (* Border width utilities, side-major: the sides run x, y, s, e, bs, be,
+       then t, r, b, l, which is the order Tailwind writes them in. *)
+    | Border -> width_band ""
+    | Border_0 -> width_slot "" 0
+    | Border_2 -> width_slot "" 2
+    | Border_4 -> width_slot "" 4
+    | Border_8 -> width_slot "" 8
+    | Border_width n -> width_slot "" n
+    | Border_width_bracket _ -> width_bracket_slot ""
+    | Border_x -> width_band "x"
+    | Border_x_width n -> width_slot "x" n
+    | Border_y -> width_band "y"
+    | Border_y_width n -> width_slot "y" n
+    | Border_s -> width_band "s"
+    | Border_s_width n -> width_slot "s" n
+    | Border_e -> width_band "e"
+    | Border_e_width n -> width_slot "e" n
+    | Border_bs -> width_band "bs"
+    | Border_bs_width n -> width_slot "bs" n
+    | Border_be -> width_band "be"
+    | Border_be_width n -> width_slot "be" n
+    | Border_side_width_bracket (side, _, _) -> width_bracket_slot side
+    | Border_side_width (side, n) -> width_slot side n
+    | Border_t -> width_band "t"
+    | Border_r -> width_band "r"
+    | Border_b -> width_band "b"
+    | Border_l -> width_band "l"
     (* Border style utilities (1400-1499) - alphabetical *)
     | Border_dashed -> 1400
     | Border_dotted -> 1401
@@ -761,6 +738,12 @@ module Handler = struct
     | Outline_offset n -> 2210 + n
     | Outline_offset_var _ -> 2299
     | Outline_offset_arbitrary _ -> 2215
+
+  (* The ten sides a border width can name: the two axes, the four logical sides
+     and the four physical ones. *)
+  let is_border_side = function
+    | "t" | "r" | "b" | "l" | "x" | "y" | "s" | "e" | "bs" | "be" -> true
+    | _ -> false
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
@@ -823,9 +806,8 @@ module Handler = struct
           | Some w -> Ok (Border_width_bracket (inner, w))
           | None -> err_not_utility
         else err_not_utility
-    | [ "border"; side; v ]
-      when (match side with "t" | "r" | "b" | "l" -> true | _ -> false)
-           && Parse.is_bracket_value v ->
+    | [ "border"; side; v ] when is_border_side side && Parse.is_bracket_value v
+      ->
         let inner = Parse.bracket_inner v in
         let is_numeric_start c = (c >= '0' && c <= '9') || c = '.' in
         let is_width =

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -859,14 +859,19 @@ module Handler = struct
        oklab as well made it depend on a colour-space round trip. *)
     let base_value, with_alpha =
       match c with
+      (* A modifier reading a custom property has no percentage for an alpha
+         byte to carry, so the hex stays whole and the property mixes into the
+         guarded value instead. *)
+      | (Hex _ | Authored_hex _)
+        when Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) ->
+          (c, Color.mix_alpha ~in_space:Oklab opacity c)
       | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
           let hex = "#" ^ rgba_hex_string r g b a in
           ( Css.hex (Color.hex_with_alpha hex percent),
             Color.hex_to_oklab_alpha hex alpha )
       (* A colour with no sRGB hex has nothing to carry the alpha byte, so the
          modifier stays a mix: sRGB for the plain fallback, oklab for the
-         guarded value. A modifier reading a custom property has no percentage a
-         plain fallback can hold, so only the guarded value mixes. *)
+         guarded value. *)
       | _ ->
           let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
           if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
@@ -1487,6 +1492,9 @@ module Handler = struct
        colour with no hex keeps its alpha as a mix in each space. *)
     let base_value, with_alpha =
       match c with
+      | (Hex _ | Authored_hex _)
+        when Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) ->
+          (c, Color.mix_alpha ~in_space:Oklab opacity c)
       | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
           let hex = "#" ^ rgba_hex_string r g b a in
           ( Css.hex (Color.hex_with_alpha hex percent),

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -32,6 +32,9 @@ module Handler = struct
     | Text_shadow_transparent_opacity of Color.opacity_modifier
     | Text_shadow_bracket_hex of string
     | Text_shadow_bracket_hex_opacity of string * Color.opacity_modifier
+    | Text_shadow_bracket_color of string * Css.color
+    | Text_shadow_bracket_color_opacity of
+        string * Css.color * Color.opacity_modifier
     | Text_shadow_bracket_color_var of string
     | Text_shadow_bracket_cvar_opacity of string * Color.opacity_modifier
     | Text_shadow_bracket_shadow of string
@@ -503,6 +506,40 @@ module Handler = struct
     style ~rules:(Some [ supports_block ])
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
+  (* A bracket colour spelled any way but a [#] hex: a name, a colour function
+     or a relative colour. One with an sRGB hex takes it, so it reads the same
+     as the hex arm above; one without stays as written. *)
+  let set_bracket_color (c : Css.color) =
+    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
+    let base_decl, _ = Var.binding text_shadow_color_var c in
+    let enhanced_color =
+      Css.color_mix_var_percent ~in_space:Oklab ~var_name:text_shadow_alpha_name
+        c Css.Transparent
+    in
+    let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
+    let supports_block = color_mix_supports [ enhanced_decl ] in
+    style ~rules:(Some [ supports_block ])
+      ~property_rules:text_shadow_property_rules [ base_decl ]
+
+  let set_bracket_color_opacity (c : Css.color) opacity =
+    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
+    let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
+    (* A modifier reading a custom property has no percentage a plain fallback
+       can hold, so the fallback keeps the colour as written. *)
+    let base_value =
+      if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then c
+      else Color.mix_alpha ~in_space:Srgb opacity c
+    in
+    let base_decl, _ = Var.binding text_shadow_color_var base_value in
+    let enhanced_color =
+      Css.color_mix_var_percent ~in_space:Oklab ~var_name:text_shadow_alpha_name
+        guarded Css.Transparent
+    in
+    let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
+    let supports_block = color_mix_supports [ enhanced_decl ] in
+    style ~rules:(Some [ supports_block ])
+      ~property_rules:text_shadow_property_rules [ base_decl ]
+
   let set_bracket_color_var var_expr =
     let var_name = Parse.extract_var_name var_expr in
     let var_color = make_color_var var_name in
@@ -676,6 +713,9 @@ module Handler = struct
     | Text_shadow_bracket_hex hex -> set_bracket_hex hex
     | Text_shadow_bracket_hex_opacity (hex, opacity) ->
         set_bracket_hex_opacity hex opacity
+    | Text_shadow_bracket_color (_orig, c) -> set_bracket_color c
+    | Text_shadow_bracket_color_opacity (_orig, c, opacity) ->
+        set_bracket_color_opacity c opacity
     | Text_shadow_bracket_color_var var_expr -> set_bracket_color_var var_expr
     | Text_shadow_bracket_cvar_opacity (var_expr, opacity) ->
         set_bracket_color_var_opacity var_expr opacity
@@ -783,14 +823,22 @@ module Handler = struct
               match opacity with
               | Color.No_opacity -> Ok (Text_shadow_bracket_hex hex)
               | op -> Ok (Text_shadow_bracket_hex_opacity (hex, op))
-            else if parse_arbitrary_shadow inner = Stdlib.Option.None then
-              (* Not a shadow, so not a utility: it used to fall back to
-                 [text-shadow: none]. *)
-              err_not_utility
             else
-              match opacity with
-              | Color.No_opacity -> Ok (Text_shadow_arbitrary inner)
-              | op -> Ok (Text_shadow_arbitrary_opacity (inner, op)))
+              match Color.parse_bracket_color inner with
+              | Some c -> (
+                  match opacity with
+                  | Color.No_opacity ->
+                      Ok (Text_shadow_bracket_color (inner, c))
+                  | op -> Ok (Text_shadow_bracket_color_opacity (inner, c, op)))
+              | Stdlib.Option.None -> (
+                  if parse_arbitrary_shadow inner = Stdlib.Option.None then
+                    (* Not a shadow, so not a utility: it used to fall back to
+                       [text-shadow: none]. *)
+                    err_not_utility
+                  else
+                    match opacity with
+                    | Color.No_opacity -> Ok (Text_shadow_arbitrary inner)
+                    | op -> Ok (Text_shadow_arbitrary_opacity (inner, op))))
         (* Not a size: a shadeless colour, which the multi-segment colour cases
            below never see because it fits in this single segment. *)
         | Stdlib.Option.None, Color.No_opacity -> (
@@ -845,6 +893,9 @@ module Handler = struct
     | Text_shadow_bracket_hex hex -> "text-shadow-[#" ^ hex ^ "]"
     | Text_shadow_bracket_hex_opacity (hex, opacity) ->
         "text-shadow-[#" ^ hex ^ "]/" ^ Color.pp_opacity opacity
+    | Text_shadow_bracket_color (orig, _) -> "text-shadow-[" ^ orig ^ "]"
+    | Text_shadow_bracket_color_opacity (orig, _, opacity) ->
+        "text-shadow-[" ^ orig ^ "]/" ^ Color.pp_opacity opacity
     | Text_shadow_bracket_color_var var_expr ->
         "text-shadow-[color:" ^ var_expr ^ "]"
     | Text_shadow_bracket_cvar_opacity (var_expr, opacity) ->

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -437,6 +437,74 @@ let test_side_width_order () =
       "border-t-[3px]";
     ]
 
+(* The axis and logical sides take an arbitrary width the same way the physical
+   sides do. The bracket arm matched the four physical sides only, so an axis or
+   logical side fell through to the colour path and failed there. *)
+let test_axis_arbitrary_width () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits affix cls =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "border-inline-width: 3px" "border-x-[3px]";
+  emits "border-block-width: 3px" "border-y-[3px]";
+  emits "border-inline-start-width: 3px" "border-s-[3px]";
+  emits "border-inline-end-width: 3px" "border-e-[3px]";
+  emits "border-block-start-width: 3px" "border-bs-[3px]";
+  emits "border-block-end-width: 3px" "border-be-[3px]";
+  emits "border-inline-width: .5rem" "border-x-[0.5rem]";
+  emits "border-inline-style: var(--tw-border-style)" "border-x-[3px]";
+  (* a bracket that is not a length is still not a width *)
+  Alcotest.(check bool)
+    "border-x-[1e] is rejected" true
+    (Result.is_error (Tw.of_string "border-x-[1e]"))
+
+(* Every axis and logical side writes a width some other side writes too, so
+   their relative order decides which one wins. The families were packed into
+   bands ten wide, so [border-x-25] landed on [border-s-5]'s slot and the two
+   sorted by class name instead. *)
+let test_axis_width_order () =
+  Test_helpers.check_class_order ~test_name:"border axis widths"
+    [
+      "border-x";
+      "border-x-25";
+      "border-y";
+      "border-y-25";
+      "border-s";
+      "border-s-5";
+      "border-e";
+      "border-e-5";
+      "border-bs";
+      "border-bs-5";
+      "border-be";
+      "border-be-5";
+      "border-t-6";
+      "border-l-2";
+    ]
+
+(* An axis or logical bracket width sorts inside its own side's band, after the
+   numeric widths, the way the physical sides already do. *)
+let test_axis_arbitrary_width_order () =
+  Test_helpers.check_class_order ~test_name:"border axis bracket widths"
+    [
+      "border-x-2";
+      "border-x-[3px]";
+      "border-y-2";
+      "border-y-[3px]";
+      "border-s-2";
+      "border-s-[3px]";
+      "border-e-2";
+      "border-e-[3px]";
+      "border-bs-2";
+      "border-bs-[3px]";
+      "border-be-2";
+      "border-be-[3px]";
+      "border-t-[3px]";
+    ]
+
 (* A bracket whose content is not a length is not an outline or border width:
    the parser rejects it, rather than accepting it and raising from the length
    conversion once the sheet is rendered. *)
@@ -463,6 +531,10 @@ let tests =
       test_bracket_math_function_width;
     test_case "project radius token" `Quick test_project_radius_token;
     test_case "border side width order" `Slow test_side_width_order;
+    test_case "border axis arbitrary widths" `Quick test_axis_arbitrary_width;
+    test_case "border axis width order" `Slow test_axis_width_order;
+    test_case "border axis bracket width order" `Slow
+      test_axis_arbitrary_width_order;
     test_case "rounded-sm default radius" `Quick test_rounded_sm_default;
     test_case "rounded-xs default radius" `Quick test_rounded_xs;
     test_case "rounded-4xl default radius" `Quick test_rounded_4xl;

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -434,6 +434,7 @@ let test_side_width_order () =
       "border-t-4";
       "border-t-6";
       "border-t-8";
+      "border-t-40";
       "border-t-[3px]";
     ]
 
@@ -485,6 +486,24 @@ let test_axis_width_order () =
       "border-l-2";
     ]
 
+(* The all-sides widths sort by the number they name, and the bracket sorts
+   after every one of them. The four the scale names (0, 2, 4, 8) took the first
+   four slots of the band and the rest counted from the same base, so [border-3]
+   landed on [border-8]'s slot and [border-40] sorted past the bracket. *)
+let test_all_sides_width_order () =
+  Test_helpers.check_class_order ~test_name:"border widths"
+    [
+      "border";
+      "border-0";
+      "border-2";
+      "border-3";
+      "border-4";
+      "border-5";
+      "border-8";
+      "border-40";
+      "border-[3px]";
+    ]
+
 (* An axis or logical bracket width sorts inside its own side's band, after the
    numeric widths, the way the physical sides already do. *)
 let test_axis_arbitrary_width_order () =
@@ -532,6 +551,7 @@ let tests =
     test_case "project radius token" `Quick test_project_radius_token;
     test_case "border side width order" `Slow test_side_width_order;
     test_case "border axis arbitrary widths" `Quick test_axis_arbitrary_width;
+    test_case "border all-sides width order" `Slow test_all_sides_width_order;
     test_case "border axis width order" `Slow test_axis_width_order;
     test_case "border axis bracket width order" `Slow
       test_axis_arbitrary_width_order;

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -373,6 +373,29 @@ let test_bracket_colour_opacity_without_hex () =
     "--tw-inset-shadow-color:color-mix(in srgb,";
   lacks "inset-shadow-[oklch(0.7_0.1_200)]/50" "--tw-inset-shadow-color:oklch("
 
+(* A hex bracket colour whose modifier reads a custom property keeps that
+   property inside the guarded [color-mix]. The hex arm folded the modifier into
+   an alpha byte, which a var() has no value for, so the modifier was dropped
+   and the shadow painted fully opaque. *)
+let test_bracket_hex_opacity_var () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  (* the plain fallback has no percentage to hold, so it keeps the hex *)
+  has "shadow-[#f00]/[var(--x)]" "--tw-shadow-color:#f00";
+  has "shadow-[#f00]/[var(--x)]"
+    "color-mix(in oklab,color-mix(in oklab,#f00 var(--x),transparent) \
+     var(--tw-shadow-alpha),transparent)";
+  has "inset-shadow-[#f00]/[var(--x)]" "--tw-inset-shadow-color:#f00";
+  has "inset-shadow-[#f00]/[var(--x)]"
+    "color-mix(in oklab,color-mix(in oklab,#f00 var(--x),transparent) \
+     var(--tw-inset-shadow-alpha),transparent)"
+
 (* A bracket alpha modifier with no [%] sign (shadow-lg/[25]) tracks the
    modifier's own written text in --tw-shadow-alpha, the way Tailwind does,
    rather than scaling it into a percentage: the alpha the shadow paints with
@@ -551,6 +574,8 @@ let tests =
       test_arbitrary_shadow_colour_opacity;
     test_case "bracket colour opacity without a hex" `Quick
       test_bracket_colour_opacity_without_hex;
+    test_case "bracket hex opacity from a var" `Quick
+      test_bracket_hex_opacity_var;
     test_case "shadow bracket alpha tracking" `Quick
       test_shadow_bracket_alpha_tracking;
     test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -165,6 +165,40 @@ let test_invalid_bracket_hex () =
   emits "text-shadow-[0_1px_2px_#ff0000]"
     "text-shadow:0 1px 2px var(--tw-text-shadow-color,#f00)"
 
+(* A bracket colour is a colour whatever spelling it takes. The bare-colour arm
+   reached only the hex reader, so a name, an [oklch()] or an [rgb()] fell
+   through to the arbitrary-shadow reader and was rejected outright. *)
+let test_bracket_plain_colour () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "text-shadow-[red]" "--tw-text-shadow-color:red";
+  emits "text-shadow-[red]"
+    "color-mix(in oklab,red var(--tw-text-shadow-alpha),transparent)";
+  emits "text-shadow-[oklch(0.7_0.1_200)]"
+    "--tw-text-shadow-color:oklch(.7 .1 200)";
+  (* a colour function with a byte value for every channel folds to its hex
+     spelling, the same as the arbitrary-shadow reader does with one *)
+  emits "text-shadow-[rgb(255_0_0)]" "--tw-text-shadow-color:#f00";
+  (* the modifier folds into the colour: sRGB for the plain fallback, oklab for
+     the value the @supports block guards *)
+  emits "text-shadow-[red]/50"
+    "--tw-text-shadow-color:color-mix(in srgb,red 50%,transparent)";
+  emits "text-shadow-[red]/50"
+    "color-mix(in oklab,color-mix(in oklab,red 50%,transparent) \
+     var(--tw-text-shadow-alpha),transparent)";
+  (* a modifier reading a custom property has no percentage a plain fallback can
+     hold, so only the guarded value mixes *)
+  emits "text-shadow-[red]/[var(--x)]" "--tw-text-shadow-color:red";
+  emits "text-shadow-[red]/[var(--x)]"
+    "color-mix(in oklab,color-mix(in oklab,red var(--x),transparent) \
+     var(--tw-text-shadow-alpha),transparent)"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -179,6 +213,7 @@ let tests =
       Alcotest.test_case "arbitrary named colour" `Quick
         test_arbitrary_named_colour;
       Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+      Alcotest.test_case "bracket plain colour" `Quick test_bracket_plain_colour;
     ]
 
 let suite = ("text_shadow", tests)


### PR DESCRIPTION
Three classes Tailwind renders and tw refused or rendered wrongly.

The `text-shadow-[<colour>]` arm ran hex, then var, then the arbitrary-shadow reader, with no arm for a plain colour, so `text-shadow-[red]` and `text-shadow-[oklch(...)]` fell through to the shadow reader and were rejected while `text-shadow-[#0088cc]/50` worked.

A hex bracket shadow colour with a `var()` opacity dropped the modifier's own variable: inside the `@supports` block the property mixed into nothing. The same bug sat verbatim in the inset builder, so `inset-shadow-[#f00]/[var(--x)]` is fixed too.

`border-x-[3px]`, `border-y-`, `border-s-` and `border-e-` were unknown classes because the bracket-width arm matched the four physical sides only. That needed a renumbering rather than a guard: the axis families sat in ten-wide bands with numeric widths at `band + n`, so `border-x-25 border-s-5` already came out in the wrong order. Two more collisions of the same shape turned up and are fixed with it - `border-3 border-4` came out reversed because the nullary constructors took the band's first slots while `Border_width n` counted from the same base, and `border-40` sorted past its own bracket. Each of the eleven width families now has a hundred-slot band. A 42-class mixed set emits byte-identical to `--tailwind`, and the sort fuzzer is clean on thirteen seeds.