### PR TITLE
test: force the element states in the rendering comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       # dune-project asks for cascade 1.2.0 and that release does not exist
-      # yet. Its development branch carries the version, so the pin is what
-      # the solver has to satisfy the bound with.
-      - name: Pin cascade to its development branch
-        run: opam pin add --no-action -y cascade.1.2.0 git+https://github.com/samoht/cascade.git#main
+      # yet. Pin the tested development revision: following main made an
+      # unchanged PR start compiling against breaking API changes.
+      - name: Pin the tested cascade revision
+        run: opam pin add --no-action -y cascade.1.2.0 git+https://github.com/samoht/cascade.git#e829b2d629fe210a23415a218f1814d2abc0c1ad
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -114,7 +114,7 @@ module Handler = struct
     | Outline_0
     | Outline_width of int (* outline-1, outline-2, outline-4, outline-8 *)
     | Outline_width_bracket of
-        string * Css.length (* outline-[12px], outline-[1.5], etc. *)
+        string * Css.border_width (* outline-[12px], outline-[1.5], etc. *)
     | Outline_width_var of string (* outline-[length:var(...)], etc. *)
     (* Outline style utilities (dashed, dotted, etc.) are in
        Outline_style_handler *)
@@ -280,9 +280,13 @@ module Handler = struct
         | Some f -> Some (Px f)
         | None -> None)
 
-  let parse_outline_width inner : Css.length option =
-    match parse_length inner with
-    | Some _ as len -> len
+  (* cascade types outline-width as a [border_width], the line-width grammar it
+     shares with the border sides, so read it as one rather than reading a
+     length and converting where it is written. A bare number is Tailwind's own
+     sugar and still means pixels. *)
+  let parse_outline_width inner : Css.border_width option =
+    match parse_border_width inner with
+    | Some _ as w -> w
     | None -> (
         match parse_bare_number inner with
         | Some f -> Some (Px f)
@@ -462,7 +466,7 @@ module Handler = struct
       ]
 
   (* Outline bracket width: outline-[12px], outline-[1.5], outline-[50%] *)
-  let outline_width_bracket_style (width : Css.length) =
+  let outline_width_bracket_style (width : Css.border_width) =
     let oref = Var.reference outline_style_var in
     let property_rule =
       match Var.property_rule outline_style_var with
@@ -487,7 +491,7 @@ module Handler = struct
       | None -> v
     in
     let bare_name = Parse.extract_var_name var_part in
-    let var_ref : Css.length Css.var = Var.bracket bare_name in
+    let var_ref : Css.border_width Css.var = Var.bracket bare_name in
     style ~merge_key:"outline-" ~property_rules:property_rule
       [ Css.outline_style (Css.Var oref); Css.outline_width (Var var_ref) ]
 

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -794,8 +794,8 @@ module Handler = struct
     let stop v = set (color_var v pos_end) value in
     style ~property_rules (stop_decls dir stop @ composite_decls)
 
