### PR TITLE
test: sweep adversarial arbitrary values over every family

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1701,7 +1701,10 @@ module Handler = struct
             )
         | None, _ -> Error (`Msg ("Unknown direction: " ^ dir_s)))
     (* bg-linear-[value] - bracket linear gradient *)
-    | [ "bg"; "linear"; bracket ] when Parse.is_bracket_value bracket ->
+    | [ "bg"; "linear"; bracket ]
+      when Parse.is_bracket_value bracket
+           && Parse.is_declaration_value
+                (Parse.decode_underscores (Parse.bracket_inner bracket)) ->
         let inner = Parse.bracket_inner bracket in
         Ok (Bg_linear_bracket inner)
     (* bg-linear-{angle} and bg-linear-{angle}/interp *)
@@ -1787,7 +1790,10 @@ module Handler = struct
         | Some css -> Ok (Bg_radial_interp (interp, css))
         | None -> Error (`Msg ("Invalid gradient interpolation: " ^ interp)))
     (* bg-radial-[value] - bracket radial gradient *)
-    | [ "bg"; "radial"; bracket ] when Parse.is_bracket_value bracket ->
+    | [ "bg"; "radial"; bracket ]
+      when Parse.is_bracket_value bracket
+           && Parse.is_declaration_value
+                (Parse.decode_underscores (Parse.bracket_inner bracket)) ->
         let inner = Parse.bracket_inner bracket in
         Ok (Bg_radial_bracket inner)
     (* bg-position-[...] bracket notation *)

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -41,7 +41,7 @@ module Handler = struct
     | Basis_full
     | Basis_fraction of int * int
     | Basis_named of string
-    | Basis_arbitrary of Css.flex_basis (* basis-[123px] *)
+    | Basis_arbitrary of string * Css.flex_basis (* basis-[123px] *)
     (* Order *)
     | Order of int
     | Neg_order of int (* -order-4 = calc(4 * -1) *)
@@ -197,7 +197,7 @@ module Handler = struct
     | Basis_full -> basis_full
     | Basis_fraction (n, m) -> basis_fraction_style n m
     | Basis_named name -> basis_named_style name
-    | Basis_arbitrary len -> style [ flex_basis len ]
+    | Basis_arbitrary (_, len) -> style [ flex_basis len ]
     | Order n -> order_style n
     | Neg_order n -> style [ order (Int (-n)) ]
     | Neg_order_arbitrary (_, o) ->
@@ -332,7 +332,7 @@ module Handler = struct
           | value -> value
           | exception Cascade.Cursor.Parse_error _ -> None)
         |> Option.fold ~none:err_not_utility ~some:(fun value ->
-            Ok (Basis_arbitrary value))
+            Ok (Basis_arbitrary (inner, value)))
     | [ "basis"; value ] -> (
         match Parse.decimal_int value with
         | Some n when n >= 0 -> Ok (Basis_spacing n)
@@ -432,10 +432,7 @@ module Handler = struct
     | Basis_fraction (n, m) ->
         "basis-" ^ string_of_int n ^ "/" ^ string_of_int m
     | Basis_named s -> "basis-" ^ s
-    | Basis_arbitrary len ->
-        "basis-["
-        ^ Css.Pp.to_string ~minify:true Css.Properties.pp_flex_basis len
-        ^ "]"
+    | Basis_arbitrary (raw, _) -> "basis-[" ^ raw ^ "]"
     (* Order *)
     | Order n -> "order-" ^ string_of_int n
     | Neg_order n -> "-order-" ^ string_of_int n

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -938,10 +938,12 @@ module Handler = struct
   (* Parse a value from the class suffix *)
   let parse_value suffix =
     if String.length suffix > 0 && suffix.[0] = '[' then
-      (* Arbitrary value - reject negative values *)
+      (* Arbitrary value - reject negative values, and any text that would not
+         stay inside the declaration it is written into. *)
       if Parse.is_bracket_value suffix then
         let inner = Parse.bracket_inner suffix in
         if String.length inner > 0 && inner.[0] = '-' then Option.none
+        else if not (Parse.is_declaration_value inner) then Option.none
         else Option.some (Arbitrary inner)
       else Option.none
     else if String.length suffix > 0 && suffix.[String.length suffix - 1] = '%'
@@ -1138,7 +1140,9 @@ module Handler = struct
         let size_value =
           String.map (fun c -> if c = '_' then ' ' else c) size_value
         in
-        Ok (Mask_radial_size (Arbitrary_size size_value))
+        if not (Parse.is_declaration_value size_value) then
+          Error (`Msg ("Invalid mask-radial size: " ^ size_value))
+        else Ok (Mask_radial_size (Arbitrary_size size_value))
     | _ -> Error (`Msg "Not a mask gradient utility")
 
   let format_value = function

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -64,9 +64,8 @@ let arbitrary_breakpoint_class prefix (w : Style.arbitrary_px) cls =
 let compact_length = Style.compact_length
 
 (** Build class selector for an arbitrary length breakpoint *)
-let arbitrary_length_class prefix (l : Css.length) cls =
-  let len_str = compact_length l in
-  Css.Selector.Class (prefix ^ "[" ^ len_str ^ "]:" ^ cls)
+let arbitrary_length_class prefix (l : Style.arbitrary_length) cls =
+  Css.Selector.Class (prefix ^ "[" ^ l.text ^ "]:" ^ cls)
 
 (* Substitute the resolved value into a template's [{}] placeholder. *)
 let custom_variant_apply template value =
@@ -1054,7 +1053,10 @@ let extract_bracket_content_with_name ~prefix s =
 (* Parse a CSS length from a string like "600px", "40rem", "100vh". Arbitrary
    value syntax is decoded first, so [min-[calc(1000px+12em)]] becomes a
    spec-valid [calc(1000px + 12em)] the length reader accepts. *)
-let parse_css_length s : Css.length option = Parse.arbitrary_length s
+let parse_css_length s : Style.arbitrary_length option =
+  Option.map
+    (fun len : Style.arbitrary_length -> { len; text = s })
+    (Parse.arbitrary_length s)
 
 (* Parse a pixel value from a string like "600px" or "600", keeping the
    spelling: it is what the variant's own class is named after. *)

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1659,6 +1659,21 @@ let is_not_compatible = function
       false
   | _ -> true
 
+(* [not-[...]] whose content is neither a media condition nor a pseudo-class
+   negates the content read as a selector, so text the selector grammar cannot
+   read - or can read only a prefix of - is not a negation at all. The reader
+   raises rather than answering, and it stops at the first thing it cannot use,
+   so the cursor has to be exhausted too: a trailing remainder would otherwise
+   be dropped and the rule would negate less than the class says. *)
+let reads_as_selector content =
+  let s = String.map (fun c -> if c = '_' then ' ' else c) content in
+  let cursor = Cascade.Cursor.of_string s in
+  match Css.Selector.read cursor with
+  | exception (Cascade.Cursor.Parse_error _ | Invalid_argument _) -> false
+  | _ ->
+      Cascade.Cursor.ws cursor;
+      Cascade.Cursor.is_done cursor
+
 (** Check if bracket content is valid for not-[...] patterns. Rejects combinator
     selectors (+, >, ~), media conditions with commas, and bare selectors. *)
 let is_valid_not_bracket_content content =
@@ -1672,7 +1687,8 @@ let is_valid_not_bracket_content content =
       (String.length content > 6 && String.sub content 0 6 = "@media")
       || (String.length content > 7 && String.sub content 0 7 = "@media_")
     then not (String.contains content ',')
-    else true
+    else if first = ':' then true
+    else reads_as_selector content
 
 (** Try parsing a not-[...] bracket pattern. Returns the Not_bracket modifier
     for pseudo-class or media bracket content. *)

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -329,6 +329,14 @@ let arbitrary_length_percentage s =
    that are not CSS, and passing one through emits an invalid declaration. *)
 let is_ident = Cascade.Syntax.is_ident
 
+(* An arbitrary value reaching a custom property is author text, so it can carry
+   a top-level [;] or [}] that ends the declaration early, or an unterminated
+   function, block or string that swallows the rest of the rule. cascade refuses
+   such a pair from [custom_property] by raising, which is right for a caller
+   holding CSS it wrote; here the text comes from a class name, so the class is
+   the thing to refuse. Tailwind refuses the same ones. *)
+let is_declaration_value = Cascade.Css.Declaration.is_declaration_value
+
 (** Check if a string starts with "var(" — works on inner bracket content *)
 let is_var s = String.length s > 4 && String.sub s 0 4 = "var("
 

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -94,6 +94,16 @@ val is_ident : string -> bool
     {!Cascade.Syntax.is_ident}, which is the CSS Syntax 3 grammar: a bare [-], a
     [-] before a digit, and a leading digit all open no ident. *)
 
