### PR TITLE
test/upstream: make a hand-edited corpus fixture impossible to miss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,8 +372,9 @@ and the fields it keys on.
   where feasible.
 * `test/`: Tailwind v4 parity by utility, one `test_<module>.ml` per
   `lib/<module>.ml`.
-* `test/upstream/`: replay of Tailwind's own fixture corpus. Generated; never
-  hand-edit.
+* `test/upstream/`: replay of Tailwind's own fixture corpus. `utilities.txt`
+  and `variants.txt` are generated; never hand-edit them. A case upstream has
+  no test for goes in `handwritten.txt`, which no regeneration writes.
 * **Rules:**
 
   1. Define named test functions (`let test_foo () = ...`).

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -9,11 +9,14 @@ All three run under `dune runtest`.
 
 **Upstream fixtures, `test/upstream/`.** `utilities.txt` and `variants.txt` are
 Tailwind's own test corpus, extracted from the v4.3.3 tag: a class list and the
-CSS Tailwind emits for it. `test/upstream/test.exe` replays 801 cases and fails
+CSS Tailwind emits for it. `test/upstream/test.exe` replays 800 cases and fails
 when tw rejects a class Tailwind accepts, or emits different CSS for one it
 accepts. The two fixtures are generated, and `test/upstream/extract_tests.ml`
 carries the command that regenerates them. Editing them by hand removes the
-oracle the check depends on.
+oracle the check depends on, and the runner rejects a file whose block count no
+longer matches the banner the extractor stamped on it. A case Tailwind has no
+test for lives in `handwritten.txt`, read beside the two and written by no
+regeneration.
 
 **Example pages, `examples/*/dune`.** Each of the nine examples builds its CSS
 twice, once through tw and once through `npx tailwindcss`, then diffs the two

--- a/test/upstream/empty_expect_expected.txt
+++ b/test/upstream/empty_expect_expected.txt
@@ -1,3 +1,4 @@
+#! 5 blocks extracted from empty_expect_input.ts by extract_tests.exe -- do not edit
 # wrapped-empty
 @config run
 wrapped-keep

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -20,21 +20,35 @@
 
     {v
     # Clone tailwindcss (or use an existing clone) at the v4.3.3 tag
-    git clone https://github.com/tailwindlabs/tailwindcss.git /tmp/tailwindcss
-    cd /tmp/tailwindcss && git checkout v4.3.3
+    git clone https://github.com/tailwindlabs/tailwindcss.git tmp/tailwindcss
+    cd tmp/tailwindcss && git checkout v4.3.3
+
+    # Confirm the tag before extracting: another version rewrites values
+    # (v4.3.2 spells 22 of the lengths v4.3.3 spells 0px as 0).
+    head -3 packages/tailwindcss/package.json
 
     # Extract both fixtures
     dune exec test/upstream/extract_tests.exe -- \
-      /tmp/tailwindcss/packages/tailwindcss/src/utilities.test.ts \
+      tmp/tailwindcss/packages/tailwindcss/src/utilities.test.ts \
       > test/upstream/utilities.txt
     dune exec test/upstream/extract_tests.exe -- \
-      /tmp/tailwindcss/packages/tailwindcss/src/variants.test.ts \
+      tmp/tailwindcss/packages/tailwindcss/src/variants.test.ts \
       > test/upstream/variants.txt
     v}
 
     {b Do NOT edit the .txt fixtures directly.} If test expectations need
     updating, regenerate from the pinned Tailwind version or fix the extraction
-    script.
+    script. A case upstream does not have is a tw regression test and belongs in
+    its own [test_<module>.ml], never here: the next regeneration would drop it
+    silently.
+
+    {2 The provenance banner}
+
+    Each generated fixture opens with a [#!] line naming this script and the
+    number of blocks it wrote. [test/upstream/test.ml] counts the blocks back
+    and fails when the two disagree, so a block added to a generated fixture by
+    hand is reported at once instead of being dropped, unremarked, by the next
+    regeneration.
 
     Usage: dune exec test/upstream/extract_tests.exe -- <utilities.test.ts> *)
 
@@ -1065,6 +1079,15 @@ let () =
   let filename = Sys.argv.(1) in
   Fmt.epr "Parsing %s...@." filename;
   let tests = parse_file filename in
