### PR TITLE
parse: read the ident and function-name tests from cascade

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -323,18 +323,7 @@ let arbitrary_length_percentage s =
 (* A CSS identifier, which is what a custom-ident or a property name written in
    an arbitrary value has to be. The docs pages carry [<value>] placeholders
    that are not CSS, and passing one through emits an invalid declaration. *)
-let is_ident s =
-  s <> ""
-  && (match s.[0] with
-    | 'a' .. 'z' | 'A' .. 'Z' | '_' -> true
-    | '-' -> String.length s > 1
-    | c -> Char.code c >= 0x80)
-  && String.for_all
-       (fun c ->
-         match c with
-         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
-         | c -> Char.code c >= 0x80)
-       s
+let is_ident = Cascade.Syntax.is_ident
 
 (** Check if a string starts with "var(" — works on inner bracket content *)
 let is_var s = String.length s > 4 && String.sub s 0 4 = "var("

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -144,12 +144,14 @@ let function_name_before s i =
     String.lowercase_ascii (String.sub s (!j + 1) (stop - !j - 1))
   else ""
 
-let is_css_math_function = function
-  | "abs" | "calc" | "calc-size" | "clamp" | "hypot" | "max" | "min" | "mod"
-  | "rem" | "round" | "sign" ->
-      true
-  | _ -> false
-
+(* A substitution function ([var()], [attr()], [env()]) stands for a token
+   stream, not a value CSS Values 4 sec. 10 math grammar parses, so entering one
+   inside a math function must not inherit the surrounding operator context: a
+   dash inside the name it carries (["--spacing-6"]) is not a minus sign.
+   cascade exports no name table for this - [Properties.is_color_function]
+   answers a different question (which functions are colours) and using it here
+   instead corrupts [p-[calc(var(--spacing-6)-1px)]] into [calc(var(--spacing -
+   6) - 1px)]. Kept hand-written on purpose. *)
 let is_css_non_math_function = function
   | "attr" | "env" | "url" | "var" -> true
   | _ -> false
@@ -159,7 +161,9 @@ let is_css_non_math_function = function
    width from a colour by the bracket's first character need to know. *)
 let starts_with_math_function s =
   match String.index_opt s '(' with
-  | Some i -> is_css_math_function (String.lowercase_ascii (String.sub s 0 i))
+  | Some i ->
+      Cascade.Css.Properties.is_math_function
+        (String.lowercase_ascii (String.sub s 0 i))
   | None -> false
 
 let normalize_css_math_operators s =
@@ -192,7 +196,7 @@ let normalize_css_math_operators s =
     | '(' ->
         let fn = function_name_before s i in
         let ctx =
-          if is_css_math_function fn then true
+          if Cascade.Css.Properties.is_math_function fn then true
           else if is_css_non_math_function fn then false
           else current_math ()
         in
@@ -336,14 +340,9 @@ let is_bracket_var s =
     "hsl(...)", "oklch(...)"). Returns true for known CSS color function names
     followed by '('. *)
 let is_css_color_fn s =
-  let starts prefix =
-    String.length s >= String.length prefix + 1
-    && String.sub s 0 (String.length prefix) = prefix
-    && s.[String.length prefix] = '('
-  in
-  starts "rgb" || starts "rgba" || starts "hsl" || starts "hsla" || starts "hwb"
-  || starts "oklch" || starts "oklab" || starts "lch" || starts "lab"
-  || starts "color" || starts "color-mix" || starts "light-dark"
+  match String.index_opt s '(' with
+  | Some i -> Cascade.Css.Properties.is_color_function (String.sub s 0 i)
+  | None -> false
 
 (** Check if a string is a bare var reference like "(--name)" *)
 let is_bare_var s =

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -111,9 +111,10 @@ val is_bracket_var : string -> bool
 
 val is_css_color_fn : string -> bool
 (** [is_css_color_fn s] returns [true] if [s] looks like a CSS color function
-    call such as ["rgba(...)"], ["hsl(...)"], or ["oklch(...)"]. Recognizes all
-    standard CSS color functions: rgb, rgba, hsl, hsla, hwb, oklch, oklab, lch,
-    lab, color, and color-mix. *)
+    call such as ["rgba(...)"], ["hsl(...)"], or ["oklch(...)"]: the part of [s]
+    before its first ['('] names a function
+    {!Cascade.Css.Properties.is_color_function} recognises - a colour syntax
+    fixes, case-insensitively. *)
 
 val is_bare_var : string -> bool
 (** [is_bare_var s] returns [true] if [s] is a bare var reference like

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -90,7 +90,9 @@ val arbitrary_length_percentage : string -> Cascade.Css.length_percentage option
 
 val is_ident : string -> bool
 (** [is_ident s] is [true] when [s] is a CSS identifier, as a custom-ident or a
-    property name written in an arbitrary value has to be. *)
+    property name written in an arbitrary value has to be. Delegates to
+    {!Cascade.Syntax.is_ident}, which is the CSS Syntax 3 grammar: a bare [-], a
+    [-] before a digit, and a leading digit all open no ident. *)
 
 val starts_with_math_function : string -> bool
 (** [starts_with_math_function s] is [true] when [s] opens with a CSS math


### PR DESCRIPTION
Three asks filed against cascade have landed, so three hand-written copies go.

`Parse.is_ident` accepted a leading `-` followed by anything and treated any byte at or above 0x80 as valid; `Syntax.is_ident` answers the CSS Syntax 3 question properly. The math and colour function-name tables sat here as divergent copies of cascade's own, with a third consumer, and both are exported now - so a function cascade learns about is one tw knows too.

`normalize_css_math_operators` keeps its hand-written test on purpose and now says why. A substitution function stands for a token stream rather than a math value, so the dash in `var(--spacing-6)` is not a minus sign: swapping the colour table in there corrupts `p-[calc(var(--spacing-6)-1px)]` into `calc(var(--spacing - 6) - 1px)`.

Two of the five asks are still open upstream - `parse_calc_body` and a properties-layer declaration built from a `property_info` - and their TODO entries stay.