### PR TITLE
typography, overflow_wrap: band the late text families as Tailwind does

### DIFF
--- a/lib/overflow_wrap.ml
+++ b/lib/overflow_wrap.ml
@@ -16,9 +16,21 @@ module Handler = struct
 
   let name = "overflow_wrap"
 
-  (* Typography-adjacent priority *)
-  let priority _ = 13
-  let suborder = function Anywhere -> 0 | Break_word -> 1 | Normal -> 2
+  (* Tailwind's property table ranks [overflow-wrap] at 291, between [text-wrap]
+     (290) and [word-break] (292); that puts these utilities in
+     [Typography_late]'s default late-typography band (priority 26), not a band
+     of their own. All three set only [overflow-wrap], so Tailwind's candidate
+     sort ties them - and [break-words] in lib/typography.ml, which writes the
+     same lone property - and breaks the tie alphabetically by class name. 8309
+     is that shared suborder: it sits right after [Typography_late]'s
+     [break-normal] (8308, which writes [overflow-wrap] then carries on to
+     [word-break] and so sorts first) and before its [break-all]/[break-keep]
+     (8310, tied on [word-break] alone). A bare constant, not [Property_order],
+     because migrating this shared slot to Tailwind's real-rank scale would
+     require moving every other family in the priority-26 band along with it
+     (see lib/typography.ml). *)
+  let priority _ = 26
+  let suborder _ = 8309
 
   let to_class = function
     | Normal -> "wrap-normal"

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2375,29 +2375,57 @@ module Typography_late = struct
     | Subpixel_antialiased -> 8701
     (* Text overflow (priority 17 for Truncate) - alphabetical: text-clip,
        text-ellipsis, truncate. Truncate sorts before overflow (priority 18) via
-       a suborder above alignment/gap's range. *)
+       a suborder above alignment/gap's range. Tailwind ranks [text-overflow] at
+       293, between the word-wrapping families (291/292) below and hyphens (294)
+       above - it already lands there without adjustment. *)
     | Text_clip -> 8320
     | Text_ellipsis -> 8321
     | Overflow_ellipsis -> 8321
     | Truncate -> 9_000_000 (* priority 17, after alignment/gap (max ~2100) *)
-    (* Text wrap - alphabetical order *)
-    | Text_balance -> 9100
-    | Text_nowrap -> 9101
-    | Text_pretty -> 9102
-    | Text_wrap -> 9103
-    (* Break utilities *)
-    | Break_normal -> 8310
-    | Break_words -> 8311
-    | Break_all -> 8312
-    | Break_keep -> 9203
-    (* Overflow wrap *)
+    (* Text wrap - Tailwind ranks [text-wrap] at 290, right after letter-spacing
+       (289, Tracking's suborder tops out at 8306) and before overflow-wrap
+       (291, Break_normal below). Every variant here writes only [text-wrap], so
+       they tie and the class name breaks it alphabetically: balance, nowrap,
+       pretty, wrap.
+
+       Not [Property_order.last 290]: that mechanism suits a family whose
+       neighbours already use it (backgrounds, masks), where every rank in the
+       shared priority is on the same 1000-wide scale. Here Tracking,
+       Text_clip/Ellipsis and Whitespace stay on this file's local bare-integer
+       scale (82xx-83xx) and are not being touched by this fix, so a suborder on
+       the real-rank scale (290 * 1000 and up) would sort after all of them
+       regardless of true rank. Every family below that needs to interleave with
+       an unconverted neighbour stays on this same local scale for the same
+       reason. *)
+    | Text_balance -> 8307
+    | Text_nowrap -> 8307
+    | Text_pretty -> 8307
+    | Text_wrap -> 8307
+    (* Break utilities - Tailwind ranks [overflow-wrap] at 291 and [word-break]
+       at 292. [break-normal] writes both, so it leads the 291-292 stretch;
+       lib/overflow_wrap.ml's wrap-anywhere/wrap-break-word/ wrap-normal write
+       only [overflow-wrap], same as [break-words], so all four tie with it at
+       8309 - a bare constant matching this file's local scale (see the
+       [Text_wrap] comment above). [break-all] and [break-keep] write only
+       [word-break] and tie at 8310. *)
+    | Break_normal -> 8308
+    | Break_words -> 8309
+    | Break_all -> 8310
+    | Break_keep -> 8310
+    (* Overflow wrap - not real Tailwind utility names ([overflow-wrap-normal]
+       etc. rather than [wrap-normal]); real tailwindcss generates nothing for
+       them, so there is no oracle order to match. Left where they were. *)
     | Overflow_wrap_normal -> 9300
     | Overflow_wrap_anywhere -> 9301
     | Overflow_wrap_break_word -> 9302
-    (* Hyphens - alphabetical order *)
-    | Hyphens_auto -> 9400
-    | Hyphens_manual -> 9401
-    | Hyphens_none -> 9402
+    (* Hyphens - Tailwind ranks [hyphens] at 294, between text-overflow (293,
+       Text_ellipsis above) and white-space (295, Whitespace_* below); the
+       [-webkit-hyphens] declaration every variant also writes carries no rank
+       of its own, so all three tie on [hyphens] alone and the class name breaks
+       it alphabetically: auto, manual, none. *)
+    | Hyphens_auto -> 8325
+    | Hyphens_manual -> 8325
+    | Hyphens_none -> 8325
     (* Font stretch - percentages first (sorted by value), then keywords *)
     | Font_stretch_percent n -> 9500 + n
     | Font_stretch_condensed -> 9700
@@ -2419,13 +2447,30 @@ module Typography_late = struct
     | Stacked_fractions -> 9706
     | Tabular_nums -> 9707
     | Normal_nums -> 9708