+
+  (* The provenance banner: [#!] keeps it out of the block scan, which reads a
+     [#] and a space as a block header, and the count is what
+     [test/upstream/test.ml] holds the file to. *)
+  let count = List.length tests in
+  Fmt.pr "#! %d %s extracted from %s by extract_tests.exe -- do not edit@."
+    count
+    (if count = 1 then "block" else "blocks")
+    (Filename.basename filename);
 
   (* Output format: # test-name @config <theme-config> class1 class2 --- css
      output here with newlines preserved <<<>>> *)

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -23,6 +23,16 @@
     No filtering, no tree diffing, no special-casing. If a test fails, either
     fix our code or fix the extraction.
 
+    Both fixtures are generated, and nothing else belongs in them. A case
+    upstream does not have is a tw regression test: it goes in the
+    [test_<module>.ml] for the behaviour it pins, where it runs by name and the
+    next reader of that module finds it. Put one here and the next regeneration
+    drops it with the run still green -- which is how a [supports] block and a
+    container-query block sat here duplicating coverage [test_modifiers.ml] and
+    [test_sort.ml] already had. {!check_generated} counts each fixture's blocks
+    against the banner the extractor wrote, so an addition is reported while it
+    is still there.
+
     CSS whitespace normalisation (parse + re-emit) is already a stretch but
     necessary because the expected CSS comes from JS template literals with
     extra indentation. *)
@@ -723,22 +733,22 @@ let print_parity_report () =
      breaks parity fails the CSS diff and names the rejected classes)@.";
   Fmt.epr "==============================@."
 
-(* Both fixtures are checked in and declared as dune deps, so a missing one is a
-   broken checkout rather than an optional extra. A floor on the parsed cases
-   catches the other way this gate can go quiet: a fixture whose format drifts
-   still parses, just into far fewer cases than it holds.
+(* All three fixtures are checked in and declared as dune deps, so a missing one
+   is a broken checkout rather than an optional extra. A floor on the parsed
+   cases catches the other way this gate can go quiet: a fixture whose format
+   drifts still parses, just into far fewer cases than it holds.
 
    Set near the real counts rather than at half. Half (300 and 80) let a fixture
    lose most of itself and still pass, which is the drift the floor is for; a
    regenerated corpus that legitimately shrinks past these wants a human to look
-   and move the number. Counts on 2026-08-29: 696 utilities, 168 variants. *)
+   and move the number. Counts on 2026-08-29: 696 utilities, 166 variants. *)
 let utilities_floor = 620
 let variants_floor = 150
 
 let load basename floor =
   match path basename with
   | None ->
-      Fmt.epr "%s not found. Run extract_tests.exe first.@." basename;
+      Fmt.epr "%s not found. All three fixtures are checked in here.@." basename;
       exit 1
   | Some p ->
       let cases = read p in
@@ -749,8 +759,36 @@ let load basename floor =
         exit 1);
       cases
 
+(* The floors count what a fixture holds, not where it came from: a block added
+   to a generated fixture by hand raises the count and passes them, then
+   disappears at the next regeneration with nothing to say it went. The
+   extractor writes the number of blocks it produced into the file's banner, so
+   counting the blocks back names such a block while it is still there. *)
+let check_generated basename =
+  match path basename with
+  | None -> ()
+  | Some p -> (
+      match declared_blocks p with
+      | None ->
+          Fmt.epr
+            "%s has no provenance banner. Regenerate it with \
+             extract_tests.exe.@."
+            p;
+          exit 1
+      | Some declared ->
+          let found = blocks p in
+          if found <> declared then (
+            Fmt.epr
+              "%s holds %d blocks but was generated with %d, so it has been \
+               edited since. A case upstream does not have is a tw regression \
+               test and belongs in its own test_<module>.ml.@."
+              p found declared;
+            exit 1))
+
 let () =
   Tw_tools.Cascade_provenance.report ();
+  check_generated "utilities.txt";
+  check_generated "variants.txt";
   let utility_tests = load "utilities.txt" utilities_floor in
   let variant_tests = load "variants.txt" variants_floor in
   let total = List.length utility_tests + List.length variant_tests in
