### PR TITLE
test/parity: gate the whole sheet's utility order against Tailwind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
         # TW_TAILWIND_TESTS=1 does the same for the Tailwind CLI: without it a
         # missing CLI, or one whose version no longer matches the pin, retires
         # the parity half of the suite into skips that dune swallows on
-        # success, so a lockfile bump would disable it unnoticed.
+        # success, so a lockfile bump would disable it unnoticed. The
+        # whole-sheet order gate takes its oracle from that same CLI.
         env:
           TW_BROWSER_TESTS: 1
           TW_TAILWIND_TESTS: 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -208,6 +208,14 @@
   case; the same breakage now fails it (#512).
 - The typography plugin's descendant rules are exercised against real markup
   rather than bare divs, which is most of the largest plugin (#519).
+- A whole-sheet order gate measures where every utility lands, not only the
+  handful a test names. Every Tailwind oracle here runs the differ in canonical
+  mode, which normalises cascade-neutral rule order, so a family emitted in the
+  wrong band was invisible to all of them. The gate reads the statement sequence
+  out of both sheets over the site class list and pins the fewest statements
+  that have to move, which stands at 581 of 3885 unambiguous pairs and only
+  ratchets down. A missing or off-version Tailwind CLI skips it with a line
+  saying so, and `TW_TAILWIND_TESTS=1`, which CI sets, makes that a failure.
 
 ## 1.0.0
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -1,11 +1,11 @@
 Title: Measuring parity with Tailwind
 
-tw aims to produce the same CSS as Tailwind v4.3.3. Two checks in CI measure how
-close it gets, and a third comparison against tailwindcss.com runs by hand.
+tw aims to produce the same CSS as Tailwind v4.3.3. Three checks in CI measure
+how close it gets, and a fuller comparison against tailwindcss.com runs by hand.
 
 ## Checks that run in CI
 
-Both run under `dune runtest`.
+All three run under `dune runtest`.
 
 **Upstream fixtures, `test/upstream/`.** `utilities.txt` and `variants.txt` are
 Tailwind's own test corpus, extracted from the v4.3.3 tag: a class list and the
@@ -22,6 +22,18 @@ guarded by `(enabled_if %{bin-available:npx})`, so it is skipped where npx is
 absent, and `%{bin:cascade}` resolves through the dune workspace, so the diff
 runs the freshly built cascade rather than whatever sits on `PATH`.
 
+**Whole-sheet order, `test/parity/dune`.** The site inputs below feed a third
+check, which takes the top-level statement sequence out of `@layer utilities` on
+each side and reports the fewest statements that have to move for tw's order to
+match Tailwind's. Only keys occurring exactly once on both sides are paired, so
+the number owes nothing to a pairing choice. It is pinned at 581 over 3885 pairs
+and ratchets: the gate fails when it rises and prints the new figure when it
+falls, so the ceiling can be tightened. Both other checks run the differ in
+canonical mode, which normalises cascade-neutral rule order on purpose, so this
+is the only one that sees a family emitted in the wrong band. A missing or
+off-version CLI skips it with a line saying so; `TW_TAILWIND_TESTS=1`, which CI
+sets, turns that into a failure.
+
 ## The site comparison
 
 The comparison against tailwindcss.com finds most real bugs, because it
@@ -36,8 +48,8 @@ sh test/parity/measure.sh
 That takes about 17 seconds on a warm build: a fifth of a second in Tailwind,
 three seconds in tw, the rest in the differ. It writes `ref_local.css`,
 `tw_all.css` and `diff.txt` under `tmp/parity` and prints the diff followed by
-its top-level entries. It is not wired into `dune runtest`, because the
-reference half needs `npx tailwindcss`.
+its top-level entries. The report is not wired into `dune runtest`; the order
+gate above, which reads the same inputs, is.
 
 The inputs are:
 
@@ -161,6 +173,9 @@ report. That is why the sort tests read byte positions out of the sheet
 `check_ordering_matches` goes through the differ, and the differ has nothing to
 say. A priority-band bug in `lib/typography.ml` and `lib/overflow_wrap.ml` was
 invisible to every per-class comparison and was found this way.
+`check_class_order` names the classes it checks, so it pins order inside one
+family and says nothing about where the family sits; `test/parity/dune` covers
+that half by reading the whole sheet.
 
 ### Recurring bug shapes
 

--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -332,10 +332,9 @@ let generate_entrypoint ?(minify = true) entry =
   in
   let start_time = Stats.start_timer () in
   let status =
-    Sys.command
-      (Fmt.str "%s -i %s -o %s%s 2>/dev/null" cmd (Filename.quote entry)
-         (Filename.quote out)
-         (if minify then " --minify" else ""))
+    Fmt.kstr Sys.command "%s -i %s -o %s%s 2>/dev/null" cmd
+      (Filename.quote entry) (Filename.quote out)
+      (if minify then " --minify" else "")
   in
   Stats.record_call (Unix.gettimeofday () -. start_time);
   if status <> 0 then

--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -314,3 +314,33 @@ let generate ?(minify = false) ?(optimize = true) ?forms ?input_css classnames =
   with e ->
     cleanup ();
     raise e
+
+(* A project entrypoint is generated where it sits. Tailwind resolves its
+   [@import]s, its [@source] and its [@plugin]s relative to the file, and
+   [@import "tailwindcss"] against the nearest node_modules above it, so copying
+   the file elsewhere breaks all three; only the output moves. An entrypoint
+   that pins [source(none)] plus an explicit [@source] therefore scans exactly
+   what it names, which is what keeps a comparison against tw from reading tw's
+   own output back in. *)
+let generate_entrypoint ?(minify = true) entry =
+  check_tailwindcss_available ();
+  let out = tmp_file "tw_entry" ".css" in
+  let remove () = try Sys.remove out with Sys_error _ -> () in
+  Fun.protect ~finally:remove @@ fun () ->
+  let cmd =
+    match !tailwind_command with Some c -> c | None -> "tailwindcss"
+  in
+  let start_time = Stats.start_timer () in
+  let status =
+    Sys.command
+      (Fmt.str "%s -i %s -o %s%s 2>/dev/null" cmd (Filename.quote entry)
+         (Filename.quote out)
+         (if minify then " --minify" else ""))
+  in
+  Stats.record_call (Unix.gettimeofday () -. start_time);
+  if status <> 0 then
+    failwith ("Failed to generate Tailwind CSS from the entrypoint " ^ entry);
+  let ic = open_in out in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))