+val is_declaration_value : string -> bool
+(** [is_declaration_value s] is [true] when [s] can be the whole value of one
+    declaration: no top-level [;], no unmatched closing bracket, and no
+    unterminated function, block or string (CSS Syntax 3 (ED) sec. 7.2).
+
+    A bracket value that fails this ends the declaration it is written into, or
+    swallows the rest of the rule, so the class carrying it is refused rather
+    than emitted. {!Cascade.Css.custom_property} takes the same values and
+    raises on the rest. *)
+
 val starts_with_math_function : string -> bool
 (** [starts_with_math_function s] is [true] when [s] opens with a CSS math
     function ([calc], [min], [max], [clamp], ...). A utility whose bracket takes

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -291,11 +291,9 @@ let responsive_modifier_condition ?theme = function
   | Style.Max_arbitrary w ->
       (media_not_min_width_px w.px, "max-[" ^ w.text ^ "]")
   | Style.Min_arbitrary_length l ->
-      let len_str = Modifiers.compact_length l in
-      (Css.media_min_width_length l, "min-[" ^ len_str ^ "]")
+      (Css.media_min_width_length l.len, "min-[" ^ l.text ^ "]")
   | Style.Max_arbitrary_length l ->
-      let len_str = Modifiers.compact_length l in
-      (Css.media_not_min_width_length l, "max-[" ^ len_str ^ "]")
+      (Css.media_not_min_width_length l.len, "max-[" ^ l.text ^ "]")
   | Style.Custom_responsive name ->
       let length =
         match Scheme.breakpoint_length (resolve_scheme theme) name with
@@ -390,21 +388,22 @@ let max_arbitrary_rule ?inner_has_hover (w : Style.arbitrary_px) base_class
     (media_not_min_width_px w.px)
     base_class selector props
 
-let arbitrary_length_rule ?inner_has_hover prefix condition l base_class
-    selector props =
-  let len_str = Modifiers.compact_length l in
+let arbitrary_length_rule ?inner_has_hover prefix condition
+    (l : Style.arbitrary_length) base_class selector props =
   media_rule_with_prefix ?inner_has_hover
-    (prefix ^ "-[" ^ len_str ^ "]")
+    (prefix ^ "-[" ^ l.text ^ "]")
     condition base_class selector props
 
-let min_arbitrary_length_rule ?inner_has_hover l base_class selector props =
+let min_arbitrary_length_rule ?inner_has_hover (l : Style.arbitrary_length)
+    base_class selector props =
   arbitrary_length_rule ?inner_has_hover "min"
-    (Css.media_min_width_length l)
+    (Css.media_min_width_length l.len)
     l base_class selector props
 
-let max_arbitrary_length_rule ?inner_has_hover l base_class selector props =
+let max_arbitrary_length_rule ?inner_has_hover (l : Style.arbitrary_length)
+    base_class selector props =
   arbitrary_length_rule ?inner_has_hover "max"
-    (Css.media_not_min_width_length l)
+    (Css.media_not_min_width_length l.len)
     l base_class selector props
 
 let custom_breakpoint ?theme name =
@@ -1134,11 +1133,11 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
       not_media_rule ~condition:(media_min_width_px w.px) modified_class props
   | Style.Min_arbitrary_length l ->
       not_media_rule
-        ~condition:(Css.media_not_min_width_length l)
+        ~condition:(Css.media_not_min_width_length l.len)
         modified_class props
   | Style.Max_arbitrary_length l ->
       not_media_rule
-        ~condition:(Css.media_min_width_length l)
+        ~condition:(Css.media_min_width_length l.len)
         modified_class props
   | _ -> [ sel_rule () ]
 

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -69,6 +69,11 @@ type container_query =
    exponent. *)
 type arbitrary_px = { px : float; text : string }
 
