### PR TITLE
entrypoint: resolve --value() and --modifier() in a declared utility

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -742,9 +742,12 @@ let var_names_of_output = function
 (* Theme tokens referenced via var() (e.g. an arbitrary [color:var(--color-red-
    500)]) must appear in @layer theme, but the extractor above only collects
    tokens utilities SET. Emit the catalogued colour tokens those references name
-   (typed value + canonical order via [Color.Handler.theme_color_decl]). Other
-   token kinds need a general typed value parser and are left for now. [exclude]
-   holds the already-emitted (set) token names. *)
+   (typed value + canonical order via [Color.Handler.theme_color_decl]), and any
+   other token the project's own [@theme] declared: nothing else in the sheet
+   declares it, so a utility that only reads it would name a variable with no
+   value. An [@theme inline] token has no declaration by definition, and an
+   [@theme reference] one is declared outside the sheet, so neither is emitted.
+   [exclude] holds the already-emitted (set) token names. *)
 let referenced_theme_decls ~theme ~exclude selector_props =
   selector_props
   |> List.concat_map var_names_of_output
@@ -771,7 +774,18 @@ let referenced_theme_decls ~theme ~exclude selector_props =
                    ~default:Theme.spacing_base)
             in
             Some decl
-        | _ -> Color.Handler.theme_color_decl ~theme bare)
+        | _ -> (
+            match Color.Handler.theme_color_decl ~theme bare with
+            | Some _ as decl -> decl
+            | None ->
+                if
+                  Scheme.is_inline_token theme bare
+                  || Scheme.is_reference_token theme bare
+                then None
+                else
+                  Option.map
+                    (Css.custom_property ~layer:"theme" full)
+                    (Scheme.token_override theme bare)))
 
 (* [--default-font-family] points at [--font-sans], [--default-mono-font-family]
    at [--font-mono]. Tailwind spells the pair [--theme(--font-sans, initial)],

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -47,6 +47,7 @@ type t = {
           instead of rem-based values. *)
   token_overrides : (string * string) list;
   inline_tokens : string list;
+  reference_tokens : string list;
   static_theme : bool;
       (** Per-render theme token overrides (from a [@theme] block). Key is the
           variable name without the leading [--] (e.g. "text-shadow-2xs"), value
@@ -88,6 +89,7 @@ let default : t =
     breakpoints = [];
     token_overrides = [];
     inline_tokens = [];
+    reference_tokens = [];
     static_theme = false;
     custom_variants = [];
     container_variants = [];
@@ -271,7 +273,7 @@ let has_breakpoint scheme name = List.mem_assoc name (all_breakpoints scheme)
 
 (** [with_overrides scheme overrides] returns [scheme] with [overrides] applied
     on top of any existing token overrides (new entries win). *)
-let with_overrides ?(inline = []) scheme overrides =
+let with_overrides ?(inline = []) ?(reference = []) scheme overrides =
   let breakpoints =
     List.fold_left
       (fun breakpoints (name, value) ->
@@ -292,6 +294,8 @@ let with_overrides ?(inline = []) scheme overrides =
     breakpoints;
     token_overrides = overrides @ scheme.token_overrides;
     inline_tokens = inline @ scheme.inline_tokens;
+    reference_tokens = reference @ scheme.reference_tokens;
   }
 
 let is_inline_token scheme name = List.mem name scheme.inline_tokens
+let is_reference_token scheme name = List.mem name scheme.reference_tokens

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -53,6 +53,11 @@ type t = {
       (** Names of the tokens a project declared in an [\@theme inline] block.
           Such a token has no declaration of its own: a utility reading it
           inlines the value instead of referencing [var(--name)]. *)
+  reference_tokens : string list;
+      (** Names of the tokens a project declared in an [\@theme reference]
+          block. The block declares the token elsewhere, so the theme layer
+          emits no declaration for it and a reader spells the value as the
+          fallback of its own reference. *)
   static_theme : bool;
       (** Whether the package was imported with [theme(static)], which emits
           every theme variable rather than only the ones a utility used. *)
@@ -109,15 +114,26 @@ val token : t -> string -> string option
 (** [token t name] resolves a theme token: override (if any) else default, or
     nothing at all when the [\@theme] block removed it. *)
 
-val with_overrides : ?inline:string list -> t -> (string * string) list -> t
-(** [with_overrides ?inline t overrides] applies [overrides] on top of [t]'s
-    existing token overrides (new entries win). [inline] names the tokens that
-    came from an [\@theme inline] block. *)
+val with_overrides :
+  ?inline:string list ->
+  ?reference:string list ->
+  t ->
+  (string * string) list ->
+  t
+(** [with_overrides ?inline ?reference t overrides] applies [overrides] on top
+    of [t]'s existing token overrides (new entries win). [inline] names the
+    tokens that came from an [\@theme inline] block, [reference] those from an
+    [\@theme reference] one. *)
 
 val is_inline_token : t -> string -> bool
 (** [is_inline_token t name] is whether [name] was declared in an
     [\@theme inline] block, so a utility reading it inlines the value rather
     than referencing [var(--name)]. *)
+
+val is_reference_token : t -> string -> bool
+(** [is_reference_token t name] is whether [name] was declared in an
+    [\@theme reference] block, so nothing declares it in the generated sheet and
+    a reader carries the value as its own [var()] fallback. *)
 
 val color : t -> string -> color_value option
 (** [color t name] looks up a color in the scheme. *)

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -581,9 +581,30 @@ let rec expand_variants ~depth defs css =
     let out = Buffer.contents buf in
     if !changed then expand_variants ~depth:(depth + 1) defs out else out
 
+(* A project that declared [--spacing] in an [@theme inline] block has no
+   variable to reference, so the step is multiplied out here instead, the way
+   Tailwind's inline theme does. *)
+let inline_spacing ~theme multiple =
+  if not (Tw.Scheme.is_inline_token theme "spacing") then None
+  else
+    let scaled (step : Css.length) times : Css.length option =
+      match step with
+      | Css.Px v -> Some (Css.Px (v *. times))
+      | Css.Rem v -> Some (Css.Rem (v *. times))
+      | Css.Em v -> Some (Css.Em (v *. times))
+      | _ -> None
+    in
+    match
+      ( Option.bind (Tw.Scheme.token theme "spacing") Css.parse_length,
+        float_of_string_opt (String.trim multiple) )
+    with
+    | Some step, Some times ->
+        Option.map (Css.Pp.to_string Css.pp_length) (scaled step times)
+    | _ -> None
+
 (* Tailwind's [--spacing(N)] is shorthand for the spacing scale. It is not CSS,
    so a parser rejects the declaration and it drops out of the output. *)
-let expand_spacing_fn css =
+let expand_spacing_fn ~theme css =
   let scan = Scan.v css in
   let len = String.length css in
   let buf = Buffer.create len in
@@ -593,7 +614,9 @@ let expand_spacing_fn css =
       match Scan.call scan ~name:"--spacing" i with
       | Some { body; next } ->
           Buffer.add_string buf
-            (String.concat "" [ "calc(var(--spacing) * "; body; ")" ]);
+            (match inline_spacing ~theme body with
+            | Some value -> value
+            | None -> String.concat "" [ "calc(var(--spacing) * "; body; ")" ]);
           go next
       | None ->
           Buffer.add_char buf css.[i];
@@ -986,7 +1009,7 @@ let apply_variants ?(extra_defs = []) ?(udefs = []) ~theme css =
   in
   drop_directives
     (resolve_theme_fn ~theme
-       (expand_spacing_fn (expand_variants ~depth:0 defs (expand 0 css))))
+       (expand_spacing_fn ~theme (expand_variants ~depth:0 defs (expand 0 css))))
 
 (* Preload every transitively-referenced stylesheet, keyed by the URL resolved
    against its importer, which is what the inliner looks up. Mirrors cascade's

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -476,12 +476,763 @@ let take_custom_variants css =
   go 0;
   (Buffer.contents buf, !defs)
 
-(* [@utility NAME { ... }] declares a project's own utility class. Only the
-   static form is read here; the functional [@utility NAME-* { ... }] one needs
-   [--value()]/[--modifier()] resolution. *)
-let take_custom_utilities css =
-  let css, defs = take_named_defs "@utility" css in
-  (css, List.filter (fun (n, _) -> not (String.contains n '*')) defs)
+(* {2 Functional [@utility NAME-*] declarations}
+
+   A functional declaration is a template rather than a rule: its body reads the
+   candidate's own value back with [--value(...)] and the [/half] after it with
+   [--modifier(...)]. A declaration whose reads do not all resolve is dropped,
+   and a candidate that resolved no [--value(...)] at all is not a utility. This
+   is Tailwind's [createCssUtility], and the arguments a read takes are its
+   documented API: a quoted literal, a bare data type, a [[data-type]] for an
+   arbitrary value, a [--namespace] to look up in the theme, and
+   [--default(...)] for the candidate that spelled no value. *)
+
+(* Tailwind's [segment]: split [s] on [sep] at the top level, so a separator
+   inside a bracket group or a quoted string belongs to the piece around it. *)
+let segment sep s =
+  let len = String.length s in
+  let pieces = ref [] in
+  let buf = Buffer.create len in
+  let depth = ref 0 in
+  let quote = ref None in
+  let i = ref 0 in
+  while !i < len do
+    let c = s.[!i] in
+    (match !quote with
+    | Some q ->
+        Buffer.add_char buf c;
+        if c = '\\' && !i + 1 < len then (
+          Buffer.add_char buf s.[!i + 1];
+          incr i)
+        else if c = q then quote := None
+    | None -> (
+        match c with
+        | '\'' | '"' ->
+            quote := Some c;
+            Buffer.add_char buf c
+        | '(' | '[' | '{' ->
+            incr depth;
+            Buffer.add_char buf c
+        | ')' | ']' | '}' ->
+            if !depth > 0 then decr depth;
+            Buffer.add_char buf c
+        | c when c = sep && !depth = 0 ->
+            pieces := Buffer.contents buf :: !pieces;
+            Buffer.clear buf
+        | c -> Buffer.add_char buf c));
+    incr i
+  done;
+  List.rev (Buffer.contents buf :: !pieces)
+
+(* Index of the first [sub] in [s]. *)
+let sub_index s sub =
+  let n = String.length s and m = String.length sub in
+  let rec go i =
+    if i + m > n then None
+    else if String.sub s i m = sub then Some i
+    else go (i + 1)
+  in
+  go 0
+
+let has_sub s sub = Option.is_some (sub_index s sub)
+let is_digit c = c >= '0' && c <= '9'
+
+(* A [<number>] as a candidate spells one: an optional sign, digits with at most
+   one decimal point, and an optional exponent. *)
+let is_number text =
+  let n = String.length text in
+  let i = ref 0 in
+  if !i < n && (text.[!i] = '+' || text.[!i] = '-') then incr i;
+  let digits () =
+    let from = !i in
+    while !i < n && is_digit text.[!i] do
+      incr i
+    done;
+    !i - from
+  in
+  let whole = digits () in
+  let fraction =
+    if !i < n && text.[!i] = '.' then (
+      incr i;
+      digits ())
+    else -1
+  in
+  let mantissa = if fraction < 0 then whole >= 1 else fraction >= 1 in
+  let exponent =
+    if !i < n && (text.[!i] = 'e' || text.[!i] = 'E') then begin
+      incr i;
+      if !i < n && (text.[!i] = '+' || text.[!i] = '-') then incr i;
+      digits () >= 1
+    end
+    else true
+  in
+  mantissa && exponent && !i = n
+
+let is_percentage text =
+  let n = String.length text in
+  n > 1 && text.[n - 1] = '%' && is_number (String.sub text 0 (n - 1))
+
+let is_fraction text =
+  match segment '/' text with
+  | [ left; right ] ->
+      is_number (String.trim left) && is_number (String.trim right)
+  | _ -> false
+
+(* The spelling a round trip through a number leaves unchanged, which is what
+   Tailwind's [String(Number(value)) === String(value)] asks for: no sign, no
+   redundant leading zero, no trailing zero in the fraction, no bare [.]. *)
+let is_canonical_number text =
+  let whole, fraction =
+    match String.index_opt text '.' with
+    | None -> (text, None)
+    | Some i ->
+        ( String.sub text 0 i,
+          Some (String.sub text (i + 1) (String.length text - i - 1)) )
+  in
+  let digits s = s <> "" && String.for_all is_digit s in
+  digits whole
+  && (String.length whole = 1 || whole.[0] <> '0')
+  &&
+  match fraction with
+  | None -> true
+  | Some f -> digits f && f.[String.length f - 1] <> '0'
+
+let is_positive_integer text =
+  is_canonical_number text && not (String.contains text '.')
+
+(* Tailwind's spacing multiplier: a canonical non-negative number that is a
+   whole multiple of [0.25]. *)
+let is_spacing_multiplier text =
+  is_canonical_number text
+  &&
+  match float_of_string_opt text with
+  | None -> false
+  | Some value -> Float.rem value 0.25 = 0.
+
+(* MDN's list of CSS length units, the one Tailwind reads a bare length
+   against. *)
+let length_units =
+  [
+    "cm";
+    "mm";
+    "Q";
+    "in";
+    "pc";
+    "pt";
+    "px";
+    "em";
+    "ex";
+    "ch";
+    "rem";
+    "lh";
+    "rlh";
+    "vw";
+    "vh";
+    "vmin";
+    "vmax";
+    "vb";
+    "vi";
+    "svw";
+    "svh";
+    "lvw";
+    "lvh";
+    "dvw";
+    "dvh";
+    "cqw";
+    "cqh";
+    "cqi";
+    "cqb";
+    "cqmin";
+    "cqmax";
+  ]
+
+let math_functions =
+  [
+    "calc";
+    "min";
+    "max";
+    "clamp";
+    "round";
+    "mod";
+    "rem";
+    "sin";
+    "cos";
+    "tan";
+    "asin";
+    "acos";
+    "atan";
+    "atan2";
+    "pow";
+    "sqrt";
+    "hypot";
+    "log";
+    "exp";
+    "abs";
+    "sign";
+  ]
+
+(* A math function stands for the value it computes, so it reads as every
+   numeric type. *)
+let has_math_fn text =
+  List.exists (fun name -> has_sub text (name ^ "(")) math_functions
+
+let is_length text =
+  has_math_fn text
+  || List.exists
+       (fun unit ->
+         let n = String.length text and u = String.length unit in
+         n > u
+         && String.sub text (n - u) u = unit
+         && is_number (String.sub text 0 (n - u)))
+       length_units
+
+(* Whether [text] reads as the CSS data type [kind]. A [var()] is opaque, so it
+   reads as nothing at all. The kinds beyond these are ones no [--value([kind])]
+   here asks for; one that does resolves to nothing rather than to a guess. *)
+let infer_data_type text kind =
+  if String.starts_with ~prefix:"var(" text then false
+  else
+    match kind with
+    | "color" -> Option.is_some (Css.parse_color text)
+    | "length" -> is_length text
+    | "percentage" -> is_percentage text || has_math_fn text
+    | "ratio" -> is_fraction text || has_math_fn text
+    | "number" -> is_number text || has_math_fn text
+    | "integer" -> is_positive_integer text
+    | _ -> false
+
+(* Only these four data types are read from a bare candidate value, so no
+   [--value(color)] can turn [example-red] into a utility. *)
+let bare_value_data_types = [ "number"; "integer"; "ratio"; "percentage" ]
+
+(** The value a candidate carries: a bare word, or an arbitrary value with the
+    data-type hint it was spelled with. The modifier takes the same two shapes.
+*)
+type candidate_value =
+  | Bare of string
+  | Bracketed of { hint : string option; text : string }
+
+type functional_candidate = {
+  root : string;  (** the [@utility] name without its [-*] *)
+  value : candidate_value option;
+  fraction : string option;
+      (** [2/3] when the value and the modifier read as one fraction, which is
+          what a [--value(ratio)] resolves against. *)
+  modifier : candidate_value option;
+}
+
+(* [example-*] declares a functional utility rooted at [example], and
+   [border--*] one rooted at [border-]. *)
+let functional_root name =
+  let n = String.length name in
+  if n > 2 && String.sub name (n - 2) 2 = "-*" then
+    Some (String.sub name 0 (n - 2))
+  else None
+
+let is_named_value s =
+  s <> ""
+  && String.for_all
+       (fun c ->
+         is_digit c
+         || (c >= 'a' && c <= 'z')
+         || (c >= 'A' && c <= 'Z')
+         || c = '_' || c = '.' || c = '%' || c = '-')
+       s
+
+(* [color:var(--x)] carries the hint [color]. A [:] after anything but lower
+   case letters and dashes is part of the value, not the end of a hint. *)
+let split_hint text =
+  let n = String.length text in
+  let rec go i =
+    if i >= n then (None, text)
+    else
+      match text.[i] with
+      | ':' -> (Some (String.sub text 0 i), String.sub text (i + 1) (n - i - 1))
+      | c when (c >= 'a' && c <= 'z') || c = '-' -> go (i + 1)
+      | _ -> (None, text)
+  in
+  go 0
+
+let parse_modifier raw =
+  let n = String.length raw in
+  let inner () = String.sub raw 1 (n - 2) in
+  if n < 1 then None
+  else if n >= 2 && raw.[0] = '[' && raw.[n - 1] = ']' then
+    let text = Tw.Parse.decode_arbitrary_value (inner ()) in
+    if String.trim text = "" then None
+    else Some (Bracketed { hint = None; text })
+  else if n >= 2 && raw.[0] = '(' && raw.[n - 1] = ')' then
+    let name = inner () in
+    if String.length name >= 2 && String.sub name 0 2 = "--" then
+      Some
+        (Bracketed
+           { hint = None; text = String.concat "" [ "var("; name; ")" ] })
+    else None
+  else if is_named_value raw then Some (Bare raw)
+  else None
+
+(* The roots a candidate could have, as Tailwind's [findRoots] yields them: the
+   whole base when it is a root, then every prefix ending before a [-]. A prefix
+   that leaves no value behind ends the search. *)
+let candidate_roots is_root base =
+  let found = ref (if is_root base then [ (base, None) ] else []) in
+  let rec go idx =
+    if idx > 0 then begin
+      let head = String.sub base 0 idx in
+      let rest = String.sub base (idx + 1) (String.length base - idx - 1) in
+      let next () =
+        go (Option.value ~default:0 (String.rindex_from_opt base (idx - 1) '-'))
+      in
+      if not (is_root head) then next ()
+      else if rest <> "" then begin
+        found := (head, Some rest) :: !found;
+        next ()
+      end
+    end
+  in
+  Option.iter go (String.rindex_opt base '-');
+  List.rev !found
+
+(* The [(--x)] and [(color:--x)] shorthands stand for an arbitrary [var()]. *)
+let paren_shorthand base idx =
+  let n = String.length base in
+  let inner = String.sub base (idx + 2) (n - idx - 3) in
+  let hint, name =
+    match segment ':' inner with [ h; v ] -> (Some h, v) | _ -> (None, inner)
+  in
+  if String.length name < 2 || String.sub name 0 2 <> "--" then None
+  else
+    let reference = String.concat "" [ "var("; name; ")" ] in
+    Some (Bracketed { hint; text = reference })
+
+let bracket_value raw =
+  match String.index_opt raw '[' with
+  | None -> None
+  | Some from ->
+      let n = String.length raw in
+      if raw.[n - 1] <> ']' then None
+      else
+        let text =
+          Tw.Parse.decode_arbitrary_value
+            (String.sub raw (from + 1) (n - from - 2))
+        in
+        let hint, text = split_hint text in
+        if String.trim text = "" || hint = Some "" then None
+        else Some (Bracketed { hint; text })
+
+(* The candidates [cls] reads as, given the roots the project declared. *)
+let parse_functional_candidates ~is_root cls =
+  match segment '/' cls with
+  | [] | _ :: _ :: _ :: _ -> []
+  | base :: rest ->
+      let modifier_raw = match rest with [ m ] -> Some m | _ -> None in
+      let modifier = Option.bind modifier_raw parse_modifier in
+      let n = String.length base in
+      (* A candidate carrying a modifier the reader refuses is no candidate at
+         all, and neither is an empty base. *)
+      if n = 0 || (modifier_raw <> None && modifier = None) then []
+      else
+        let candidate root value fraction =
+          { root; value; fraction; modifier }
+        in
+        (* The base spells a value after the root; the whole base is a root of
+           its own only when the utility takes no value. *)
+        let with_value (root, raw) =
+          match raw with
+          | None -> Some (candidate root None None)
+          | Some raw when String.contains raw '[' ->
+              Option.map
+                (fun value -> candidate root (Some value) None)
+                (bracket_value raw)
+          | Some raw when is_named_value raw ->
+              (* A named value and a named modifier also read as the one
+                 fraction a [--value(ratio)] resolves against. *)
+              let fraction =
+                match (modifier_raw, modifier) with
+                | Some m, Some (Bare _) ->
+                    Some (String.concat "" [ raw; "/"; m ])
+                | _ -> None
+              in
+              Some (candidate root (Some (Bare raw)) fraction)
+          | Some _ -> None
+        in
+        (* An arbitrary value ends the base, so what stands before its opener is
+           the root outright rather than one of several the base could name. *)
+        let arbitrary opener read =
+          match sub_index base opener with
+          | Some idx when is_root (String.sub base 0 idx) ->
+              read (String.sub base 0 idx) idx
+          | _ -> []
+        in
+        if base.[n - 1] = ']' then
+          arbitrary "-[" (fun root idx ->
+              Option.to_list
+                (with_value
+                   (root, Some (String.sub base (idx + 1) (n - idx - 1)))))
+        else if base.[n - 1] = ')' then
+          arbitrary "-(" (fun root idx ->
+              Option.to_list
+                (Option.map
+                   (fun value -> candidate root (Some value) None)
+                   (paren_shorthand base idx)))
+        else List.filter_map with_value (candidate_roots is_root base)
+
+(* Normalise one [--value(...)] argument the way Tailwind's preprocessing does,
+   so the spellings a formatter leaves behind all name the same thing:
+   [--text-\* --line-height], [--text- * --line-height] and [--text
+   --line-height] are all [--text-*--line-height], and a bare namespace grows
+   the [-*] it left out. *)
+let normalize_value_arg arg =
+  let unescape s =
+    let len = String.length s in
+    let buf = Buffer.create len in
+    let i = ref 0 in
+    while !i < len do
+      if s.[!i] = '\\' && !i + 1 < len && s.[!i + 1] = '*' then (
+        Buffer.add_char buf '*';
+        i := !i + 2)
+      else (
+        Buffer.add_char buf s.[!i];
+        incr i)
+    done;
+    Buffer.contents buf
+  in
+  (* Whitespace before a [--] separates a namespace from a sub-key: it stands
+     for the wildcard the sub-key hangs off. Every other run of it goes. *)
+  let wildcard_or_drop_space s =
+    let len = String.length s in
+    let space c = c = ' ' || c = '\t' || c = '\n' || c = '\r' in
+    let buf = Buffer.create len in
+    let i = ref 0 in
+    while !i < len do
+      if space s.[!i] then
+        if !i + 2 < len && s.[!i + 1] = '-' && s.[!i + 2] = '-' then
+          Buffer.add_string buf "-*"
+        else ()
+      else Buffer.add_char buf s.[!i];
+      incr i
+    done;
+    Buffer.contents buf
+  in
+  let rec collapse s =
+    match sub_index s "-*-*" with
+    | None -> s
+    | Some i ->
+        collapse
+          (String.concat ""
+             [
+               String.sub s 0 i; String.sub s (i + 2) (String.length s - i - 2);
+             ])
+  in
+  let arg = collapse (wildcard_or_drop_space (unescape arg)) in
+  if
+    String.length arg >= 2
+    && String.sub arg 0 2 = "--"
+    && (not (String.contains arg '('))
+    && not (has_sub arg "-*")
+  then arg ^ "-*"
+  else arg
+
+(* The CSS a declared utility writes for the theme token [name]: an inline token
+   stands for its own value, a reference token carries that value as the
+   fallback of its own reference because nothing declares it in the generated
+   sheet, and any other token is a plain reference the theme layer declares.
+
+   Written as text, like the [--spacing()] expansion above and for the same
+   reason: this pass runs over the dialect before cascade parses any of it, and
+   the token's value is whatever the [@theme] block wrote, with no value type to
+   build a typed reference at. What comes out is read back by cascade. *)
+let theme_token_css ~theme name =
+  Option.map
+    (fun value ->
+      if Tw.Scheme.is_inline_token theme name then value
+      else if Tw.Scheme.is_reference_token theme name then
+        String.concat "" [ "var(--"; name; ", "; value; ")" ]
+      else String.concat "" [ "var(--"; name; ")" ])
+    (Tw.Scheme.token theme name)
+
+(* Split [arg] on the wildcard [-*]: [--text-*--line-height] is the namespace
+   [--text] and the sub-key [--line-height], and [--example-*] is a namespace
+   with nothing behind it. *)
+let split_wildcard arg =
+  let rec go acc s =
+    match sub_index s "-*" with
+    | None -> List.rev (s :: acc)
+    | Some i ->
+        go (String.sub s 0 i :: acc)
+          (String.sub s (i + 2) (String.length s - i - 2))
+  in
+  go [] arg
+
+(* A [--value] argument naming a theme namespace reads the entry the candidate
+   names in it, and one naming a sub-key ([--text-*--line-height]) reads that
+   sub-key of the entry, which is there only when the entry itself is. *)
+let theme_arg_css ~theme arg name =
+  let bare s = String.sub s 2 (String.length s - 2) in
+  if String.length arg < 2 || String.sub arg 0 2 <> "--" then None
+  else
+    match split_wildcard arg with
+    | [ namespace; "" ] ->
+        theme_token_css ~theme (String.concat "-" [ bare namespace; name ])
+    | namespace :: (_ :: _ as subs) ->
+        let entry = String.concat "-" [ bare namespace; name ] in
+        if Option.is_none (Tw.Scheme.token theme entry) then None
+        else
+          theme_token_css ~theme (entry ^ List.nth subs (List.length subs - 1))
+    | _ -> None
+
+type resolution = { css : string; is_ratio : bool }
+(** What one [--value(...)] or [--modifier(...)] resolved to, and whether it
+    read the candidate as a ratio - which rules out its modifier and takes every
+    declaration that read it as something else out of the utility. *)
+
+let plain css = Some { css; is_ratio = false }
+
+(* A bare data type reads the candidate's own word, except [ratio], which reads
+   the value and the modifier back as the one fraction they spell. *)
+let resolve_bare_arg ~fraction text kind =
+  let read = if kind = "ratio" then fraction else Some text in
+  match read with
+  | None -> None
+  | Some read -> (
+      if not (infer_data_type read kind) then None
+      else
+        match kind with
+        | "ratio" -> (
+            match List.map String.trim (segment '/' read) with
+            | [ left; right ]
+              when is_positive_integer left && is_positive_integer right ->
+                Some
+                  {
+                    css = String.concat " " [ left; "/"; right ];
+                    is_ratio = true;
+                  }
+            | _ -> None)
+        | "number" -> if is_spacing_multiplier read then plain read else None
+        | "percentage" ->
+            if is_positive_integer (String.sub read 0 (String.length read - 1))
+            then plain read
+            else None
+        | _ -> plain read)
+
+(* One argument of a read, against the value the candidate spelled. *)
+let resolve_arg ~theme ~fraction value arg =
+  let arg = normalize_value_arg arg in
+  let n = String.length arg in
+  let quoted =
+    n >= 2 && (arg.[0] = '\'' || arg.[0] = '"') && arg.[n - 1] = arg.[0]
+  in
+  let theme_arg = n >= 2 && String.sub arg 0 2 = "--" in
+  let bracketed = n >= 2 && arg.[0] = '[' && arg.[n - 1] = ']' in
+  match value with
+  | Bare text when quoted ->
+      if String.sub arg 1 (n - 2) = text then plain text else None
+  | Bare text when theme_arg ->
+      Option.bind (theme_arg_css ~theme arg text) plain
+  | Bare text when List.mem arg bare_value_data_types ->
+      resolve_bare_arg ~fraction text arg
+  | Bare _ -> None
+  | Bracketed _ when not bracketed -> None
+  | Bracketed { hint; text } -> (
+      let kind = String.sub arg 1 (n - 2) in
+      if kind = "*" then plain text
+      else
+        match hint with
+        | Some spelled -> if spelled = kind then plain text else None
+        | None -> if infer_data_type text kind then plain text else None)
+
+(* [--default(4)] answers for a candidate that spelled no value at all. *)
+let default_arg arg =
+  let arg = String.trim arg in
+  let n = String.length arg in
+  let head = "--default(" in
+  let m = String.length head in
+  if n > m && String.sub arg 0 m = head && arg.[n - 1] = ')' then
+    Some (String.trim (String.sub arg m (n - m - 1)))
+  else None
+
+let resolve_read ~theme ~value ~fraction args =
+  match value with
+  | None -> Option.bind (List.find_map default_arg args) plain
+  | Some value -> List.find_map (resolve_arg ~theme ~fraction value) args
+
+type read_state = {
+  mutable used_value : bool;
+  mutable resolved_value : bool;
+  mutable used_modifier : bool;
+  mutable resolved_modifier : bool;
+  mutable ratio : bool;
+}
+(** What the whole body's reads did, which is what decides whether the candidate
+    is a utility at all. *)
+
+(** A declaration once its reads are resolved: kept, dropped because a read did
+    not resolve, or kept unless a [--value(ratio)] resolved somewhere else. *)
+type declaration_result = Keep of string | Drop | Ratio_drop of string
+
+(* Resolve every read in one declaration. A read that does not resolve takes the
+   declaration with it, and stops the rest of it from being read at all. *)
+let resolve_declaration ~theme ~candidate ~state text =
+  let scan = Scan.v text in
+  let len = String.length text in
+  let buf = Buffer.create len in
+  let dropped = ref false in
+  let non_ratio = ref false in
+  let read ~value ~fraction (block : Scan.block) =
+    match
+      resolve_read ~theme ~value ~fraction
+        (List.map String.trim (segment ',' block.body))
+    with
+    | None ->
+        dropped := true;
+        None
+    | Some resolved ->
+        Buffer.add_string buf resolved.css;
+        Some (resolved, block.next)
+  in
+  let rec go i =
+    if i >= len || !dropped then ()
+    else
+      match Scan.call scan ~name:"--value" i with
+      | Some block -> (
+          state.used_value <- true;
+          match
+            read ~value:candidate.value ~fraction:candidate.fraction block
+          with
+          | None -> ()
+          | Some (resolved, next) ->
+              state.resolved_value <- true;
+              if resolved.is_ratio then state.ratio <- true
+              else non_ratio := true;
+              go next)
+      | None -> (
+          match Scan.call scan ~name:"--modifier" i with
+          | Some block -> (
+              state.used_modifier <- true;
+              match read ~value:candidate.modifier ~fraction:None block with
+              | None -> ()
+              | Some (_, next) ->
+                  state.resolved_modifier <- true;
+                  go next)
+          | None ->
+              Buffer.add_char buf text.[i];
+              go (i + 1))
+  in
+  go 0;
+  if !dropped then Drop
+  else if !non_ratio then Ratio_drop (Buffer.contents buf)
+  else Keep (Buffer.contents buf)
+
+(** A body read as declarations and the punctuation between them, so one whose
+    reads did not resolve can be dropped without disturbing the rest. *)
+type body_piece = Declaration of string | Punctuation of string
+
+(* A [;] inside a bracket group is part of the declaration around it; a [;], [{]
+   or [}] outside one ends it, nested rules included. *)
+let body_pieces body =
+  let toks = tokens body in
+  let pieces = ref [] in
+  let from = ref 0 in
+  let depth = ref 0 in
+  let cut (token : Cascade.Token.t) =
+    let at = start token in
+    pieces :=
+      Punctuation (String.sub body at (stop token - at))
+      :: Declaration (String.sub body !from (at - !from))
+      :: !pieces;
+    from := stop token
+  in
+  Array.iter
+    (fun (token : Cascade.Token.t) ->
+      match token.kind with
+      | Cascade.Token.Open (Cascade.Token.Paren | Cascade.Token.Square)
+      | Cascade.Token.Function _ ->
+          incr depth
+      | Cascade.Token.Close (Cascade.Token.Paren | Cascade.Token.Square) ->
+          if !depth > 0 then decr depth
+      | Cascade.Token.Semicolon
+      | Cascade.Token.Open Cascade.Token.Curly
+      | Cascade.Token.Close Cascade.Token.Curly ->
+          if !depth = 0 then cut token
+      | _ -> ())
+    toks;
+  List.rev
+    (Declaration (String.sub body !from (String.length body - !from)) :: !pieces)
+
+let rec rebuild_body ~ratio = function
+  | [] -> []
+  | (Declaration _, Keep text) :: rest -> text :: rebuild_body ~ratio rest
+  | (Declaration _, Ratio_drop text) :: rest when not ratio ->
+      text :: rebuild_body ~ratio rest
+  | (Declaration _, _) :: (Punctuation ";", _) :: rest ->
+      rebuild_body ~ratio rest
+  | (Declaration _, _) :: rest -> rebuild_body ~ratio rest
+  | (Punctuation text, _) :: rest -> text :: rebuild_body ~ratio rest
+
+(* The body one [@utility NAME-*] declaration gives [candidate], or nothing when
+   the candidate is no utility of that declaration. *)
+let functional_body ~theme ~body candidate =
+  let state =
+    {
+      used_value = false;
+      resolved_value = false;
+      used_modifier = false;
+      resolved_modifier = false;
+      ratio = false;
+    }
+  in
+  let resolved =
+    List.map
+      (fun piece ->
+        match piece with
+        | Punctuation _ -> (piece, Keep "")
+        | Declaration text ->
+            if has_sub text "--value(" || has_sub text "--modifier(" then
+              (piece, resolve_declaration ~theme ~candidate ~state text)
+            else (piece, Keep text))
+      (body_pieces body)
+  in
+  let modifier = candidate.modifier <> None in
+  if not (state.used_value && state.resolved_value) then None
+  else if state.used_modifier && modifier && not state.resolved_modifier then
+    None
+  else if state.ratio && state.resolved_modifier then None
+  else if modifier && (not state.ratio) && not state.resolved_modifier then None
+  else Some (String.concat "" (rebuild_body ~ratio:state.ratio resolved))
+
+let functional_roots udefs =
+  List.filter_map (fun (n, _) -> functional_root n) udefs
+
+(* The candidates [cls] reads as against the functional [@utility] names of
+   [udefs]. *)
+let functional_candidates udefs cls =
+  match functional_roots udefs with
+  | [] -> []
+  | roots ->
+      parse_functional_candidates ~is_root:(fun r -> List.mem r roots) cls
+
+(* The body [cls] gets from the functional [@utility] declarations of [udefs]:
+   every declaration whose root it names, resolved against it, in the order they
+   were written. Tailwind registers each of them and applies them all. *)
+let functional_utility_body ~theme ~udefs cls =
+  List.find_map
+    (fun candidate ->
+      match
+        List.filter_map
+          (fun (name, body) ->
+            if functional_root name = Some candidate.root then
+              functional_body ~theme ~body candidate
+            else None)
+          udefs
+      with
+      | [] -> None
+      | bodies -> Some (String.concat "" bodies))
+    (functional_candidates udefs cls)
+
+(* [@utility NAME { ... }] declares a project's own utility class, and [@utility
+   NAME-* { ... }] one whose candidate carries a value its body reads back with
+   [--value()] and [--modifier()]. Both forms are read. *)
+let take_custom_utilities css = take_named_defs "@utility" css
 
 (* The at-keywords Tailwind's dialect adds to CSS. They are input for the
    generator, which reads each of them above -- for a definition, for an
@@ -869,7 +1620,10 @@ let emit_apply_name ~theme ~defs ~udefs ~buf ~hoisted ~seen name =
   let body, top =
     match List.assoc_opt bare udefs with
     | Some decls -> (decls, [])
-    | None -> nested_utilities ~theme [ bare ]
+    | None -> (
+        match functional_utility_body ~theme ~udefs bare with
+        | Some decls -> (decls, [])
+        | None -> nested_utilities ~theme [ bare ])
   in
   add_once hoisted seen top;
   if body <> "" then begin
@@ -883,7 +1637,10 @@ let emit_apply_name ~theme ~defs ~udefs ~buf ~hoisted ~seen name =
 
 let plain_apply_name ~defs ~udefs name =
   match split_declared_variants defs name with
-  | [], bare when not (List.mem_assoc bare udefs) -> Some bare
+  | [], bare
+    when (not (List.mem_assoc bare udefs))
+         && functional_candidates udefs bare = [] ->
+      Some bare
   | _ -> None
 
 let rec take_plain_apply_run ~defs ~udefs acc = function
@@ -1298,11 +2055,14 @@ let wrapped_block cls variants body =
   String.concat "" [ class_sel; "{"; wrapped; "}" ]
 
 (* A candidate the project's own declarations govern: it carries a declared
-   variant, or it is a declared utility. *)
+   variant, it is a declared utility, or it reads as one of a declared
+   functional utility's candidates. *)
 let is_custom_routed ~defs ~udefs cls =
   let variants, bare = split_declared_variants defs cls in
   let segs = variant_segments bare in
-  variants <> [] || List.mem_assoc (List.nth segs (List.length segs - 1)) udefs
+  let name = List.nth segs (List.length segs - 1) in
+  variants <> [] || List.mem_assoc name udefs
+  || functional_candidates udefs name <> []
 
 (* Candidates the built-in generator cannot produce: a variant the project
    redefined via [@custom-variant] (e.g. a class-based [dark:]), which
@@ -1363,8 +2123,13 @@ let routed_block ~theme ~defs ~udefs ~hoisted ~seen ~derived ~own_order cls =
   (* Every body declared for the name, in the order they were written: Tailwind
      registers each [@utility] of a name and applies them all, so a second
      declaration adds to the first rather than replacing it. *)
-  match List.filter (fun (n, _) -> n = name) udefs with
-  | _ :: _ as declared ->
+  let declared =
+    match List.filter (fun (n, _) -> n = name) udefs with
+    | _ :: _ as declared -> Some (String.concat "" (List.map snd declared))
+    | [] -> functional_utility_body ~theme ~udefs name
+  in
+  match declared with
+  | Some body ->
       (* A declared utility means nothing to [Tw.of_string], so every prefix has
          to become a [@variant], the built-in ones included. *)
       if
@@ -1372,13 +2137,10 @@ let routed_block ~theme ~defs ~udefs ~hoisted ~seen ~derived ~own_order cls =
           (fun variant ->
             Option.is_some (routed_template ~theme derived variant))
           builtin
-      then
-        Some
-          (wrapped_block cls (variants @ builtin)
-             (String.concat "" (List.map snd declared)))
+      then Some (wrapped_block cls (variants @ builtin) body)
       else None
-  | [] when variants = [] -> None
-  | [] ->
+  | None when variants = [] -> None
+  | None ->
       let body, top = nested_utilities ~theme [ bare ] in
       add_once hoisted seen top;
       if body = "" then None

--- a/lib/tools/entrypoint.mli
+++ b/lib/tools/entrypoint.mli
@@ -42,9 +42,10 @@ val take_custom_variants : string -> string * (string * string) list
 
 val take_custom_utilities : string -> string * (string * string) list
 (** [take_custom_utilities css] is [css] without its [@utility] declarations,
-    and those declarations as [(name, body)] pairs. Only the static form is
-    read; the functional [@utility NAME-* { ... }] one needs [--value()] and
-    [--modifier()] resolution, so it is dropped. *)
+    and those declarations as [(name, body)] pairs. Both forms are read: the
+    static [@utility NAME], and the functional [@utility NAME-*] whose body
+    reads the candidate's own value with [--value()] and its modifier with
+    [--modifier()]. A functional declaration keeps the [-*] in its name. *)
 
 val entry_variant_defs : string option -> (string * string) list
 (** [entry_variant_defs path] is the [@custom-variant] declarations of the
@@ -69,7 +70,8 @@ val split_declared_variants :
 val is_custom_routed :
   defs:(string * string) list -> udefs:(string * string) list -> string -> bool
 (** [is_custom_routed ~defs ~udefs cls] is [true] when [cls] names a variant or
-    a utility the project declared, which {!Tw.of_string} cannot produce and
+    a utility the project declared - a functional one included, whose root [cls]
+    carries a value for - which {!Tw.of_string} cannot produce and
     {!custom_routed_utilities} generates instead. *)
 
 val custom_routed_utilities :

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -365,6 +365,7 @@ module Contain = Contain
 module Scroll = Scroll
 module Arbitrary = Arbitrary
 module Touch = Touch
+module Parse = Parse
 module Mask_gradient = Mask_gradient
 module Property = Property
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -4387,3 +4387,4 @@ module Text_shadow = Text_shadow
 module Touch = Touch
 module Arbitrary = Arbitrary
 module Property = Property
+module Parse = Parse

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -548,6 +548,40 @@ let test_theme_layer_media_refs () =
   check bool "includes --text-xl--line-height var" true
     (List.exists (fun v -> v = "--text-xl--line-height") all_vars)
 
+(* A token the project's own [@theme] declared and a utility only reads has
+   nothing else in the sheet to declare it, so the theme layer has to. Before,
+   only the catalogued colours and [--spacing] were emitted that way, and a
+   reference to any other project token named a variable with no value. *)
+let test_theme_layer_emits_read_project_token () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("brand-ink", "#123456") ]
+  in
+  let utility =
+    match Tw.of_string ~theme "[color:var(--brand-ink)]" with
+    | Ok u -> u
+    | Error (`Msg m) -> Alcotest.failf "arbitrary property rejected: %s" m
+  in
+  let declared name theme =
+    Tw.to_css ~theme ~base:false [ utility ]
+    |> Css.layer_block [ "theme" ]
+    |> Option.map Css.rules_of_statements
+    |> Option.map Css.custom_props_of_rules
+    |> Option.value ~default:[] |> List.mem name
+  in
+  check bool "the read token reaches the theme layer" true
+    (declared "--brand-ink" theme);
+  (* An [@theme inline] token stands for its value at the use site and an
+     [@theme reference] one is declared outside the sheet, so neither gets a
+     declaration of its own. *)
+  check bool "an inline token gets none" false
+    (declared "--brand-ink"
+       (Tw.Scheme.with_overrides ~inline:[ "brand-ink" ] Tw.Scheme.default
+          [ ("brand-ink", "#123456") ]));
+  check bool "a reference token gets none" false
+    (declared "--brand-ink"
+       (Tw.Scheme.with_overrides ~reference:[ "brand-ink" ] Tw.Scheme.default
+          [ ("brand-ink", "#123456") ]))
+
 let test_theme_media_refs_md () =
   (* Vars referenced only under md media queries should still end up in
      theme. *)
@@ -1091,6 +1125,8 @@ let tests =
       test_theme_layer_media_refs;
     test_case "theme_layer_collects_media_refs (md)" `Quick
       test_theme_media_refs_md;
+    test_case "theme layer emits a read project token" `Quick
+      test_theme_layer_emits_read_project_token;
     test_case "rule_sets_injects_hover_media_query" `Quick
       test_rule_sets_hover_media;
     test_case "rule_sets_groups_md_media_query" `Quick test_rule_sets_md_media;

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -126,6 +126,19 @@ let test_take_custom_utilities () =
     [ ("line-y", " border-block: 1px solid ") ]
     defs
 
+(* [--spacing(N)] is a reference to the spacing scale, except under an [@theme
+   inline] [--spacing]: there the token has no declaration to reference, so the
+   step is multiplied out. *)
+let test_spacing_shorthand () =
+  let scheme inline =
+    Tw.Scheme.with_overrides ~inline Tw.Scheme.default [ ("spacing", "4px") ]
+  in
+  check string "a declared token is referenced"
+    ".a { margin: calc(var(--spacing) * 12) }"
+    (apply_variants ~theme:(scheme []) ".a { margin: --spacing(12) }");
+  check string "an inline token is worked out" ".a { margin: 48px }"
+    (apply_variants ~theme:(scheme [ "spacing" ]) ".a { margin: --spacing(12) }")
+
 let test_drop_directives () =
   check string "directives gone, author CSS kept" "\n\n.a { color: red }\n"
     (drop_directives
@@ -262,6 +275,7 @@ let tests =
     test_case "slots filled" `Quick test_fill_slots;
     test_case "custom variants taken" `Quick test_take_custom_variants;
     test_case "custom utilities taken" `Quick test_take_custom_utilities;
+    test_case "spacing shorthand" `Quick test_spacing_shorthand;
     test_case "directives dropped" `Quick test_drop_directives;
     test_case "theme keyframes hoisted" `Quick test_hoist_theme_keyframes;
     test_case "@apply merges into one rule" `Quick test_apply_merges_one_rule;

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -122,8 +122,13 @@ let test_take_custom_utilities () =
        @utility tab-* { tab-size: --value(integer) }\n"
   in
   check string "declarations removed" "\n\n" css;
-  check pair_list "the functional one is dropped"
-    [ ("line-y", " border-block: 1px solid ") ]
+  (* The functional form keeps its [-*]: that is what tells a candidate's root
+     from the whole name a static declaration spells. *)
+  check pair_list "both forms are read"
+    [
+      ("tab-*", " tab-size: --value(integer) ");
+      ("line-y", " border-block: 1px solid ");
+    ]
     defs
 
 (* [--spacing(N)] is a reference to the spacing scale, except under an [@theme
@@ -237,6 +242,110 @@ let test_declared_utility_keeps_its_nesting () =
         (Cascade.Css.to_string ~minify:true (Cascade.Css.v statements))
   | _ -> Alcotest.failf "expected one entry, got %d" (List.length entries)
 
+(* {2 Functional utilities} *)
+
+(* The CSS each candidate gets from the declarations, as [class -> minified
+   rule], so a candidate the declarations resolve nothing for shows up as an
+   absent entry rather than an empty one. *)
+let routed_css ~theme ~udefs candidates =
+  let _, entries, _ =
+    custom_routed_utilities ~theme ~defs:[] ~udefs candidates
+  in
+  List.map
+    (fun (cls, _, statements) ->
+      (cls, Cascade.Css.to_string ~minify:true (Cascade.Css.v statements)))
+    entries
+
+let check_routed ~udefs ?(theme = Tw.Scheme.default) msg expected candidates =
+  check pair_list msg expected
+    (List.sort compare (routed_css ~theme ~udefs candidates))
+
+(* [@utility example-* { ... }] declares a utility whose candidate carries a
+   value, read back in the body with [--value(...)]. A candidate the reads do
+   not all resolve is no utility of that declaration and produces nothing. *)
+let test_functional_value () =
+  let udefs = [ ("example-*", " --resolved-value: --value(integer) ") ] in
+  check_routed ~udefs "the integer the candidate spells"
+    [
+      ("example-1", ".example-1{--resolved-value:1}");
+      ("example-76", ".example-76{--resolved-value:76}");
+    ]
+    [ "example-1"; "example-76"; "example-foo"; "example"; "example-2.5" ]
+
+(* A [--value(--namespace)] reads the theme entry the candidate names. How it is
+   spelled follows the block the token was declared in: a plain one is a
+   reference the theme layer declares, an [@theme reference] one carries its
+   value as the fallback, an [@theme inline] one stands for the value. *)
+let test_functional_theme_value () =
+  let udefs = [ ("example-*", " --resolved-value: --value(--example) ") ] in
+  let theme ?inline ?reference () =
+    Tw.Scheme.with_overrides ?inline ?reference Tw.Scheme.default
+      [ ("example-a", "8") ]
+  in
+  check_routed ~udefs ~theme:(theme ()) "a declared token is referenced"
+    [ ("example-a", ".example-a{--resolved-value:var(--example-a)}") ]
+    [ "example-a"; "example-b" ];
+  check_routed ~udefs
+    ~theme:(theme ~reference:[ "example-a" ] ())
+    "a reference token carries its value"
+    [ ("example-a", ".example-a{--resolved-value:var(--example-a,8)}") ]
+    [ "example-a" ];
+  check_routed ~udefs
+    ~theme:(theme ~inline:[ "example-a" ] ())
+    "an inline token stands for its value"
+    [ ("example-a", ".example-a{--resolved-value:8}") ]
+    [ "example-a" ]
+
+(* An arbitrary value resolves against [--value([type])], which reads the hint
+   the candidate spelled when there is one and infers the type otherwise. *)
+let test_functional_arbitrary_value () =
+  let udefs = [ ("example-*", " --resolved-value: --value([integer]) ") ] in
+  check_routed ~udefs "only the values that read as integers"
+    [
+      ("example-[1]", ".example-\\[1\\]{--resolved-value:1}");
+      ( "example-[integer:var(--my-value)]",
+        ".example-\\[integer\\:var\\(--my-value\\)\\]{--resolved-value:var(--my-value)}"
+      );
+    ]
+    [
+      "example-[1]";
+      "example-[1px]";
+      "example-[integer:var(--my-value)]";
+      "example-[color:var(--my-value)]";
+      "example-(--my-value)";
+    ]
+
+(* [--modifier(...)] reads the [/half] of the candidate, and [--default(...)]
+   answers for the half - or the value - the candidate left out. A modifier the
+   body never resolves makes the whole candidate invalid. *)
+let test_functional_modifier () =
+  let udefs =
+    [
+      ( "example-*",
+        " --resolved-value: --value(integer, --default(12)); \
+         --resolved-modifier: --modifier(integer) " );
+    ]
+  in
+  check_routed ~udefs "the modifier, and the default for the value"
+    [
+      ("example", ".example{--resolved-value:12}");
+      ("example-1/1", ".example-1\\/1{--resolved-value:1;--resolved-modifier:1}");
+      ("example/25", ".example\\/25{--resolved-value:12;--resolved-modifier:25}");
+    ]
+    [ "example"; "example/25"; "example-1/1"; "example/foo" ]
+
+(* A candidate the project's functional declarations root is theirs to generate:
+   [Tw.of_string] does not know it, so the routing has to claim it even when the
+   declarations end up resolving nothing for it. *)
+let test_functional_routing () =
+  let udefs = [ ("example-*", " --resolved-value: --value(integer) ") ] in
+  let routed cls = is_custom_routed ~defs:[] ~udefs cls in
+  check bool "a candidate of the root" true (routed "example-4");
+  check bool "the root on its own" true (routed "example");
+  check bool "one the declaration resolves nothing for" true
+    (routed "example-foo");
+  check bool "a built-in utility" false (routed "flex")
+
 (* A [@utility] body is author text tw does not validate. An unclosed brace in
    one must cost that class alone: assembled into a single sheet, the block
    swallows every utility written after it, and the sheet as a whole no longer
@@ -283,6 +392,12 @@ let tests =
       test_apply_hoists_each_property_once;
     test_case "declared utility keeps its nesting" `Quick
       test_declared_utility_keeps_its_nesting;
+    test_case "functional value" `Quick test_functional_value;
+    test_case "functional theme value" `Quick test_functional_theme_value;
+    test_case "functional arbitrary value" `Quick
+      test_functional_arbitrary_value;
+    test_case "functional modifier" `Quick test_functional_modifier;
+    test_case "functional routing" `Quick test_functional_routing;
     test_case "malformed utility spares the others" `Quick
       test_malformed_utility_spares_the_others;
   ]

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -6,7 +6,7 @@
 (executable
  (name extract_tests)
  (modules extract_tests)
- (libraries re fmt astring cascade))
+ (libraries re fmt astring cascade tw_tools))
 
 (test
  (name test)
@@ -59,8 +59,8 @@
 ; indented inside one or more [describe(...)] blocks, the three quote styles a
 ; name can take, a [test.each([...])(...)] block staying out, a block defining
 ; its own [@utility] carried through with its definition and the layer its
-; template compiles into, and one defining a functional [@utility] dropped
-; whole.
+; template compiles into, and one defining a functional [@utility NAME-*]
+; carried through with the [-*] kept in its name.
 
 (rule
  (action

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -125,6 +125,12 @@ type test_case = {
           template. Captures tokens (e.g. [text-shadow-2xs]) that Tailwind
           inlines into utilities rather than emitting to [:root], so the runner
           can reconstruct the test's theme as token overrides. *)
+  theme_modes : (string * string list) list;
+      (** The modifiers of the [@theme] block each token was declared in, for
+          the tokens whose block had any. [inline] and [reference] change how a
+          token reads rather than what it is, and a test can put two tokens of
+          one namespace in blocks that differ, so the mode belongs to the token
+          rather than to the test. *)
   utility_defs : (string * string) list;
       (** [@utility <name> { <body> }] declarations from the test's CSS
           template, so the runner can compile the case through the same
@@ -408,8 +414,23 @@ let is_empty_string_arg arg =
   in
   arg = "''" || arg = {|""|}
 
-let contains_var body = Astring.String.is_infix ~affix:"var(--" body
 let contains_apply body = Astring.String.is_infix ~affix:"@apply" body
+
+(* The theme tokens a definition body reads with [var(--name)]. *)
+let var_reference_re = Re.Pcre.regexp {|var\(\s*--([A-Za-z0-9_-]+)|}
+
+let var_references body =
+  List.map (fun g -> Re.Group.get g 1) (Re.all var_reference_re body)
+
+(* Tailwind runs its output through a minifier that adds vendor prefixes. A
+   declared utility's body reaches the sheet as written, so a snapshot spelling
+   a prefixed property no definition wrote is one tw cannot produce. *)
+let vendor_prefixes = [ "-webkit-"; "-moz-"; "-ms-" ]
+
+(* [@utility example-*] declares a functional utility: its body is a template
+   whose [--value(...)] and [--modifier(...)] reads stand for the candidate's
+   own value, so no CSS parser reads it as written. *)
+let is_functional (name, _) = String.contains name '*'
 
 (* The property of a declaration cascade rejects the value of, if the body has
    one. *)
@@ -460,13 +481,12 @@ let variant_prefixes cls =
   | None -> []
   | Some i -> String.split_on_char ':' (String.sub cls 0 i)
 
+(* The math functions whose result Tailwind's minifier writes out. *)
+let math_functions = [ "calc("; "min("; "max("; "clamp("; "round(" ]
+
 (* Why the runner cannot reproduce a block that declares its own [@utility], or
    [None] when it can. Each reason is a gap to close, not a property of the
    corpus: the check goes when the gap does.
-
-   A functional [@utility NAME-*] resolves [--value()] and [--modifier()]
-   against the candidate's own suffix, which neither this fixture format nor
-   {!Tw_tools.Entrypoint.take_custom_utilities} carries.
 
    An [@utility] the scanner did not read would leave the case compiled without
    its definitions, so a scanner gap shows up as a missing case.
@@ -480,22 +500,56 @@ let variant_prefixes cls =
    writes its declarations by expansion, so it is counted out of this one.
 
    [@theme reference] declares a token elsewhere: Tailwind inlines its value as
-   a [var()] fallback and emits no [:root] declaration, and tw has no
-   reference-token mode.
+   a [var()] fallback and emits no [:root] declaration. A declared utility
+   spells that fallback itself, so a case whose classes the declarations all
+   govern replays; every other class still goes through the built-in generator,
+   which has no reference-token mode.
 
-   A token the case's [@theme] declares and only a declared utility reads is not
-   emitted to the theme layer: tw emits a referenced-but-unset token only for
-   the catalogued colours and [--spacing].
+   A [var(--name)] a definition reads is rendered against tw's own theme when
+   the fixture carries no value for it, which is either a token Tailwind never
+   emitted or a value it emitted from the case's theme. A case with no class for
+   the declarations to govern never reads it, so it is kept.
+
+   Tailwind's minifier vendor-prefixes what it emits. A declared utility's body
+   reaches tw's sheet as written, so a snapshot holding a prefixed property no
+   definition wrote is out of reach.
+
+   An [@theme inline] token stands for its value at every use site, and
+   Tailwind's minifier folds a math function there to a number of its own
+   spelling ([calc(1 / 0.75)] comes out as [1.33333]). tw inlines the value as
+   written, and cascade prints a math function rather than working it out.
 
    [run()] compiles against an empty theme, so a named breakpoint variant the
    template never declares resolves to nothing upstream; tw's [Scheme.t] has no
    way to say "no breakpoints" (an empty list means the built-in ones). *)
-let unreplayable ~defs ~config ~theme_vars ~classes expected =
-  let functional = List.filter (fun (n, _) -> String.contains n '*') defs in
-  let unreadable =
-    List.filter_map (fun (_, b) -> unreadable_declaration b) defs
+let unreplayable ~defs ~config ~theme_vars ~theme_modes ~classes expected =
+  let routed =
+    List.filter
+      (Tw_tools.Entrypoint.is_custom_routed ~defs:[] ~udefs:defs)
+      classes
   in
-  let reads_var = List.exists (fun (_, b) -> contains_var b) defs in
+  let unreadable =
+    List.filter_map
+      (fun def ->
+        if is_functional def then None else unreadable_declaration (snd def))
+      defs
+  in
+  let unresolved_reference name = not (List.mem_assoc name theme_vars) in
+  let reads_unknown_token =
+    List.exists
+      (fun (_, body) -> List.exists unresolved_reference (var_references body))
+      defs
+  in
+  let prefixed_snapshot =
+    List.exists
+      (fun prefix ->
+        Astring.String.is_infix ~affix:prefix expected
+        && not
+             (List.exists
+                (fun (_, body) -> Astring.String.is_infix ~affix:prefix body)
+                defs))
+      vendor_prefixes
+  in
   let applies = List.exists (fun (_, b) -> contains_apply b) defs in
   let undeclared_breakpoint =
     List.exists
@@ -506,6 +560,19 @@ let unreplayable ~defs ~config ~theme_vars ~classes expected =
             && not (List.mem_assoc ("breakpoint-" ^ v) theme_vars))
           (variant_prefixes cls))
       classes
+  in
+  let inlined_math =
+    List.exists
+      (fun (name, modes) ->
+        List.mem "inline" modes
+        &&
+        match List.assoc_opt name theme_vars with
+        | None -> false
+        | Some value ->
+            List.exists
+              (fun fn -> Astring.String.is_infix ~affix:fn value)
+              math_functions)
+      theme_modes
   in
   let merged_with_builtin =
     (not applies)
@@ -520,10 +587,10 @@ let unreplayable ~defs ~config ~theme_vars ~classes expected =
          defs
   in
   let some = Fmt.kstr (fun s -> Some s) in
-  if functional <> [] then
-    some "functional @utility %s" (String.concat ", " (List.map fst functional))
-  else if defs = [] then
-    Some "an @utility declaration the extractor could not read"
+  (* [some] is fixed at the first format it is used with, so a reason carrying a
+     count needs its own. *)
+  let counted = Fmt.kstr (fun s -> Some s) in
+  if defs = [] then Some "an @utility declaration the extractor could not read"
   else if unreadable <> [] then
     some "cascade cannot read the declared %s" (String.concat ", " unreadable)
   else if merged_with_builtin then
@@ -531,9 +598,22 @@ let unreplayable ~defs ~config ~theme_vars ~classes expected =
   else if
     (config = Theme_reference || config = Theme_inline_reference)
     && expected <> ""
-  then Some "@theme reference: tw has no reference-token mode"
-  else if reads_var then
-    Some "a declared utility reads a theme token tw's theme layer will not emit"
+    && List.length routed < List.length classes
+  then
+    counted
+      "@theme reference and %d class(es) the declarations do not govern, which \
+       tw has no reference-token mode for"
+      (List.length classes - List.length routed)
+  else if prefixed_snapshot then
+    Some "Tailwind's minifier vendor-prefixed a declared utility's property"
+  else if reads_unknown_token && routed <> [] then
+    Some
+      "a declared utility reads a theme token the fixture does not carry, so \
+       tw cannot render it against the case's own theme"
+  else if inlined_math then
+    Some
+      "an inline theme token whose value is a math function Tailwind's \
+       minifier works out and cascade prints as written"
   else if undeclared_breakpoint then
     Some "a breakpoint variant the case's own theme does not declare"
   else None
@@ -688,8 +768,9 @@ let parse_file filename =
   (* Capture [@theme] token declarations [--name: value;]. [in_theme] holds the
      scanner of the active [@theme {...}] block within a compileCss template. *)
   let current_theme_vars = ref [] in
+  let current_theme_modes = ref [] in
   let in_theme = ref None in
-  let theme_open_re = Re.Pcre.regexp {|@theme\b[^{]*\{|} in
+  let theme_open_re = Re.Pcre.regexp {|@theme\b([^{]*)\{|} in
   (* Scanner of the [.toEqual(] call still being read, if any. *)
   let in_expect = ref None in
 
@@ -711,6 +792,7 @@ let parse_file filename =
           expected;
           variants;
           theme_vars = List.rev !current_theme_vars;
+          theme_modes = List.rev !current_theme_modes;
           utility_defs = [];
           layer_wrap = !current_layer_wrap;
         }
@@ -718,6 +800,7 @@ let parse_file filename =
     current_classes := [];
     current_variant_names := [];
     current_theme_vars := [];
+    current_theme_modes := [];
     in_theme := None;
     in_expect := None
   in
@@ -730,7 +813,7 @@ let parse_file filename =
         List.find_map
           (fun t ->
             unreplayable ~defs ~config:t.config ~theme_vars:t.theme_vars
-              ~classes:t.classes
+              ~theme_modes:t.theme_modes ~classes:t.classes
               (Option.value ~default:"" t.expected))
           (List.rev !block_tests)
     in
@@ -805,19 +888,27 @@ let parse_file filename =
              [{] and read on until the block's closing [}]. *)
           let scan_from =
             match !in_theme with
-            | Some s -> Some (s, 0)
+            | Some (modes, s) -> Some (modes, s, 0)
             | None -> (
                 match Re.exec_opt theme_open_re line with
                 | Some g ->
+                    let modes =
+                      String.split_on_char ' ' (String.trim (Re.Group.get g 1))
+                      |> List.filter (fun m -> m <> "")
+                    in
                     let s = theme_scanner () in
-                    in_theme := Some s;
-                    Some (s, snd (Re.Group.offset g 0))
+                    in_theme := Some (modes, s);
+                    Some (modes, s, snd (Re.Group.offset g 0))
                 | None -> None)
           in
           (match scan_from with
           | None -> ()
-          | Some (s, start) ->
-              let emit v = current_theme_vars := v :: !current_theme_vars in
+          | Some (modes, s, start) ->
+              let emit ((name, _) as v) =
+                current_theme_vars := v :: !current_theme_vars;
+                if modes <> [] then
+                  current_theme_modes := (name, modes) :: !current_theme_modes
+              in
               if not (scanner_feed s line ~start emit) then in_theme := None);
 
           (* Capture [@utility <name> { ... }] declarations the same way. *)
@@ -983,6 +1074,10 @@ let () =
       Fmt.pr "@config %s@." (config_to_string test.config);
       List.iter (fun v -> Fmt.pr "@variant %s@." v) test.variants;
       List.iter (fun (n, v) -> Fmt.pr "@theme-var %s %s@." n v) test.theme_vars;
+      List.iter
+        (fun (n, modes) ->
+          Fmt.pr "@theme-mode %s %s@." n (String.concat " " modes))
+        test.theme_modes;
       List.iter
         (fun (n, body) -> Fmt.pr "@utility-def %s %s@." n body)
         test.utility_defs;

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -532,7 +532,20 @@ let run_test_case test () =
       let theme_vars =
         List.filter (fun (name, _) -> not (is_runtime_var name)) test.theme_vars
       in
-      Tw.Scheme.with_overrides scheme
+      (* [@theme inline] and [@theme reference] change how a token reads, not
+         what it is: an inline one stands for its value at the use site, a
+         reference one is declared elsewhere and carries its value as the
+         fallback of the reference. A case can put two tokens of one namespace
+         in blocks that differ, so the modes come from the token's own block
+         rather than from the case's [@config]. *)
+      let tokens_in_mode mode =
+        List.filter_map
+          (fun (name, modes) -> if List.mem mode modes then Some name else None)
+          test.theme_modes
+      in
+      let inline = tokens_in_mode "inline" in
+      let reference = tokens_in_mode "reference" in
+      Tw.Scheme.with_overrides ~inline ~reference scheme
         (theme_overrides_of ~declared test.config test.expected @ theme_vars)
     in
     let resolve_theme = theme_resolution ~declared test.config test.expected in
@@ -718,8 +731,8 @@ let print_parity_report () =
    Set near the real counts rather than at half. Half (300 and 80) let a fixture
    lose most of itself and still pass, which is the drift the floor is for; a
    regenerated corpus that legitimately shrinks past these wants a human to look
-   and move the number. Counts on 2026-08-29: 632 utilities, 168 variants. *)
-let utilities_floor = 560
+   and move the number. Counts on 2026-08-29: 696 utilities, 168 variants. *)
+let utilities_floor = 620
 let variants_floor = 150
 
 let load basename floor =

--- a/test/upstream/test_blocks_expected.txt
+++ b/test/upstream/test_blocks_expected.txt
@@ -44,6 +44,17 @@ custom-thing
       }
       
 <<<>>>
+# defines a functional utility
+@config run
+@utility-def sized-* width: --value(integer);
+sized-4
+---
+
+      .sized-4 {
+        width: 4;
+      }
+      
+<<<>>>
 # indented twice
 @config run
 indented-twice

--- a/test/upstream/upstream_fixture.ml
+++ b/test/upstream/upstream_fixture.ml
@@ -8,6 +8,7 @@
     @config <theme config>
     @variant <matchVariant directive>     (optional, repeatable)
     @theme-var <name> <value>             (optional, repeatable)
+    @theme-mode <name> <modifiers>        (optional, repeatable)
     @utility-def <name> <body>            (optional, repeatable)
     @layer-wrap <layer>                   (optional)
     <space-separated class list>
@@ -48,6 +49,11 @@ type case = {
       (** [@theme] token overrides (name, value) captured from the test's CSS
           template by the extractor (e.g. text-shadow sizes Tailwind inlines).
       *)
+  theme_modes : (string * string list) list;
+      (** The modifiers of the [@theme] block each token was declared in, for
+          the tokens whose block had any. [inline] and [reference] change how a
+          token reads, and one test can declare two tokens of a namespace in
+          blocks that differ, so the mode belongs to the token. *)
   utility_defs : (string * string) list;
       (** [@utility] declarations (name, body) the test's CSS template makes. A
           case that has any is compiled through the declared-utility path rather
@@ -91,6 +97,7 @@ let read filename =
     let tests = ref [] in
     let current_variants = ref [] in
     let current_theme_vars = ref [] in
+    let current_theme_modes = ref [] in
     let current_utility_defs = ref [] in
     let current_layer_wrap = ref None in
     let lines = String.split_on_char '\n' content in
@@ -122,6 +129,7 @@ let read filename =
             let name = String.sub line 2 (String.length line - 2) in
             current_variants := [];
             current_theme_vars := [];
+            current_theme_modes := [];
             current_utility_defs := [];
             current_layer_wrap := None;
             parse_config name No_theme rest)
@@ -148,19 +156,26 @@ let read filename =
                 current_theme_vars := pair :: !current_theme_vars;
                 parse_variants name config rest
             | None -> (
-                match named_pair "@utility-def " tl with
-                | Some pair ->
-                    current_utility_defs := pair :: !current_utility_defs;
+                match named_pair "@theme-mode " tl with
+                | Some (n, modes) ->
+                    current_theme_modes :=
+                      (n, String.split_on_char ' ' modes)
+                      :: !current_theme_modes;
                     parse_variants name config rest
-                | None ->
-                    if
-                      String.length tl >= 12
-                      && String.sub tl 0 12 = "@layer-wrap "
-                    then (
-                      current_layer_wrap :=
-                        Some (String.sub tl 12 (String.length tl - 12));
-                      parse_variants name config rest)
-                    else parse_classes name config (line :: rest)))
+                | None -> (
+                    match named_pair "@utility-def " tl with
+                    | Some pair ->
+                        current_utility_defs := pair :: !current_utility_defs;
+                        parse_variants name config rest
+                    | None ->
+                        if
+                          String.length tl >= 12
+                          && String.sub tl 0 12 = "@layer-wrap "
+                        then (
+                          current_layer_wrap :=
+                            Some (String.sub tl 12 (String.length tl - 12));
+                          parse_variants name config rest)
+                        else parse_classes name config (line :: rest))))
     and parse_classes name config lines =
       match lines with
       | [] -> ()
@@ -176,6 +191,7 @@ let read filename =
             let new_name = String.sub line 2 (String.length line - 2) in
             current_variants := [];
             current_theme_vars := [];
+            current_theme_modes := [];
             current_utility_defs := [];
             current_layer_wrap := None;
             parse_config new_name No_theme rest)
@@ -207,6 +223,7 @@ let read filename =
                 expected;
                 variants = List.rev !current_variants;
                 theme_vars = List.rev !current_theme_vars;
+                theme_modes = List.rev !current_theme_modes;
                 utility_defs = List.rev !current_utility_defs;
                 layer_wrap = !current_layer_wrap;
               }
@@ -224,6 +241,7 @@ let read filename =
                   expected;
                   variants = List.rev !current_variants;
                   theme_vars = List.rev !current_theme_vars;
+                  theme_modes = List.rev !current_theme_modes;
                   utility_defs = List.rev !current_utility_defs;
                   layer_wrap = !current_layer_wrap;
                 }

--- a/test/upstream/upstream_fixture.mli
+++ b/test/upstream/upstream_fixture.mli
@@ -8,6 +8,7 @@
     @config <theme config>
     @variant <matchVariant directive>     (optional, repeatable)
     @theme-var <name> <value>             (optional, repeatable)
+    @theme-mode <name> <modifiers>        (optional, repeatable)
     @utility-def <name> <body>            (optional, repeatable)
     @layer-wrap <layer>                   (optional)
     <space-separated class list>
@@ -44,6 +45,11 @@ type case = {
       (** [@theme] token overrides (name, value) captured from the test's CSS
           template by the extractor (e.g. text-shadow sizes Tailwind inlines).
       *)
+  theme_modes : (string * string list) list;
+      (** The modifiers of the [@theme] block each token was declared in, for
+          the tokens whose block had any. [inline] and [reference] change how a
+          token reads, and one test can declare two tokens of a namespace in
+          blocks that differ, so the mode belongs to the token. *)
   utility_defs : (string * string) list;
       (** [@utility] declarations (name, body) the test's CSS template makes. A
           case that has any is compiled through the declared-utility path rather

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -327,6 +327,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px #0000000d
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -inset-x-4/foo -inset-x-full/foo inset-x inset-x--1 inset-x--1/-2 inset-x--1/2 inset-x-1/-2 inset-x-3/4/foo inset-x-4/foo inset-x-[4px]/foo inset-x-auto/foo inset-x-full/foo inset-x-shadow-sm
 ---
 
@@ -380,6 +382,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -inset-y-4/foo -inset-y-full/foo inset-1/-2 inset-y inset-y--1 inset-y--1/-2 inset-y--1/2 inset-y-3/4/foo inset-y-4/foo inset-y-[4px]/foo inset-y-auto/foo inset-y-full/foo inset-y-shadow-sm
 ---
 
@@ -433,6 +437,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -inset-s-4/foo -inset-s-full/foo inset-s inset-s--1 inset-s--1/-2 inset-s--1/2 inset-s-1/-2 inset-s-3/4/foo inset-s-4/foo inset-s-[4px]/foo inset-s-auto/foo inset-s-full/foo inset-s-shadow-sm
 ---
 
@@ -486,6 +492,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -inset-e-4/foo -inset-e-full/foo inset-e inset-e--1 inset-e--1/-2 inset-e--1/2 inset-e-1/-2 inset-e-3/4/foo inset-e-4/foo inset-e-[4px]/foo inset-e-auto/foo inset-e-full/foo inset-e-shadow-sm
 ---
 
@@ -539,6 +547,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -inset-bs-4/foo -inset-bs-full/foo inset-bs inset-bs--1 inset-bs--1/-2 inset-bs--1/2 inset-bs-1/-2 inset-bs-3/4/foo inset-bs-4/foo inset-bs-[4px]/foo inset-bs-auto/foo inset-bs-full/foo inset-bs-shadow-sm
 ---
 
@@ -592,6 +602,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -inset-be-4/foo -inset-be-full/foo inset-be inset-be--1 inset-be--1/-2 inset-be--1/2 inset-be-1/-2 inset-be-3/4/foo inset-be-4/foo inset-be-[4px]/foo inset-be-auto/foo inset-be-full/foo inset-be-shadow-sm
 ---
 
@@ -645,6 +657,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -top-4/foo -top-full/foo top top--1 top--1/-2 top--1/2 top-1/-2 top-3/4/foo top-4/foo top-[4px]/foo top-auto/foo top-full/foo top-shadow-sm
 ---
 
@@ -698,6 +712,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -right-4/foo -right-full/foo right right--1 right--1/-2 right--1/2 right-1/-2 right-3/4/foo right-4/foo right-[4px]/foo right-auto/foo right-full/foo right-shadow-sm
 ---
 
@@ -751,6 +767,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -bottom-4/foo -bottom-full/foo bottom bottom--1 bottom--1/-2 bottom--1/2 bottom-1/-2 bottom-3/4/foo bottom-4/foo bottom-[4px]/foo bottom-auto/foo bottom-full/foo bottom-shadow-sm
 ---
 
@@ -808,6 +826,8 @@ absolute fixed relative static sticky
 @config theme-reference
 @theme-var spacing-4 1rem
 @theme-var inset-shadow-sm inset 0 1px 1px rgb(0 0 0 / 0.05)
+@theme-mode spacing-4 reference
+@theme-mode inset-shadow-sm reference
 -left-4/foo -left-full/foo left left--1 left--1/-2 left--1/2 left-1/-2 left-3/4/foo left-4/foo left-[4px]/foo left-auto/foo left-full/foo left-shadow-sm
 ---
 
@@ -3165,6 +3185,13 @@ container max-w-[var(--breakpoint-sm)] w-1/2
 @theme-var breakpoint-2xl 96rem
 @theme-var breakpoint-xs 30px
 @theme-var breakpoint-md 48em
+@theme-mode breakpoint-lg reference
+@theme-mode breakpoint-xl reference
+@theme-mode breakpoint-3xl reference
+@theme-mode breakpoint-sm reference
+@theme-mode breakpoint-2xl reference
+@theme-mode breakpoint-xs reference
+@theme-mode breakpoint-md reference
 container
 ---
 
@@ -10467,6 +10494,8 @@ border
 @config theme-reference
 @theme-var opacity-half 0.5
 @theme-var opacity-custom var(--custom-opacity)
+@theme-mode opacity-half reference
+@theme-mode opacity-custom reference
 [color:red]/half bg-current/custom bg-current/half
 ---
 
@@ -11733,6 +11762,8 @@ mask-[120px] mask-[120px_120px] mask-[50%] mask-[contain] mask-[cover] mask-[ima
 @config theme-reference
 @theme-var opacity-half 0.5
 @theme-var opacity-custom var(--custom-opacity)
+@theme-mode opacity-half reference
+@theme-mode opacity-custom reference
 [color:red]/half mask-current/custom mask-current/half
 ---
 
@@ -17493,6 +17524,8 @@ font-["arial_rounded"] font-[100] font-[family-name:var(--my-family)] font-[gene
 @config theme-reference
 @theme-var font-sans ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'
 @theme-var font-weight-bold 650
+@theme-mode font-sans reference
+@theme-mode font-weight-bold reference
 -font-bold -font-sans font font-["arial_rounded"]/foo font-[100]/foo font-[family-name:var(--my-family)]/foo font-[generic-name:var(--my-family)]/foo font-[number:var(--my-weight)]/foo font-[ui-sans-serif]/foo font-[var(--my-family)]/foo font-bold/foo font-sans/foo font-weight-bold
 ---
 
@@ -18070,6 +18103,7 @@ animate-none
 @theme-var drop-shadow-xl 0 9px 7px rgb(0 0 0 / 0.1)
 @theme-var drop-shadow-calc 0 0 calc(1 * var(--spacing)) black
 @theme-var drop-shadow-multi 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1)
+@theme-mode drop-shadow-multi inline
 -hue-rotate-15 -hue-rotate-[45deg] blur-[4px] blur-none blur-xl brightness-50 brightness-[1.23] contrast-50 contrast-[1.23] drop-shadow drop-shadow-[0_0_red] drop-shadow-calc drop-shadow-inherit drop-shadow-multi drop-shadow-none drop-shadow-red-500 drop-shadow-red-500/50 drop-shadow-xl drop-shadow/12.5 drop-shadow/25 filter filter-[var(--value)] filter-none grayscale grayscale-0 grayscale-[var(--value)] hue-rotate-15 hue-rotate-[45deg] invert invert-0 invert-[var(--value)] saturate-0 saturate-[1.75] saturate-[var(--value)] sepia sepia-0 sepia-[50%] sepia-[var(--value)]
 ---
 
@@ -18908,6 +18942,8 @@ transition transition-[var(--value)] transition-all transition-colors transition
 @config run
 @theme-var default-transition-timing-function ease
 @theme-var default-transition-duration 100ms
+@theme-mode default-transition-timing-function inline
+@theme-mode default-transition-duration inline
 transition transition-all transition-colors
 ---
 
@@ -20249,6 +20285,7 @@ text-[#0088cc] text-[#0088cc]/50 text-[#0088cc]/[0.5] text-[#0088cc]/[50%] text-
 # text
 @config run
 @theme-var text-sm 0.875rem
+@theme-mode text-sm inline reference
 -text-[#0088cc] -text-[#0088cc]/50 -text-[#0088cc]/[0.5] -text-[#0088cc]/[50%] -text-current -text-current/50 -text-current/[0.5] -text-current/[50%] -text-inherit -text-red-500 -text-red-500/50 -text-red-500/[0.5] -text-red-500/[50%] -text-sm -text-sm/6 -text-sm/[4px] -text-transparent text text-[10px]/foo text-sm/foo
 ---
 
@@ -22428,6 +22465,7 @@ px-.75 px-0.25 px-0.375 px-1.5 px-2.50 px-2.75
 # spacing utilities must have a value
 @config theme-reference
 @theme-var spacing 4px
+@theme-mode spacing reference
 px
 ---
 
@@ -22585,4 +22623,976 @@ bar foo
 @utility-def bar @apply flex dark:baz;
 @utility-def baz @apply flex-wrap hover:foo;
 bar foo
+<<<>>>
+# functional utilities require a `--value(…)`
+@config run
+@utility-def example-* --resolved-value: 4;
+example example-foo
+---
+
+<<<>>>
+# functional utilities must resolve at least one `--value(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer);
+example-1 example-2
+---
+
+        .example-1 {
+          --resolved-value: 1;
+        }
+
+        .example-2 {
+          --resolved-value: 2;
+        }
+        
+<<<>>>
+# functional utilities must resolve at least one `--value(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer);
+example example-2.5 example-foo
+---
+
+<<<>>>
+# resolving values from `@theme`
+@config run
+@theme-var example-1 1
+@theme-var example-2 2
+@theme-var example-4 4
+@theme-var example-a 8
+@theme-mode example-1 reference
+@theme-mode example-2 reference
+@theme-mode example-4 reference
+@theme-mode example-a reference
+@utility-def example-* --resolved-value: --value(--example);
+example-1 example-2 example-4 example-a
+---
+
+          .example-1 {
+            --resolved-value: var(--example-1, 1);
+          }
+
+          .example-2 {
+            --resolved-value: var(--example-2, 2);
+          }
+
+          .example-4 {
+            --resolved-value: var(--example-4, 4);
+          }
+
+          .example-a {
+            --resolved-value: var(--example-a, 8);
+          }
+          
+<<<>>>
+# resolving values from `@theme`
+@config run
+@utility-def example-* --resolved-value: --value(--example);
+example-3 example-gitlab
+---
+
+<<<>>>
+# functional utility with double-dash separator
+@config run
+@theme-var color-border-0 #e5e7eb
+@theme-var color-border-1 #d1d5db
+@theme-var color-border-2 #9ca3af
+@theme-mode color-border-0 reference
+@theme-mode color-border-1 reference
+@theme-mode color-border-2 reference
+@utility-def border--* border-color: --value(--color-border-*, [color]);
+border--0 border--1 border--2
+---
+
+        .border--0 {
+          border-color: var(--color-border-0, #e5e7eb);
+        }
+
+        .border--1 {
+          border-color: var(--color-border-1, #d1d5db);
+        }
+
+        .border--2 {
+          border-color: var(--color-border-2, #9ca3af);
+        }
+        
+<<<>>>
+# functional utility with double-dash separator
+@config run
+@utility-def border--* border-color: --value(--color-border-*, [color]);
+border--3
+---
+
+<<<>>>
+# resolving values from `@theme`, with `--example-*` syntax
+@config run
+@theme-var example-1 1
+@theme-var example-2 2
+@theme-var example-4 4
+@theme-var example-a 8
+@theme-mode example-1 reference
+@theme-mode example-2 reference
+@theme-mode example-4 reference
+@theme-mode example-a reference
+@utility-def example-* --resolved-value: --value(--example-*);
+example-1 example-2 example-4 example-a
+---
+
+          .example-1 {
+            --resolved-value: var(--example-1, 1);
+          }
+
+          .example-2 {
+            --resolved-value: var(--example-2, 2);
+          }
+
+          .example-4 {
+            --resolved-value: var(--example-4, 4);
+          }
+
+          .example-a {
+            --resolved-value: var(--example-a, 8);
+          }
+          
+<<<>>>
+# resolving values from `@theme`, with `--example-*` syntax
+@config run
+@utility-def example-* --resolved-value: --value(--example-*);
+example-3 example-gitlab
+---
+
+<<<>>>
+# resolving values from `@theme`, with `--example-\\*` syntax (prettier friendly)
+@config run
+@theme-var example-1 1
+@theme-var example-2 2
+@theme-var example-4 4
+@theme-var example-a 8
+@theme-mode example-1 reference
+@theme-mode example-2 reference
+@theme-mode example-4 reference
+@theme-mode example-a reference
+@utility-def example-* --resolved-value: --value(--example-\*);
+example-1 example-2 example-4 example-a
+---
+
+          .example-1 {
+            --resolved-value: var(--example-1, 1);
+          }
+
+          .example-2 {
+            --resolved-value: var(--example-2, 2);
+          }
+
+          .example-4 {
+            --resolved-value: var(--example-4, 4);
+          }
+
+          .example-a {
+            --resolved-value: var(--example-a, 8);
+          }
+          
+<<<>>>
+# resolving values from `@theme`, with `--example-\\*` syntax (prettier friendly)
+@config run
+@utility-def example-* --resolved-value: --value(--example-\*);
+example-3 example-gitlab
+---
+
+<<<>>>
+# resolving bare values
+@config run
+@utility-def example-* --resolved-value: --value(integer);
+example-1 example-76 example-971
+---
+
+        .example-1 {
+          --resolved-value: 1;
+        }
+
+        .example-76 {
+          --resolved-value: 76;
+        }
+
+        .example-971 {
+          --resolved-value: 971;
+        }
+        
+<<<>>>
+# resolving bare values
+@config run
+@utility-def example-* --resolved-value: --value(integer);
+example-foo
+---
+
+<<<>>>
+# bare values with unsupported data types should result in a warning
+@config run
+@utility-def paint-* paint: --value([color], color);
+paint-#0088cc paint-red
+---
+
+<<<>>>
+# resolve literal values
+@config run
+@utility-def example-* --resolved-value: --value('revert');
+example-revert
+---
+
+        .example-revert {
+          --resolved-value: revert;
+        }
+        
+<<<>>>
+# resolve literal values
+@config run
+@utility-def example-* --resolved-value: --value('revert');
+example-initial
+---
+
+<<<>>>
+# resolving bare values with constraints for integer, percentage, and ratio
+@config run
+@utility-def example-* --value-as-number: --value(number); --value-as-percentage: --value(percentage); --value-as-ratio: --value(ratio);
+example-0.5 example-1 example-2/3 example-20%
+---
+
+          .example-0\.5 {
+            --value-as-number: .5;
+          }
+
+          .example-1 {
+            --value-as-number: 1;
+          }
+
+          .example-2\/3 {
+            --value-as-ratio: 2 / 3;
+          }
+
+          .example-20\% {
+            --value-as-percentage: 20%;
+          }
+          
+<<<>>>
+# resolving bare values with constraints for integer, percentage, and ratio
+@config run
+@utility-def example-* --value-as-number: --value(number); --value-as-percentage: --value(percentage); --value-as-ratio: --value(ratio);
+example-1.2/3 example-1.2/3.4 example-1.23 example-1/2.3 example-12.34%
+---
+
+<<<>>>
+# resolving unsupported bare values
+@config run
+@utility-def example-* --resolved-value: --value(color);
+example-#0088cc example-foo
+---
+
+<<<>>>
+# resolving arbitrary values
+@config run
+@utility-def example-* --resolved-value: --value([integer]);
+example-(integer:my-value) example-[1] example-[76] example-[971] example-[integer:var(--my-value)]
+---
+
+        .example-\[1\] {
+          --resolved-value: 1;
+        }
+
+        .example-\[76\] {
+          --resolved-value: 76;
+        }
+
+        .example-\[971\] {
+          --resolved-value: 971;
+        }
+
+        .example-\[integer\:var\(--my-value\)\] {
+          --resolved-value: var(--my-value);
+        }
+        
+<<<>>>
+# resolving arbitrary values
+@config run
+@utility-def example-* --resolved-value: --value([integer]);
+example-(--my-value) example-(color:--my-value) example-[#0088cc] example-[1px] example-[color:var(--my-value)] example-[var(--my-value)]
+---
+
+<<<>>>
+# resolving any arbitrary values
+@config run
+@utility-def example-* --resolved-value: --value([*]);
+example-(--my-value) example-[1] example-[76] example-[971] example-[var(--my-value)]
+---
+
+        .example-\(--my-value\) {
+          --resolved-value: var(--my-value);
+        }
+
+        .example-\[1\] {
+          --resolved-value: 1;
+        }
+
+        .example-\[76\] {
+          --resolved-value: 76;
+        }
+
+        .example-\[971\] {
+          --resolved-value: 971;
+        }
+
+        .example-\[var\(--my-value\)\] {
+          --resolved-value: var(--my-value);
+        }
+        
+<<<>>>
+# resolving any arbitrary values (without space)
+@config run
+@utility-def example-* --resolved-value: --value([*]);
+example-(--my-value) example-[1] example-[76] example-[971] example-[var(--my-value)]
+---
+
+        .example-\(--my-value\) {
+          --resolved-value: var(--my-value);
+        }
+
+        .example-\[1\] {
+          --resolved-value: 1;
+        }
+
+        .example-\[76\] {
+          --resolved-value: 76;
+        }
+
+        .example-\[971\] {
+          --resolved-value: 971;
+        }
+
+        .example-\[var\(--my-value\)\] {
+          --resolved-value: var(--my-value);
+        }
+        
+<<<>>>
+# resolving any arbitrary values (with escaped `*`)
+@config run
+@utility-def example-* --resolved-value: --value([\*]);
+example-(--my-value) example-[1] example-[76] example-[971] example-[var(--my-value)]
+---
+
+        .example-\(--my-value\) {
+          --resolved-value: var(--my-value);
+        }
+
+        .example-\[1\] {
+          --resolved-value: 1;
+        }
+
+        .example-\[76\] {
+          --resolved-value: 76;
+        }
+
+        .example-\[971\] {
+          --resolved-value: 971;
+        }
+
+        .example-\[var\(--my-value\)\] {
+          --resolved-value: var(--my-value);
+        }
+        
+<<<>>>
+# resolving theme, bare and arbitrary values all at once
+@config run
+@theme-var example-a 8
+@theme-mode example-a reference
+@utility-def example-* --resolved-value: --value([integer]); --resolved-value: --value(integer); --resolved-value: --value(--example);
+example-76 example-[123] example-a
+---
+
+        .example-76 {
+          --resolved-value: 76;
+        }
+
+        .example-\[123\] {
+          --resolved-value: 123;
+        }
+
+        .example-a {
+          --resolved-value: var(--example-a, 8);
+        }
+        
+<<<>>>
+# resolving theme, bare and arbitrary values all at once
+@config run
+@utility-def example-* --resolved-value: --value([integer]); --resolved-value: --value(integer); --resolved-value: --value(--example);
+example-[#0088cc] example-[1px]
+---
+
+<<<>>>
+# in combination with calc to produce different data types of values
+@config run
+@theme-var example-full 100%
+@theme-mode example-full reference
+@utility-def example-* --resolved-value: --value([percentage]); --resolved-value: calc(--value(integer) * 1%); --resolved-value: --value(--example);
+example-12 example-[20%] example-full
+---
+
+          .example-12 {
+            --resolved-value: calc(12 * 1%);
+          }
+
+          .example-\[20\%\] {
+            --resolved-value: 20%;
+          }
+
+          .example-full {
+            --resolved-value: var(--example-full, 100%);
+          }
+          
+<<<>>>
+# in combination with calc to produce different data types of values
+@config run
+@utility-def example-* --resolved-value: --value([percentage]); --resolved-value: calc(--value(integer) * 1%); --resolved-value: --value(--example);
+example-[#0088cc] example-half
+---
+
+<<<>>>
+# shorthand if resulting values are of the same type
+@config run
+@theme-var example-full 100%
+@theme-mode example-full reference
+@utility-def example-* --resolved-value: calc(--value(integer) * 1%); --resolved-value: --value(--example, [percentage]);
+example-37 example-[50%] example-full
+---
+
+          .example-37 {
+            --resolved-value: calc(37 * 1%);
+          }
+
+          .example-\[50\%\] {
+            --resolved-value: 50%;
+          }
+
+          .example-full {
+            --resolved-value: var(--example-full, 100%);
+          }
+          
+<<<>>>
+# shorthand if resulting values are of the same type
+@config run
+@utility-def example-* --resolved-value: calc(--value(integer) * 1%); --resolved-value: --value(--example, [percentage]);
+example-[13px] example-foo
+---
+
+<<<>>>
+# negative values
+@config run
+@theme-var example-full 100%
+@theme-mode example-full reference
+@utility-def example-* --resolved-value: --value(--example, [percentage], [length]);
+@utility-def -example-* --resolved-value: calc(--value(--example, [percentage], [length]) * -1);
+-example-[10px] -example-[20%] -example-full example-[10px] example-[20%] example-full
+---
+
+        .-example-\[10px\] {
+          --resolved-value: calc(10px * -1);
+        }
+
+        .-example-\[20\%\] {
+          --resolved-value: calc(20% * -1);
+        }
+
+        .-example-full {
+          --resolved-value: calc(var(--example-full, 100%) * -1);
+        }
+
+        .example-\[10px\] {
+          --resolved-value: 10px;
+        }
+
+        .example-\[20\%\] {
+          --resolved-value: 20%;
+        }
+
+        .example-full {
+          --resolved-value: var(--example-full, 100%);
+        }
+        
+<<<>>>
+# negative values
+@config run
+@utility-def example-* --resolved-value: --value(--example, [percentage], [length]);
+@utility-def -example-* --resolved-value: calc(--value(--example, [percentage], [length]) * -1);
+example-10
+---
+
+<<<>>>
+# using `--spacing(…)` shorthand
+@config run
+@theme-var spacing 4px
+@utility-def example-* margin: --spacing(--value(number));
+example-12
+---
+
+        :root, :host {
+          --spacing: 4px;
+        }
+
+        .example-12 {
+          margin: calc(var(--spacing) * 12);
+        }
+        
+<<<>>>
+# using `--spacing(…)` shorthand (inline theme)
+@config run
+@theme-var spacing 4px
+@theme-mode spacing inline reference
+@utility-def example-* margin: --spacing(--value(number));
+example-12
+---
+
+        .example-12 {
+          margin: 48px;
+        }
+        
+<<<>>>
+# functional utilities can use `--default(…)` in `--value(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer, --default(4));
+example example-123
+---
+
+        .example {
+          --resolved-value: 4;
+        }
+
+        .example-123 {
+          --resolved-value: 123;
+        }
+        
+<<<>>>
+# functional utilities can use `--default(…)` in `--value(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer, --default(4));
+example-foo
+---
+
+<<<>>>
+# functional utilities can use `--default(…)` in complex expressions
+@config run
+@utility-def example-* --resolved-value: calc(--value(integer, --default(4)) * 2);
+example example-123
+---
+
+        .example {
+          --resolved-value: calc(4 * 2);
+        }
+
+        .example-123 {
+          --resolved-value: calc(123 * 2);
+        }
+        
+<<<>>>
+# functional utilities can use `--default(…)` in complex expressions
+@config run
+@utility-def example-* --resolved-value: calc(--value(integer, --default(4)) * 2);
+example-foo
+---
+
+<<<>>>
+# functional utilities can use `--default(…)` with `--modifier(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer, --default(4)); --resolved-modifier: --modifier(integer);
+example example/25
+---
+
+        .example\/25 {
+          --resolved-value: 4;
+          --resolved-modifier: 25;
+        }
+
+        .example {
+          --resolved-value: 4;
+        }
+        
+<<<>>>
+# functional utilities can use `--default(…)` with `--modifier(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer, --default(4)); --resolved-modifier: --modifier(integer);
+example/foo
+---
+
+<<<>>>
+# functional utilities can use `--default(…)` in `--modifier(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer); --resolved-modifier: --modifier(integer, --default(1));
+example-123 example-123/25
+---
+
+        .example-123 {
+          --resolved-value: 123;
+          --resolved-modifier: 1;
+        }
+
+        .example-123\/25 {
+          --resolved-value: 123;
+          --resolved-modifier: 25;
+        }
+        
+<<<>>>
+# functional utilities can use `--default(…)` in `--modifier(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer); --resolved-modifier: --modifier(integer, --default(1));
+example-123/foo
+---
+
+<<<>>>
+# functional utilities can use `--default(…)` in `--value(…)` and `--modifier(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer, --default(12)); --resolved-modifier: --modifier(integer, --default(34));
+example example-1 example-1/1 example/1
+---
+
+          .example {
+            --resolved-value: 12;
+            --resolved-modifier: 34;
+          }
+
+          .example-1 {
+            --resolved-value: 1;
+            --resolved-modifier: 34;
+          }
+
+          .example-1\/1 {
+            --resolved-value: 1;
+            --resolved-modifier: 1;
+          }
+
+          .example\/1 {
+            --resolved-value: 12;
+            --resolved-modifier: 1;
+          }
+          
+<<<>>>
+# functional utilities can use `--default(…)` in `--value(…)` and `--modifier(…)`
+@config run
+@utility-def example-* --resolved-value: --value(integer, --default(12)); --resolved-modifier: --modifier(integer, --default(34));
+example-123/foo
+---
+
+<<<>>>
+# modifiers
+@config run
+@theme-var value-sm 14px
+@theme-var modifier-7 28px
+@theme-mode value-sm reference
+@theme-mode modifier-7 reference
+@utility-def example-* --resolved-value: --value(--value, [length]); --resolved-modifier: --modifier(--modifier, [length]); --resolved-modifier-with-calc: calc(--modifier(--modifier, [length]) * 2); --resolved-modifier-literals: --modifier('literal', 'literal-2');
+example-[12px] example-[12px]/[16px] example-sm example-sm/7 example-sm/literal example-sm/literal-2
+---
+
+        .example-\[12px\]\/\[16px\] {
+          --resolved-value: 12px;
+          --resolved-modifier: 16px;
+          --resolved-modifier-with-calc: calc(16px * 2);
+        }
+
+        .example-sm\/7 {
+          --resolved-value: var(--value-sm, 14px);
+          --resolved-modifier: var(--modifier-7, 28px);
+          --resolved-modifier-with-calc: calc(var(--modifier-7, 28px) * 2);
+        }
+
+        .example-sm\/literal {
+          --resolved-value: var(--value-sm, 14px);
+          --resolved-modifier-literals: literal;
+        }
+
+        .example-sm\/literal-2 {
+          --resolved-value: var(--value-sm, 14px);
+          --resolved-modifier-literals: literal-2;
+        }
+
+        .example-\[12px\] {
+          --resolved-value: 12px;
+        }
+
+        .example-sm {
+          --resolved-value: var(--value-sm, 14px);
+        }
+        
+<<<>>>
+# modifiers
+@config run
+@utility-def example-* --resolved-value: --value(--value, [length]); --resolved-modifier: --modifier(--modifier, [length]); --resolved-modifier-with-calc: calc(--modifier(--modifier, [length]) * 2); --resolved-modifier-literals: --modifier('literal', 'literal-2');
+example-foo example-foo/12 example-foo/[12px] example-sm/unknown-literal
+---
+
+<<<>>>
+# fractions
+@config run
+@theme-var example-video 16 / 9
+@theme-mode example-video reference
+@utility-def example-* --resolved-value: --value(--example, ratio, [ratio]);
+example-1/1 example-[7/9] example-video
+---
+
+          .example-1\/1 {
+            --resolved-value: 1 / 1;
+          }
+
+          .example-\[7\/9\] {
+            --resolved-value: 7/9;
+          }
+
+          .example-video {
+            --resolved-value: var(--example-video, 16 / 9);
+          }
+          
+<<<>>>
+# fractions
+@config run
+@utility-def example-* --resolved-value: --value(--example, ratio, [ratio]);
+example-foo
+---
+
+<<<>>>
+# resolve theme values with sub-namespace (--text- * --line-height)
+@config run
+@theme-var text-xs 0.75rem
+@theme-var text-xs--line-height calc(1 / 0.75)
+@theme-mode text-xs reference
+@theme-mode text-xs--line-height reference
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-* --line-height); line-height: --modifier(number);
+example-xs example-xs/6
+---
+
+        .example-xs\/6 {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+          line-height: 6;
+        }
+
+        .example-xs {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+        }
+        
+<<<>>>
+# resolve theme values with sub-namespace (--text- * --line-height)
+@config run
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-* --line-height); line-height: --modifier(number);
+example-foo example-xs/foo
+---
+
+<<<>>>
+# resolve theme values with sub-namespace (--text-\\* --line-height)
+@config run
+@theme-var text-xs 0.75rem
+@theme-var text-xs--line-height calc(1 / 0.75)
+@theme-mode text-xs reference
+@theme-mode text-xs--line-height reference
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-\* --line-height); line-height: --modifier(number);
+example-xs example-xs/6
+---
+
+        .example-xs\/6 {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+          line-height: 6;
+        }
+
+        .example-xs {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+        }
+        
+<<<>>>
+# resolve theme values with sub-namespace (--text-\\* --line-height)
+@config run
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-\* --line-height); line-height: --modifier(number);
+example-foo example-xs/foo
+---
+
+<<<>>>
+# resolve theme values with sub-namespace (--value(--text --line-height))
+@config run
+@theme-var text-xs 0.75rem
+@theme-var text-xs--line-height calc(1 / 0.75)
+@theme-mode text-xs reference
+@theme-mode text-xs--line-height reference
+@utility-def example-* font-size: --value(--text); line-height: --value(--text --line-height); line-height: --modifier(number);
+example-xs example-xs/6
+---
+
+        .example-xs\/6 {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+          line-height: 6;
+        }
+
+        .example-xs {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+        }
+        
+<<<>>>
+# resolve theme values with sub-namespace (--value(--text --line-height))
+@config run
+@utility-def example-* font-size: --value(--text); line-height: --value(--text --line-height); line-height: --modifier(number);
+example-foo example-xs/foo
+---
+
+<<<>>>
+# resolve theme values with sub-namespace (--value(--text-*--line-height))
+@config run
+@theme-var text-xs 0.75rem
+@theme-var text-xs--line-height calc(1 / 0.75)
+@theme-mode text-xs reference
+@theme-mode text-xs--line-height reference
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-*--line-height); line-height: --modifier(number);
+example-xs example-xs/6
+---
+
+        .example-xs\/6 {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+          line-height: 6;
+        }
+
+        .example-xs {
+          font-size: var(--text-xs, .75rem);
+          line-height: var(--text-xs--line-height, calc(1 / .75));
+        }
+        
+<<<>>>
+# resolve theme values with sub-namespace (--value(--text-*--line-height))
+@config run
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-*--line-height); line-height: --modifier(number);
+example-foo example-xs/foo
+---
+
+<<<>>>
+# variables used in `@utility` will not be emitted if the utility is not used
+@config run
+@theme-var example-foo red
+@theme-var color-red-500 #f00
+@utility-def example-* color: var(--color-red-500); background-color: --value(--example);
+flex
+---
+
+        .flex {
+          display: flex;
+        }
+        
+<<<>>>
+# variables used in `@utility` will be emitted if the utility is used
+@config run
+@theme-var example-foo red
+@theme-var color-red-500 #f00
+@utility-def example-* color: var(--color-red-500); background-color: --value(--example);
+example-foo
+---
+
+        :root, :host {
+          --example-foo: red;
+          --color-red-500: red;
+        }
+
+        .example-foo {
+          color: var(--color-red-500);
+          background-color: var(--example-foo);
+        }
+        
+<<<>>>
+# resolve value based on `@theme`
+@config run
+@theme-var example-a 8
+@utility-def example-* --resolved-value: --value(--example);
+example-a
+---
+
+      :root, :host {
+        --example-a: 8;
+      }
+
+      .example-a {
+        --resolved-value: var(--example-a);
+      }
+      
+<<<>>>
+# resolve value based on `@theme reference`
+@config run
+@theme-var example-a 8
+@theme-mode example-a reference
+@utility-def example-* --resolved-value: --value(--example);
+example-a
+---
+
+      .example-a {
+        --resolved-value: var(--example-a, 8);
+      }
+      
+<<<>>>
+# resolve value based on `@theme inline`
+@config run
+@theme-var example-a 8
+@theme-mode example-a inline
+@utility-def example-* --resolved-value: --value(--example);
+example-a
+---
+
+      .example-a {
+        --resolved-value: 8;
+      }
+      
+<<<>>>
+# resolve value based on `@theme inline reference`
+@config run
+@theme-var example-a 8
+@theme-mode example-a inline reference
+@utility-def example-* --resolved-value: --value(--example);
+example-a
+---
+
+      .example-a {
+        --resolved-value: 8;
+      }
+      
+<<<>>>
+# sub namespaces can live in different @theme blocks (2)
+@config run
+@theme-var text-xs 0.75rem
+@theme-var text-xs--line-height calc(1 / 0.75)
+@theme-mode text-xs inline reference
+@theme-mode text-xs--line-height reference
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-*--line-height);
+example-xs
+---
+
+      .example-xs {
+        font-size: .75rem;
+        line-height: var(--text-xs--line-height, calc(1 / .75));
+      }
+      
+<<<>>>
+# multiple @utility definitions with the same name but different value types
+@config run
+@theme-var color-red-500 #ef4444
+@theme-var spacing 0.25rem
+@utility-def foo-* color: --value(--color-*);
+@utility-def foo-* font-size: --spacing(--value(number));
+foo-123 foo-red-500
+---
+
+      :root, :host {
+        --color-red-500: #ef4444;
+        --spacing: .25rem;
+      }
+
+      .foo-123 {
+        font-size: calc(var(--spacing) * 123);
+      }
+
+      .foo-red-500 {
+        color: var(--color-red-500);
+      }
+      
 <<<>>>


### PR DESCRIPTION
A functional `@utility tab-*` declaration could not be compiled: `--value()` and `--modifier()` had no resolution, so 43 upstream test names stayed out of the corpus. Forty of them replay now (632 to 696 cases). The three that remain are dropped on a signal computed from the case and logged with its reason.

Getting them green surfaced four bugs, each fixed in its own commit first: the theme layer declared a referenced-but-unset token only for the catalogued colours and `--spacing`, so any other token a utility only read through `var()` named a variable with no value; `--spacing(N)` always expanded to `calc(var(--spacing) * N)` even where the project put `--spacing` in an `@theme inline` block, again naming nothing; `@theme reference` had no representation at all; and `@apply` of a functional declared utility silently produced nothing.