@@ -759,15 +797,8 @@ let () =
     (List.length variant_tests);
   at_exit print_parity_report;
 
-  let utility_cases =
-    List.map
-      (fun tc -> test_case tc.name `Quick (run_test_case tc))
-      utility_tests
-  in
-  let variant_cases =
-    List.map
-      (fun tc -> test_case tc.name `Quick (run_test_case tc))
-      variant_tests
+  let alcotest_cases tests =
+    List.map (fun tc -> test_case tc.name `Quick (run_test_case tc)) tests
   in
   let tolerance_cases =
     [
@@ -785,9 +816,9 @@ let () =
   in
   let suites =
     [
-      ("utilities", utility_cases);
+      ("utilities", alcotest_cases utility_tests);
       ("tolerance", tolerance_cases);
-      ("variants", variant_cases);
+      ("variants", alcotest_cases variant_tests);
     ]
   in
   Alcotest.run "upstream" suites

--- a/test/upstream/test_blocks_expected.txt
+++ b/test/upstream/test_blocks_expected.txt
@@ -1,3 +1,4 @@
+#! 9 blocks extracted from test_blocks_input.ts by extract_tests.exe -- do not edit
 # top level
 @config run
 top-level

--- a/test/upstream/theme_scanner_expected.txt
+++ b/test/upstream/theme_scanner_expected.txt
@@ -1,3 +1,4 @@
+#! 1 block extracted from theme_scanner_input.ts by extract_tests.exe -- do not edit
 # multiline-theme
 @config theme
 @theme-var spacing-* initial

--- a/test/upstream/upstream_fixture.ml
+++ b/test/upstream/upstream_fixture.ml
@@ -88,148 +88,135 @@ let split_classes line =
   if s <> "" then acc := s :: !acc;
   List.rev !acc
 
-let read filename =
+let lines_of filename =
   if not (Sys.file_exists filename) then []
   else
     let ic = open_in filename in
     let content = really_input_string ic (in_channel_length ic) in
     close_in ic;
-    let tests = ref [] in
-    let current_variants = ref [] in
-    let current_theme_vars = ref [] in
-    let current_theme_modes = ref [] in
-    let current_utility_defs = ref [] in
-    let current_layer_wrap = ref None in
-    let lines = String.split_on_char '\n' content in
-    let parse_config_line line =
-      let line = String.trim line in
-      if String.length line > 8 && String.sub line 0 8 = "@config " then
-        Some (config_of_string (String.sub line 8 (String.length line - 8)))
-      else None
-    in
-    (* A directive line is "<keyword> <name> <rest>"; the name runs to the first
-       space and the rest is kept as written. *)
-    let named_pair keyword line =
-      let n = String.length keyword in
-      if String.length line < n || String.sub line 0 n <> keyword then None
-      else
-        let tail = String.sub line n (String.length line - n) in
-        Option.map
-          (fun i ->
-            ( String.sub tail 0 i,
-              String.sub tail (i + 1) (String.length tail - i - 1) ))
-          (String.index_opt tail ' ')
-    in
-    let rec parse lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let line = String.trim line in
-          if String.length line > 2 && line.[0] = '#' && line.[1] = ' ' then (
-            let name = String.sub line 2 (String.length line - 2) in
-            current_variants := [];
-            current_theme_vars := [];
-            current_theme_modes := [];
-            current_utility_defs := [];
-            current_layer_wrap := None;
-            parse_config name No_theme rest)
-          else parse rest
-    and parse_config name default_config lines =
-      match lines with
-      | [] -> ()
-      | line :: rest -> (
-          match parse_config_line line with
-          | Some config -> parse_variants name config rest
-          | None -> parse_variants name default_config (line :: rest))
-    and parse_variants name config lines =
-      match lines with
-      | [] -> ()
-      | line :: rest -> (
-          let tl = String.trim line in
-          if String.length tl >= 9 && String.sub tl 0 9 = "@variant " then (
-            current_variants :=
-              String.sub tl 9 (String.length tl - 9) :: !current_variants;
-            parse_variants name config rest)
-          else
-            match named_pair "@theme-var " tl with
-            | Some pair ->
-                current_theme_vars := pair :: !current_theme_vars;
-                parse_variants name config rest
-            | None -> (
-                match named_pair "@theme-mode " tl with
-                | Some (n, modes) ->
-                    current_theme_modes :=
-                      (n, String.split_on_char ' ' modes)
-                      :: !current_theme_modes;
-                    parse_variants name config rest
-                | None -> (
-                    match named_pair "@utility-def " tl with
-                    | Some pair ->
-                        current_utility_defs := pair :: !current_utility_defs;
-                        parse_variants name config rest
-                    | None ->
-                        if
-                          String.length tl >= 12
-                          && String.sub tl 0 12 = "@layer-wrap "
-                        then (
-                          current_layer_wrap :=
-                            Some (String.sub tl 12 (String.length tl - 12));
-                          parse_variants name config rest)
-                        else parse_classes name config (line :: rest))))
-    and parse_classes name config lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let line = String.trim line in
-          if line = "<<<>>>" then parse rest
-          else if line = "---" then
-            (* No classes line before ---, skip *)
-            parse_expected name config [] (Buffer.create 256) rest
-          else if String.length line > 2 && line.[0] = '#' && line.[1] = ' '
-          then (
-            (* New test without classes *)
-            let new_name = String.sub line 2 (String.length line - 2) in
-            current_variants := [];
-            current_theme_vars := [];
-            current_theme_modes := [];
-            current_utility_defs := [];
-            current_layer_wrap := None;
-            parse_config new_name No_theme rest)
-          else
-            let classes = split_classes line in
-            parse_after_classes name config classes rest
-    and parse_after_classes name config classes lines =
-      match lines with
-      | [] -> ()
-      | line :: rest ->
-          let line = String.trim line in
-          if line = "---" then
-            parse_expected name config classes (Buffer.create 256) rest
-          else if line = "<<<>>>" then
-            (* No expected CSS, skip this test *)
-            parse rest
-          else parse rest
-    and parse_expected name config classes buf lines =
-      match lines with
-      | [] ->
-          let expected = Buffer.contents buf |> String.trim in
-          if classes <> [] then
-            tests :=
-              {
-                source = filename;
-                name;
-                config;
-                classes;
-                expected;
-                variants = List.rev !current_variants;
-                theme_vars = List.rev !current_theme_vars;
-                theme_modes = List.rev !current_theme_modes;
-                utility_defs = List.rev !current_utility_defs;
-                layer_wrap = !current_layer_wrap;
-              }
-              :: !tests
-      | line :: rest ->
-          if String.trim line = "<<<>>>" then (
+    String.split_on_char '\n' content
+
+let read filename =
+  match lines_of filename with
+  | [] -> []
+  | lines ->
+      let tests = ref [] in
+      let current_variants = ref [] in
+      let current_theme_vars = ref [] in
+      let current_theme_modes = ref [] in
+      let current_utility_defs = ref [] in
+      let current_layer_wrap = ref None in
+      let parse_config_line line =
+        let line = String.trim line in
+        if String.length line > 8 && String.sub line 0 8 = "@config " then
+          Some (config_of_string (String.sub line 8 (String.length line - 8)))
+        else None
+      in
+      (* A directive line is "<keyword> <name> <rest>"; the name runs to the
+         first space and the rest is kept as written. *)
+      let named_pair keyword line =
+        let n = String.length keyword in
+        if String.length line < n || String.sub line 0 n <> keyword then None
+        else
+          let tail = String.sub line n (String.length line - n) in
+          Option.map
+            (fun i ->
+              ( String.sub tail 0 i,
+                String.sub tail (i + 1) (String.length tail - i - 1) ))
+            (String.index_opt tail ' ')
+      in
+      let rec parse lines =
+        match lines with
+        | [] -> ()
+        | line :: rest ->
+            let line = String.trim line in
+            if String.length line > 2 && line.[0] = '#' && line.[1] = ' ' then (
+              let name = String.sub line 2 (String.length line - 2) in
+              current_variants := [];
+              current_theme_vars := [];
+              current_theme_modes := [];
+              current_utility_defs := [];
+              current_layer_wrap := None;
+              parse_config name No_theme rest)
+            else parse rest
+      and parse_config name default_config lines =
+        match lines with
+        | [] -> ()
+        | line :: rest -> (
+            match parse_config_line line with
+            | Some config -> parse_variants name config rest
+            | None -> parse_variants name default_config (line :: rest))
+      and parse_variants name config lines =
+        match lines with
+        | [] -> ()
+        | line :: rest -> (
+            let tl = String.trim line in
+            if String.length tl >= 9 && String.sub tl 0 9 = "@variant " then (
+              current_variants :=
+                String.sub tl 9 (String.length tl - 9) :: !current_variants;
+              parse_variants name config rest)
+            else
+              match named_pair "@theme-var " tl with
+              | Some pair ->
+                  current_theme_vars := pair :: !current_theme_vars;
+                  parse_variants name config rest
+              | None -> (
+                  match named_pair "@theme-mode " tl with
+                  | Some (n, modes) ->
+                      current_theme_modes :=
+                        (n, String.split_on_char ' ' modes)
+                        :: !current_theme_modes;
+                      parse_variants name config rest
+                  | None -> (
+                      match named_pair "@utility-def " tl with
+                      | Some pair ->
+                          current_utility_defs := pair :: !current_utility_defs;
+                          parse_variants name config rest
+                      | None ->
+                          if
+                            String.length tl >= 12
+                            && String.sub tl 0 12 = "@layer-wrap "
+                          then (
+                            current_layer_wrap :=
+                              Some (String.sub tl 12 (String.length tl - 12));
+                            parse_variants name config rest)
+                          else parse_classes name config (line :: rest))))
+      and parse_classes name config lines =
+        match lines with
+        | [] -> ()
+        | line :: rest ->
+            let line = String.trim line in
+            if line = "<<<>>>" then parse rest
+            else if line = "---" then
+              (* No classes line before ---, skip *)
+              parse_expected name config [] (Buffer.create 256) rest
+            else if String.length line > 2 && line.[0] = '#' && line.[1] = ' '
+            then (
+              (* New test without classes *)
+              let new_name = String.sub line 2 (String.length line - 2) in
+              current_variants := [];
+              current_theme_vars := [];
+              current_theme_modes := [];
+              current_utility_defs := [];
+              current_layer_wrap := None;
+              parse_config new_name No_theme rest)
+            else
+              let classes = split_classes line in
+              parse_after_classes name config classes rest
+      and parse_after_classes name config classes lines =
+        match lines with
+        | [] -> ()
+        | line :: rest ->
+            let line = String.trim line in
+            if line = "---" then
+              parse_expected name config classes (Buffer.create 256) rest
+            else if line = "<<<>>>" then
+              (* No expected CSS, skip this test *)
+              parse rest
+            else parse rest
+      and parse_expected name config classes buf lines =
+        match lines with
+        | [] ->
             let expected = Buffer.contents buf |> String.trim in
             if classes <> [] then
               tests :=
@@ -245,15 +232,61 @@ let read filename =
                   utility_defs = List.rev !current_utility_defs;
                   layer_wrap = !current_layer_wrap;
                 }
-                :: !tests;
-            parse rest)
-          else (
-            if Buffer.length buf > 0 then Buffer.add_char buf '\n';
-            Buffer.add_string buf line;
-            parse_expected name config classes buf rest)
-    in
-    parse lines;
-    List.rev !tests
+                :: !tests
+        | line :: rest ->
+            if String.trim line = "<<<>>>" then (
+              let expected = Buffer.contents buf |> String.trim in
+              if classes <> [] then
+                tests :=
+                  {
+                    source = filename;
+                    name;
+                    config;
+                    classes;
+                    expected;
+                    variants = List.rev !current_variants;
+                    theme_vars = List.rev !current_theme_vars;
+                    theme_modes = List.rev !current_theme_modes;
+                    utility_defs = List.rev !current_utility_defs;
+                    layer_wrap = !current_layer_wrap;
+                  }
+                  :: !tests;
+              parse rest)
+            else (
+              if Buffer.length buf > 0 then Buffer.add_char buf '\n';
+              Buffer.add_string buf line;
+              parse_expected name config classes buf rest)
+      in
+      parse lines;
+      List.rev !tests
+
+(* A fixture is found beside the executable under the dune sandbox, and under
+   [upstream/] or [test/upstream/] when the test runs from a parent
+   directory. *)
+(* Blocks are counted on the separator the reader splits on, so the count is the
+   reader's own notion of a block rather than a second one beside it. *)
+let blocks filename =
+  List.length
+    (List.filter (fun line -> String.trim line = "<<<>>>") (lines_of filename))
+
+(* The banner the extractor writes: "#! <n> blocks extracted from ...". It
+   starts with [#!] rather than [# ] so the block scan walks past it. *)
+let declared_blocks filename =
+  match lines_of filename with
+  | [] -> None
+  | first :: _ ->
+      let first = String.trim first in
+      let prefix = "#! " in
+      let n = String.length prefix in
+      if String.length first <= n || String.sub first 0 n <> prefix then None
+      else
+        let tail = String.sub first n (String.length first - n) in
+        let count =
+          match String.index_opt tail ' ' with
+          | Some i -> String.sub tail 0 i
+          | None -> tail
+        in
+        int_of_string_opt count
 
 (* A fixture is found beside the executable under the dune sandbox, and under
    [upstream/] or [test/upstream/] when the test runs from a parent

--- a/test/upstream/upstream_fixture.mli
+++ b/test/upstream/upstream_fixture.mli
@@ -1,7 +1,7 @@
-(** Reader for the generated upstream fixtures ([utilities.txt],
-    [variants.txt]).
+(** Reader for the upstream fixtures: the generated [utilities.txt] and
+    [variants.txt], both generated.
 
-    The fixtures are one block per upstream test, separated by [<<<>>>]:
+    The fixtures are one block per test, separated by [<<<>>>]:
 
     {v
     # <test name>
@@ -15,6 +15,10 @@
     ---
     <expected CSS>
     v}
+
+    A generated fixture opens with a [#!] provenance banner naming the number of
+    blocks the extractor wrote; {!blocks} and {!declared_blocks} read the two
+    counts so a caller can hold one against the other.
 
     Both the fixture replay in [test/upstream/test.ml] and the parse-parity gate
     in [test/test_tw.ml] read the same corpus, so they read it here: two readers
@@ -67,6 +71,18 @@ val split_classes : string -> string list
 val read : string -> case list
 (** [read path] reads every block of the fixture at [path]. A file that does not
     exist reads as no cases, which the caller's floor turns into a failure. *)
+
+val blocks : string -> int
+(** [blocks path] is the number of blocks in the fixture at [path], counted on
+    the [<<<>>>] separator {!read} splits on. A file that does not exist has
+    none. *)
+
+val declared_blocks : string -> int option
+(** [declared_blocks path] is the block count the fixture's [#!] provenance
+    banner declares, or [None] for a file without one: a hand-maintained
+    fixture, or one that does not exist. A generated fixture whose {!blocks}
+    disagrees with this has been edited since it was generated, and the edit is
+    what the next regeneration would drop. *)
 
 val path : string -> string option
 (** [path basename] is where [basename] sits relative to the running test:

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -1,3 +1,4 @@
+#! 699 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
 # sr-only
 @config run
 sr-only

--- a/test/upstream/variants.txt
+++ b/test/upstream/variants.txt
@@ -1,3 +1,4 @@
+#! 166 blocks extracted from variants.test.ts by extract_tests.exe -- do not edit
 # *
 @config run
 *:flex
@@ -1110,6 +1111,11 @@ print/foo:flex
 @theme-var breakpoint-lg 1024px
 @theme-var breakpoint-xl 1280px
 @theme-var breakpoint-2xl 1536px
+@theme-mode breakpoint-sm reference
+@theme-mode breakpoint-md reference
+@theme-mode breakpoint-lg reference
+@theme-mode breakpoint-xl reference
+@theme-mode breakpoint-2xl reference
 2xl/foo:flex lg/foo:flex md/foo:flex sm/foo:flex xl/foo:flex
 ---
 
@@ -1159,6 +1165,9 @@ max-lg:flex max-md:flex max-sm:flex
 @theme-var breakpoint-sm 640px
 @theme-var breakpoint-lg 1024px
 @theme-var breakpoint-md 768px
+@theme-mode breakpoint-sm reference
+@theme-mode breakpoint-lg reference
+@theme-mode breakpoint-md reference
 max-lg/foo:flex max-md/foo:flex max-sm/foo:flex
 ---
 
@@ -1195,6 +1204,9 @@ min-lg:flex min-md:flex min-sm:flex
 @theme-var breakpoint-sm 640px
 @theme-var breakpoint-lg 1024px
 @theme-var breakpoint-md 768px
+@theme-mode breakpoint-sm reference
+@theme-mode breakpoint-lg reference
+@theme-mode breakpoint-md reference
 min-lg/foo:flex min-md/foo:flex min-sm/foo:flex
 ---
 
@@ -1505,40 +1517,6 @@ supports-[(display:grid)_and_font-format(opentype)]:grid supports-[--test]:flex 
 
     @supports var(--test) {
       .supports-\[var\(--test\)\]\:flex {
-        display: flex;
-      }
-    }
-    
-<<<>>>
-# supports
-@config run
-supports-[user-select]:flex supports-backdrop-filter:flex supports-hyphens:flex supports-text-size-adjust:flex supports-user-select:flex
----
-
-    @supports (backdrop-filter: var(--tw)) {
-      .supports-backdrop-filter\:flex {
-        display: flex;
-      }
-    }
-
-    @supports (hyphens: var(--tw)) {
-      .supports-hyphens\:flex {
-        display: flex;
-      }
-    }
-
-    @supports (text-size-adjust: var(--tw)) {
-      .supports-text-size-adjust\:flex {
-        display: flex;
-      }
-    }
-
-    @supports (user-select: var(--tw)) {
-      .supports-user-select\:flex {
-        display: flex;
-      }
-
-      .supports-\[user-select\]\:flex {
         display: flex;
       }
     }
@@ -2261,43 +2239,6 @@ group-peer-focus/name:flex has-group-focus/name:flex in-group-focus/name:flex no
 
     .not-group-focus\/name\:flex:not(:is(:where(.group\/name):focus *)), .group-peer-focus\/name\:flex:is(:where(.group\/name):is(:where(.peer):focus ~ *) *), :where(:is(:where(.group\/name):focus *)) .in-group-focus\/name\:flex, .has-group-focus\/name\:flex:has(:is(:where(.group\/name):focus *)) {
       display: flex;
-    }
-    
-<<<>>>
-
-# container queries are sorted by the value the class spells
-@config run
-@min-[100px]:inline @min-[2rem]:table @lg:grid @min-[64rem]:block @min-[theme(--breakpoint-sm)]:flex
----
-
-    @container (min-width: 100px) {
-      .\@min-\[100px\]\:inline {
-        display: inline;
-      }
-    }
-
-    @container (min-width: 2rem) {
-      .\@min-\[2rem\]\:table {
-        display: table;
-      }
-    }
-
-    @container (min-width: 32rem) {
-      .\@lg\:grid {
-        display: grid;
-      }
-    }
-
-    @container (min-width: 64rem) {
-      .\@min-\[64rem\]\:block {
-        display: block;
-      }
-    }
-
-    @container (min-width: 40rem) {
-      .\@min-\[theme\(--breakpoint-sm\)\]\:flex {
-        display: flex;
-      }
     }
     
 <<<>>>


### PR DESCRIPTION
`variants.txt` declares itself generated, but carried two blocks that do not exist in Tailwind v4.3.3, added by hand in 89cb6c97 and 0254f257. Regenerating dropped them silently, and nothing failed.

Both turned out to be tw regression tests duplicating coverage `test_modifiers.ml` and `test_sort.ml` already had, and had more precisely -- the modifiers test also asserts no vendor prefixes, and the sort test explains why a container variant sorts on the value's text rather than its resolved width. So they are removed rather than relocated: a case upstream does not have is a regression test and belongs in its own `test_<module>.ml`.

The extractor now writes a `#!` provenance banner naming the block count, and the runner fails when a fixture's real count disagrees with it, so a hand-added block is reported while it is still there instead of vanishing at the next regeneration. Both fixtures now reproduce byte for byte from the pinned v4.3.3 sources.