+(* Same for a breakpoint written as a CSS length: the length reader stops at the
+   first thing it cannot use, so re-printing it drops any remainder as well as
+   respelling the number. The class is named after [text]. *)
+type arbitrary_length = { len : Css.length; text : string }
+
 type modifier =
   | Hover
   | Focus
@@ -82,8 +87,8 @@ type modifier =
   | Max_responsive of breakpoint
   | Min_arbitrary of arbitrary_px
   | Max_arbitrary of arbitrary_px
-  | Min_arbitrary_length of Css.length
-  | Max_arbitrary_length of Css.length
+  | Min_arbitrary_length of arbitrary_length
+  | Max_arbitrary_length of arbitrary_length
   | Peer_hover
   | Peer_focus
   | Peer_checked
@@ -498,8 +503,8 @@ let rec pp_modifier = function
   | Max_responsive `Xl_2 -> "max-2xl"
   | Min_arbitrary w -> String.concat "" [ "min-["; w.text; "]" ]
   | Max_arbitrary w -> String.concat "" [ "max-["; w.text; "]" ]
-  | Min_arbitrary_length l -> "min-[" ^ compact_length l ^ "]"
-  | Max_arbitrary_length l -> "max-[" ^ compact_length l ^ "]"
+  | Min_arbitrary_length l -> String.concat "" [ "min-["; l.text; "]" ]
+  | Max_arbitrary_length l -> String.concat "" [ "max-["; l.text; "]" ]
   | Container q -> "@" ^ container_size_name q
   | Group_hover -> "group-hover"
   | Group_focus -> "group-focus"

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -43,6 +43,15 @@ type arbitrary_px = {
     in: re-printing [px] drops a trailing zero, a leading zero or an exponent
     and leaves a selector the markup does not carry. *)
 
+type arbitrary_length = {
+  len : Css.length;  (** the length the bracket denotes *)
+  text : string;  (** the bracket as the author wrote it, e.g. ["1px/*x"] *)
+}
+(** A [min-[<len>]] or [max-[<len>]] breakpoint written as a CSS length. Same
+    reason as {!arbitrary_px} for keeping the text: the length reader stops at
+    the first thing it cannot use, so re-printing the length respells the number
+    and drops any remainder, leaving a selector the markup does not carry. *)
+
 type modifier =
   | Hover
   | Focus
@@ -56,8 +65,8 @@ type modifier =
   | Max_responsive of breakpoint
   | Min_arbitrary of arbitrary_px
   | Max_arbitrary of arbitrary_px
-  | Min_arbitrary_length of Css.length
-  | Max_arbitrary_length of Css.length
+  | Min_arbitrary_length of arbitrary_length
+  | Max_arbitrary_length of arbitrary_length
   | Peer_hover
   | Peer_focus
   | Peer_checked

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -101,7 +101,7 @@ module Handler = struct
     | Perspective_normal
     | Perspective_midrange
     | Perspective_distant
-    | Perspective_arbitrary of Css.length
+    | Perspective_arbitrary of string * Css.length
     | (* Perspective origin *)
       Perspective_origin_center
     | Perspective_origin_top
@@ -1324,7 +1324,7 @@ module Handler = struct
     | Perspective_normal -> perspective_normal
     | Perspective_midrange -> perspective_midrange
     | Perspective_distant -> perspective_distant
-    | Perspective_arbitrary len -> perspective_arbitrary len
+    | Perspective_arbitrary (_, len) -> perspective_arbitrary len
     | Perspective_origin_center -> perspective_origin_center ()
     | Perspective_origin_top -> perspective_origin_top ()
     | Perspective_origin_bottom -> perspective_origin_bottom ()
@@ -1807,7 +1807,7 @@ module Handler = struct
       when match rest with "origin" :: _ | [] -> false | _ -> true -> (
         let value = String.concat "-" rest in
         match parse_bracket_length value with
-        | Ok len -> Ok (Perspective_arbitrary len)
+        | Ok len -> Ok (Perspective_arbitrary (Parse.bracket_inner value, len))
         | Error _ -> err_not_utility)
     | [ "perspective"; "origin"; "center" ] -> Ok Perspective_origin_center
     | [ "perspective"; "origin"; "top" ] -> Ok Perspective_origin_top
@@ -1986,8 +1986,7 @@ module Handler = struct
     | Perspective_normal -> "perspective-normal"
     | Perspective_midrange -> "perspective-midrange"
     | Perspective_distant -> "perspective-distant"
-    | Perspective_arbitrary len ->
-        "perspective-[" ^ Css.Pp.to_string (pp_length ~always:true) len ^ "]"
+    | Perspective_arbitrary (raw, _) -> "perspective-[" ^ raw ^ "]"
     | Perspective_origin_center -> "perspective-origin-center"
     | Perspective_origin_top -> "perspective-origin-top"
     | Perspective_origin_bottom -> "perspective-origin-bottom"

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1702,7 +1702,10 @@ module Handler = struct
         | Error _ -> err_not_utility)
     | [ "scale"; "y"; n ] ->
         Parse.int_pos ~name:"scale-y" n >|= fun n -> Scale_y n
-    | [ "scale"; "z"; n ] when Parse.is_bracket_value n ->
+    | [ "scale"; "z"; n ]
+      when Parse.is_bracket_value n
+           && Parse.is_declaration_value
+                (Parse.decode_arbitrary_value (Parse.bracket_inner n)) ->
         Ok (Scale_z_arbitrary (Parse.bracket_inner n))
     | [ "scale"; "z"; n ] ->
         Parse.int_pos ~name:"scale-z" n >|= fun n -> Scale_z n

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1675,8 +1675,10 @@ module Typography_late = struct
     | Underline_offset_4
     | Underline_offset_8
     | Underline_offset_px of float
+    | Underline_offset_arbitrary of string * Css.length
     | Underline_offset_var of string
     | Underline_offset_neg_px of float
+    | Underline_offset_neg_arbitrary of string * Css.length
     | Underline_offset_neg_var of string
     | (* Antialiased *)
       Antialiased
@@ -1975,8 +1977,8 @@ module Typography_late = struct
         let inner = Parse.bracket_inner n in
         if Parse.is_var inner then Ok (Underline_offset_var inner)
         else
-          match float_of_string_opt inner with
-          | Some px -> Ok (Underline_offset_px px)
+          match Parse.arbitrary_length inner with
+          | Some len -> Ok (Underline_offset_arbitrary (inner, len))
           | None -> err_not_utility)
     | [ "underline"; "offset"; n ] -> (
         match float_of_string_opt n with
@@ -1986,8 +1988,8 @@ module Typography_late = struct
         let inner = Parse.bracket_inner n in
         if Parse.is_var inner then Ok (Underline_offset_neg_var inner)
         else
-          match float_of_string_opt inner with
-          | Some px -> Ok (Underline_offset_neg_px px)
+          match Parse.arbitrary_length inner with
+          | Some len -> Ok (Underline_offset_neg_arbitrary (inner, len))
           | None -> err_not_utility)
     | [ ""; "underline"; "offset"; n ] -> (
         match float_of_string_opt n with
@@ -2206,6 +2208,7 @@ module Typography_late = struct
           else s
         in
         "underline-offset-" ^ s
+    | Underline_offset_arbitrary (raw, _) -> "underline-offset-[" ^ raw ^ "]"
     | Underline_offset_var v -> "underline-offset-[" ^ v ^ "]"
     | Underline_offset_neg_px px ->
         let s = string_of_float px in
@@ -2215,6 +2218,8 @@ module Typography_late = struct
           else s
         in
         "-underline-offset-" ^ s
+    | Underline_offset_neg_arbitrary (raw, _) ->
+        "-underline-offset-[" ^ raw ^ "]"
     | Underline_offset_neg_var v -> "-underline-offset-[" ^ v ^ "]"
     | Antialiased -> "antialiased"
     | Subpixel_antialiased -> "subpixel-antialiased"
@@ -2363,6 +2368,7 @@ module Typography_late = struct
     | List_image_url _ -> 2_000_000 + 8706
     (* Underline offset — negatives first, then positives, then auto *)
     | Underline_offset_neg_px px -> 50000 + int_of_float px
+    | Underline_offset_neg_arbitrary _ -> 59989
     | Underline_offset_neg_var _ -> 59990
     | Underline_offset_0 -> 60000
     | Underline_offset_1 -> 60001
@@ -2370,6 +2376,7 @@ module Typography_late = struct
     | Underline_offset_4 -> 60003
     | Underline_offset_8 -> 60004
     | Underline_offset_px px -> 60005 + int_of_float px
+    | Underline_offset_arbitrary _ -> 69989
     | Underline_offset_var _ -> 69990
     | Underline_offset_auto -> 69999
     (* Antialiased *)
@@ -3259,6 +3266,7 @@ module Typography_late = struct
     | Underline_offset_4 -> underline_offset_4
     | Underline_offset_8 -> underline_offset_8
     | Underline_offset_px px -> style [ text_underline_offset (Px px) ]
+    | Underline_offset_arbitrary (_, len) -> style [ text_underline_offset len ]
     | Underline_offset_var v ->
         let bare_name = Parse.extract_var_name v in
         let var_ref : Css.length Css.var = Var.bracket bare_name in
@@ -3268,6 +3276,12 @@ module Typography_late = struct
           [
             text_underline_offset
               (Calc (Calc.mul (Calc.length (Px px)) (Calc.float (-1.))));
+          ]
+    | Underline_offset_neg_arbitrary (_, len) ->
+        style
+          [
+            text_underline_offset
+              (Calc (Calc.mul (Calc.length len) (Calc.float (-1.))));
           ]
     | Underline_offset_neg_var v ->
         let bare_name = Parse.extract_var_name v in

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -974,3 +974,393 @@ let check_typed_class cls value =
   | Ok u -> Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u)
   | Error (`Msg m) ->
       Alcotest.failf "%s: parser rejected its own class: %s" cls m
