### PR TITLE
color, scroll, text_shadow: sort side-major and read a colour hint

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -3112,8 +3112,24 @@ module Handler = struct
     | Border_current_opacity _ -> 1500
     | Border_bracket_color _ -> 1500
     | Border_bracket_color_opacity _ -> 1500
-    (* Per-side border colors sort after the all-sides colors. *)
-    | Border_side_color _ -> 1600
+    (* Per-side border colours sort after the all-sides ones, and side-major:
+       every colour a side names writes a colour another side writes too, so
+       their order decides which one wins. Tailwind runs the axes and the
+       logical sides first, then the physical ones. Within a side the colours
+       tie and sort by class name, so one slot per side is enough; they stay ten
+       apart to leave room. *)
+    | Border_side_color (side, _) -> (
+        match side with
+        | Side.Inline_axis -> 1600
+        | Side.Block_axis -> 1610
+        | Side.Inline_start -> 1620
+        | Side.Inline_end -> 1630
+        | Side.Block_start -> 1640
+        | Side.Block_end -> 1650
+        | Side.Top -> 1660
+        | Side.Right -> 1670
+        | Side.Bottom -> 1680
+        | Side.Left -> 1690)
     (* The three colour families that close the late-typography block, in
        Tailwind's order: placeholder, then caret, then accent, all after the
        underline offset (max 69999). Each family shares one suborder so its

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -118,26 +118,32 @@ module Handler = struct
 
   let suborder { kind; negative; axis; value } =
     let kind_offset = match kind with Margin -> 0 | Padding -> 10000000 in
-    let neg_offset = if negative then -5000000 else 0 in
+    (* Side decides first and the sign is a tie-break inside the side, which is
+       the order Tailwind emits: the negative of a side sits with that side, not
+       ahead of every positive. The logical sides come before the physical
+       ones. *)
     let axis_offset =
       match axis with
       | All -> 0
       | X -> 100000
       | Y -> 200000
-      | T -> 300000
-      | R -> 400000
-      | B -> 500000
-      | L -> 600000
-      | S -> 700000
-      | E -> 800000
-      | Bs -> 900000
-      | Be -> 1000000
+      | S -> 300000
+      | E -> 400000
+      | Bs -> 500000
+      | Be -> 600000
+      | T -> 700000
+      | R -> 800000
+      | B -> 900000
+      | L -> 1000000
     in
+    let neg_offset = if negative then 0 else 50000 in
+    (* Half the axis band each, so a value can never carry a rule across the
+       sign boundary: the arbitrary spellings sit at the top of their half. *)
     let value_order =
       match value with
       | Spacing n -> int_of_float (n *. 10.)
-      | Arbitrary _ -> 50000
-      | Arbitrary_var _ -> 50001
+      | Arbitrary _ -> 49000
+      | Arbitrary_var _ -> 49001
     in
     kind_offset + neg_offset + axis_offset + value_order
 

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -809,10 +809,29 @@ module Handler = struct
         | Stdlib.Option.None, _ when Parse.is_bracket_value base -> (
             let inner = Parse.bracket_inner base in
             if starts_with "color:" inner then
-              let var_part = String.sub inner 6 (String.length inner - 6) in
-              match opacity with
-              | Color.No_opacity -> Ok (Text_shadow_bracket_color_var var_part)
-              | op -> Ok (Text_shadow_bracket_cvar_opacity (var_part, op))
+              (* The hint says the payload is a colour, not that it names a
+                 variable. A [var()] still reads as one; a colour CSS can spell
+                 is that colour, as Tailwind emits it. *)
+              let payload = String.sub inner 6 (String.length inner - 6) in
+              (* A [var()] keeps the variable path even though it parses as a
+                 colour: with an opacity modifier Tailwind writes the plain
+                 reference as the fallback and mixes only inside the [@supports]
+                 guard, which is what that path builds. *)
+              let as_colour =
+                if Parse.is_var payload then Stdlib.Option.None
+                else Color.parse_bracket_color payload
+              in
+              match (as_colour, opacity) with
+              (* [inner], not [payload]: the class name keeps the hint the
+                 author wrote, so it reads back as the class they spelled. *)
+              | Some c, Color.No_opacity ->
+                  Ok (Text_shadow_bracket_color (inner, c))
+              | Some c, op ->
+                  Ok (Text_shadow_bracket_color_opacity (inner, c, op))
+              | Stdlib.Option.None, Color.No_opacity ->
+                  Ok (Text_shadow_bracket_color_var payload)
+              | Stdlib.Option.None, op ->
+                  Ok (Text_shadow_bracket_cvar_opacity (payload, op))
             else if starts_with "shadow:" inner then
               let var_part = String.sub inner 7 (String.length inner - 7) in
               Ok (Text_shadow_bracket_shadow var_part)

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -232,6 +232,47 @@ let test_border_side_color () =
     (Astring.String.is_infix ~affix:"border-block-end-color:"
        (css "border-be-red-500"))
 
+(* Every per-side border colour writes a colour another side writes too, so
+   their relative order decides which one wins. Tailwind groups them side-major:
+   the all-sides colour first, then the axes and the logical sides, then the
+   physical ones. The ten sides shared one suborder, so they tied and fell back
+   to class-name order: [border-t-blue-500] sorted before [border-x-red-500]. *)
+let test_border_side_color_order () =
+  Test_helpers.check_class_order ~test_name:"border side colors"
+    [
+      "border-red-500";
+      "border-x-red-500";
+      "border-y-red-500";
+      "border-s-red-500";
+      "border-e-red-500";
+      "border-bs-red-500";
+      "border-be-red-500";
+      "border-t-blue-500";
+      "border-r-red-500";
+      "border-b-red-500";
+      "border-l-red-500";
+    ]
+
+(* An arbitrary per-side colour sorts in its own side's band, next to the named
+   colours of that side. *)
+let test_border_side_bracket_color_order () =
+  Test_helpers.check_class_order ~test_name:"border side bracket colors"
+    [
+      "border-[#f00]";
+      "border-x-[#f00]";
+      "border-y-[#f00]";
+      "border-s-[#f00]";
+      "border-e-[#f00]";
+      "border-bs-[#f00]";
+      "border-be-[#f00]";
+      "border-t-[#00f]";
+      "border-t-red-500";
+      "border-t-transparent";
+      "border-r-[#f00]";
+      "border-b-[#f00]";
+      "border-l-[#f00]";
+    ]
+
 (* A CSS variable in a border color bracket, and its v4 paren shorthand, resolve
    to var(): border-[var(--x)] and border-(--x) both set border-color. *)
 let test_border_color_var () =
@@ -973,6 +1014,10 @@ let tests =
     ("Per-side border colors", `Quick, test_border_side_color);
     ("Border color var", `Quick, test_border_color_var);
     ("Border side color opacity", `Quick, test_border_side_color_opacity);
+    ("Per-side border color order", `Slow, test_border_side_color_order);
+    ( "Per-side border bracket color order",
+      `Slow,
+      test_border_side_bracket_color_order );
     ("Bracket CSS colors", `Quick, test_bracket_css_colors);
     ("Bracket colour opacity", `Quick, test_bracket_colour_opacity);
     ("hsl hue units", `Quick, test_hsl_hue_units);

--- a/test/test_scroll.ml
+++ b/test/test_scroll.ml
@@ -61,12 +61,57 @@ let test_arbitrary_length () =
   | Ok _ -> Alcotest.fail "expected scroll-m-[bogus] to be rejected"
   | Error _ -> ()
 
+(* Every scroll margin writes a property another one writes too, so their order
+   decides which one wins. Tailwind sorts them by side - all, the two axes, the
+   four logical sides, then the four physical ones - and puts the negative of a
+   side before its positive. The sign was weighed ahead of the side, so
+   [-scroll-ml-6] sorted before [scroll-mt-4]; the logical sides also trailed
+   the physical ones. *)
+let test_margin_order () =
+  Test_helpers.check_class_order ~test_name:"scroll margins"
+    [
+      "-scroll-m-4";
+      "scroll-m-4";
+      "scroll-mx-4";
+      "scroll-my-4";
+      "scroll-ms-4";
+      "scroll-me-4";
+      "scroll-mbs-4";
+      "scroll-mbe-4";
+      "-scroll-mt-4";
+      "-scroll-mt-8";
+      "scroll-mt-4";
+      "scroll-mr-4";
+      "scroll-mb-4";
+      "-scroll-ml-6";
+      "scroll-ml-6";
+    ]
+
+(* Scroll padding takes no negative, and sorts by the same side order. *)
+let test_padding_order () =
+  Test_helpers.check_class_order ~test_name:"scroll paddings"
+    [
+      "scroll-p-4";
+      "scroll-px-4";
+      "scroll-py-4";
+      "scroll-ps-4";
+      "scroll-pe-4";
+      "scroll-pbs-4";
+      "scroll-pbe-4";
+      "scroll-pt-4";
+      "scroll-pr-4";
+      "scroll-pb-4";
+      "scroll-pl-4";
+    ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "typed constructors: half-step" `Quick test_typed_prime;
       Alcotest.test_case "arbitrary length" `Quick test_arbitrary_length;
+      Alcotest.test_case "scroll margin order" `Slow test_margin_order;
+      Alcotest.test_case "scroll padding order" `Slow test_padding_order;
     ]
 
 let suite = ("scroll", tests)

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -199,8 +199,34 @@ let test_bracket_plain_colour () =
     "color-mix(in oklab,color-mix(in oklab,red var(--x),transparent) \
      var(--tw-text-shadow-alpha),transparent)"
 
+(* The [color:] hint says the payload is a colour, not that it names a variable.
+   Every payload was read as a variable name, so [text-shadow-[color:red]]
+   emitted [var(--red)] where Tailwind emits [red]. A [var()] payload still
+   reads as one, and the class name keeps the hint. *)
+let test_colour_hint_takes_a_colour () =
+  let value cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (value cls))
+  in
+  has "text-shadow-[color:red]" "--tw-text-shadow-color:red";
+  has "text-shadow-[color:var(--x)]" "--tw-text-shadow-color:var(--x)";
+  (* A var() with an opacity modifier keeps the plain reference as the fallback
+     and mixes only inside the @supports guard, so it must not take the colour
+     path even though var() parses as a colour. *)
+  has "text-shadow-[color:var(--x)]/50" "--tw-text-shadow-color:var(--x)";
+  (* The hint survives into the class name, so the class reads back. *)
+  has "text-shadow-[color:red]" ".text-shadow-\\[color\\:red\\]"
+
 let tests =
-  Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  [
+    Alcotest.test_case "colour hint takes a colour" `Quick
+      test_colour_hint_takes_a_colour;
+  ]
+  @ Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "arbitrary lengths" `Quick test_arbitrary_lengths;
       Alcotest.test_case "default scale (v4.3.1)" `Quick test_default_scale;


### PR DESCRIPTION
Reopening the five commits from #531. That PR merged into `bracket-parity-gaps` after that branch had already gone into `main`, so its content never reached `main` - the same way #482 to #499 stopped one hop short earlier. Nothing was lost; the branch is rebased here.

`Border_side_color` gave all ten sides one suborder, so they tied and fell back to class-name order: `border-x-red-500 border-t-blue-500` came out reversed. Same shape as the width bug, fixed in `color.ml` where the colours live.

Scroll margins weighed the sign ahead of the side. `neg_offset` was -5000000 against axis offsets topping out at 600000, so every negative sorted before every positive and `-scroll-ml-6` came before `scroll-mt-4`. The sign is a tie-break inside the side now, and the logical sides precede the physical ones, matching Tailwind for all fifteen spellings. The per-class `--diff` oracle cannot see this - it takes one class at a time and this needs two - so it surfaced only in the whole-site measurement.

`text-shadow-[color:red]` emitted `var(--red)`: the hint says the payload is a colour, and every payload was read as a variable name. A `var()` still takes the variable path, deliberately - with an opacity modifier Tailwind writes the plain reference as the fallback and mixes only inside the `@supports` guard. That combination is pinned, because the first cut passed both single-axis checks and broke it.