### PR TITLE
modifiers, style: spell a class-name length the way the author wrote it

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -59,40 +59,9 @@ let breakpoint_name qual bp =
 let arbitrary_breakpoint_class prefix (w : Style.arbitrary_px) cls =
   Css.Selector.Class (prefix ^ "[" ^ w.text ^ "]:" ^ cls)
 
-(** Render a CSS length in compact form (no spaces in calc operators) for class
-    names. *)
-let format_float f =
-  if Float.is_integer f then Int.to_string (Float.to_int f)
-  else Float.to_string f
-
-let rec compact_length (l : Css.length) =
-  match l with
-  | Px f -> format_float f ^ "px"
-  | Em f -> format_float f ^ "em"
-  | Rem f -> format_float f ^ "rem"
-  | Vh f -> format_float f ^ "vh"
-  | Vw f -> format_float f ^ "vw"
-  | Cm f -> format_float f ^ "cm"
-  | Mm f -> format_float f ^ "mm"
-  | In f -> format_float f ^ "in"
-  | Pt f -> format_float f ^ "pt"
-  | Calc c -> "calc(" ^ compact_calc c ^ ")"
-  | _ -> Css.Pp.to_string (Css.pp_length ~always:true) l
-
-and compact_calc : Css.length Css.calc -> string = function
-  | Val l -> compact_length l
-  | Num n -> format_float n
-  | Expr (left, Add, right) -> compact_calc left ^ "+" ^ compact_calc right
-  | Expr (left, Sub, right) -> compact_calc left ^ "-" ^ compact_calc right
-  | Expr (left, Mul, right) -> compact_calc left ^ "*" ^ compact_calc right
-  | Expr (left, Div, right) -> compact_calc left ^ "/" ^ compact_calc right
-  | Var v -> "var(--" ^ Css.var_name v ^ ")"
-  | Nested inner -> "calc(" ^ compact_calc inner ^ ")"
-  | Parens inner -> "(" ^ compact_calc inner ^ ")"
-  | Sibling_index -> "sibling-index()"
-  | Sibling_count -> "sibling-count()"
-  | (Math_const _ | Math_fn _) as c ->
-      Css.Pp.to_string (Css.pp_length ~always:true) (Calc c)
+(* One spelling for a class name, shared with [Style], which names the same
+   utilities through [Style.to_class]. *)
+let compact_length = Style.compact_length
 
 (** Build class selector for an arbitrary length breakpoint *)
 let arbitrary_length_class prefix (l : Css.length) cls =

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -2,6 +2,44 @@
 
 module Css = Cascade.Css
 
+(** Render a CSS length in compact form (no spaces in calc operators) for class
+    names. *)
+let format_float f =
+  if Float.is_integer f then Int.to_string (Float.to_int f)
+  else Float.to_string f
+
+let rec compact_length (l : Css.length) =
+  match l with
+  | Calc c -> "calc(" ^ compact_calc c ^ ")"
+  (* [Dimension] is the arm cascade uses when the authored number is not its own
+     canonical spelling, and it keeps that text in [repr]. A class name has to
+     echo what the author wrote, so cascade's printer is the right one here: it
+     is what carries [min-[0600px]] and [min-[1e3px]] back out intact. *)
+  | Dimension _ -> Css.Pp.to_string (Css.pp_length ~always:true) l
+  | l -> (
+      (* Every other unit-carrying length goes through one formatter.
+         [format_float] keeps a leading zero where [Pp.float] drops it
+         unconditionally, and a dropped zero renames the class: the author's
+         [min-[0.5ch]] became [.min-\[.5ch\]], which matches no markup. *)
+      match Cascade.Values.calc_length_unit l with
+      | Some (unit, f) -> format_float f ^ unit
+      | None -> Css.Pp.to_string (Css.pp_length ~always:true) l)
+
+and compact_calc : Css.length Css.calc -> string = function
+  | Val l -> compact_length l
+  | Num n -> format_float n
+  | Expr (left, Add, right) -> compact_calc left ^ "+" ^ compact_calc right
+  | Expr (left, Sub, right) -> compact_calc left ^ "-" ^ compact_calc right
+  | Expr (left, Mul, right) -> compact_calc left ^ "*" ^ compact_calc right
+  | Expr (left, Div, right) -> compact_calc left ^ "/" ^ compact_calc right
+  | Var v -> "var(--" ^ Css.var_name v ^ ")"
+  | Nested inner -> "calc(" ^ compact_calc inner ^ ")"
+  | Parens inner -> "(" ^ compact_calc inner ^ ")"
+  | Sibling_index -> "sibling-index()"
+  | Sibling_count -> "sibling-count()"
+  | (Math_const _ | Math_fn _) as c ->
+      Css.Pp.to_string (Css.pp_length ~always:true) (Calc c)
+
 type breakpoint = [ `Sm | `Md | `Lg | `Xl | `Xl_2 ]
 type container_cmp = Min | Max
 
@@ -460,10 +498,8 @@ let rec pp_modifier = function
   | Max_responsive `Xl_2 -> "max-2xl"
   | Min_arbitrary w -> String.concat "" [ "min-["; w.text; "]" ]
   | Max_arbitrary w -> String.concat "" [ "max-["; w.text; "]" ]
-  | Min_arbitrary_length l ->
-      "min-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
-  | Max_arbitrary_length l ->
-      "max-[" ^ Css.Pp.to_string (Css.pp_length ~always:true) l ^ "]"
+  | Min_arbitrary_length l -> "min-[" ^ compact_length l ^ "]"
+  | Max_arbitrary_length l -> "max-[" ^ compact_length l ^ "]"
   | Container q -> "@" ^ container_size_name q
   | Group_hover -> "group-hover"
   | Group_focus -> "group-focus"

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -293,6 +293,12 @@ type t =
   | Modified of modifier * t
   | Group of t list
 
+val compact_length : Css.length -> string
+(** [compact_length l] renders [l] the way a class name spells it: the author's
+    own number, with no spaces around calc operators. It is not
+    {!Css.pp_length}, which canonicalises the number and so would rename the
+    class -- [min-[0.5ch]] must not become [min-[.5ch]]. *)
+
 val pp : t -> string
 (** [pp t] returns a string representation of a style. *)
 

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -350,6 +350,14 @@ let test_arbitrary_breakpoint_spelling () =
       "min-[.5rem]:flex";
       "max-[48rem]:flex";
       "max-[37.50px]:flex";
+      (* Units with no arm of their own in [compact_length] fell through to
+         cascade's printer, which drops a leading zero, so the selector named a
+         class the author never wrote. *)
+      "min-[0.5ch]:flex";
+      "min-[0.5vmin]:flex";
+      "min-[0.5cqw]:flex";
+      "min-[0.5lh]:flex";
+      "max-[0.5ex]:flex";
     ]
 
 (* The bracket holds a length, so a word is not a breakpoint at all. *)


### PR DESCRIPTION
A class name is also the selector that has to match the markup, so it must echo the author's own spelling. `compact_length` gave ten length units an arm of their own and sent the other thirty-odd through `Css.pp_length`, which canonicalises the number: `min-[0.5ch]:flex` emitted `.min-\[\.5ch\]\:flex`, a rule that can never match. `rem` was right only because it had an arm.

`Style.pp` named the same class through a second `Css.Pp.to_string` call and disagreed with the selector. The formatter now lives in `style.ml`, which both paths share, and every unit-carrying length goes through `Cascade.Values.calc_length_unit` rather than an enumeration that can fall out of date. `Dimension` still prints through cascade, which is what carries `0600px`, `1e3px` and `0.50rem` back out intact.