+
+(* ------------------------------------------------------------------ *)
+(* Adversarial sweep over arbitrary values                             *)
+(* ------------------------------------------------------------------ *)
+
+let rec all_selectors stmts =
+  List.concat_map
+    (fun stmt ->
+      match Css.as_rule stmt with
+      | Some (selector, _, _) -> [ Css.Selector.to_string selector ]
+      | None -> (
+          match Css.as_media stmt with
+          | Some (_, inner) -> all_selectors inner
+          | None -> (
+              match Css.as_supports stmt with
+              | Some (_, inner) -> all_selectors inner
+              | None -> (
+                  match Css.as_container stmt with
+                  | Some (_, _, inner) -> all_selectors inner
+                  | None -> (
+                      match Css.as_layer stmt with
+                      | Some (_, inner) -> all_selectors inner
+                      | None -> [])))))
+    stmts
+
+let selectors_of_utility u =
+  all_selectors (Css.statements (Tw.to_css ~base:false [ u ]))
+
+(* Undo CSS Syntax 3 (ED) sec. 4.3.7 escaping so an emitted selector can be
+   compared against the class the author wrote. A backslash escapes either one
+   to six hex digits naming a code point, with an optional single whitespace
+   closing the run, or the next character literally. Comparing this way rather
+   than re-escaping the class keeps the check independent of which spelling
+   cascade picks: [caf\\e9 ] and [café] are the same selector. *)
+let unescape_selector s =
+  let n = String.length s in
+  let buf = Buffer.create n in
+  let is_hex c =
+    (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+  in
+  let rec go i =
+    if i >= n then ()
+    else if s.[i] <> '\\' || i + 1 >= n then (
+      Buffer.add_char buf s.[i];
+      go (i + 1))
+    else
+      let j = ref (i + 1) in
+      while !j < n && !j - i <= 6 && is_hex s.[!j] do
+        incr j
+      done;
+      if !j = i + 1 then (
+        (* a literal escape: the next character stands for itself *)
+        Buffer.add_char buf s.[i + 1];
+        go (i + 2))
+      else
+        let code = int_of_string ("0x" ^ String.sub s (i + 1) (!j - i - 1)) in
+        let code =
+          if Uchar.is_valid code then code else Uchar.to_int Uchar.rep
+        in
+        Buffer.add_utf_8_uchar buf (Uchar.of_int code);
+        (* one whitespace may close the hex run and is not part of the text *)
+        let k =
+          if !j < n && (s.[!j] = ' ' || s.[!j] = '\n' || s.[!j] = '\t') then
+            !j + 1
+          else !j
+        in
+        go k
+  in
+  go 0;
+  Buffer.contents buf
+
+let adversarial_payloads =
+  [
+    (* a number whose canonical spelling is not the author's *)
+    "0.5ch";
+    "1.50px";
+    "1e2px";
+    "1E2px";
+    "1e-2px";
+    "0.0";
+    ".5px";
+    "+1px";
+    "0600px";
+    (* text that ends the declaration it is written into, or the rule *)
+    "0)/*1";
+    "a;b";
+    "a}b";
+    "a{b";
+    "1px}";
+    "var(--x);";
+    "1px;color:red";
+    "}.x{color:red";
+    "0)";
+    "(";
+    "()";
+    "url(a;b)";
+    (* a comment, quotes, and text no CSS grammar reads *)
+    "1px/*x";
+    "*/";
+    {|"q"|};
+    "'q'";
+    "--custom";
+    "<value>";
+    "a:b";
+    "#";
+    "&";
+    "a\\b";
+    (* a non-ASCII identifier *)
+    "caf\xc3\xa9";
+    "\xc3\xbcnicode";
+    (* a bare word that also names a variant shorthand, so a family which folds
+       the bracket onto the shorthand loses the brackets from the class *)
+    "hover";
+  ]
+
+type sweep_verdict =
+  | Rejected  (** [of_string] refused the class: a legitimate outcome *)
+  | Emitted_nothing  (** parsed, but contributed no rule *)
+  | Matched  (** parsed, and every rule it emits is selected by the class *)
+  | Mismatched of string
+      (** parsed, and emitted a rule the class cannot match *)
+
+let sweep_one cls =
+  match Tw.of_string cls with
+  | exception e ->
+      Alcotest.failf "%s: of_string raised %s" cls (Printexc.to_string e)
+  | Error (`Msg _) -> Rejected
+  | Ok u -> (
+      match selectors_of_utility u with
+      | exception e ->
+          Alcotest.failf "%s: to_css raised %s" cls (Printexc.to_string e)
+      | [] -> Emitted_nothing
+      | selectors ->
+          let printed = Tw.pp u in
+          let carries sel =
+            Astring.String.is_infix ~affix:cls (unescape_selector sel)
+          in
+          let detail suffix =
+            Mismatched
+              (String.concat ""
+                 [
+                   suffix;
+                   " (pp=";
+                   printed;
+                   ", selectors=";
+                   String.concat "; " selectors;
+                   ")";
+                 ])
+          in
+          if not (List.exists carries selectors) then
+            detail "no emitted selector carries the class"
+          else if printed <> cls then detail "pp respells the class"
+          else Matched)
+
+(* Every class prefix that takes a bracket value, found by feeding a benign one
+   to each [val] exported by [lib/tw.mli] and by the family modules it
+   re-exports, and to each literal match-arm prefix in [lib/*.ml] - the string
+   parser accepts families no OCaml constructor names ([filter-],
+   [drop-shadow-]) so the [.mli] alone does not see them. *)
+let arbitrary_families =
+  [
+    "accent";
+    "align";
+    "animate";
+    "aspect";
+    "auto-cols";
+    "auto-rows";
+    "backdrop-blur";
+    "backdrop-brightness";
+    "backdrop-contrast";
+    "backdrop-filter";
+    "backdrop-grayscale";
+    "backdrop-hue-rotate";
+    "backdrop-invert";
+    "backdrop-opacity";
+    "backdrop-saturate";
+    "backdrop-sepia";
+    "basis";
+    "bg";
+    "bg-linear";
+    "bg-position";
+    "bg-radial";
+    "bg-size";
+    "block";
+    "blur";
+    "border";
+    "border-b";
+    "border-be";
+    "border-bs";
+    "border-e";
+    "border-l";
+    "border-r";
+    "border-s";
+    "border-spacing";
+    "border-spacing-x";
+    "border-spacing-y";
+    "border-t";
+    "border-x";
+    "border-y";
+    "bottom";
+    "brightness";
+    "caret";
+    "col";
+    "col-end";
+    "col-span";
+    "col-start";
+    "columns";
+    "contain";
+    "content";
+    "contrast";
+    "cursor";
+    "decoration";
+    "delay";
+    "divide";
+    "divide-x";
+    "divide-y";
+    "drop-shadow";
+    "duration";
+    "ease";
+    "fill";
+    "filter";
+    "flex";
+    "font";
+    "font-features";
+    "from";
+    "gap";
+    "gap-x";
+    "gap-y";
+    "grayscale";
+    "grid-cols";
+    "grid-rows";
+    "grow";
+    "h";
+    "hue-rotate";
+    "indent";
+    "inline";
+    "inset";
+    "inset-be";
+    "inset-bs";
+    "inset-e";
+    "inset-ring";
+    "inset-s";
+    "inset-shadow";
+    "inset-x";
+    "inset-y";
+    "invert";
+    "leading";
+    "left";
+    "line-clamp";
+    "list";
+    "list-image";
+    "list-image-none";
+    "list-image-url";
+    "m";
+    "mask";
+    "mask-b-from";
+    "mask-b-to";
+    "mask-conic";
+    "mask-conic-from";
+    "mask-conic-to";
+    "mask-l-from";
+    "mask-l-to";
+    "mask-linear";
+    "mask-linear-from";
+    "mask-linear-to";
+    "mask-position";
+    "mask-r-from";
+    "mask-r-to";
+    "mask-radial";
+    "mask-radial-at";
+    "mask-radial-from";
+    "mask-radial-to";
+    "mask-size";
+    "mask-t-from";
+    "mask-t-to";
+    "mask-x-from";
+    "mask-x-to";
+    "mask-y-from";
+    "mask-y-to";
+    "max-block";
+    "max-h";
+    "max-inline";
+    "max-w";
+    "mb";
+    "min-block";
+    "min-h";
+    "min-inline";
+    "min-w";
+    "ml";
+    "mr";
+    "mt";
+    "mx";
+    "my";
+    "object";
+    "opacity";
+    "order";
+    "origin";
+    "outline";
+    "outline-offset";
+    "p";
+    "pb";
+    "perspective";
+    "perspective-origin";
+    "pl";
+    "placeholder";
+    "pr";
+    "pt";
+    "px";
+    "py";
+    "right";
+    "ring";
+    "ring-offset";
+    "rotate";
+    "rotate-x";
+    "rotate-y";
+    "rotate-z";
+    "rounded";
+    "rounded-b";
+    "rounded-bl";
+    "rounded-br";
+    "rounded-e";
+    "rounded-ee";
+    "rounded-es";
+    "rounded-l";
+    "rounded-r";
+    "rounded-s";
+    "rounded-se";
+    "rounded-ss";
+    "rounded-t";
+    "rounded-tl";
+    "rounded-tr";
+    "row";
+    "row-end";
+    "row-span";
+    "row-start";
+    "saturate";
+    "scale";
+    "scale-x";
+    "scale-y";
+    "scale-z";
+    "scroll-m";
+    "scroll-mb";
+    "scroll-mbe";
+    "scroll-mbs";
+    "scroll-me";
+    "scroll-ml";
+    "scroll-mr";
+    "scroll-ms";
+    "scroll-mt";
+    "scroll-mx";
+    "scroll-my";
+    "scroll-p";
+    "scroll-pb";
+    "scroll-pbe";
+    "scroll-pbs";
+    "scroll-pe";
+    "scroll-pl";
+    "scroll-pr";
+    "scroll-ps";
+    "scroll-pt";
+    "scroll-px";
+    "scroll-py";
+    "sepia";
+    "shadow";
+    "shrink";
+    "size";
+    "skew";
+    "skew-x";
+    "skew-y";
+    "space-x";
+    "space-y";
+    "stroke";
+    "tab";
+    "text";
+    "text-shadow";
+    "to";
+    "top";
+    "tracking";
+    "transform";
+    "transition";
+    "translate";
+    "translate-x";
+    "translate-y";
+    "underline-offset";
+    "via";
+    "w";
+    "will-change";
+    "z";
+    "zoom";
+  ]

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -286,3 +286,40 @@ val check_typed_class : string -> Tw.t -> unit
 (** [check_typed_class cls value] checks that the typed constructor [value]
     pretty-prints to [cls] and that [cls] round-trips back through
     [Tw.of_string]. *)
+
+val adversarial_payloads : string list
+(** [adversarial_payloads] are bracket values chosen to break the two things a
+    utility does with author text: respell it into the class name, and place it
+    into a declaration. Numbers whose canonical spelling differs from the
+    author's, text that ends the declaration or the rule, comments, quotes,
+    placeholders no CSS grammar reads, and non-ASCII identifiers. *)
+
+val arbitrary_families : string list
+(** [arbitrary_families] is every class prefix that accepts [<prefix>-[value]],
+    found by feeding a benign bracket value to each [val] exported by
+    [lib/tw.mli] and the family modules it re-exports, and to each literal
+    match-arm prefix in [lib/*.ml]. *)
+
+type sweep_verdict =
+  | Rejected  (** [of_string] refused the class: a legitimate outcome *)
+  | Emitted_nothing  (** parsed, but contributed no rule *)
+  | Matched  (** parsed, and every rule it emits is selected by the class *)
+  | Mismatched of string
+      (** parsed, and emitted a rule the class cannot match *)
+
+val sweep_one : string -> sweep_verdict
+(** [sweep_one cls] compiles [cls] and reports what came of it. It fails the
+    test if [of_string] or [to_css] raises: an exception escaping is never a
+    legitimate answer, whereas [Error] is. {!constructor-Mismatched} is the one
+    verdict that is a bug - the class was accepted and named a rule it cannot
+    select - and it covers both halves: no emitted selector carries the class,
+    or {!Tw.pp} spells the class differently from the author. *)
+
+val unescape_selector : string -> string
+(** [unescape_selector s] undoes CSS Syntax 3 (ED) sec. 4.3.7 escaping, so a
+    selector can be compared against the class text it was built from whichever
+    spelling the printer chose. *)
+
+val selectors_of_utility : Tw.t -> string list
+(** [selectors_of_utility u] is every selector [u] emits, nested rules inside
+    [\@media], [\@supports], [\@container] and [\@layer] included. *)

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -113,20 +113,114 @@ let test_custom_prop_opacity () =
     (Astring.String.is_infix
        ~affix:"--x: color-mix(in oklab, #ff0000 50%, transparent)" out)
 
-(* The previously-crashing inputs must never raise: they either render or are
-   rejected, but [to_css] must complete. *)
+(* A class either compiles or is refused; an exception escaping [of_string] or
+   [to_css] is neither. Swallowing [Error] here is the point - Tailwind refuses
+   many of these too - but a raise is a failure, which is what
+   {!Test_helpers.sweep_one} enforces. *)
 let test_no_crash () =
   List.iter
-    (fun cls ->
-      match Tw.of_string cls with
-      | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
-      | Error _ -> ())
+    (fun cls -> ignore (Test_helpers.sweep_one cls))
     [
       "[--gradient-bg:var(--color-black)]/15";
       "[color:var(--color-red-500)]/40";
       "[--foo:bar]";
       "[mask-type:luminance]";
     ]
+
+(* A class tw accepts must name a rule the class itself selects. Getting that
+   wrong is silent: the sheet grows a rule no markup can ever match, and every
+   oracle that compares declarations reads the two sheets as equal.
+
+   Two shipped bugs had exactly this shape - a class name re-printed through a
+   CSS printer that drops a leading zero, and one rebuilt from a parsed length
+   that had stopped at a comment - so the sweep runs the payloads that produce
+   it across every family taking a bracket value, every arbitrary property, and
+   every variant that brackets a breakpoint or a selector.
+
+   Refusal is a legitimate answer and is not counted. The one thing asserted is
+   that nothing is accepted under a name it cannot be selected by. *)
+let known_selector_gaps =
+  (* [has-[<name>]] where <name> is one of the has- shorthands collapses onto
+     the shorthand variant: [Style.Has], [Style.Group_has] and [Style.Peer_has]
+     each carry the selector text with no record of whether the author bracketed
+     it, so [has-[hover]] and [has-hover] are one value and the bracket is gone
+     when the class is spelled back. Tailwind reads the bracket as a type
+     selector instead ([:has(:is(hover))]), so closing this splits the
+     constructor rather than fixing a printer. *)
+  [ "has-[hover]:flex"; "group-has-[hover]:flex"; "peer-has-[hover]:flex" ]
+
+let sweep_classes =
+  List.concat
+    [
+      (* <family>-[<payload>] *)
+      List.concat_map
+        (fun f ->
+          List.map
+            (fun p -> String.concat "" [ f; "-["; p; "]" ])
+            Test_helpers.adversarial_payloads)
+        Test_helpers.arbitrary_families;
+      (* the arbitrary-property form, on both sides of the colon *)
+      List.concat_map
+        (fun p ->
+          [
+            String.concat "" [ "[color:"; p; "]" ];
+            String.concat "" [ "[--x:"; p; "]" ];
+            String.concat "" [ "["; p; ":red]" ];
+          ])
+        Test_helpers.adversarial_payloads;
+      (* variants that bracket a breakpoint, a condition or a selector *)
+      List.concat_map
+        (fun v ->
+          List.map
+            (fun p -> String.concat "" [ v; "-["; p; "]:flex" ])
+            Test_helpers.adversarial_payloads)
+        [
+          "min";
+          "max";
+          "supports";
+          "data";
+          "aria";
+          "has";
+          "group-has";
+          "peer-has";
+          "not";
+          "in";
+          "nth";
+          "nth-last";
+          "group";
+          "peer";
+          "group-data";
+          "peer-data";
+        ];
+    ]
+
+let test_adversarial_value_sweep () =
+  let classes = sweep_classes in
+  let mismatches =
+    List.filter_map
+      (fun cls ->
+        match Test_helpers.sweep_one cls with
+        | Test_helpers.Mismatched why -> Some (cls, why)
+        | Rejected | Emitted_nothing | Matched -> None)
+      classes
+  in
+  let names = List.map fst mismatches in
+  let unexpected =
+    List.filter
+      (fun (cls, _) -> not (List.mem cls known_selector_gaps))
+      mismatches
+  in
+  (match unexpected with
+  | [] -> ()
+  | l ->
+      Alcotest.failf "%d classes emit a rule they cannot select:\n%s"
+        (List.length l)
+        (String.concat "\n"
+           (List.map (fun (c, w) -> String.concat "" [ "  "; c; ": "; w ]) l)));
+  (* The gap list is exact, so it fails when it grows and again when it is
+     closed, rather than quietly covering more each release. *)
+  Alcotest.(check (slist string String.compare))
+    "the known gaps are exactly the ones still open" known_selector_gaps names
 
 (* Tailwind's [--spacing(N)] shorthand reads the spacing scale, so it has to be
    expanded here too: the value used to reach the sheet verbatim. *)
@@ -227,6 +321,8 @@ let tests =
       test_encoded_space_color_opacity;
     test_case "custom property with opacity" `Quick test_custom_prop_opacity;
     test_case "deferred and var inputs never crash" `Quick test_no_crash;
+    test_case "adversarial arbitrary values name their own rules" `Quick
+      test_adversarial_value_sweep;
   ]
 
 let suite = ("arbitrary", tests)

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -116,6 +116,29 @@ let test_basis_named_prefers_spacing () =
     "basis-sm declares --spacing-sm" true
     (Astring.String.is_infix ~affix:"--spacing-sm: 8px" css)
 
+(* [basis-[...]] names its rule with the bracket text the author wrote, not with
+   the parsed flex-basis printed back: the CSS printer canonicalises a number
+   ([0.5ch] to [.5ch]) and drops a comment, and a rule spelled that way cannot
+   be matched by the class that generated it. [order-[...]] below carries its
+   text the same way. *)
+let test_basis_arbitrary_keeps_the_authored_spelling () =
+  List.iter
+    (fun (cls, escaped) ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u ->
+          Alcotest.(check string) "class round-trips" cls (Tw.pp u);
+          let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string in
+          Alcotest.(check bool)
+            (cls ^ " selects itself") true
+            (Astring.String.is_infix ~affix:escaped css))
+    [
+      ("basis-[0.5ch]", {|.basis-\[0\.5ch\]|});
+      ("basis-[0.0]", {|.basis-\[0\.0\]|});
+      ("basis-[1px/*x]", {|.basis-\[1px\/\*x\]|});
+      ("basis-[10px]", {|.basis-\[10px\]|});
+    ]
+
 (* [order-[...]] takes an order value. A bracket the order grammar cannot read
    is accepted and then raises out of [to_css], a pure conversion, so the
    rejection belongs at parse time. *)
@@ -148,6 +171,8 @@ let tests =
     test_case "flex_props suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "invalid arbitrary order" `Quick test_invalid_arbitrary_order;
+    test_case "basis-[...] keeps the authored spelling" `Quick
+      test_basis_arbitrary_keeps_the_authored_spelling;
   ]
 
 let suite = ("flex_props", tests)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -1057,6 +1057,40 @@ let test_not_bracket_arbitrary_selector () =
   check bool "not-[.foo]:block negates a plain class" true
     (Astring.String.is_infix ~affix:":not(.foo)" (css "not-[.foo]:block"))
 
+(* The bracket is negated as a selector, so content the selector grammar cannot
+   read is not a negation and the class is refused at parse time. The reader
+   raises rather than answering, and it stops at the first thing it cannot use,
+   so a trailing remainder is refused too rather than silently dropped. *)
+let test_not_bracket_unreadable_selector_rejected () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok u ->
+          Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+      | Error (`Msg _) -> ())
+    [
+      "not-[a;b]:flex";
+      "not-[0.5ch]:flex";
+      "not-[1px}]:flex";
+      "not-[a{b]:flex";
+      "not-[*/]:flex";
+      "not-[<value>]:flex";
+      "not-[url(a;b)]:flex";
+      "not-[()]:flex";
+    ];
+  (* the readable ones still parse *)
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok _ -> ()
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m)
+    [
+      "not-[.foo]:flex";
+      "not-[.os-macos_&]:flex";
+      "not-[:checked]:flex";
+      "not-[@media_print]:flex";
+    ]
+
 (* A group/peer arbitrary variant whose [&] anchor is preceded by a context
    (e.g. group-[:nth-of-type(3)_&]) keeps that prefix ahead of the anchor,
    rather than dropping it down to just :where(.group). *)
