### PR TITLE
test/upstream: replay the cases that declare their own @utility

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -282,20 +282,7 @@ let native_stylesheet ~(opts : gen_opts) ~include_base all_classes =
     Tw.to_css ~theme:opts.theme ~base:include_base ~extra:routed_extra
       (List.map snd known)
   in
-  (* A declared utility hoists the same [@layer properties] fallback block the
-     generated sheet emits, and that block belongs where the sheet puts its own:
-     ahead of the theme, not after the utilities it initialises. The rest of
-     what it hoists follows the sheet. *)
-  let is_properties_layer stmt =
-    match Css.layer_block_name stmt with
-    | Some name -> Css.Stylesheet.equal_layer_name name [ "properties" ]
-    | None -> false
-  in
-  let stylesheet =
-    match List.partition is_properties_layer routed_stmts with
-    | [], [] -> stylesheet
-    | lead, trail -> Css.v (lead @ Css.statements stylesheet @ trail)
-  in
+  let stylesheet = Entrypoint.place_routed routed_stmts stylesheet in
   let stylesheet =
     match opts.input_css_path with
     | Some path ->

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1337,8 +1337,11 @@ let routed_block ~theme ~defs ~udefs ~hoisted ~seen ~derived ~own_order cls =
   let last = List.length segments - 1 in
   let name = List.nth segments last in
   let builtin = List.filteri (fun index _ -> index < last) segments in
-  match List.assoc_opt name udefs with
-  | Some decls ->
+  (* Every body declared for the name, in the order they were written: Tailwind
+     registers each [@utility] of a name and applies them all, so a second
+     declaration adds to the first rather than replacing it. *)
+  match List.filter (fun (n, _) -> n = name) udefs with
+  | _ :: _ as declared ->
       (* A declared utility means nothing to [Tw.of_string], so every prefix has
          to become a [@variant], the built-in ones included. *)
       if
@@ -1346,10 +1349,13 @@ let routed_block ~theme ~defs ~udefs ~hoisted ~seen ~derived ~own_order cls =
           (fun variant ->
             Option.is_some (routed_template ~theme derived variant))
           builtin
-      then Some (wrapped_block cls (variants @ builtin) decls)
+      then
+        Some
+          (wrapped_block cls (variants @ builtin)
+             (String.concat "" (List.map snd declared)))
       else None
-  | None when variants = [] -> None
-  | None ->
+  | [] when variants = [] -> None
+  | [] ->
       let body, top = nested_utilities ~theme [ bare ] in
       add_once hoisted seen top;
       if body = "" then None

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1414,24 +1414,20 @@ let compare_routed_entries ~own_order ~order_of (c1, _) (c2, _) =
   let suborder = if priority <> 0 then priority else Int.compare s1 s2 in
   if suborder <> 0 then suborder else String.compare c1 c2
 
-let ordered_routed_entries ~own_order ~order_of group =
-  Hashtbl.fold (fun cls stmts acc -> (cls, stmts) :: acc) group []
-  |> List.sort (compare_routed_entries ~own_order ~order_of)
-
-let place_routed_entries ~own_order ~order_of ~classless entries =
-  let ordered, unordered =
-    List.fold_left
-      (fun (ordered, unordered) (cls, stmts) ->
-        match Hashtbl.find_opt own_order cls with
-        | Some order -> ((cls, order, stmts) :: ordered, unordered)
-        | None -> (
-            match Hashtbl.find_opt order_of cls with
-            | Some (priority, suborder) ->
-                ((cls, (priority, suborder), stmts) :: ordered, unordered)
-            | None -> (ordered, unordered @ stmts)))
-      ([], classless) entries
+(* Within one declared utility, the rules it writes outright come before the
+   ones a variant wrapped in an at-rule, the order the generator gives a
+   built-in utility and its own media queries. *)
+let unwrapped_first stmts =
+  let plain, wrapped =
+    List.partition (fun stmt -> Option.is_some (Css.as_rule stmt)) stmts
   in
