### PR TITLE
var, property, build: build the initial value typed

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1122,9 +1122,7 @@ let property_layer_content first_usage_order initial_values other_statements =
   let sorted_values =
     sort_properties_by_order first_usage_order initial_values
   in
-  let initial_declarations =
-    List.map (fun (name, value) -> Css.custom_property name value) sorted_values
-  in
+  let initial_declarations = List.map snd sorted_values in
   let rule = Css.rule ~selector initial_declarations in
   let supports_stmt = Css.supports ~condition:browser_detection [ rule ] in
   let layer_content = [ supports_stmt ] @ other_statements in

--- a/lib/property.ml
+++ b/lib/property.ml
@@ -34,8 +34,8 @@ let initial_values property_rules =
     (fun acc stmt ->
       match Css.as_property stmt with
       | Some (Css.Property_info info as prop_info) ->
-          let value = Var.property_initial_string prop_info in
-          (info.name, value) :: acc
+          let decl = Var.property_initial_declaration prop_info in
+          (info.name, decl) :: acc
       | None -> acc)
     [] property_rules
   |> List.rev

--- a/lib/property.mli
+++ b/lib/property.mli
@@ -12,11 +12,13 @@ val dedup : Css.statement list -> Css.statement list
     nothing rides on the difference here because tw's duplicates all come from
     one {!Var} and are identical. *)
 
-val initial_values : Css.statement list -> (string * string) list
-(** [initial_values stmts] extracts (name, initial-value) pairs from
+val initial_values : Css.statement list -> (string * Css.declaration) list
+(** [initial_values stmts] extracts (name, initial-value declaration) pairs from
     {i \@property} rules, in order. *)
 
 val sort_by_order :
-  (string -> int) -> (string * string) list -> (string * string) list
+  (string -> int) ->
+  (string * Css.declaration) list ->
+  (string * Css.declaration) list
 (** [sort_by_order f pairs] sorts (name, initial) pairs using a provided
     name->order function. *)

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -7,15 +7,13 @@ module Css = Cascade.Css
 (* Layer classification for CSS variables *)
 type layer = Theme | Utility
 
-(* Registry for custom properties-layer initial CSS values. Some variables need
-   a different string in the properties layer than what pp_length produces
-   (e.g., ring-offset-width needs "0px" in properties but "0" in @property). *)
-(* The properties layer and the [@property] rule want different spellings of one
-   registered zero, and Tailwind emits both: [--tw-ring-offset-width: 0px] in
-   the layer, [initial-value: 0] in the rule. The layer's spelling is stated
-   here rather than carried on the variable, because the layer is built from
-   parsed [@property] statements whose only handle is the name. A total
-   function, so nothing depends on definition order. *)
+(* Tailwind spells one registered zero two ways: [--tw-ring-offset-width: 0px]
+   in the properties layer's bulk declaration, but [initial-value: 0] in its own
+   [@property] rule. Other zero-initialised [Length] variables (e.g.
+   border-spacing-x/y) get "0" in both places, so this isn't a general
+   Length-zero rule cascade's printer could apply - it's a one-name quirk of
+   Tailwind's own output that has to be special-cased here. A total function, so
+   nothing depends on definition order. *)
 let properties_layer_override = function
   | "--tw-ring-offset-width" -> Some "0px"
   | _ -> None
@@ -485,36 +483,17 @@ let theme_ref : type a. ?default:a -> ?default_css:string -> string -> a Css.var
 
 let resolve_theme_refs name = Hashtbl.find_opt theme_ref_registry name
 
-(* Convert Property_info to the string value for properties layer This extracts
-   the initial value and converts it to the appropriate CSS string *)
-let property_info_to_declaration_value (Css.Property_info info) =
+(* Turn a parsed [@property] statement's typed initial value into the
+   declaration that sets it in the properties layer. [typed_custom_property]
+   prints the value with cascade's own [pp_value] for [info.syntax], so this
+   never hand-dispatches on the syntax or reprints a value itself. *)
+let declaration_of_property_info (Css.Property_info info) =
   match properties_layer_override info.name with
-  | Some css -> css
+  | Some css -> Css.custom_property info.name css
   | None -> (
       match info.initial_value with
-      | None -> "initial"
-      | Some v -> (
-          let open Css.Variables in
-          match info.syntax with
-          | Universal -> v (* Universal syntax already stores strings *)
-          | _ -> (
-              let (* For non-Universal syntax, we shouldn't be in the properties
-                     layer but handle it gracefully using the existing pp
-                     functions *)
-                open
-                Css.Values
-              in
-              match info.syntax with
-              | Length -> (
-                  match v with
-                  | Zero -> "0"
-                  | _ -> Css.Pp.to_string (pp_length ~always:true) v)
-              (* A [<number>] initial value is a number: appending [%] made it a
-                 percentage, which is a different type. Unreachable today
-                 because [property_typed] emits no Number syntax, so this is the
-                 arm a new one would land on. *)
-              | Number -> Pp.float v
-              | syntax -> Css.Pp.to_string (pp_value syntax) v)))
+      | None -> Css.custom_property info.name "initial"
+      | Some v -> Css.Variables.typed_custom_property info.name info.syntax v)
 
 let name var = var.name
 let css_name var = "--" ^ var.name