@@ -1382,6 +1416,8 @@ let tests =
         test_prose_element_variant_invalid;
       test_case "variant cascade ladder" `Quick test_variant_cascade_ladder;
       test_case "variant inner order" `Quick test_variant_inner_order;
+      test_case "not-[selector] unreadable content rejected" `Quick
+        test_not_bracket_unreadable_selector_rejected;
     ]
 
 let suite = ("modifiers", tests)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -358,6 +358,12 @@ let test_arbitrary_breakpoint_spelling () =
       "min-[0.5cqw]:flex";
       "min-[0.5lh]:flex";
       "max-[0.5ex]:flex";
+      (* The length reader stops at the first thing it cannot use, so a value
+         with a remainder came back as the prefix alone: [min-[1px/*x]] named
+         [.min-\[1px\]]. *)
+      "min-[1px/*x]:flex";
+      "max-[1px/*x]:flex";
+      "min-[0.5rem]:flex";
     ]
 
 (* The bracket holds a length, so a word is not a breakpoint at all. *)

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -141,6 +141,35 @@ let test_double_bracket_class_rejected () =
   accepted "text-[10px]/[1.5]";
   accepted "bg-red-500/[0.5]"
 
+(* A bracket value reaching a custom property is author text. One that would not
+   stay inside the declaration it is written into - a top-level [;] or [}], an
+   unmatched [)], an unterminated function or block - ends that declaration
+   early or swallows the rest of the rule, so the class carrying it is refused
+   rather than handed to [Css.custom_property], which raises on it. Tailwind
+   emits nothing for any of these either. *)
+let test_bracket_value_leaving_the_declaration_is_rejected () =
+  List.iter unknown
+    [
+      "scale-z-[a;b]";
+      "scale-z-[0)]";
+      "scale-z-[1px}]";
+      "bg-linear-[a;b]";
+      "bg-linear-[0)/*1]";
+      "bg-radial-[}.x{color:red]";
+      "mask-t-from-[a;b]";
+      "mask-x-to-[var(--x);]";
+      "mask-y-from-[1px}]";
+      "mask-radial-[a{b]";
+    ];
+  (* and every value that does stay inside it is still kept *)
+  List.iter round_trips
+    [
+      "scale-z-[1.5]";
+      "bg-linear-[45deg]";
+      "mask-t-from-[10px]";
+      "mask-x-to-[calc(100%-1px)]";
+    ]
+
 (* [--spacing(N)] is Tailwind's spacing-scale shorthand, expanded outside any
    quoting. The same bytes inside a quoted string are a CSS string literal, not
    the function, so [expand_spacing_fn] must leave them alone. *)
@@ -178,6 +207,8 @@ let tests =
         test_redundant_zero_spellings_are_rejected;
       test_case "parsing is independent of parse history" `Quick
         test_parse_is_independent_of_history;
