### PR TITLE
changes: note the stack's user-visible fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,12 @@
   render, recognize source boundaries correctly, tokenize entrypoint rewrites,
   and make recursive content scans safe
   (#142, #144, #145, #208, #288, #318, #321).
+- A functional `@utility name-*` resolves `--value()` and `--modifier()`, and
+  `@apply` of one produces its declarations instead of nothing. A token a
+  utility only reads through `var()` is now declared in the theme layer whatever
+  its family, `--spacing(N)` is multiplied out where the project inlines
+  `--spacing`, and an `@theme reference` block is represented (#554).
+- Every `@utility` declared for one name applies, not only the first (#550).
 - Reject conflicting CLI backends instead of silently selecting one (#317).
 - Keep Tailwind's own at-rules out of the generated CSS: `@theme`, `@source`,
   `@plugin`, `@config`, `@reference`, and `@tailwind` used to reach the
@@ -57,6 +63,14 @@
 
 ### Arbitrary values and validation
 
+- An arbitrary length in a variant's class name is spelled as the author wrote
+  it, so the selector matches the markup. `min-[0.5ch]:flex` emitted
+  `.min-\[\.5ch\]\:flex`, a rule nothing on the page could match, for every
+  unit outside a handful (#543).
+- A class whose arbitrary value has an unbalanced paren is rejected rather than
+  compiled. The value was re-parsed inside a `calc()` the code wrapped around
+  it, so the added `)` silently closed the author's stray one and
+  `-left-[0)/*1]` became `left: calc(0 * -1)` (#548).
 - Parse arbitrary lengths, calculations, theme and spacing functions, grid
   tracks, colours, list styles, and custom properties through the shared CSS
   parsers while preserving their original meaning
@@ -144,6 +158,13 @@
 - One malformed declared `@utility` costs only its own class. The re-parse
   answered an error for the whole buffer, so a single unclosed brace silently
   dropped every routed utility in the sheet (#526).
+- `text-indent` and the late text families emit where Tailwind puts them.
+  `text-indent` sat a whole priority band late, and `text-wrap`,
+  `overflow-wrap`/`word-break` and `hyphens` came after the decoration block
+  instead of before white-space (#541, #552).
+- A declared utility's own rules come before the ones its variants wrap in an
+  at-rule, and one whose first property has no order slot sorts among the
+  built-ins instead of opening a second `@layer utilities` (#550).
 
 ### Public OCaml API
 


### PR DESCRIPTION
None of the fourteen PRs below it added a changelog entry. This adds them in the house shape, one entry per observable change with its references, rather than one per PR.