@@ -536,7 +515,7 @@ let order_of_declaration decl =
   | Some meta -> (
       match info_of_meta meta with Some (Info t) -> t.order | None -> None)
 
-let property_initial_string = property_info_to_declaration_value
+let property_initial_declaration = declaration_of_property_info
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]
 
 let bracket ?fallback name =
@@ -546,7 +525,16 @@ let bracket ?fallback name =
     | None ->
         let expression =
           if String.starts_with ~prefix:"var(" name then Some name
-          else if String.contains name ',' then Some ("var(--" ^ name ^ ")")
+          else if String.contains name ',' then
+            (* [Css.Variables.read_reference_body] reads this same grammar
+               straight off a cursor, without the [var(]/[)] wrapper - but it
+               takes a [Cursor.t -> 'a] reader for the fallback and hands back
+               an ['a var], and [bracket] has no witness for 'a here: it is
+               called at many different value types with nothing to pick a
+               reader from. [read_reference]'s string-returning fallback is what
+               [Css.Values.syntax_fallback] (below) is built to consume, so the
+               wrapper still has to be assembled for it. *)
+            Some ("var(--" ^ name ^ ")")
           else None
         in
         Option.bind expression (fun expression ->

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -639,9 +639,10 @@ val order_of_declaration : Css.declaration -> (int * int) option
 (** [order_of_declaration d] returns theme ordering information for a custom
     declaration. *)
 
-val property_initial_string : Css.property_info -> string
-(** [property_initial_string info] converts the typed initial value of a
-    [@property] declaration into a string suitable for [initial-value:]. *)
+val property_initial_declaration : Css.property_info -> Css.declaration
+(** [property_initial_declaration info] is the declaration that sets a parsed
+    [@property] statement's typed initial value in the properties layer's bulk
+    rule (e.g. [--tw-ring-offset-width: 0px]). *)
 
 (** {1 Bracket Variable References}
 

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -88,6 +88,28 @@ let var_in_theme_layer () =
         ]
         (List.sort_uniq String.compare custom_props)
 
+(* Tailwind spells one registered zero two ways: [--tw-ring-offset-width: 0px]
+   in the properties layer's bulk declaration, but [initial-value: 0] in its own
+   [@property] rule (checked 2026-08-29 against the real CLI). Every other
+   zero-initialised [Length] variable (border-spacing-x/y) gets "0" in both
+   places, and the canonical [--diff] comparison treats "0" and "0px" as the
+   same length, so a regression here would not show up there - only this pinned
+   literal catches it. *)
+let ring_offset_width_properties_layer_spelling () =
+  let css =
+    match Tw.of_string "ring-2" with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Css.to_string ~minify:true
+    | Error (`Msg m) -> fail m
+  in
+  check bool "properties layer keeps the unit" true
+    (Astring.String.is_infix ~affix:"--tw-ring-offset-width:0px" css);
+  check bool "@property initial-value drops it" true
+    (Astring.String.is_infix
+       ~affix:
+         "@property \
+          --tw-ring-offset-width{syntax:\"<length>\";inherits:false;initial-value:0}"
+       css)
+
 let order = testable Fmt.(option (pair int int)) ( = )
 
 let render ?theme classes =
@@ -230,6 +252,8 @@ let tests =
     test_case "var fallback in CSS" `Quick var_fallback_in_css;
     test_case "arbitrary var fallbacks" `Quick arbitrary_var_fallbacks;
     test_case "var in theme layer" `Quick var_in_theme_layer;
+    test_case "ring-offset-width properties layer spelling" `Quick
+      ring_offset_width_properties_layer_spelling;
     test_case "order of shared slot" `Quick order_of_shared_slot;
     test_case "order of family bands" `Quick order_of_family_bands;
     test_case "order of theme-named tokens" `Quick order_of_theme_named_tokens;


### PR DESCRIPTION
The properties layer was rebuilt by hand-dispatching over the syntax of a parsed `@property`, printing each arm with tw's own float formatter, and handing the resulting string to `Css.custom_property` - the assembled-token-string shape CLAUDE.md section 2 forbids, kept only because no typed constructor existed.

cascade now exports `Variables.typed_custom_property`, which prints the value with `pp_value` for the syntax it was registered under, so none of that dispatch is tw's to carry. Net 49 lines out, 38 in.

The `--tw-ring-offset-width` override stays, and the comment now says what it actually is rather than what it was assumed to be. Tailwind spells that one zero `0px` in the properties layer and `0` in its own `@property` rule, while every other zero-initialised `Length` - border-spacing-x/y among them - takes `0` in both. That is a quirk of Tailwind's output, not a value the string round-trip was losing, so it does not go away with the round-trip.