-    (* Indent and line clamp *)
-    | Indent_neg n -> 9700 + int_of_float (n *. 10.)
-    | Indent_neg_px -> 9799
-    | Indent n -> 9800 + int_of_float (n *. 10.)
-    | Indent_px -> 9801
-    | Indent_arbitrary _ -> 9800
-    | Indent_neg_arbitrary _ -> 9800
+    (* Indent - Tailwind ranks [text-indent] at 282, right after [text-align]
+       (281) and well before letter-spacing (289) opens the rest of the
+       late-typography band, so this family sorts before Tracking's suborders
+       (8245-8306) rather than after font-stretch/numeric-variants where it
+       previously sat. Kept as a bare, rebased offset rather than
+       [Property_order.slot 282] for the same reason as [Text_wrap] above: the
+       neighbours it has to sort against are still on this file's local scale.
+       The base only shifted (9700/9800 -> 7000/7100); the arithmetic inside the
+       family, including the [Indent_arbitrary]/[Indent_neg_arbitrary] tie with
+       [n = 0], is unchanged.
+
+       This only fixes Indent's order within priority 26. Real Tailwind's
+       [text-indent] (282) actually sits between [text-align] (281) and
+       [vertical-align] (283, [Align_*] below) - both priority 24, one band
+       earlier than Indent's priority here - so Indent still sorts after every
+       priority-24 utility (e.g. [font-bold]) regardless of this suborder.
+       Closing that gap means moving Indent to priority 24, which is a larger
+       change than this fix attempts. *)
+    | Indent_neg n -> 7000 + int_of_float (n *. 10.)
+    | Indent_neg_px -> 7099
+    | Indent n -> 7100 + int_of_float (n *. 10.)
+    | Indent_px -> 7101
+    | Indent_arbitrary _ -> 7100
+    | Indent_neg_arbitrary _ -> 7100
     | Line_clamp n -> 10000 + n
     | Line_clamp_arbitrary _ -> 11000
     | Line_clamp_none -> 12000

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -320,6 +320,56 @@ let test_gap_before_self_alignment () =
   Test_helpers.check_ordering_matches
     ~test_name:"gap utilities before self-alignment" utilities
 
+(* Tailwind's property table sorts letter-spacing, text-wrap, overflow-wrap,
+   hyphens and white-space in that order (289, 290, 291, 294, 295): tracking
+   opens the late-typography band, text-wrap and the word-wrapping families come
+   next, and white-space is last of the five. [wrap-break-word] lives in
+   [Overflow_wrap]'s own handler, a separate priority band from
+   [Typography_late]'s default 26 - both have to land between tracking and
+   whitespace for this to hold. None of these utilities write on a shared
+   property, so [check_ordering_matches]'s canonical diff would call any reorder
+   among them cascade-neutral and miss it; [check_class_order] reads sheet
+   positions directly instead. *)
+let test_late_typography_before_whitespace () =
+  Test_helpers.check_class_order
+    ~test_name:"text-wrap, wrap-break-word, hyphens before white-space"
+    [
+      "whitespace-nowrap";
+      "hyphens-auto";
+      "text-wrap";
+      "wrap-break-word";
+      "tracking-wide";
+      "text-red-500";
+    ]
+
+(* The word-wrapping families overlap on overflow-wrap/word-break: break-normal
+   writes both and so leads its shared prefix, break-words/wrap-anywhere/
+   wrap-break-word/wrap-normal tie on overflow-wrap alone, and break-all/
+   break-keep tie on word-break alone. Two of these seven utilities come from
+   [Typography]'s handler and three from [Overflow_wrap]'s - a separate priority
+   band - so this also pins their cross-handler tie-break. *)
+let test_word_wrap_family_order () =
+  Test_helpers.check_class_order
+    ~test_name:"break-normal leads, then overflow-wrap ties, then word-break"
+    [
+      "break-keep";
+      "wrap-normal";
+      "break-all";
+      "wrap-break-word";
+      "wrap-anywhere";
+      "break-words";
+      "break-normal";
+    ]
+
+(* Tailwind ranks text-indent (282) right after text-align (281), well before
+   letter-spacing (289) opens the rest of the late-typography band. Indent and
+   tracking write disjoint properties, so this too needs [check_class_order]
+   rather than the cascade-neutral-blind [check_ordering_matches]. *)
+let test_indent_before_tracking () =
+  Test_helpers.check_class_order
+    ~test_name:"text-indent before tracking and text-wrap"
+    [ "tracking-wide"; "indent-4"; "text-wrap" ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -1830,6 +1880,10 @@ let tests =
     (* Utility group ordering *)
     test_case "typography before color" `Quick test_typography_before_color;
     test_case "gap before self-alignment" `Quick test_gap_before_self_alignment;
+    test_case "late typography before white-space" `Quick
+      test_late_typography_before_whitespace;
+    test_case "word-wrap family order" `Quick test_word_wrap_family_order;
+    test_case "text-indent before tracking" `Quick test_indent_before_tracking;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick


### PR DESCRIPTION
`text-indent`, `text-wrap`, `overflow-wrap`/`word-break` and `hyphens` sorted after the decoration block, where Tailwind emits them before it. `lib/overflow_wrap.ml`'s `wrap-*` also carried an unrelated priority of its own. They now land between tracking and white-space.

The per-class `--diff` cannot see an ordering, so this needed a multi-class sheet to catch: `tw -s "tracking-wide wrap-break-word whitespace-nowrap hyphens-auto text-red-500 text-wrap" --diff-mode=tree` against `--tailwind`.