-  (List.rev ordered, unordered)
+  plain @ wrapped
+
+let ordered_routed_entries ~own_order ~order_of group =
+  Hashtbl.fold
+    (fun cls stmts acc -> (cls, unwrapped_first stmts) :: acc)
+    group []
+  |> List.sort (compare_routed_entries ~own_order ~order_of)
 
 let routed_statements ~block_count ~own_order stmts =
   (* [@layer properties] and [@property] sit beside the utilities layer, not in
@@ -1442,12 +1438,18 @@ let routed_statements ~block_count ~own_order stmts =
       stmts
   in
   let group, order_of, classless = group_routed_rules ~own_order rules in
-  let entries = ordered_routed_entries ~own_order ~order_of group in
-  let ordered, unordered =
-    place_routed_entries ~own_order ~order_of ~classless entries
+  (* A declared utility whose first property tw has no slot for still belongs
+     among the utilities, at the end, so it goes over with the rest: sorted with
+     them, and read by the theme layer for the tokens it names. A statement
+     naming no class at all has nothing to sort by, and gets a utilities layer
+     of its own after them. *)
+  let ordered =
+    ordered_routed_entries ~own_order ~order_of group
+    |> List.map (fun (cls, stmts) ->
+        (cls, routed_slot ~own_order ~order_of cls, stmts))
   in
   let unplaced =
-    if unordered = [] then [] else [ Css.layer ~name:[ "utilities" ] unordered ]
+    if classless = [] then [] else [ Css.layer ~name:[ "utilities" ] classless ]
   in
   (block_count, ordered, unplaced @ dedup_statements hoisted)
 

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1478,6 +1478,20 @@ let parse_routed_blocks ~own_order ~hoisted blocks =
   List.concat parsed @ hoisted
   |> routed_statements ~block_count:(List.length parsed) ~own_order
 
+(* A declared utility hoists the same [@layer properties] fallback block the
+   generated sheet emits, and that block belongs where the sheet puts its own:
+   ahead of the theme, not after the utilities it initialises. The rest of what
+   it hoists follows the sheet. *)
+let place_routed stmts sheet =
+  let is_properties_layer stmt =
+    match Css.layer_block_name stmt with
+    | Some name -> Css.Stylesheet.equal_layer_name name [ "properties" ]
+    | None -> false
+  in
+  match List.partition is_properties_layer stmts with
+  | [], [] -> sheet
+  | lead, trail -> Css.v (lead @ Css.statements sheet @ trail)
+
 let custom_routed_utilities ~theme ~defs ~udefs candidates =
   let hoisted = Buffer.create 0 in
   let seen = Hashtbl.create 64 in

--- a/lib/tools/entrypoint.mli
+++ b/lib/tools/entrypoint.mli
@@ -85,6 +85,12 @@ val custom_routed_utilities :
     {!Tw.to_css} as [~extra] so they sort among the built-in utilities, and the
     statements that belong beside the utilities layer rather than in it. *)
 
+val place_routed : Cascade.Css.statement list -> Cascade.Css.t -> Cascade.Css.t
+(** [place_routed stmts sheet] puts the statements {!custom_routed_utilities}
+    left beside the utilities layer around [sheet]: the [@layer properties]
+    fallback block a declared utility hoists leads, where the generated sheet
+    puts its own, and the rest follows. *)
+
 (** {1 Text passes} *)
 
 val hoist_theme_keyframes : string -> string

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -309,6 +309,14 @@ let check_upstream_positive_fixture_parse filename () =
         let selectors = emitted_selectors c.expected in
         c.classes
         |> List.filter (class_is_emitted selectors)