--- a/lib/tools/tailwind_gen.mli
+++ b/lib/tools/tailwind_gen.mli
@@ -36,3 +36,13 @@ val availability : unit -> (unit, string) result
 val with_stats : (unit -> 'a) -> 'a
 (** [with_stats f] runs function [f] and prints Tailwind CSS generation
     statistics afterward. *)
+
+val generate_entrypoint : ?minify:bool -> string -> string
+(** [generate_entrypoint ?minify entry] is the CSS the pinned CLI produces from
+    the project entrypoint at path [entry], minified by default. The entrypoint
+    is read where it sits, so its [@import]s, its [@source] and its [@plugin]s
+    resolve the way they would in the project: an entry pinning [source(none)]
+    plus an explicit [@source] scans exactly what it names and nothing else,
+    which is what keeps a comparison against tw from reading tw's own output
+    back in.
+    @raise Failure if Tailwind CSS is unavailable or the run fails. *)

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -539,6 +539,212 @@ let check_class_order ?forms ~test_name classes =
     test_name expected
     (order "tw" (our_css utilities))
 
+(* Whole-sheet statement order. [class_position] answers where one named class
+   sits, and [check_class_order] asks that of a handful at a time; the pair
+   below asks it of every statement in a layer at once. Both read the minified
+   text rather than a parsed AST, because the order a browser resolves is the
+   order the bytes carry, and both sheets are read the same way, so a difference
+   is tw's and not the reader's. *)
+
+(* One pass over CSS text has to honour strings and escapes, or a [}] inside
+   [content: "}"] closes the wrong block. [skip_quoted s hi i q] is the index
+   after the string that [q] opened at [i]. *)
+let rec skip_quoted s hi i q =
+  if i >= hi then i
+  else if s.[i] = '\\' then skip_quoted s hi (i + 2) q
+  else if s.[i] = q then i + 1
+  else skip_quoted s hi (i + 1) q
+
+(* Whitespace runs collapse to one space, so a prelude reads the same however
+   the printer broke it. *)
+let normalize_prelude s =
+  let buf = Buffer.create (String.length s) in
+  let space = ref false in
+  String.iter
+    (fun c ->
+      match c with
+      | ' ' | '\t' | '\r' | '\n' -> space := true
+      | c ->
+          if !space && Buffer.length buf > 0 then Buffer.add_char buf ' ';
+          space := false;
+          Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+
+(* The statements of [sheet] between [lo] and [hi] as (prelude, body) pairs,
+   where a body is the span inside the braces and [None] marks a [;]-terminated
+   statement such as [@layer a, b;]. Bodies are not descended into: what is
+   measured is one layer's top-level sequence. *)
+let statements_between sheet lo hi =
+  let rec skip_ws i =
+    if i < hi then
+      match sheet.[i] with
+      | ' ' | '\t' | '\r' | '\n' -> skip_ws (i + 1)
+      | _ -> i
+    else i
+  in
+  let rec prelude_end i =
+    if i >= hi then `Eof i
+    else
+      match sheet.[i] with
+      | '\\' -> prelude_end (i + 2)
+      | ('"' | '\'') as q -> prelude_end (skip_quoted sheet hi (i + 1) q)
+      | '{' -> `Block i
+      | ';' -> `Semi i
+      | _ -> prelude_end (i + 1)
+  in
+  let rec block_end i depth =
+    if i >= hi then i
+    else
+      match sheet.[i] with
+      | '\\' -> block_end (i + 2) depth
+      | ('"' | '\'') as q -> block_end (skip_quoted sheet hi (i + 1) q) depth
+      | '{' -> block_end (i + 1) (depth + 1)
+      | '}' -> if depth = 1 then i + 1 else block_end (i + 1) (depth - 1)
+      | _ -> block_end (i + 1) depth
+  in
+  let rec loop i acc =
+    let i = skip_ws i in
+    if i >= hi then List.rev acc
+    else
+      match prelude_end i with
+      | `Eof j ->
+          let last = String.sub sheet i (j - i) in
+          List.rev (if String.trim last = "" then acc else (last, None) :: acc)
+      | `Semi j -> loop (j + 1) ((String.sub sheet i (j - i), None) :: acc)
+      | `Block j ->
+          let e = block_end (j + 1) 1 in
+          loop e ((String.sub sheet i (j - i), Some (j + 1, e - 1)) :: acc)
+  in
+  loop lo []
+
+(* A selector list is one statement but several rules as far as order goes, so
+   each branch is keyed on its own. The split takes a [,] outside any string,
+   escape, [(...)] or [[...]]: [:is(a, b)] and [[title="a,b"]] carry their
+   own. *)
+let selector_branches sel =
+  let hi = String.length sel in
+  let out = ref [] and start = ref 0 and depth = ref 0 and i = ref 0 in
+  let emit stop =
+    let s = String.trim (String.sub sel !start (stop - !start)) in
+    if s <> "" then out := s :: !out
+  in
+  while !i < hi do
+    (match sel.[!i] with
+    | '\\' -> incr i
+    | ('"' | '\'') as q -> i := skip_quoted sel hi (!i + 1) q - 1
+    | '(' | '[' -> incr depth
+    | ')' | ']' -> decr depth
+    | ',' when !depth = 0 ->
+        emit !i;
+        start := !i + 1
+    | _ -> ());
+    incr i
+  done;
+  emit hi;
+  List.rev !out
+
+let layer_statement_keys sheet ~layer =
+  let wanted = "@layer " ^ layer in
+  let body =
+    List.find_map
+      (fun (prelude, body) ->
+        match body with
+        | Some span when normalize_prelude prelude = wanted -> Some span
+        | _ -> None)
+      (statements_between sheet 0 (String.length sheet))
+  in
+  match body with
+  | None -> []
+  | Some (lo, hi) ->
+      List.concat_map
+        (fun (prelude, _) ->
+          let p = normalize_prelude prelude in
+          if p = "" then []
+          else if p.[0] = '@' then [ p ]
+          else selector_branches p)
+        (statements_between sheet lo hi)
+
+(* Patience sorting. [tails.(l)] holds the index of the smallest value that can
+   end an increasing run of length [l + 1], so a binary search places each
+   element and the predecessor links rebuild one longest run. Everything outside
+   that run has to move, and nothing smaller does. *)
+let longest_increasing_subsequence seq =
+  let n = Array.length seq in
+  if n = 0 then [||]
+  else begin
+    let tails = Array.make n 0 and prev = Array.make n (-1) and len = ref 0 in
+    for i = 0 to n - 1 do
+      let lo = ref 0 and hi = ref !len in
+      while !lo < !hi do
+        let mid = (!lo + !hi) / 2 in
+        if seq.(tails.(mid)) < seq.(i) then lo := mid + 1 else hi := mid
+      done;
+      let l = !lo in
+      prev.(i) <- (if l > 0 then tails.(l - 1) else -1);
+      tails.(l) <- i;
+      if l = !len then incr len
+    done;
+    let out = Array.make !len 0 and k = ref tails.(!len - 1) in
+    for j = !len - 1 downto 0 do
+      out.(j) <- !k;
+      k := prev.(!k)
+    done;
+    out
+  end
+
+type order_gap = { pairs : int; moves : int; moved : (string * int * int) list }
+
+let sheet_order_gap ~layer ~tailwind ~tw =
+  let ours = layer_statement_keys tw ~layer in
+  let theirs = layer_statement_keys tailwind ~layer in
+  let occurrences keys =
+    let tbl = Hashtbl.create 4096 in
+    List.iter
+      (fun k ->
+        let n = Option.value ~default:0 (Hashtbl.find_opt tbl k) in
+        Hashtbl.replace tbl k (n + 1))
+      keys;
+    tbl
+  in
+  let ours_count = occurrences ours and theirs_count = occurrences theirs in
+  let ours_at = Hashtbl.create 4096 in
+  List.iteri
+    (fun i k -> if not (Hashtbl.mem ours_at k) then Hashtbl.add ours_at k i)
+    ours;
+  (* Only a key occurring exactly once on each side pairs without a choice, so
+     no pairing decision of the gate's can inflate or deflate what follows. *)
+  let common =
+    List.filter
+      (fun k ->
+        Hashtbl.find_opt ours_count k = Some 1
+        && Hashtbl.find_opt theirs_count k = Some 1)
+      theirs
+    |> Array.of_list
+  in
+  let seq = Array.map (fun k -> Hashtbl.find ours_at k) common in
+  let keep = longest_increasing_subsequence seq in
+  let kept = Hashtbl.create (Array.length keep) in
+  Array.iter (fun i -> Hashtbl.replace kept i ()) keep;
+  (* Rank inside the paired set on each side: a byte offset means nothing to a
+     reader, and a full-sheet index counts statements the pairing dropped. *)
+  let rank = Hashtbl.create (Array.length common) in
+  Array.to_list common
+  |> List.mapi (fun i k -> (seq.(i), k))
+  |> List.sort compare
+  |> List.iteri (fun r (_, k) -> Hashtbl.replace rank k r);
+  let moved = ref [] in
+  Array.iteri
+    (fun i k ->
+      if not (Hashtbl.mem kept i) then
+        moved := (k, i, Hashtbl.find rank k) :: !moved)
+    common;
+  {
+    pairs = Array.length common;
+    moves = Array.length common - Array.length keep;
+    moved = List.rev !moved;
+  }
+
 (** CSS Test Helpers *)
 
 (** Check if a layer exists in the stylesheet *)

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -102,6 +102,38 @@ val check_class_order : ?forms:bool -> test_name:string -> string list -> unit
     positions back is what catches a reorder. Skips when the CLI is unavailable.
 *)
 
+val layer_statement_keys : string -> layer:string -> string list
+(** [layer_statement_keys sheet ~layer] is the sequence of top-level statements
+    inside [sheet]'s [@layer layer] block, in the order the bytes carry, each
+    keyed by its selector or its at-rule prelude. A selector list is expanded
+    onto its branches, since a list is one statement but several rules as far as
+    order goes. [sheet] is read as text, not parsed, so both a tw sheet and a
+    Tailwind one go through the same reader; a sheet with no such layer gives
+    the empty list. *)
+
+type order_gap = {
+  pairs : int;  (** keys occurring exactly once on each side *)
+  moves : int;  (** the fewest of those that have to move *)
+  moved : (string * int * int) list;
+      (** each moved key with its rank among [pairs] on Tailwind's side and on
+          tw's *)
+}
+(** What separates two sheets' statement order, in one number. *)
+
+val sheet_order_gap : layer:string -> tailwind:string -> tw:string -> order_gap
+(** [sheet_order_gap ~layer ~tailwind ~tw] measures how far tw's statement order
+    in [@layer layer] is from Tailwind's. Only keys occurring exactly once on
+    both sides are paired, so no pairing choice of the gate's own can move the
+    number; over those, [moves] is the count outside a longest increasing
+    subsequence, which is the fewest statements that have to move for the orders
+    to agree.
+
+    {!check_class_order} asks the same question of a handful of named classes
+    and {!check_ordering_matches} cannot ask it at all, the canonical differ
+    being blind to a cascade-neutral reorder by design. This is the whole-sheet
+    form: it sees a family placed in the wrong band even when no two utilities
+    it reorders share a property. *)
+
 val render_elements : string list -> string list
 (** [render_elements classnames] is the element list {!check_rendering_matches}
     renders: each class on its own, then one element per {!interacting_pairs}

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -115,8 +115,8 @@ type order_gap = {
   pairs : int;  (** keys occurring exactly once on each side *)
   moves : int;  (** the fewest of those that have to move *)
   moved : (string * int * int) list;
-      (** each moved key with its rank among [pairs] on Tailwind's side and on
-          tw's *)
+      (** each moved key with its rank among {!field-pairs} on Tailwind's side
+          and on tw's *)
 }
 (** What separates two sheets' statement order, in one number. *)
 
@@ -124,7 +124,7 @@ val sheet_order_gap : layer:string -> tailwind:string -> tw:string -> order_gap
 (** [sheet_order_gap ~layer ~tailwind ~tw] measures how far tw's statement order
     in [@layer layer] is from Tailwind's. Only keys occurring exactly once on
     both sides are paired, so no pairing choice of the gate's own can move the
-    number; over those, [moves] is the count outside a longest increasing
+    number; over those, {!field-moves} is the count outside a longest
     subsequence, which is the fewest statements that have to move for the orders
     to agree.
 

--- a/test/parity/dune
+++ b/test/parity/dune
@@ -11,8 +11,18 @@
  (modules sheet_order)
  (libraries fmt tw_tools test_helpers))
 
+; package-lock.json pins the tailwindcss the reference comes from, and the CLI
+; is not a dune dependency of its own, so a version bump has to re-run the
+; measurement rather than leave the cached one standing.
+
 (rule
  (alias runtest)
- (deps ref-entry.css globals.css search.css typography.css classlist.txt)
+ (deps
+  ref-entry.css
+  globals.css
+  search.css
+  typography.css
+  classlist.txt
+  ../../package-lock.json)
  (action
   (run %{exe:sheet_order.exe} %{exe:../../bin/main.exe})))

--- a/test/parity/dune
+++ b/test/parity/dune
@@ -1,0 +1,18 @@
+; The whole-sheet order gate. It reads the same inputs measure.sh does, and
+; reduces the comparison to one number per layer rather than a report to read.
+;
+; It is a rule rather than a (test) stanza because the tw half has to come from
+; the built binary: the entrypoint pipeline that compiles globals.css lives in
+; bin/main.ml, and running it is what keeps the gate measuring the sheet the
+; documented command produces.
+
+(executable
+ (name sheet_order)
+ (modules sheet_order)
+ (libraries fmt tw_tools test_helpers))
+
+(rule
+ (alias runtest)
+ (deps ref-entry.css globals.css search.css typography.css classlist.txt)
+ (action
+  (run %{exe:sheet_order.exe} %{exe:../../bin/main.exe})))

--- a/test/parity/dune
+++ b/test/parity/dune
@@ -8,7 +8,6 @@
 
 (executable
  (name sheet_order)
- (modules sheet_order)
  (libraries fmt tw_tools test_helpers))
 
 ; package-lock.json pins the tailwindcss the reference comes from, and the CLI

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -1,0 +1,132 @@
+(* The whole-sheet order gate: [measure.sh] reduced to one number that can only
+   go down.
+
+   Every other Tailwind oracle in the repo runs the differ in canonical mode,
+   which normalises cascade-neutral rule order on purpose, so a family emitted
+   in the wrong band is invisible to all of them - [check_ordering_matches]
+   included, despite its name. [check_class_order] does read positions back, but
+   its call sites pass one family at a time, which pins order inside a family
+   and says nothing about where the family sits.
+
+   This measures the whole sheet. Both sides are generated over the committed
+   site class list, the top-level statement sequence of a layer is taken out of
+   each, and the two are compared over the keys that occur exactly once on both
+   sides, where no pairing choice exists. What is reported is the fewest
+   statements that have to move for the orders to agree.
+
+   The numbers below are pinned, not aspirational: the gate fails when one goes
+   up and prints the new figure when it goes down, so the ceiling can be
+   tightened. *)
+
+module Tailwind_gen = Tw_tools.Tailwind_gen
+
+(* Measured 2026-08-30 over [classlist.txt], 4825 classes of tailwindcss.com.
+   [pairs] is pinned as a floor as well: a sheet that lost most of its rules
+   would otherwise have nothing left to be out of order, and the gate would read
+   that as a pass. *)
+let pinned =
+  [
+    ("utilities", `Moves 581, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+  ]
+
+(* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
+   reports a sheet as correctly ordered because nothing looked. Set
+   TW_TAILWIND_TESTS=1 where the CLI is meant to be present and a missing or
+   off-version one fails instead. *)
+let required () = Sys.getenv_opt "TW_TAILWIND_TESTS" = Some "1"
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+(* tw's half comes from the built binary rather than from the library, so what
+   is measured is the sheet the documented command produces, entrypoint
+   compilation and all. *)
+let tw_sheet tw_bin =
+  let out = Filename.temp_file ~temp_dir:"." "tw_all" ".css" in
+  let remove () = try Sys.remove out with Sys_error _ -> () in
+  Fun.protect ~finally:remove @@ fun () ->
+  let cmd =
+    Fmt.str "%s --input-css globals.css --minify classlist.txt > %s"
+      (Filename.quote tw_bin) (Filename.quote out)
+  in
+  if Sys.command cmd <> 0 then failwith ("failed to run " ^ tw_bin);
+  read_file out
+
+let sample = 25
+
+let report_moved moved =
+  let shown = List.filteri (fun i _ -> i < sample) moved in
+  List.iter
+    (fun (key, tailwind_rank, tw_rank) ->
+      Fmt.pr "    %-58s Tailwind #%d, tw #%d@." key tailwind_rank tw_rank)
+    shown;
+  let hidden = List.length moved - List.length shown in
+  if hidden > 0 then Fmt.pr "    ... and %d more@." hidden
+
+let check ~tailwind ~tw (layer, `Moves ceiling, `Pairs floor) =
+  let gap = Test_helpers.sheet_order_gap ~layer ~tailwind ~tw in
+  Fmt.pr "@@layer %s: %d of %d unambiguous pairs must move (ceiling %d)@." layer
+    gap.Test_helpers.moves gap.Test_helpers.pairs ceiling;
+  if gap.Test_helpers.pairs < floor then begin
+    Fmt.pr
+      "  FAIL: only %d pairs left to compare, was at least %d. The measurement \
+       got weaker, so the count above says less than it did.@."
+      gap.Test_helpers.pairs floor;
+    false
+  end
+  else if gap.Test_helpers.moves > ceiling then begin
+    Fmt.pr
+      "  FAIL: %d more statements are out of Tailwind's order than before.@."
+      (gap.Test_helpers.moves - ceiling);
+    Fmt.pr "  What moved, %d of %d shown:@."
+      (min sample gap.Test_helpers.moves)
+      gap.Test_helpers.moves;
+    report_moved gap.Test_helpers.moved;
+    Fmt.pr
+      "  The ranks are positions among the paired statements, so a large gap \
+       is a family sorted into the wrong band.@.";
+    false
+  end
+  else begin
+    if gap.Test_helpers.moves < ceiling then
+      Fmt.pr
+        "  IMPROVED: %d fewer than the pinned %d. Tighten the ceiling in \
+         test/parity/sheet_order.ml to %d.@."
+        (ceiling - gap.Test_helpers.moves)
+        ceiling gap.Test_helpers.moves;
+    true
+  end
+
+let () =
+  let tw_bin =
+    if Array.length Sys.argv > 1 then Sys.argv.(1)
+    else failwith "usage: sheet_order.exe <path to the tw binary>"
+  in
+  if not (Tailwind_gen.available ()) then begin
+    let reason =
+      "the pinned tailwindcss CLI is missing or answers with another version"
+    in
+    if required () then begin
+      Fmt.epr "whole-sheet order gate: TW_TAILWIND_TESTS=1 but %s@." reason;
+      exit 1
+    end
+    else begin
+      Fmt.pr
+        "whole-sheet order gate SKIPPED: %s. Set TW_TAILWIND_TESTS=1 to make \
+         that a failure.@."
+        reason;
+      exit 0
+    end
+  end;
+  let tailwind = Tailwind_gen.generate_entrypoint "ref-entry.css" in
+  let tw = tw_sheet tw_bin in
+  let ok = List.for_all Fun.id (List.map (check ~tailwind ~tw) pinned) in
+  if not ok then begin
+    Fmt.pr
+      "@.Re-derive by hand with `sh test/parity/measure.sh`; docs/parity.md \
+       reads the output.@.";
+    exit 1
+  end

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -20,7 +20,14 @@
 
 module Tailwind_gen = Tw_tools.Tailwind_gen
 
-(* Measured 2026-08-30 over [classlist.txt], 4825 classes of tailwindcss.com.
+(* Measured 2026-08-30 over [classlist.txt], 4825 classes of tailwindcss.com,
+   against cascade main at e829b2d6. Both keys and grouping come out of
+   cascade's printer, so the number is only comparable against the cascade a run
+   was built with, and every run prints which one that was. CI resolves cascade
+   through opam from the range [dune-project] pins; a local [cascade/] symlink
+   sitting on someone's branch is the first thing to check when the count moves
+   for no reason in the sort code.
+
    [pairs] is pinned as a floor as well: a sheet that lost most of its rules
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
@@ -101,6 +108,8 @@ let check ~tailwind ~tw (layer, `Moves ceiling, `Pairs floor) =
   end
 
 let () =
+  (* Which cascade this run compiled against, since the count depends on it. *)
+  Tw_tools.Cascade_provenance.report ();
   let tw_bin =
     if Array.length Sys.argv > 1 then Sys.argv.(1)
     else failwith "usage: sheet_order.exe <path to the tw binary>"

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -114,22 +114,20 @@ let () =
     if Array.length Sys.argv > 1 then Sys.argv.(1)
     else failwith "usage: sheet_order.exe <path to the tw binary>"
   in
-  if not (Tailwind_gen.available ()) then begin
-    let reason =
-      "the pinned tailwindcss CLI is missing or answers with another version"
-    in
-    if required () then begin
-      Fmt.epr "whole-sheet order gate: TW_TAILWIND_TESTS=1 but %s@." reason;
-      exit 1
-    end
-    else begin
-      Fmt.pr
-        "whole-sheet order gate SKIPPED: %s. Set TW_TAILWIND_TESTS=1 to make \
-         that a failure.@."
-        reason;
-      exit 0
-    end
-  end;
+  (match Tailwind_gen.availability () with
+  | Ok () -> ()
+  | Error reason ->
+      if required () then begin
+        Fmt.epr "whole-sheet order gate: TW_TAILWIND_TESTS=1 but %s@." reason;
+        exit 1
+      end
+      else begin
+        Fmt.pr
+          "whole-sheet order gate SKIPPED: %s. Set TW_TAILWIND_TESTS=1 to make \
+           that a failure.@."
+          reason;
+        exit 0
+      end);
   let tailwind = Tailwind_gen.generate_entrypoint "ref-entry.css" in
   let tw = tw_sheet tw_bin in
   let ok = List.for_all Fun.id (List.map (check ~tailwind ~tw) pinned) in

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -123,6 +123,59 @@ let test_render_elements_are_unique_and_ordered () =
     [ "m-2"; "ml-2"; "m-2 ml-2" ]
     (Test_helpers.render_elements [ "m-2"; "ml-2"; "m-2" ])
 
+(* The whole-sheet reader, on a sheet spelling every shape it has to survive: a
+   [;]-terminated [@layer] list, a layer that is not the wanted one, a selector
+   list, a nested at-rule block, and a [}] inside a string. *)
+let layered =
+  "@layer theme,utilities;" ^ "@layer theme{:root{--spacing:.25rem}}"
+  ^ "@layer utilities{" ^ ".flex{display:flex}" ^ ".a,.b{color:red}"
+  ^ ".q:before{content:\"}\"}"
+  ^ "@media (min-width:40rem){.md\\:flex{display:flex}}" ^ "}"
+
+let test_layer_keys_expand_and_stop_at_the_layer () =
+  Alcotest.(check (list string))
+    "the utilities layer's own statements, selector lists expanded"
+    [ ".flex"; ".a"; ".b"; ".q:before"; "@media (min-width:40rem)" ]
+    (Test_helpers.layer_statement_keys layered ~layer:"utilities")
+
+let test_layer_keys_absent_layer () =
+  Alcotest.(check (list string))
+    "a layer the sheet does not declare has no statements" []
+    (Test_helpers.layer_statement_keys layered ~layer:"components")
+
+let utilities_layer selectors =
+  "@layer utilities{"
+  ^ String.concat "" (List.map (fun s -> s ^ "{color:red}") selectors)
+  ^ "}"
+
+let gap ~tailwind ~tw =
+  Test_helpers.sheet_order_gap ~layer:"utilities"
+    ~tailwind:(utilities_layer tailwind) ~tw:(utilities_layer tw)
+
+(* One swapped pair is one statement out of place, not two: moving either half
+   past the other settles it, and the gate reports the minimum. *)
+let test_order_gap_counts_the_minimum_move () =
+  let g =
+    gap ~tailwind:[ ".a"; ".b"; ".c"; ".d" ] ~tw:[ ".b"; ".a"; ".c"; ".d" ]
+  in
+  Alcotest.(check (pair int int))
+    "four pairs, one has to move" (4, 1)
+    (g.Test_helpers.pairs, g.Test_helpers.moves)
+
+(* A key either side spells twice could be paired with either occurrence, so it
+   is left out rather than counted under a guess. *)
+let test_order_gap_drops_a_repeated_key () =
+  let g = gap ~tailwind:[ ".x"; ".y"; ".z" ] ~tw:[ ".z"; ".y"; ".x"; ".x" ] in
+  Alcotest.(check (pair int int))
+    "the repeated key leaves two pairs, one of them moved" (2, 1)
+    (g.Test_helpers.pairs, g.Test_helpers.moves)
+
+let test_order_gap_agreeing_sheets () =
+  let g = gap ~tailwind:[ ".a"; ".b"; ".c" ] ~tw:[ ".a"; ".b"; ".c" ] in
+  Alcotest.(check (pair int int))
+    "nothing moves when the orders agree" (3, 0)
+    (g.Test_helpers.pairs, g.Test_helpers.moves)
+
 let tests =
   [
     Alcotest.test_case "class position: continuing selector" `Quick
@@ -147,6 +200,16 @@ let tests =
       test_unrelated_classes_are_not_paired;
     Alcotest.test_case "render elements are unique and ordered" `Quick
       test_render_elements_are_unique_and_ordered;
+    Alcotest.test_case "layer keys: expanded and layer-bounded" `Quick
+      test_layer_keys_expand_and_stop_at_the_layer;
+    Alcotest.test_case "layer keys: absent layer" `Quick
+      test_layer_keys_absent_layer;
+    Alcotest.test_case "order gap: minimum move" `Quick
+      test_order_gap_counts_the_minimum_move;
+    Alcotest.test_case "order gap: repeated key" `Quick
+      test_order_gap_drops_a_repeated_key;
+    Alcotest.test_case "order gap: agreeing sheets" `Quick
+      test_order_gap_agreeing_sheets;
   ]
 
 let suite = ("test_helpers", tests)


### PR DESCRIPTION
A reorder among utilities with disjoint properties is cascade-neutral, so the canonical differ folds it away and every Tailwind oracle in the repo is canonical. Ordering was therefore unmeasured: `check_ordering_matches` asks the differ and the differ has nothing to say, and 14 of `check_class_order`'s 18 call sites pass a single family, so they pin order within a family and say nothing about where the family sits.

This adds a gate that reads both sheets' `@layer utilities` statement order and reports the minimum number of statements that must move. It stands at 581 of 3885 unambiguous pairs; `@layer components` is 0 of 50. The ceiling is pinned there and only goes down.

It pins a floor on the pair count too: without one, a tw sheet that lost most of its rules would have nothing left to be out of order and the gate would read that as a pass. The number is unchanged across three cascade checkouts, so it should not move for anyone else, and each run prints which cascade it compiled against.