### PR TITLE
position, scheme, theme: read through cascade instead of round-tripping strings

### DIFF
--- a/lib/position.ml
+++ b/lib/position.ml
@@ -58,8 +58,8 @@ let negate_length (l : Css.length) : Css.length =
   | other -> Calc (Calc.mul (Calc.length other) (Calc.float (-1.)))
 
 (* Parse a negative arbitrary inset value like [-left-[(var(--a)+var(--b))]]. A
-   bare parenthesised expression is not a length on its own, so parse it as a
-   calc body and negate the typed calc. *)
+   bare parenthesised expression is not a length on its own, so read it as a
+   calc body straight off a cursor and negate the typed calc. *)
 let parse_neg_bracket_length s : Css.length option =
   if String.length s > 2 && s.[0] = '[' && s.[String.length s - 1] = ']' then
     let inner =
@@ -68,11 +68,13 @@ let parse_neg_bracket_length s : Css.length option =
     match Css.parse_length inner with
     | Some l -> Some (negate_length l)
     | None -> (
-        match Css.parse_length (String.concat "" [ "calc("; inner; ")" ]) with
-        | Some (Css.Calc c) ->
-            Some (Css.Calc (Css.Calc.mul c (Css.Calc.float (-1.))))
-        | Some l -> Some (negate_length l)
-        | None -> None)
+        match
+          Cascade.Cursor.try_parse_full_err
+            (Css.Values.read_calc_expr Css.Values.read_length)
+            (Cascade.Cursor.of_string inner)
+        with
+        | Ok c -> Some (Css.Calc (Css.Calc.mul c (Css.Calc.float (-1.))))
+        | Error _ -> None)
   else None
 
 (* Memoization cache for inset-named theme variables *)

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -143,7 +143,7 @@ let breakpoint scheme name = List.assoc_opt name scheme.breakpoints
     precedence over the legacy px-only record field. *)
 let breakpoint_length scheme name =
   match List.assoc_opt ("breakpoint-" ^ name) scheme.token_overrides with
-  | Some value -> Css.parse_length (String.trim value)
+  | Some value -> Css.parse_length value
   | None ->
       Option.map (fun px -> (Css.Px px : Css.length)) (breakpoint scheme name)
 
@@ -154,7 +154,7 @@ let breakpoint_names scheme =
         let prefix = "breakpoint-" in
         if
           String.starts_with ~prefix name
-          && Option.is_some (Css.parse_length (String.trim value))
+          && Option.is_some (Css.parse_length value)
         then
           Some
             (String.sub name (String.length prefix)
@@ -260,10 +260,7 @@ let all_breakpoints scheme =
         let length =
           match breakpoint_length scheme name with
           | Some _ as length -> length
-          | None ->
-              Option.bind
-                (token_default (prefix ^ name))
-                (fun css -> Css.parse_length (String.trim css))
+          | None -> Option.bind (token_default (prefix ^ name)) Css.parse_length
         in
         Option.map (fun length -> (name, length)) length)
 
@@ -284,7 +281,7 @@ let with_overrides ?(inline = []) scheme overrides =
             String.sub name (String.length prefix)
               (String.length name - String.length prefix)
           in
-          match Css.parse_length (String.trim value) with
+          match Css.parse_length value with
           | Some (Css.Px px) -> (name, px) :: List.remove_assoc name breakpoints
           | _ -> breakpoints
         else breakpoints)

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -49,9 +49,7 @@ let explicit_spacing scheme n =
   match Scheme.spacing scheme n with
   | Some _ as length -> length
   | None ->
-      Option.bind
-        (Scheme.token scheme ("spacing-" ^ Pp.int n))
-        (fun css -> Css.parse_length (String.trim css))
+      Option.bind (Scheme.token scheme ("spacing-" ^ Pp.int n)) Css.parse_length
 
 (* Whether the bare step [n] of the spacing scale still resolves: [@theme {
    --spacing: initial }] removes the multiplier, and every step that relied on

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -149,6 +149,14 @@ let test_arbitrary_calc () =
        (css "left-[calc(50%+var(--offset))]"));
   check "left-[calc(5%-2px)]"
 
+(* An arbitrary inset whose body is not a whole calc expression is not a
+   utility. In [-left-[0)/*1]] the stray ')' closes nothing and the '/*' opens a
+   comment that never ends, so Tailwind emits no rule for it. *)
+let test_unbalanced_arbitrary_rejected () =
+  Alcotest.(check bool)
+    "-left-[0)/*1] is not a utility" true
+    (Result.is_error (Tw.of_string "-left-[0)/*1]"))
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -228,6 +236,8 @@ let tests =
     test_case "arbitrary var insets" `Quick test_arbitrary_var;
     test_case "spacing steps (fractional + px)" `Quick test_spacing_steps;
     test_case "arbitrary calc insets" `Quick test_arbitrary_calc;
+    test_case "unbalanced arbitrary inset rejected" `Quick
+      test_unbalanced_arbitrary_rejected;
     test_case "position suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "inset value order matches Tailwind" `Quick


### PR DESCRIPTION
`parse_neg_bracket_length` assembled `"calc(" ^ inner ^ ")"` and re-parsed it. The injected `)` silently closed an author's stray paren, so `-left-[0)/*1]` compiled to `left: calc(0 * -1)` where Tailwind emits nothing. It now reads the calc body off a cursor with `Values.read_calc_expr` and rejects the malformed class.

The five `String.trim` calls before `Css.parse_length` were recorded as working around a cascade limitation. There is none: `Cursor.is_done` drops whitespace before its check.

Commit 8436155a carries the parse fix and its regression test; 1770ed9b is the trims.