+      test_case "bracket value leaving the declaration is rejected" `Quick
+        test_bracket_value_leaving_the_declaration_is_rejected;
       test_case "--spacing() shorthand ignored inside quotes" `Quick
         test_spacing_shorthand_ignored_in_quotes;
     ]

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -350,6 +350,11 @@ let test_arbitrary_transform_spelling () =
       "skew-[1.50deg]";
       "skew-x-[1.50deg]";
       "skew-y-[1.50deg]";
+      (* [perspective] takes a length rather than a number or an angle, and its
+         printer canonicalises one the same way. *)
+      "perspective-[1.50px]";
+      "perspective-[0.5rem]";
+      "perspective-[100px]";
     ]
 
 (* The bracket holds a number or an angle, so a word is not a transform. *)

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -621,6 +621,38 @@ let late_typography_colour_block_order () =
       "accent-red-500";
     ]
 
+(* [underline-offset-[N]] is a bracket value, not a spelling of the bare
+   [underline-offset-N] step: it names its own rule and its value carries the
+   unit the author wrote rather than the [px] the scale supplies. Folding the
+   two together emitted [.underline-offset-0] for [underline-offset-[0.0]], a
+   rule nothing selects. *)
+let test_underline_offset_bracket_keeps_its_class () =
+  List.iter
+    (fun (cls, escaped) ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u ->
+          Alcotest.(check string) "class round-trips" cls (Tw.pp u);
+          let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string in
+          Alcotest.(check bool)
+            (cls ^ " selects itself") true
+            (Astring.String.is_infix ~affix:escaped css))
+    [
+      ("underline-offset-[0.0]", {|.underline-offset-\[0\.0\]|});
+      ("underline-offset-[3px]", {|.underline-offset-\[3px\]|});
+      ("underline-offset-[1.50px]", {|.underline-offset-\[1\.50px\]|});
+      ("underline-offset-[calc(1px+2px)]", {|.underline-offset-\[calc\(|});
+      ("-underline-offset-[3px]", {|.-underline-offset-\[3px\]|});
+    ];
+  (* the bare step keeps its own class and the [px] the scale gives it *)
+  match Tw.of_string "underline-offset-3" with
+  | Error (`Msg m) -> Alcotest.failf "underline-offset-3: %s" m
+  | Ok u ->
+      Alcotest.(check bool)
+        "bare step stays on the spacing scale" true
+        (Astring.String.is_infix ~affix:"text-underline-offset: 3px"
+           (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string))
+
 let suborder_matches_tailwind () =
   let open Tw in
   let utilities =
@@ -1183,6 +1215,8 @@ let tests =
       test_decoration_opacity_fallback;
     test_case "decoration bracket named colour" `Quick
       test_decoration_bracket_named_color;
+    test_case "underline-offset-[...] keeps its bracket" `Quick
+      test_underline_offset_bracket_keeps_its_class;
     test_case "typography renders like Tailwind" `Slow
       rendering_matches_tailwind;
   ]


### PR DESCRIPTION
`test_no_crash` walked four hand-written strings and swallowed every `Error`, which was the whole robustness story for arbitrary values. Two shipped bugs of that shape went unseen, and feeding the families something adversarial found five more.

The sweep runs 34 payloads over 228 bracket families, the arbitrary-property form and 16 variants, and asserts that each accepted class names a rule it can actually select. Refusing a class stays a legitimate answer; raising does not. Three `has-` shorthand gaps are listed exactly, so the list fails if it grows or if one is closed.

The six commits below it are the bugs it found, each with a regression test: a bracket value that escaped its own declaration, `basis-[...]`, `perspective-[...]` and `min-[...]` breakpoints losing the authored spelling so the selector could not match the class, `underline-offset-[...]` needing its own class, and `not-[...]` accepting content no selector reader can read.