+        (* A class the case's own [@utility] declares is CSS the case brought
+           with it, not a utility [of_string] is meant to know: the fixture
+           carries the declaration and the upstream runner compiles it through
+           [Entrypoint]. *)
+        |> List.filter (fun cls ->
+            not
+              (Tw_tools.Entrypoint.is_custom_routed ~defs:[]
+                 ~udefs:c.utility_defs cls))
         |> List.filter_map (fun cls ->
             match Tw.of_string ~theme cls with
             | Ok _ -> None

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -6,7 +6,7 @@
 (executable
  (name extract_tests)
  (modules extract_tests)
- (libraries re fmt astring))
+ (libraries re fmt astring cascade))
 
 (test
  (name test)
@@ -57,8 +57,10 @@
 
 ; Pins the [test(] scan on the block shapes utilities.test.ts uses: a block
 ; indented inside one or more [describe(...)] blocks, the three quote styles a
-; name can take, a [test.each([...])(...)] block staying out, and a block
-; defining its own [@utility] dropped whole.
+; name can take, a [test.each([...])(...)] block staying out, a block defining
+; its own [@utility] carried through with its definition and the layer its
+; template compiles into, and one defining a functional [@utility] dropped
+; whole.
 
 (rule
  (action

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -3,8 +3,13 @@
     This script parses the upstream Tailwind CSS test file and extracts:
     - Test names
     - Theme configuration ({!theme_config})
+    - [@utility] declarations and the layer the template compiles into
     - Utility class names
     - Expected CSS output from toMatchInlineSnapshot
+
+    A block that declares its own [@utility] is carried only when the runner
+    reproduces it; {!unreplayable} says which shapes it does not, and each drop
+    is named on stderr with its reason.
 
     {2 Generating the fixtures}
 
@@ -120,6 +125,14 @@ type test_case = {
           template. Captures tokens (e.g. [text-shadow-2xs]) that Tailwind
           inlines into utilities rather than emitting to [:root], so the runner
           can reconstruct the test's theme as token overrides. *)
+  utility_defs : (string * string) list;
+      (** [@utility <name> { <body> }] declarations from the test's CSS
+          template, so the runner can compile the case through the same
+          declared-utility path the CLI uses for a project entrypoint. *)
+  layer_wrap : string option;
+      (** The layer the test's CSS template puts [@tailwind utilities] in, when
+          it puts it in one at all. Tailwind emits the generated utilities
+          inside that layer and everything else beside it. *)
 }
 
 (* Parse [matchVariant('name', (value) => `template`, { values: {...} })] calls
@@ -261,6 +274,79 @@ let scanner_feed s line ~start emit =
   if not !closed then s.pending_space <- true;
   not !closed
 
+(* An [@utility <name> { ... }] body is read the same way, but whole: a nested
+   block, a [;] or a string inside it ends nothing, and only the [}] at the
+   block's own level closes it. Whitespace outside strings folds to a single
+   space so the body fits the one-line [@utility-def] fixture format. *)
+type block_scanner = {
+  text : Buffer.t;  (** the body read so far *)
+  mutable delim : char option;  (** the open string delimiter, if any *)
+  mutable commented : bool;
+  mutable nesting : int;  (** bracket nesting; [0] is the block's own level *)
+  mutable folded_space : bool;
+}
+
+let block_scanner () =
+  {
+    text = Buffer.create 128;
+    delim = None;
+    commented = false;
+    nesting = 0;
+    folded_space = false;
+  }
+
+let block_add s c =
+  if s.folded_space && Buffer.length s.text > 0 then Buffer.add_char s.text ' ';
+  s.folded_space <- false;
+  Buffer.add_char s.text c
+
+(* Read one line of an open [@utility] body from [start]. Returns [true] while
+   the body is still open. *)
+let block_feed s line ~start =
+  let len = String.length line in
+  let closed = ref false in
+  let i = ref start in
+  while (not !closed) && !i < len do
+    let c = line.[!i] in
+    (match s.delim with
+    | Some q ->
+        block_add s c;
+        if c = '\\' && !i + 1 < len then (
+          block_add s line.[!i + 1];
+          incr i)
+        else if c = q then s.delim <- None
+    | None -> (
+        if s.commented then (
+          if c = '*' && !i + 1 < len && line.[!i + 1] = '/' then (
+            s.commented <- false;
+            s.folded_space <- true;
+            incr i))
+        else if c = '/' && !i + 1 < len && line.[!i + 1] = '*' then (
+          s.commented <- true;
+          incr i)
+        else
+          match c with
+          | ' ' | '\t' | '\r' -> s.folded_space <- true
+          | '\'' | '"' ->
+              s.delim <- Some c;
+              block_add s c
+          | '(' | '[' | '{' ->
+              s.nesting <- s.nesting + 1;
+              block_add s c
+          | ')' | ']' ->
+              if s.nesting > 0 then s.nesting <- s.nesting - 1;
+              block_add s c
+          | '}' ->
+              if s.nesting = 0 then closed := true
+              else (
+                s.nesting <- s.nesting - 1;
+                block_add s c)
+          | c -> block_add s c));
+    incr i
+  done;
+  if not !closed then s.folded_space <- true;
+  not !closed
+
 (* [.toEqual('')] asserts that a candidate list compiles to nothing. Like a
    [@theme] declaration, the assertion is read as a character stream: Prettier
    wraps the call when the [expect(...)] head is long, leaving the argument and
@@ -321,6 +407,136 @@ let is_empty_string_arg arg =
     else arg
   in
   arg = "''" || arg = {|""|}
+
+let contains_var body = Astring.String.is_infix ~affix:"var(--" body
+let contains_apply body = Astring.String.is_infix ~affix:"@apply" body
+
+(* The property of a declaration cascade rejects the value of, if the body has
+   one. *)
+let unreadable_declaration body =
+  match Cascade.Css.of_string (String.concat "" [ ".x{"; body; "}" ]) with
+  | Error _ -> Some "the definition body"
+  | Ok { warnings; _ } ->
+      List.find_map
+        (fun (w : Cascade.Error.t) ->
+          match w.kind with
+          | Cascade.Error.Bad_value { property; _ } -> Some property
+          | _ -> None)
+        warnings
+
+(* The declarations a snapshot gives one class: the [;] inside every [.name {
+   ... }] block it holds, nested at-rules included. A block whose selector lists
+   several classes is not matched, so it counts as none, which reads as "no more
+   than the definition wrote" and keeps the case. *)
+let snapshot_declarations expected name =
+  let opener = Re.Pcre.regexp (Re.Pcre.quote ("." ^ name) ^ {|\s*\{|}) in
+  let len = String.length expected in
+  let count = ref 0 in
+  List.iter
+    (fun g ->
+      let i = ref (snd (Re.Group.offset g 0)) in
+      let depth = ref 0 in
+      let closed = ref false in
+      while (not !closed) && !i < len do
+        (match expected.[!i] with
+        | '{' -> incr depth
+        | '}' -> if !depth = 0 then closed := true else decr depth
+        | ';' -> incr count
+        | _ -> ());
+        incr i
+      done)
+    (Re.all opener expected);
+  !count
+
+let semicolons s =
+  String.fold_left (fun n c -> if c = ';' then n + 1 else n) 0 s
+
+(* Tailwind's own breakpoint variants. A candidate carrying one needs a
+   [--breakpoint-<name>] the case's template has to declare. *)
+let breakpoint_names = [ "sm"; "md"; "lg"; "xl"; "2xl" ]
+
+let variant_prefixes cls =
+  match String.rindex_opt cls ':' with
+  | None -> []
+  | Some i -> String.split_on_char ':' (String.sub cls 0 i)
+
+(* Why the runner cannot reproduce a block that declares its own [@utility], or
+   [None] when it can. Each reason is a gap to close, not a property of the
+   corpus: the check goes when the gap does.
+
+   A functional [@utility NAME-*] resolves [--value()] and [--modifier()]
+   against the candidate's own suffix, which neither this fixture format nor
+   {!Tw_tools.Entrypoint.take_custom_utilities} carries.
+
+   An [@utility] the scanner did not read would leave the case compiled without
+   its definitions, so a scanner gap shows up as a missing case.
+
+   A body cascade cannot read loses the same declaration on both sides of the
+   comparison, which then compares less than it appears to.
+
+   A snapshot that gives a declared class more declarations than its definition
+   wrote is one Tailwind merged with a built-in utility of the same name; tw's
+   routing replaces the built-in instead of appending to it. An [@apply] body
+   writes its declarations by expansion, so it is counted out of this one.
+
+   [@theme reference] declares a token elsewhere: Tailwind inlines its value as
+   a [var()] fallback and emits no [:root] declaration, and tw has no
+   reference-token mode.
+
+   A token the case's [@theme] declares and only a declared utility reads is not
+   emitted to the theme layer: tw emits a referenced-but-unset token only for
+   the catalogued colours and [--spacing].
+
+   [run()] compiles against an empty theme, so a named breakpoint variant the
+   template never declares resolves to nothing upstream; tw's [Scheme.t] has no
+   way to say "no breakpoints" (an empty list means the built-in ones). *)
+let unreplayable ~defs ~config ~theme_vars ~classes expected =
+  let functional = List.filter (fun (n, _) -> String.contains n '*') defs in
+  let unreadable =
+    List.filter_map (fun (_, b) -> unreadable_declaration b) defs
+  in
+  let reads_var = List.exists (fun (_, b) -> contains_var b) defs in
+  let applies = List.exists (fun (_, b) -> contains_apply b) defs in
+  let undeclared_breakpoint =
+    List.exists
+      (fun cls ->
+        List.exists
+          (fun v ->
+            List.mem v breakpoint_names
+            && not (List.mem_assoc ("breakpoint-" ^ v) theme_vars))
+          (variant_prefixes cls))
+      classes
+  in
+  let merged_with_builtin =
+    (not applies)
+    && List.exists
+         (fun (name, _) ->
+           let wrote =
+             List.fold_left
+               (fun n (m, body) -> if m = name then n + semicolons body else n)
+               0 defs
+           in
+           snapshot_declarations expected name > wrote)
+         defs
+  in
+  let some = Fmt.kstr (fun s -> Some s) in
+  if functional <> [] then
+    some "functional @utility %s" (String.concat ", " (List.map fst functional))
+  else if defs = [] then
+    Some "an @utility declaration the extractor could not read"
+  else if unreadable <> [] then
+    some "cascade cannot read the declared %s" (String.concat ", " unreadable)
+  else if merged_with_builtin then
+    Some "Tailwind merged the declared utility with a built-in of the same name"
+  else if
+    (config = Theme_reference || config = Theme_inline_reference)
+    && expected <> ""
+  then Some "@theme reference: tw has no reference-token mode"
+  else if reads_var then
+    Some "a declared utility reads a theme token tw's theme layer will not emit"
+  else if undeclared_breakpoint then
+    Some "a breakpoint variant the case's own theme does not declare"
+  else None
 
 (* A [test(...)] block opens with the call's own indentation and closes at the
    [})] sitting at that same indentation: Prettier indents every line of the
@@ -424,16 +640,33 @@ let parse_file filename =
   (* Indentation of the [test(] opening the block being read, so its own [})] is
      told apart from one closing a [describe(...)] around it. *)
   let test_indent = ref "" in
-  (* Cases produced by the block being read, held back until it ends. A block
-     that defines its own [@utility] is dropped whole: the extractor carries a
-     candidate list and the [@theme] tokens, not the CSS around them, so the
-     expected snapshot of such a block holds rules for utilities the runner is
-     never told about and no run can produce. In v4.3.3 that is the
-     [describe('custom utilities')] block and the one [@utility container]
-     case. *)
+  (* Cases produced by the block being read, held back until it ends: a test's
+     [@utility] declarations are stamped on all of them at once, because a test
+     can declare them in a template it reuses across several snapshots (the
+     definition sits above the first [expect], the candidate list below the
+     second).
+
+     A block that declares its own [@utility] is carried only when the runner's
+     declared-utility path reproduces it; {!unreplayable} names the shapes it
+     does not, and every drop is reported on stderr. *)
   let block_tests = ref [] in
   let saw_custom_utility = ref false in
   let utility_def_re = Re.Pcre.regexp {|@utility\s|} in
+  (* Capture [@utility <name> { <body> }] declarations. [in_utility] holds the
+     name and the scanner of the block still being read, if any. The name runs
+     to the [{] and is kept as spelled: an invalid one ([~push], [@push]) is a
+     test's own subject, not something to normalise away. *)
+  let current_utility_defs = ref [] in
+  let in_utility = ref None in
+  let utility_open_re = Re.Pcre.regexp {|@utility\s+([^{\n]+?)\s*\{|} in
+  (* [@layer <name> { @tailwind utilities; }] in a template puts the generated
+     utilities in [<name>]. The block is read whole, then kept only if that is
+     what it holds: an [@layer] wrapping the author's own rules names nothing
+     for the generator. *)
+  let current_layer_wrap = ref None in
+  let in_layer = ref None in
+  let layer_open_re = Re.Pcre.regexp {|@layer\s+([A-Za-z0-9_-]+)\s*\{|} in
+  let tailwind_utilities_re = Re.Pcre.regexp {|@tailwind\s+utilities|} in
   let current_classes = ref [] in
   let current_config = ref No_theme in
   (* A single test can mix a keep [@theme { ... }] block with an inline [@theme
@@ -478,6 +711,8 @@ let parse_file filename =
           expected;
           variants;
           theme_vars = List.rev !current_theme_vars;
+          utility_defs = [];
+          layer_wrap = !current_layer_wrap;
         }
         :: !block_tests;
     current_classes := [];
@@ -488,8 +723,31 @@ let parse_file filename =
   in
 
   let close_block () =
-    if not !saw_custom_utility then tests := !block_tests @ !tests;
+    let defs = List.rev !current_utility_defs in
+    let drop =
+      if not !saw_custom_utility then None
+      else
+        List.find_map
+          (fun t ->
+            unreplayable ~defs ~config:t.config ~theme_vars:t.theme_vars
+              ~classes:t.classes
+              (Option.value ~default:"" t.expected))
+          (List.rev !block_tests)
+    in
+    (match drop with
+    | Some why ->
+        List.iter
+          (fun t -> Fmt.epr "dropped '%s': %s@." t.name why)
+          (List.rev !block_tests)
+    | None ->
+        tests :=
+          List.map (fun t -> { t with utility_defs = defs }) !block_tests
+          @ !tests);
     block_tests := [];
+    current_utility_defs := [];
+    current_layer_wrap := None;
+    in_utility := None;
+    in_layer := None;
     saw_custom_utility := false
   in
 
@@ -561,6 +819,48 @@ let parse_file filename =
           | Some (s, start) ->
               let emit v = current_theme_vars := v :: !current_theme_vars in
               if not (scanner_feed s line ~start emit) then in_theme := None);
+
+          (* Capture [@utility <name> { ... }] declarations the same way. *)
+          let utility_scan =
+            match !in_utility with
+            | Some (name, s) -> Some (name, s, 0)
+            | None -> (
+                match Re.exec_opt utility_open_re line with
+                | Some g ->
+                    let name = String.trim (Re.Group.get g 1) in
+                    let s = block_scanner () in
+                    in_utility := Some (name, s);
+                    Some (name, s, snd (Re.Group.offset g 0))
+                | None -> None)
+          in
+          (match utility_scan with
+          | None -> ()
+          | Some (name, s, start) ->
+              if not (block_feed s line ~start) then (
+                in_utility := None;
+                current_utility_defs :=
+                  (name, Buffer.contents s.text) :: !current_utility_defs));
+
+          (* Note the layer a template compiles [@tailwind utilities] into. *)
+          let layer_scan =
+            match !in_layer with
+            | Some (name, s) -> Some (name, s, 0)
+            | None -> (
+                match Re.exec_opt layer_open_re line with
+                | Some g ->
+                    let name = Re.Group.get g 1 in
+                    let s = block_scanner () in
+                    in_layer := Some (name, s);
+                    Some (name, s, snd (Re.Group.offset g 0))
+                | None -> None)
+          in
+          (match layer_scan with
+          | None -> ()
+          | Some (name, s, start) ->
+              if not (block_feed s line ~start) then (
+                in_layer := None;
+                if Re.execp tailwind_utilities_re (Buffer.contents s.text) then
+                  current_layer_wrap := Some name));
 
           (* Check for run([...]) *)
           (match Re.exec_opt run_pattern line with
@@ -683,6 +983,10 @@ let () =
       Fmt.pr "@config %s@." (config_to_string test.config);
       List.iter (fun v -> Fmt.pr "@variant %s@." v) test.variants;
       List.iter (fun (n, v) -> Fmt.pr "@theme-var %s %s@." n v) test.theme_vars;
+      List.iter
+        (fun (n, body) -> Fmt.pr "@utility-def %s %s@." n body)
+        test.utility_defs;
+      Option.iter (Fmt.pr "@layer-wrap %s@.") test.layer_wrap;
       Fmt.pr "%s@." (String.concat " " test.classes);
       (match test.expected with
       | Some css ->

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -28,6 +28,7 @@
     extra indentation. *)
 
 module Css = Cascade.Css
+module Entrypoint = Tw_tools.Entrypoint
 open Cascade_diff
 open Alcotest
 open Upstream_fixture
@@ -204,6 +205,26 @@ let theme_resolution ~declared config expected =
   | Theme_reference | Theme_inline_reference -> Fun.id
 
 let canonical_stylesheet_css css = String.trim css
+
+(* [@layer <name> { @tailwind utilities; }] in a case's template puts the
+   generated utilities in [<name>] and leaves everything else beside it: the
+   theme block, the [@property] rules, and whatever a declared utility hoists.
+   tw wraps the whole sheet in its own layer scaffolding, so keep the layer the
+   template named and flatten the rest. *)
+let keep_only_layer name stylesheet =
+  let rec go stmts =
+    List.concat_map
+      (fun stmt ->
+        if Option.is_some (Css.layer_statement_name_list stmt) then []
+        else
+          match Css.as_layer stmt with
+          | Some (Some n, _) when Css.Stylesheet.equal_layer_name n [ name ] ->
+              [ stmt ]
+          | Some (_, inner) -> go inner
+          | None -> [ stmt ])
+      stmts
+  in
+  Css.v (go (Css.statements stylesheet))
 
 (* Tailwind compiled the corpus from each case's own [@theme] block, with no
    default theme behind it, so the [@keyframes] that theme declares are in no
@@ -436,6 +457,7 @@ let theme_overrides_of ~declared config expected =
 let stat_total_classes = ref 0
 let stat_parsed = ref 0
 let stat_rejected = ref 0
+let stat_routed = ref 0
 let stat_expected_empty_cases = ref 0
 
 let run_test_case test () =
@@ -514,26 +536,51 @@ let run_test_case test () =
         (theme_overrides_of ~declared test.config test.expected @ theme_vars)
     in
     let resolve_theme = theme_resolution ~declared test.config test.expected in
+    (* A class the case's own [@utility] declares means nothing to
+       [Tw.of_string]: the declaration is CSS, and it reaches the sheet the way
+       a project entrypoint's does, through [Entrypoint]. The rest of the case
+       still compiles class by class, so the two sets are generated separately
+       and sorted together by [~extra]. With no declarations the partition is
+       empty and this is the plain per-class path. *)
+    let udefs = test.utility_defs in
+    let routed, direct =
+      List.partition (Entrypoint.is_custom_routed ~defs:[] ~udefs) test.classes
+    in
     let parsed, rejected =
       List.fold_left
         (fun (ok, bad) cls ->
           match Tw.of_string ~theme:scheme cls with
           | Ok u -> (u :: ok, bad)
           | Error (`Msg m) -> (ok, (cls, m) :: bad))
-        ([], []) test.classes
+        ([], []) direct
     in
     let utilities = List.rev parsed in
     let rejected = List.rev rejected in
+    let routed_count, routed_extra, routed_stmts =
+      if routed = [] then (0, [], [])
+      else
+        Entrypoint.custom_routed_utilities ~theme:scheme ~defs:[] ~udefs routed
+    in
     stat_total_classes := !stat_total_classes + List.length test.classes;
     stat_parsed := !stat_parsed + List.length utilities;
     stat_rejected := !stat_rejected + List.length rejected;
+    stat_routed := !stat_routed + routed_count;
     if test.expected = "" then incr stat_expected_empty_cases;
     let our_stylesheet =
-      if utilities = [] then None
+      if utilities = [] && routed_extra = [] && routed_stmts = [] then None
       else
-        Some
-          (drop_theme_keyframes
-             (Tw.to_css ~theme:scheme ~base:false ~layers:false utilities))
+        let layers = Option.is_some test.layer_wrap in
+        let sheet =
+          Entrypoint.place_routed routed_stmts
+            (Tw.to_css ~theme:scheme ~base:false ~layers ~extra:routed_extra
+               utilities)
+        in
+        let sheet =
+          match test.layer_wrap with
+          | None -> sheet
+          | Some name -> keep_only_layer name sheet
+        in
+        Some (drop_theme_keyframes sheet)
     in
     let our_css =
       match our_stylesheet with
@@ -652,9 +699,12 @@ let test_color_tolerance () =
 
 let print_parity_report () =
   Fmt.epr "@.=== upstream parity report ===@.";
-  Fmt.epr "classes: %d total, %d parsed, %d rejected@." !stat_total_classes
-    !stat_parsed !stat_rejected;
+  Fmt.epr "classes: %d total, %d parsed, %d routed, %d rejected@."
+    !stat_total_classes !stat_parsed !stat_routed !stat_rejected;
   Fmt.epr "cases with empty expected CSS: %d@." !stat_expected_empty_cases;
+  Fmt.epr
+    "(a routed class is one the case's own @utility declares, compiled through \
+     Entrypoint rather than of_string)@.";
   Fmt.epr
     "(a rejection is harmless when the case's CSS still matches; one that \
      breaks parity fails the CSS diff and names the rejected classes)@.";
@@ -668,7 +718,7 @@ let print_parity_report () =
    Set near the real counts rather than at half. Half (300 and 80) let a fixture
    lose most of itself and still pass, which is the drift the floor is for; a
    regenerated corpus that legitimately shrinks past these wants a human to look
-   and move the number. Counts on 2026-08-29: 627 utilities, 168 variants. *)
+   and move the number. Counts on 2026-08-29: 632 utilities, 168 variants. *)
 let utilities_floor = 560
 let variants_floor = 150
 

--- a/test/upstream/test_blocks_expected.txt
+++ b/test/upstream/test_blocks_expected.txt
@@ -30,6 +30,20 @@ backtick
 ---
 
 <<<>>>
+# defines its own utility
+@config run
+@utility-def custom-thing display: grid;
+@layer-wrap utilities
+custom-thing
+---
+
+      @layer utilities {
+        .custom-thing {
+          display: grid;
+        }
+      }
+      
+<<<>>>
 # indented twice
 @config run
 indented-twice

--- a/test/upstream/test_blocks_input.ts
+++ b/test/upstream/test_blocks_input.ts
@@ -42,16 +42,41 @@ describe('outer', () => {
       await run(
         ['custom-thing'],
         css`
+          @layer utilities {
+            @tailwind utilities;
+          }
+
           @utility custom-thing {
             display: grid;
+          }
+        `,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      @layer utilities {
+        .custom-thing {
+          display: grid;
+        }
+      }
+      "
+    `)
+  })
+
+  test('defines a functional utility', async () => {
+    expect(
+      await run(
+        ['sized-4'],
+        css`
+          @utility sized-* {
+            width: --value(integer);
           }
           @tailwind utilities;
         `,
       ),
     ).toMatchInlineSnapshot(`
       "
-      .custom-thing {
-        display: grid;
+      .sized-4 {
+        width: 4;
       }
       "
     `)

--- a/test/upstream/upstream_fixture.ml
+++ b/test/upstream/upstream_fixture.ml
@@ -8,6 +8,8 @@
     @config <theme config>
     @variant <matchVariant directive>     (optional, repeatable)
     @theme-var <name> <value>             (optional, repeatable)
+    @utility-def <name> <body>            (optional, repeatable)
+    @layer-wrap <layer>                   (optional)
     <space-separated class list>
     ---
     <expected CSS>
@@ -46,6 +48,14 @@ type case = {
       (** [@theme] token overrides (name, value) captured from the test's CSS
           template by the extractor (e.g. text-shadow sizes Tailwind inlines).
       *)
+  utility_defs : (string * string) list;
+      (** [@utility] declarations (name, body) the test's CSS template makes. A
+          case that has any is compiled through the declared-utility path rather
+          than class by class. *)
+  layer_wrap : string option;
+      (** The layer the test's CSS template compiles [@tailwind utilities] into,
+          when it names one. Tailwind puts the generated utilities in it and
+          everything else beside it. *)
 }
 
 (** Split a class line by spaces, but don't split inside brackets. *)
@@ -81,12 +91,27 @@ let read filename =
     let tests = ref [] in
     let current_variants = ref [] in
     let current_theme_vars = ref [] in
+    let current_utility_defs = ref [] in
+    let current_layer_wrap = ref None in
     let lines = String.split_on_char '\n' content in
     let parse_config_line line =
       let line = String.trim line in
       if String.length line > 8 && String.sub line 0 8 = "@config " then
         Some (config_of_string (String.sub line 8 (String.length line - 8)))
       else None
+    in
+    (* A directive line is "<keyword> <name> <rest>"; the name runs to the first
+       space and the rest is kept as written. *)
+    let named_pair keyword line =
+      let n = String.length keyword in
+      if String.length line < n || String.sub line 0 n <> keyword then None
+      else
+        let tail = String.sub line n (String.length line - n) in
+        Option.map
+          (fun i ->
+            ( String.sub tail 0 i,
+              String.sub tail (i + 1) (String.length tail - i - 1) ))
+          (String.index_opt tail ' ')
     in
     let rec parse lines =
       match lines with
@@ -97,6 +122,8 @@ let read filename =
             let name = String.sub line 2 (String.length line - 2) in
             current_variants := [];
             current_theme_vars := [];
+            current_utility_defs := [];
+            current_layer_wrap := None;
             parse_config name No_theme rest)
           else parse rest
     and parse_config name default_config lines =
@@ -109,26 +136,31 @@ let read filename =
     and parse_variants name config lines =
       match lines with
       | [] -> ()
-      | line :: rest ->
+      | line :: rest -> (
           let tl = String.trim line in
           if String.length tl >= 9 && String.sub tl 0 9 = "@variant " then (
             current_variants :=
               String.sub tl 9 (String.length tl - 9) :: !current_variants;
             parse_variants name config rest)
-          else if String.length tl >= 11 && String.sub tl 0 11 = "@theme-var "
-          then (
-            (* "@theme-var <name> <value>" -- split on the first space. *)
-            let rest_str = String.sub tl 11 (String.length tl - 11) in
-            (match String.index_opt rest_str ' ' with
-            | Some i ->
-                let n = String.sub rest_str 0 i in
-                let v =
-                  String.sub rest_str (i + 1) (String.length rest_str - i - 1)
-                in
-                current_theme_vars := (n, v) :: !current_theme_vars
-            | None -> ());
-            parse_variants name config rest)
-          else parse_classes name config (line :: rest)
+          else
+            match named_pair "@theme-var " tl with
+            | Some pair ->
+                current_theme_vars := pair :: !current_theme_vars;
+                parse_variants name config rest
+            | None -> (
+                match named_pair "@utility-def " tl with
+                | Some pair ->
+                    current_utility_defs := pair :: !current_utility_defs;
+                    parse_variants name config rest
+                | None ->
+                    if
+                      String.length tl >= 12
+                      && String.sub tl 0 12 = "@layer-wrap "
+                    then (
+                      current_layer_wrap :=
+                        Some (String.sub tl 12 (String.length tl - 12));
+                      parse_variants name config rest)
+                    else parse_classes name config (line :: rest)))
     and parse_classes name config lines =
       match lines with
       | [] -> ()
@@ -144,6 +176,8 @@ let read filename =
             let new_name = String.sub line 2 (String.length line - 2) in
             current_variants := [];
             current_theme_vars := [];
+            current_utility_defs := [];
+            current_layer_wrap := None;
             parse_config new_name No_theme rest)
           else
             let classes = split_classes line in
@@ -173,6 +207,8 @@ let read filename =
                 expected;
                 variants = List.rev !current_variants;
                 theme_vars = List.rev !current_theme_vars;
+                utility_defs = List.rev !current_utility_defs;
+                layer_wrap = !current_layer_wrap;
               }
               :: !tests
       | line :: rest ->
@@ -188,6 +224,8 @@ let read filename =
                   expected;
                   variants = List.rev !current_variants;
                   theme_vars = List.rev !current_theme_vars;
+                  utility_defs = List.rev !current_utility_defs;
+                  layer_wrap = !current_layer_wrap;
                 }
                 :: !tests;
             parse rest)

--- a/test/upstream/upstream_fixture.mli
+++ b/test/upstream/upstream_fixture.mli
@@ -8,6 +8,8 @@
     @config <theme config>
     @variant <matchVariant directive>     (optional, repeatable)
     @theme-var <name> <value>             (optional, repeatable)
+    @utility-def <name> <body>            (optional, repeatable)
+    @layer-wrap <layer>                   (optional)
     <space-separated class list>
     ---
     <expected CSS>
@@ -42,6 +44,14 @@ type case = {
       (** [@theme] token overrides (name, value) captured from the test's CSS
           template by the extractor (e.g. text-shadow sizes Tailwind inlines).
       *)
+  utility_defs : (string * string) list;
+      (** [@utility] declarations (name, body) the test's CSS template makes. A
+          case that has any is compiled through the declared-utility path rather
+          than class by class. *)
+  layer_wrap : string option;
+      (** The layer the test's CSS template compiles [@tailwind utilities] into,
+          when it names one. Tailwind puts the generated utilities in it and
+          everything else beside it. *)
 }
 
 val split_classes : string -> string list

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -22460,3 +22460,129 @@ basis-sm max-w-sm min-w-sm w-sm
       }
       
 <<<>>>
+# Multiple static utilities are merged
+@config run
+@utility-def really-round --custom-prop: hi; border-radius: 50rem;
+@utility-def really-round border-radius: 30rem;
+@layer-wrap utilities
+really-round
+---
+
+      @layer utilities {
+        .really-round {
+          --custom-prop: hi;
+          border-radius: 30rem;
+        }
+      }
+      
+<<<>>>
+# custom utilities support some special characters
+@config run
+@utility-def push-1/2 right: 50%;
+@utility-def push-50% right: 50%;
+@layer-wrap utilities
+push-1/2 push-50%
+---
+
+      @layer utilities {
+        .push-1\/2, .push-50\% {
+          right: 50%;
+        }
+      }
+      
+<<<>>>
+# custom utilities are sorted by used properties
+@config run
+@utility-def push-left right: 100%;
+@layer-wrap utilities
+bottom-[100px] push-left right-[100px] top-[100px]
+---
+
+      @layer utilities {
+        .top-\[100px\] {
+          top: 100px;
+        }
+
+        .push-left {
+          right: 100%;
+        }
+
+        .right-\[100px\] {
+          right: 100px;
+        }
+
+        .bottom-\[100px\] {
+          bottom: 100px;
+        }
+      }
+      
+<<<>>>
+# custom utilities work with `@apply`
+@config run
+@utility-def foo @apply flex flex-col underline;
+@utility-def bar @apply z-10; .baz { @apply z-20; }
+bar foo hover:foo
+---
+
+      .bar {
+        z-index: 10;
+      }
+
+      .bar .baz {
+        z-index: 20;
+      }
+
+      .foo {
+        flex-direction: column;
+        text-decoration-line: underline;
+        display: flex;
+      }
+
+      @media (hover: hover) {
+        .hover\:foo:hover {
+          flex-direction: column;
+          text-decoration-line: underline;
+          display: flex;
+        }
+      }
+      
+<<<>>>
+# referencing custom utilities in custom utilities via `@apply` should work
+@config run
+@utility-def foo @apply flex flex-col underline;
+@utility-def bar @apply dark:foo flex-wrap;
+bar
+---
+
+      .bar {
+        flex-wrap: wrap;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .bar {
+          flex-direction: column;
+          text-decoration-line: underline;
+          display: flex;
+        }
+      }
+      
+<<<>>>
+# custom utilities with `@apply` causing circular dependencies should error
+@config run
+@utility-def foo @apply flex-wrap hover:bar;
+@utility-def bar @apply flex dark:foo;
+bar foo
+<<<>>>
+# custom utilities with `@apply` causing circular dependencies should error (deeply nesting)
+@config run
+@utility-def foo .bar { .baz { .qux { @apply flex-wrap hover:bar; } } }
+@utility-def bar .baz { .qux { @apply flex dark:foo; } }
+bar foo
+<<<>>>
+# custom utilities with `@apply` causing circular dependencies should error (multiple levels)
+@config run
+@utility-def foo @apply flex-wrap hover:bar;
+@utility-def bar @apply flex dark:baz;
+@utility-def baz @apply flex-wrap hover:foo;
+bar foo
+<<<>>>


### PR DESCRIPTION
The extractor dropped every upstream block defining an `@utility`, because it carried a candidate list and the `@theme` tokens but not the CSS around them, so no run could produce the expected snapshot. That drop removed 81 cases across 49 test names.

The fixture now carries `@utility-def` and `@layer-wrap`, and the runner compiles a case's declared utilities through `Entrypoint` while keeping the per-class path for the rest. Eight blocks replay that never did (627 to 632 cases). Six are still dropped, each on a signal computed from the case and logged with its reason, and the functional `@utility NAME-*` form needs `--value()`/`--modifier()` resolution the fixture format does not carry yet.

Getting them green surfaced three bugs: only the first `@utility` declared for a name was applied, a declared utility's own rules trailed the ones its variants wrapped in an at-rule, and one whose first property has no order slot landed in a second `@layer utilities` where nothing sorted it against the built-ins. Commits 2e503d94 (the library move), fc474999 and 641eec33 carry those; 907fc5a2 is the corpus change.