### PR TITLE
var: read a bracket reference body through cascade

### DIFF
--- a/lib/var.ml
+++ b/lib/var.ml
@@ -518,31 +518,42 @@ let order_of_declaration decl =
 let property_initial_declaration = declaration_of_property_info
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]
 
+(* CSS Syntax 3 (ED), the [<declaration-value>] production: any token sequence
+   with no unmatched [)], []] or [}] in it. A [var()] read whole gets that for
+   free - its function token ends at the first unmatched closer, and text after
+   it is text the reference does not cover - but a cursor over the arguments
+   alone has no closer to end at, so the loose one is looked for here. *)
+let closes_nothing = function
+  | Cascade.Component.Preserved { kind = Cascade.Token.Close _; _ } -> true
+  | _ -> false
+
 let bracket ?fallback name =
+  (* Both readers hand back the name without its [--] and the fallback as
+     [<declaration-value>] text, which is what [Css.Values.syntax_fallback]
+     (below) consumes. *)
+  let read_whole source read =
+    try
+      let cursor = Cascade.Cursor.of_string source in
+      if List.exists closes_nothing (Cascade.Cursor.remaining cursor) then None
+      else
+        let name, fallback = read cursor in
+        (* Text neither reader consumed is text the reference does not cover. *)
+        if Cascade.Cursor.is_done cursor then Some (name, fallback) else None
+    with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> None
+  in
   let parsed_reference =
     match fallback with
     | Some _ -> None
     | None ->
-        let expression =
-          if String.starts_with ~prefix:"var(" name then Some name
-          else if String.contains name ',' then
-            (* [Css.Variables.read_reference_body] reads this same grammar
-               straight off a cursor, without the [var(]/[)] wrapper - but it
-               takes a [Cursor.t -> 'a] reader for the fallback and hands back
-               an ['a var], and [bracket] has no witness for 'a here: it is
-               called at many different value types with nothing to pick a
-               reader from. [read_reference]'s string-returning fallback is what
-               [Css.Values.syntax_fallback] (below) is built to consume, so the
-               wrapper still has to be assembled for it. *)
-            Some ("var(--" ^ name ^ ")")
-          else None
-        in
-        Option.bind expression (fun expression ->
-            try
-              Some
-                (Css.Variables.read_reference
-                   (Cascade.Cursor.of_string expression))
-            with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> None)
+        if String.starts_with ~prefix:"var(" name then
+          read_whole name Css.Variables.read_reference
+        else if String.contains name ',' then
+          (* [name] is a [var()] body: the custom property and the fallback
+             written after the comma, the spelling {!Parse.extract_var_name}
+             retains. [--] is the property's own prefix, the one [css_name]
+             writes back. *)
+          read_whole ("--" ^ name) Css.Variables.read_reference_body_as_string
+        else None
   in
   match parsed_reference with
   | Some (name, Some fallback) ->

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -64,6 +64,37 @@ let arbitrary_var_fallbacks () =
     (Astring.String.is_infix ~affix:"top:var(--top,"
        (inline_css "top-(--top,0)"))
 
+(* CSS Syntax 3 (ED): a [<declaration-value>] carries no unmatched [)], so
+   bracket text holding one names no reference and no fallback. Splitting it at
+   the comma anyway would take [--a] with [b)c] behind it and write the loose
+   [)] into the sheet, where it closes the [var()] early and leaves a stray one
+   after it. The whole text stays the escaped name it is. *)
+let bracket_reference_with_loose_closer () =
+  let css class_name =
+    match Tw.of_string class_name with
+    | Ok utility ->
+        Css.to_string ~minify:true (Tw.to_css ~base:false [ utility ])
+    | Error (`Msg msg) -> failf "%s: %s" class_name msg
+  in
+  let declaration class_name =
+    let sheet = css class_name in
+    match Astring.String.cut ~sep:"top:" sheet with
+    | Some (_, rest) -> (
+        match Astring.String.cut ~sep:"}" rest with
+        | Some (decl, _) -> decl
+        | None -> rest)
+    | None -> failf "%s: no top declaration in %s" class_name sheet
+  in
+  check string "bracket keeps the loose closer inside the name"
+    {|var(--a\,b\)c)|}
+    (declaration "top-[var(--a,b)c)]");
+  check string "paren shorthand keeps the loose closer inside the name"
+    {|var(--a\,b\)c)|}
+    (declaration "top-(--a,b)c)");
+  (* The same text without the loose closer is the reference it looks like. *)
+  check string "a closed body is read as name and fallback" "var(--a,b)"
+    (declaration "top-[var(--a,b)]")
+
 (* Test theme layer contains variables *)
 let var_in_theme_layer () =
   let styles = Tw.[ text_xl; text red; p 4 ] in
@@ -251,6 +282,8 @@ let tests =
     test_case "var CSS output" `Quick var_css_output;
     test_case "var fallback in CSS" `Quick var_fallback_in_css;
     test_case "arbitrary var fallbacks" `Quick arbitrary_var_fallbacks;
+    test_case "bracket reference with loose closer" `Quick
+      bracket_reference_with_loose_closer;
     test_case "var in theme layer" `Quick var_in_theme_layer;
     test_case "ring-offset-width properties layer spelling" `Quick
       ring_offset_width_properties_layer_spelling;


### PR DESCRIPTION
Read var() reference arguments from the Cascade cursor API without reconstructing a synthetic function. Reject top-level close tokens so body-only parsing preserves declaration-value well-formedness and cannot emit unbalanced CSS.