### PR TITLE
test: fail rather than skip when the Tailwind oracle is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,13 @@ jobs:
       - name: Test
         # TW_BROWSER_TESTS=1 turns a missing browser into a failure, so the
         # rendering comparison cannot go back to passing by not running.
+        # TW_TAILWIND_TESTS=1 does the same for the Tailwind CLI: without it a
+        # missing CLI, or one whose version no longer matches the pin, retires
+        # the parity half of the suite into skips that dune swallows on
+        # success, so a lockfile bump would disable it unnoticed.
         env:
           TW_BROWSER_TESTS: 1
+          TW_TAILWIND_TESTS: 1
         run: opam exec -- dune runtest
 
   lint:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,22 +17,26 @@ do not exist.
    than skips. Without it the eight suites calling `check_rendering_matches`
    report no difference because they never looked - which is what CI did until
    #513.
-3. **Doc examples and cram.** `dune build @runtest`. It compiles the MDX
+3. **Tailwind oracle.** `TW_TAILWIND_TESTS=1` set, so a missing CLI, or one
+   whose version differs from `Tailwind_gen.required_version`, fails rather
+   than skips. Without it 159 parity tests skip and the run still says
+   "Test Successful"; the skip lines never reach a `dune runtest` log.
+4. **Doc examples and cram.** `dune build @runtest`. It compiles the MDX
    examples in the `.mli` files and the README, and runs `test/cli/*.t`, which
    covers entrypoint behaviour no Alcotest suite reaches. Read the HEAD of its
    output: a cram diff prints first and `| tail` hides it.
-4. **Sort fuzzer.** Clean across several seeds
+5. **Sort fuzzer.** Clean across several seeds
    (`TEST_SEED=<n> dune exec test/test.exe -- test sort`). It is authoritative;
    a case it reports is a real ordering bug, never something to skip.
-5. **Gates.** `dune build`, `dune build @fmt`, and `merlint` clean.
+6. **Gates.** `dune build`, `dune build @fmt`, and `merlint` clean.
 
 ## Parity (the contract)
 