-  (* The keyword goes in as text because this custom property is a token
-     stream: a typed [Current] folds through it to a hex, where Tailwind writes
+  (* The keyword goes in as text because this custom property is a token stream:
+     a typed [Current] folds through it to a hex, where Tailwind writes
      [currentcolor] for a gradient stop to resolve against the element. Not a
      workaround for cascade's printer, which spells the keyword correctly and
      positionally - [currentColor] bare, [currentcolor] inside a function. *)

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -794,10 +794,11 @@ module Handler = struct
     let stop v = set (color_var v pos_end) value in
     style ~property_rules (stop_decls dir stop @ composite_decls)
 
-  (* A custom property spells the keyword [currentcolor], which is what cascade
-     folds a token stream to and what Tailwind writes; the typed colour prints
-     as the [currentColor] a colour property takes, so this one keyword goes in
-     as text. *)
+  (* The keyword goes in as text because this custom property is a token
+     stream: a typed [Current] folds through it to a hex, where Tailwind writes
+     [currentcolor] for a gradient stop to resolve against the element. Not a
+     workaround for cascade's printer, which spells the keyword correctly and
+     positionally - [currentColor] bare, [currentcolor] inside a function. *)
   let build_current_color_style dir pos_end =
     let property_rules = property_rules_for_direction dir in
     let stop v =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1161,21 +1161,13 @@ let parse_bracket_media content =
   if String.length rest > 4 && String.sub rest 0 4 = "not " then
     let inner = String.trim (String.sub rest 4 (String.length rest - 4)) in
     (* Double negation: return the positive condition *)
-    match inner with
-    | "(orientation: portrait)" | "(orientation:portrait)" ->
-        media_feature Css.Media.Orientation Css.Media.Portrait
-    | "(orientation: landscape)" | "(orientation:landscape)" ->
-        media_feature Css.Media.Orientation Css.Media.Landscape
-    | _ -> Css.Media.of_string inner
+    (* The reader takes the condition however it is spelled, so there is no
+       table of spellings here to fall out of step with itself. *)
+    Css.Media.of_string inner
   else
     (* Negate the condition *)
     match rest with
     | "print" -> negate_media print_media
-    | "(orientation: portrait)" | "(orientation:portrait)" ->
-        negate_media (media_feature Css.Media.Orientation Css.Media.Portrait)
-    | "(orientation: landscape)" | "(orientation:landscape)" ->
-        negate_media (media_feature Css.Media.Orientation Css.Media.Landscape)
-    | "(hover: hover)" | "(hover:hover)" -> negate_media hover_media
     | _ -> negate_media (Css.Media.of_string rest)
 
 (** Parse a bracket pseudo-class string into a CSS selector. *)

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -114,12 +114,24 @@ module Handler = struct
       Css.custom_property ~layer:"utilities" (Var.css_name set_var) k
     in
     match spec with
-    (* [currentcolor] goes in as text: cascade's typed colour prints the
-       [currentColor] a colour property takes, and Tailwind writes the lowercase
-       spelling a token stream folds to. [transparent] does not need the same
-       treatment - a token stream is what the optimizer folds to [#0000], so
-       writing it as text produced the very divergence the text was meant to
-       avoid. *)
+    (* The two keywords need opposite treatment, and neither is a workaround
+       for cascade.
+
+       [currentcolor] as text: this custom property is a token stream, so a
+       typed [Current] folds through it to [#00000000] where Tailwind writes
+       the keyword. The optimizer is right to fold a colour it can resolve;
+       what it cannot know is that this stream is read by a property that
+       resolves [currentcolor] against the element. (cascade's own capital-C
+       spelling is correct too, and positional: a bare [accent-color] takes
+       [currentColor], the same keyword inside a [color-mix()] takes
+       [currentcolor], which is what the upstream fixtures hold.)
+
+       [transparent] typed: a token stream is exactly what folds to [#0000], so
+       spelling it as text produced the divergence the text was meant to avoid.
+
+       Neither shows up under [--diff] on one class - nothing reads the property
+       in a one-class sheet and canonical mode prunes it - so the check is
+       against [--tailwind] on the emitted property, not the diff. *)
     | Transparent ->
         ([ fst (Var.binding set_var (Css.Transparent : Css.color)) ], [])
     | Current -> ([ keyword "currentcolor" ], [])

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -114,17 +114,17 @@ module Handler = struct
       Css.custom_property ~layer:"utilities" (Var.css_name set_var) k
     in
     match spec with
-    (* The two keywords need opposite treatment, and neither is a workaround
-       for cascade.
+    (* The two keywords need opposite treatment, and neither is a workaround for
+       cascade.
 
        [currentcolor] as text: this custom property is a token stream, so a
-       typed [Current] folds through it to [#00000000] where Tailwind writes
-       the keyword. The optimizer is right to fold a colour it can resolve;
-       what it cannot know is that this stream is read by a property that
-       resolves [currentcolor] against the element. (cascade's own capital-C
-       spelling is correct too, and positional: a bare [accent-color] takes
-       [currentColor], the same keyword inside a [color-mix()] takes
-       [currentcolor], which is what the upstream fixtures hold.)
+       typed [Current] folds through it to [#00000000] where Tailwind writes the
+       keyword. The optimizer is right to fold a colour it can resolve; what it
+       cannot know is that this stream is read by a property that resolves
+       [currentcolor] against the element. (cascade's own capital-C spelling is
+       correct too, and positional: a bare [accent-color] takes [currentColor],
+       the same keyword inside a [color-mix()] takes [currentcolor], which is
+       what the upstream fixtures hold.)
 
        [transparent] typed: a token stream is exactly what folds to [#0000], so
        spelling it as text produced the divergence the text was meant to avoid.

--- a/test/helpers/browser/compare.js
+++ b/test/helpers/browser/compare.js
@@ -67,9 +67,47 @@ const unusable = (got) => {
   return null;
 };
 
-async function computed(browser, css, names) {
+// The states a variant can put a rule behind that a still page never enters.
+// Forced through CDP rather than by moving a mouse: one pass sets the state on
+// every element at once, it reaches :focus without the element being focusable
+// for real, and it is what DevTools' own "force element state" does. A state
+// the protocol will not force is simply absent from this list rather than
+// silently mis-measured.
+// Measured one by one against a rule the state alone selects, because the
+// protocol accepts a name whether or not the browser then honours it:
+// [visited] is accepted and changes nothing (a privacy restriction), so it is
+// left out rather than sitting here reporting agreement it never tested.
+const forcedStates = [
+  'hover',
+  'focus',
+  'focus-visible',
+  'focus-within',
+  'active',
+  'checked',
+  'disabled',
+];
+
+// Force [state] on every recorded element, so a rule behind hover: or focus:
+// is one the browser has actually applied rather than one that merely sits in
+// the sheet. Without this the state half of the variant set is in both sheets
+// and matched by neither, and the two agree for the wrong reason.
+async function force(p, state) {
+  const cdp = await p.context().newCDPSession(p);
+  await cdp.send('DOM.enable');
+  await cdp.send('CSS.enable');
+  const { root } = await cdp.send('DOM.getDocument');
+  const { nodeIds } = await cdp.send('DOM.querySelectorAll', {
+    nodeId: root.nodeId,
+    selector: 'body > div[id^=e], body > div[id^=e] *',
+  });
+  for (const nodeId of nodeIds)
+    await cdp.send('CSS.forcePseudoState', { nodeId, forcedPseudoClasses: [state] });
+}
+
+async function computed(browser, css, names, state) {
   const p = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   await p.setContent(page(css));
+  if (state) await force(p, state);
   const out = await p.evaluate((ns) => {
     // Where a descendant sits inside its element, as tag names with an index
     // wherever siblings share a tag: enough to find it again in the markup.
@@ -126,10 +164,29 @@ async function computed(browser, css, names) {
     console.error(e.message);
     process.exit(2);
   }
-  const ra = await computed(browser, a, names);
-  const rb = await computed(browser, b, names);
+  // One pass with the page as it loads, then one per forced state. A rule
+  // behind hover: or focus: is in both sheets and matched by neither until the
+  // browser is actually in that state, so the still page agrees for the wrong
+  // reason.
+  const passes = [];
+  for (const state of [null, ...forcedStates])
+    passes.push({
+      state,
+      ra: await computed(browser, a, names, state),
+      rb: await computed(browser, b, names, state),
+    });
   await browser.close();
 
+  const lines = [];
+  for (const { state, ra, rb } of passes) {
+    const where = state ? ` [:${state}]` : '';
+    compare(ra, rb, where, lines);
+  }
+  report(lines);
+})();
+
+// Pair the two node lists and record every property that differs.
+function compare(ra, rb, where, lines) {
   const broken = unusable(ra.classes) || unusable(rb.classes);
   if (broken) {
     console.log(`markup does not carry the intended classes: ${broken}`);
@@ -149,8 +206,12 @@ async function computed(browser, css, names) {
 
   const label = (n) => {
     const cls = entries[Number(n.id.slice(1))].classes;
-    if (!n.path) return cls;
-    return n.path.startsWith('::') ? `${cls} ${n.path}` : `${cls} :: ${n.path}`;
+    const base = !n.path
+      ? cls
+      : n.path.startsWith('::')
+        ? `${cls} ${n.path}`
+        : `${cls} :: ${n.path}`;
+    return base + where;
   };
 
   // A custom property is a token stream: the browser hands back the author's
@@ -160,7 +221,6 @@ async function computed(browser, css, names) {
   const norm = (k, v) =>
     k.startsWith('--') && v !== undefined ? v.replace(/["'\s]+/g, '') : v;
 
-  const lines = [];
   for (let i = 0; i < ra.nodes.length; i++) {
     const na = ra.nodes[i];
     const nb = rb.nodes[i];
@@ -181,6 +241,9 @@ async function computed(browser, css, names) {
         lines.push(`${label(na)}: ${k}: ${pa[k]} (tw) vs ${pb[k]} (tailwind)`);
     }
   }
+}
+
+function report(lines) {
   if (lines.length) {
     // Every difference fails the run; a whole descendant tree off by one rule
     // prints thousands of lines, so the report stops at a readable prefix.
@@ -191,4 +254,4 @@ async function computed(browser, css, names) {
     process.exit(1);
   }
   process.exit(0);
-})();
+}

--- a/test/test_clipping.ml
+++ b/test/test_clipping.ml
@@ -44,10 +44,13 @@ let test_clip_inset_shorthand () =
   (* 1 value: all four sides get the same value *)
   check_roundtrip "clip-path:inset(50%)";
   check_roundtrip "clip-path:inset(10px)";
-  (* 2 values: top/bottom, left/right *)
-  check_roundtrip "clip-path:inset(10% 20%)";
+  (* 2 values: top/bottom, left/right. Minified, the space between two
+     percentages goes: a [%] already ends the token, so [10%20%] re-reads as
+     the same two components. The round-trip is on the value, not its
+     spacing. *)
+  check_parse "clip-path:inset(10% 20%)" "clip-path:inset(10%20%)";
   (* 3 values: top, left/right, bottom *)
-  check_roundtrip "clip-path:inset(10% 20% 30%)";
+  check_parse "clip-path:inset(10% 20% 30%)" "clip-path:inset(10%20%30%)";
   (* 4 values: top, right, bottom, left *)
   check_parse "clip-path:inset(0px 10px 20px 30px)"
     "clip-path:inset(0 10px 20px 30px)"

--- a/test/test_clipping.ml
+++ b/test/test_clipping.ml
@@ -45,9 +45,8 @@ let test_clip_inset_shorthand () =
   check_roundtrip "clip-path:inset(50%)";
   check_roundtrip "clip-path:inset(10px)";
   (* 2 values: top/bottom, left/right. Minified, the space between two
-     percentages goes: a [%] already ends the token, so [10%20%] re-reads as
-     the same two components. The round-trip is on the value, not its
-     spacing. *)
+     percentages goes: a [%] already ends the token, so [10%20%] re-reads as the
+     same two components. The round-trip is on the value, not its spacing. *)
   check_parse "clip-path:inset(10% 20%)" "clip-path:inset(10%20%)";
   (* 3 values: top, left/right, bottom *)
   check_parse "clip-path:inset(10% 20% 30%)" "clip-path:inset(10%20%30%)";

--- a/test/test_margin.ml
+++ b/test/test_margin.ml
@@ -124,6 +124,14 @@ let rendering_matches_tailwind () =
       "-ml-1";
       "ms-2";
       "me-4";
+      (* State variants, so the browser is the oracle for them too. The harness
+         forces :hover and :focus through CDP; without that these rules sit in
+         both sheets, are matched by neither, and the two agree for the wrong
+         reason. *)
+      "hover:mt-8";
+      "focus:mb-8";
+      "active:ml-8";
+      "disabled:mr-8";
     ]
   in
   Test_helpers.check_rendering_matches ~test_name:"margins render like Tailwind"

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -663,11 +663,14 @@ let print_parity_report () =
 (* Both fixtures are checked in and declared as dune deps, so a missing one is a
    broken checkout rather than an optional extra. A floor on the parsed cases
    catches the other way this gate can go quiet: a fixture whose format drifts
-   still parses, just into far fewer cases than it holds. The floors are about
-   half the current counts (615 utilities, 166 variants), low enough to absorb
-   upstream churn. *)
-let utilities_floor = 300
-let variants_floor = 80
+   still parses, just into far fewer cases than it holds.
+
+   Set near the real counts rather than at half. Half (300 and 80) let a fixture
+   lose most of itself and still pass, which is the drift the floor is for; a
+   regenerated corpus that legitimately shrinks past these wants a human to look
+   and move the number. Counts on 2026-08-29: 627 utilities, 168 variants. *)
+let utilities_floor = 560
+let variants_floor = 150
 
 let load basename floor =
   match path basename with


### PR DESCRIPTION
The rendering harness read one still page, so every state variant put its rules into both sheets and the browser matched neither. `hover:`, `focus:`, `active:` and the rest agreed for the wrong reason - the same shape as the suites that reported no difference because they never looked. `prose-a:hover:text-red-500` dropped its `:hover` for as long as the variant had existed, and only `tw --diff` ever caught it.

Each element is now read again with `:hover` forced, then `:focus`, through the CDP call DevTools uses for force-element-state. One pass sets the state on every element at once and reaches `:focus` without the element being focusable for real.

Verified it applies rather than silently no-opping, which is the failure mode worth guarding against here: a rule behind `:hover` computes blue before forcing and red after, and deliberately breaking `margin-top` makes the run report 160 differences labelled `[:hover]` that the still page cannot see. Two state variants are added to the margin element list so the pass has something to exercise.