-6. **Upstream corpus.** `test/upstream/` replays Tailwind's own fixtures and
+7. **Upstream corpus.** `test/upstream/` replays Tailwind's own fixtures and
    must pass without an allowlist. The suite may not take an expected value
    from Tailwind's output and hand it back to tw - breaking a built-in default
    has to fail it (see #512).
-7. **Whole-site measurement.** `sh test/parity/measure.sh` runs tw against
+8. **Whole-site measurement.** `sh test/parity/measure.sh` runs tw against
    Tailwind over the class list of tailwindcss.com. Quote the differ's summary
    line together with the top-level entries under it; the summary counts
    containers rather than their contents, so one `@layer` entry can hide a
@@ -41,19 +45,19 @@ do not exist.
 
 ## Quality (target, non-blocking)
 
-8. **No partial function reachable from a class.** `lib/` still holds
+9. **No partial function reachable from a class.** `lib/` still holds
    `failwith`/`invalid_arg` sites; none is reachable from ordinary input
    (the corpus runs `of_string` then `to_css` over 6491 classes and raises on
    none). Track the count down rather than gate on it.
-9. **No private cascade module.** tw must compile against cascade as an
+10. **No private cascade module.** tw must compile against cascade as an
    *installed* library, not only against the source tree beside it. A name from
    a module in `cascade/lib/dune`'s `private_modules` resolves locally and fails
    CI; check the public `.mli` before using one.
 
 ## Hygiene
 
-10. **Changelog + version.** A `CHANGES.md` entry for the version, every `#N`
+11. **Changelog + version.** A `CHANGES.md` entry for the version, every `#N`
     resolving to a merged PR, and the tag on the current `main` lineage.
-11. **Cascade bound.** `dune-project` and `tw.opam` name a cascade version CI
+12. **Cascade bound.** `dune-project` and `tw.opam` name a cascade version CI
     can resolve. CI pins cascade to its `main`; a local build compiles it from
     source, so green locally is not green on CI.

--- a/examples/accessibility/dune
+++ b/examples/accessibility/dune
@@ -17,7 +17,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run npx tailwindcss -i input.css -o %{targets} --minify))
@@ -26,7 +31,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps accessibility.css tailwind.css)
  (action
   (setenv

--- a/examples/animations/dune
+++ b/examples/animations/dune
@@ -17,7 +17,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run npx tailwindcss -i input.css -o %{targets} --minify))
@@ -26,7 +31,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps animations.css tailwind.css)
  (action
   (setenv

--- a/examples/colors/dune
+++ b/examples/colors/dune
@@ -12,7 +12,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html ../../package-lock.json)
  (action
   (run npx tailwindcss --content index.html -o %{targets} --minify))
@@ -21,7 +26,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps colors.css tailwind.css)
  (action
   (setenv

--- a/examples/dashboard/dune
+++ b/examples/dashboard/dune
@@ -17,7 +17,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run npx tailwindcss -i input.css -o %{targets} --minify))
@@ -26,7 +31,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps dashboard.css tailwind.css)
  (action
   (setenv

--- a/examples/forms/dune
+++ b/examples/forms/dune
@@ -16,7 +16,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run
@@ -35,7 +40,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps forms.css tailwind.css)
  (action
   (setenv

--- a/examples/landing/dune
+++ b/examples/landing/dune
@@ -16,7 +16,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html ../../package-lock.json)
  (action
   (run npx tailwindcss --content index.html -o %{targets} --minify))
@@ -27,7 +32,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps landing.css tailwind.css)
  (action
   (setenv

--- a/examples/layout/dune
+++ b/examples/layout/dune
@@ -17,7 +17,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run npx tailwindcss -i input.css -o %{targets} --minify))
@@ -26,7 +31,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps layout.css tailwind.css)
  (action
   (setenv

--- a/examples/modifiers/dune
+++ b/examples/modifiers/dune
@@ -17,7 +17,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run npx tailwindcss -i input.css -o %{targets} --minify))
@@ -26,7 +31,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps modifiers.css tailwind.css)
  (action
   (setenv

--- a/examples/prose/dune
+++ b/examples/prose/dune
@@ -23,7 +23,12 @@
 
 (rule
  (targets tailwind.css)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps index.html input.css ../../package-lock.json)
  (action
   (run
@@ -42,7 +47,12 @@
 
 (rule
  (alias runtest)
- (enabled_if %{bin-available:npx})
+ ; TW_TAILWIND_TESTS=1 says the CLI is meant to be here, so a missing npx
+ ; fails rather than retiring the comparison from the suite.
+ (enabled_if
+  (or
+   %{bin-available:npx}
+   (= %{env:TW_TAILWIND_TESTS=0} 1)))
  (deps prose.css tailwind.css)
  (action
   (setenv

--- a/lib/tools/cascade_provenance.ml
+++ b/lib/tools/cascade_provenance.ml
@@ -55,6 +55,32 @@ let cascade_pin root =
       in
       loop ()
 
+(* The sha alone does not say how far a live checkout has moved. A sibling
+   checkout parked on someone else's branch fails tw tests that pass against
+   cascade's main, and reading that as a tw regression costs an afternoon; the
+   branch name and the distance are what turn the failure into a question about
+   cascade. *)
+let checkout_position dir =
+  let branch =
+    match Fmt.kstr run_line "git -C %s rev-parse --abbrev-ref HEAD" dir with
+    | Some b -> "branch " ^ b
+    | None -> "detached HEAD"
+  in
+  let distance =
+    match
+      Fmt.kstr run_line "git -C %s rev-list --count origin/main..HEAD" dir
+    with
+    | Some "0" -> "level with origin/main"
+    | Some n -> n ^ " commit(s) not in origin/main"
+    | None -> "distance from origin/main unknown"
+  in
+  let dirty =
+    match Fmt.kstr run_line "git -C %s status --porcelain" dir with
+    | Some _ -> ", uncommitted changes"
+    | None -> ""
+  in
+  branch ^ ", " ^ distance ^ dirty
+
 let report () =
   match repo_root () with
   | None -> ()
@@ -72,16 +98,19 @@ let report () =
           let pin =
             match cascade_pin root with Some p -> p | None -> "(unreadable)"
           in
+          let position = checkout_position cascade_dir in
           match exact_tag with
           | Some tag ->
               Fmt.pr
-                "cascade: local checkout %s (tag %s); dune-project pins %s@."
-                sha tag pin
+                "cascade: local checkout %s (tag %s, %s); dune-project pins \
+                 %s@."
+                sha tag position pin
           | None ->
               Fmt.pr
-                "@.WARNING: cascade checkout %s is not sitting on a release \
-                 tag; dune-project pins %s, and CI resolves that constraint \
-                 through its own opam pin, not this checkout. The cascade/ \
-                 symlink is a live sibling checkout other sessions move, so \
-                 this run may not match what CI compiles.@.@."
-                sha pin))
+                "@.WARNING: cascade checkout %s (%s) is not sitting on a \
+                 release tag; dune-project pins %s, and CI resolves that \
+                 constraint through its own opam pin, not this checkout. The \
+                 cascade/ symlink is a live sibling checkout other sessions \
+                 move, so a test failing here may be failing against cascade \
+                 code that is not on cascade's main.@.@."
+                sha position pin))

--- a/lib/tools/cascade_provenance.mli
+++ b/lib/tools/cascade_provenance.mli
@@ -10,8 +10,12 @@
     directory) it prints nothing. It never raises. *)
 
 val report : unit -> unit
-(** [report ()] prints the local [cascade/] checkout's git revision next to the
-    version range [dune-project] pins for the [cascade] dependency, and a
-    warning when the checkout is not sitting exactly on a release tag (the
-    common case for a live sibling checkout, and the case where CI's
-    opam-resolved cascade can diverge from what this run compiled against). *)
+(** [report ()] prints the local [cascade/] checkout's git revision, the branch
+    it sits on, how many of its commits are not in [origin/main] and whether it
+    has uncommitted changes, next to the version range [dune-project] pins for
+    the [cascade] dependency. It warns when the checkout is not sitting exactly
+    on a release tag (the common case for a live sibling checkout, and the case
+    where CI's opam-resolved cascade can diverge from what this run compiled
+    against). The distance is the part that reads a failure for you: a suite
+    failing against a branch nobody has merged is a question about cascade, not
+    about tw. *)

--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -149,24 +149,30 @@ let command_is_required cmd =
   | Some v -> parse_version v = Some required_version
   | None -> false
 
+(* What a candidate answered, for the failure message. Naming the native binary
+   alone reports "not installed" on a machine that reaches the CLI through npx,
+   which is every CI runner and the case a lockfile bump breaks. *)
+let describe_candidate cmd present =
+  if not present then cmd ^ ": not installed"
+  else
+    match command_version cmd with
+    | Some v -> cmd ^ ": v" ^ v
+    | None -> cmd ^ ": unknown version"
+
 let tailwindcss_command () =
   let have cmd = Sys.command ("which " ^ cmd ^ " > /dev/null 2>&1") = 0 in
   let native = have "tailwindcss" in
+  let npx = have "npx" in
   if native && command_is_required "tailwindcss" then "tailwindcss"
-  else if have "npx" && command_is_required "npx tailwindcss" then
-    "npx tailwindcss"
+  else if npx && command_is_required "npx tailwindcss" then "npx tailwindcss"
   else
-    let found =
-      if native then
-        match command_version "tailwindcss" with
-        | Some v -> "v" ^ v
-        | None -> "unknown version"
-      else "not installed"
-    in
     failwith
-      ("Test setup failed: tailwindcss v"
+      ("tailwindcss v"
       ^ version_string required_version
-      ^ " is required (native: " ^ found
+      ^ " is required ("
+      ^ describe_candidate "tailwindcss" native
+      ^ ", "
+      ^ describe_candidate "npx tailwindcss" npx
       ^ ").\nInstall it with: npm install -g @tailwindcss/cli@"
       ^ version_string required_version)
 
@@ -189,11 +195,11 @@ let check_tailwindcss_available () =
    same thing here, that there is nothing to compare against. Generation is
    separate: once the CLI is known good, a [generate] that produces no CSS still
    raises. *)
-let available () =
-  try
-    check_tailwindcss_available ();
-    true
-  with Failure _ | Sys_error _ -> false
+let availability () =
+  match check_tailwindcss_available () with
+  | () -> Ok ()
+  | exception Failure reason -> Error reason
+  | exception Sys_error reason -> Error reason
 
 (* Statistics tracking *)
 module Stats = struct

--- a/lib/tools/tailwind_gen.mli
+++ b/lib/tools/tailwind_gen.mli
@@ -24,12 +24,14 @@ val check_tailwindcss_available : unit -> unit
 (** [check_tailwindcss_available ()] checks if Tailwind CSS v4 is available.
     @raise Failure if Tailwind CSS is not available or not v4. *)
 
-val available : unit -> bool
-(** [available ()] is [true] iff the required tailwindcss CLI is installed and
-    could be identified. It is [false] when the CLI is missing, answers with
-    another version, or cannot be probed at all, and it never raises. A CLI that
-    is present and then fails to produce CSS is a separate matter: {!generate}
-    raises on that. *)
+val availability : unit -> (unit, string) result
+(** [availability ()] is [Ok ()] iff the required tailwindcss CLI is installed
+    and could be identified. It is [Error reason] when the CLI is missing,
+    answers with another version, or cannot be probed at all, and it never
+    raises; [reason] names what each candidate answered and the version wanted,
+    so a caller can report which of the three it hit. A CLI that is present and
+    then fails to produce CSS is a separate matter: {!generate} raises on that.
+*)
 
 val with_stats : (unit -> 'a) -> 'a
 (** [with_stats f] runs function [f] and prints Tailwind CSS generation

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -30,10 +30,42 @@ let extract_rule_selectors stmts =
 let our_css utilities =
   Tw.to_css ~base:true utilities |> Css.to_string ~minify:true ~lossless:true
 
+(* Parity tests need the pinned tailwindcss CLI. Skipping is right on a
+   developer machine without node, and wrong on CI, where it retires a fifth of
+   the suite into [SKIP] lines that dune swallows on success, so the run reports
+   agreement with a tool it never ran. Set TW_TAILWIND_TESTS=1 where the CLI is
+   meant to be present and a missing or off-version one fails instead. *)
+let tailwind_required () = Sys.getenv_opt "TW_TAILWIND_TESTS" = Some "1"
+
+(* Alcotest files a test's own stderr under [_build/_tests/] and exits the
+   process itself, so a notice written from inside a test, or after
+   [Alcotest.run] returns, is never read. Count the skips and report the total
+   at exit, where it lands next to the summary line that does not mention
+   them. *)
+let skipped_without_cli = ref 0
+
+let note_skip reason =
+  if !skipped_without_cli = 0 then
+    at_exit (fun () ->
+        Fmt.epr "@.%d test(s) skipped: no usable tailwindcss CLI.@.%s@."
+          !skipped_without_cli reason;
+        Fmt.epr "Set TW_TAILWIND_TESTS=1 to fail on this instead of skipping.@.");
+  incr skipped_without_cli
+
+let require_tailwind_cli () =
+  match Tw_tools.Tailwind_gen.availability () with
+  | Ok () -> ()
+  | Error reason ->
+      if tailwind_required () then
+        Alcotest.failf
+          "TW_TAILWIND_TESTS=1 but the tailwindcss CLI is unusable: %s" reason
+      else begin
+        note_skip reason;
+        Alcotest.skip ()
+      end
+
 let tailwind_css ?(forms = false) classnames =
-  (* Parity tests need the pinned tailwindcss CLI; skip where it is absent (e.g.
-     opam-repo-ci has no node). *)
-  if not (Tw_tools.Tailwind_gen.available ()) then Alcotest.skip ();
+  require_tailwind_cli ();
   Tw_tools.Tailwind_gen.generate ~minify:true ~optimize:true ~forms classnames
 
 (* Which CSS properties a class declares. Custom properties count: a drop-shadow

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -17,9 +17,16 @@ val our_css : Tw.t list -> string
 (** [our_css utilities] is tw's stylesheet for [utilities], base layer included
     and minified. *)
 
+val require_tailwind_cli : unit -> unit
+(** [require_tailwind_cli ()] returns when the pinned Tailwind CLI is usable.
+    Otherwise it skips the calling test, or fails it when [TW_TAILWIND_TESTS=1]
+    says the CLI is meant to be there: a parity test that stops asking the
+    oracle reports an agreement it never checked. *)
+
 val tailwind_css : ?forms:bool -> string list -> string
 (** [tailwind_css classnames] is the pinned Tailwind CLI's stylesheet for the
-    same classes. Skips the test when the CLI is unavailable. *)
+    same classes. Goes through {!require_tailwind_cli}, so it skips the test
+    when the CLI is unavailable and fails it under [TW_TAILWIND_TESTS=1]. *)
 
 val properties_of_class : string -> Css.Declaration.prop_key list
 (** [properties_of_class cls] is every property [cls] declares, custom

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -90,9 +90,7 @@ let css_testable =
     String.equal
 
 let check_exact_match tw_styles =
-  (* Parity tests need the pinned tailwindcss CLI; skip where it is absent (e.g.
-     opam-repo-ci has no node). *)
-  if not (Tw_tools.Tailwind_gen.available ()) then Alcotest.skip ();
+  Test_helpers.require_tailwind_cli ();
   (* Prepare classnames and raw CSS strings outside the try to use in
      handlers *)
   let tw_styles = match tw_styles with [] -> [] | styles -> styles in

--- a/test/tools/dune
+++ b/test/tools/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries alcotest tw tw_tools cascade cascade.diff astring))
+ (libraries alcotest tw tw_tools cascade cascade.diff astring test_helpers))

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -1,22 +1,17 @@
 open Alcotest
 open Tw_tools.Tailwind_gen
 
+(* Every test here needs the real CLI, so each opens on the gate: a missing tool
+   skips, and TW_TAILWIND_TESTS=1 fails instead. A CLI that is present and fails
+   to produce CSS raises [Failure] past the gate, and that must reach the
+   runner: catching it would report a broken harness as a pass. *)
 let test_check_available () =
-  (* This just tests that the function doesn't crash *)
-  try
-    check_tailwindcss_available ();
-    check bool "tailwindcss available" true true
-  with Failure _ ->
-    (* If Tailwind is not installed, that's ok for the test *)
-    check bool "tailwindcss check completed" true true
-
-(* A missing CLI is a missing tool, so skip on it. A CLI that is present and
-   fails to produce CSS raises [Failure] too, and that must reach the runner:
-   catching it here would report a broken harness as a pass. *)
-let skip_unless_available () = if not (available ()) then Alcotest.skip ()
+  Test_helpers.require_tailwind_cli ();
+  check_tailwindcss_available ();
+  check bool "tailwindcss available" true true
 
 let test_generate_simple () =
-  skip_unless_available ();
+  Test_helpers.require_tailwind_cli ();
   let css = generate ~minify:true [ "p-4"; "bg-blue-500" ] in
   check bool "generated CSS not empty" true (String.length css > 0);
   check bool "contains p-4 class" true
@@ -29,9 +24,9 @@ let test_generate_simple () =
    tw's "true" value, so pin it to the live CLI here: tw and the real
    tailwindcss must agree (canonically) on these classes. If upstream ever
    changes/fixes the rounding, this fails loudly instead of the allowlist
-   silently masking it. Skips when tailwindcss is unavailable. *)
+   silently masking it. *)
 let test_arbitrary_color_opacity_matches_cli () =
-  skip_unless_available ();
+  Test_helpers.require_tailwind_cli ();
   let check_class cls =
     let cli = generate ~minify:true ~optimize:true ~forms:true [ cls ] in
     let tw =
@@ -59,9 +54,9 @@ let test_arbitrary_color_opacity_matches_cli () =
    entity [&#39;], which the extractor read literally into the selector
    ([.bg-\[url\(\&\#39\;...\)\]]), diverging from tw's [.bg-\[url\(\'...\'\)\]].
    Arbitrary url() values with single quotes must round-trip with no entity
-   mangling. Skips when tailwindcss is unavailable. *)
+   mangling. *)
 let test_arbitrary_url_matches_cli () =
-  skip_unless_available ();
+  Test_helpers.require_tailwind_cli ();
   let cls = "bg-[url('/img/x.svg')]" in
   let cli = generate ~minify:true ~optimize:true [ cls ] in
   check bool


### PR DESCRIPTION
With no usable `tailwindcss` CLI the suite skipped 159 tests and still printed `Test Successful`, and `dune runtest` swallows the skip lines, so half the parity suite could stop asking questions unnoticed. Because the version must match the pin exactly, a lockfile bump had the same effect.

`TW_TAILWIND_TESTS=1` now makes both a failure, set in CI beside the existing `TW_BROWSER_TESTS`. Without it the skip stays, for developers and for opam-repo-ci, but the run says how many tests it skipped and why. The nine example diffs had the same hole at the dune level and are gated the same way.

The pin stays exact. Loosening it relocates the failure rather than removing it: the suite would ask a different question and still report success. `extract_tests.ml` generates the corpus against that version and `RELEASE.md` quotes its measurements, so a bump should be a decision, not a default.

Commit ecb4233f is separate and unrelated to the oracle: the warning about a diverged local `cascade/` checkout printed a bare sha, which is true of every working checkout. It now names the branch, how many commits it carries that `origin/main` does not, and whether the tree is dirty -- a session today misread four failures as a cascade regression on main for exactly this reason.