### PR TITLE
test: gate on the tree diff, which sees what canonical folds away

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -2,6 +2,7 @@
 
 module Css = Cascade.Css
 module Css_compare = Cascade_diff.Css_compare
+module Tree_diff = Cascade_diff.Tree_diff
 
 (** Check that a utility value produces the expected class name *)
 let check_class expected t =
@@ -485,6 +486,74 @@ let check_ordering_matches ?forms ~test_name utilities =
       let buf = Buffer.create 1024 in
       Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
       Alcotest.failf "%s\n%s" test_name (Buffer.contents buf)
+
+(* Cascade's printer and Tailwind's minifier spell the same value differently
+   wherever CSS makes the difference insignificant: a custom property holds
+   [oklch(63.7% .237 25.331)] on one side and [oklch(63.7%.237 25.331)] on the
+   other, a font stack keeps its quotes on one and drops them on the other.
+   Neither sheet is wrong, so a comparison sensitive to the bytes reads both
+   through the same printer first. Parsing and re-printing respells a sheet
+   without changing what it declares: the printer merges no rules, moves none,
+   and drops no binding, so a rule written twice stays written twice and a
+   binding nothing reads stays bound. A sheet the reader rejects is passed
+   through untouched, leaving {!Css_compare} to report the parse error. *)
+let respelled css =
+  match Css.of_string css with
+  | Ok { Css.stylesheet; _ } -> Css.to_string ~minify:true stylesheet
+  | Error _ -> css
+
+let tree_diff_css ~expected ~actual =
+  Css_compare.diff ~mode:`Tree (respelled expected) (respelled actual)
+
+let tree_diff ?(forms = false) utilities =
+  let classnames = List.map Tw.pp utilities in
+  tree_diff_css
+    ~expected:(tailwind_css ~forms classnames)
+    ~actual:(our_css utilities)
+
+(* What tw's sheet carries that Tailwind's does not: a whole rule, or a
+   declaration inside a rule both sheets write. A rule emitted twice reads as
+   the second copy being added, and a custom-property binding nothing references
+   as the binding being added, so the two are one question. Mode [`Canonical]
+   answers neither: its optimizer folds the second copy away, and every caller
+   prunes unreferenced bindings off both sides before comparing.
+
+   A container only one sheet has contributes nothing: the two sheets spell an
+   [@container] query differently and the block comes and goes as a pair, so
+   reading its rules here would report the spelling. *)
+let rule_surplus where acc (rule : Tree_diff.rule_diff) =
+  match rule with
+  | Tree_diff.Added { selector; _ } ->
+      Fmt.str "%s%s (the whole rule)" where selector :: acc
+  | Tree_diff.Content_changed { selector; added_properties; _ } ->
+      List.fold_left
+        (fun acc prop -> Fmt.str "%s%s { %s }" where selector prop :: acc)
+        acc added_properties
+  | _ -> acc
+
+let rec container_surplus where acc (container : Tree_diff.container_diff) =
+  match container with
+  | Tree_diff.Modified { info; rule_changes; container_changes; _ } ->
+      let where = where ^ info.condition ^ " " in
+      let acc = List.fold_left (rule_surplus where) acc rule_changes in
+      List.fold_left (container_surplus where) acc container_changes
+  | _ -> acc
+
+let surplus (diff : Css_compare.t) =
+  match diff.Css_compare.result with
+  | Css_compare.Tree_diff t ->
+      let acc = List.fold_left (rule_surplus "") [] t.Tree_diff.rules in
+      List.rev
+        (List.fold_left (container_surplus "") acc t.Tree_diff.containers)
+  | _ -> []
+
+let check_no_surplus ~test_name diff =
+  match surplus diff with
+  | [] -> ()
+  | extra ->
+      Alcotest.failf
+        "%s: tw writes %d rule(s) or declaration(s) Tailwind does not:\n%s"
+        test_name (List.length extra) (String.concat "\n" extra)
 
 (* Where a class's rule starts in a sheet. The match has to end where the class
    name ends, so [.bg-top] does not report [.bg-top-left]; what follows it is

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -86,6 +86,48 @@ val check_ordering_matches :
     of utilities between our implementation and Tailwind CSS, failing the test
     if they differ. *)
 
+val tree_diff_css :
+  expected:string -> actual:string -> Cascade_diff.Css_compare.t
+(** [tree_diff_css ~expected ~actual] compares two sheets structurally, in mode
+    [`Tree] and with nothing pruned, after respelling both through cascade's
+    printer.
+
+    The respelling is what makes the mode usable against the real CLI. Cascade
+    and Tailwind's minifier write the same value differently wherever CSS makes
+    the difference insignificant - [oklch(63.7% .237 25.331)] against
+    [oklch(63.7%.237 25.331)], a quoted font stack against an unquoted one - and
+    a structural comparison reads a custom property's value as bytes, so those
+    spellings read as differences. Parsing and re-printing puts both sheets in
+    one spelling and changes nothing else: the printer merges no rules, moves
+    none and drops no binding.
+
+    Mode [`Canonical], which every other Tailwind oracle here uses, cannot
+    report a rule written twice (its optimizer folds the copy away) nor a
+    custom-property binding nothing reads (every caller prunes those off both
+    sides). This is the mode that can. *)
+
+val tree_diff : ?forms:bool -> Tw.t list -> Cascade_diff.Css_compare.t
+(** [tree_diff ?forms utilities] is {!tree_diff_css} between the pinned Tailwind
+    CLI's sheet for [utilities] and tw's, base layer included on both sides.
+    Goes through {!require_tailwind_cli}. *)
+
+val surplus : Cascade_diff.Css_compare.t -> string list
+(** [surplus diff] is what tw's sheet carries that Tailwind's does not: a rule
+    Tailwind has no counterpart for, and a declaration added to a rule both
+    sheets write, each described by where it sits. A rule emitted twice appears
+    as the second copy being added and a binding nothing references as the
+    binding being added, so one list answers for both. Empty for any [diff] that
+    is not a tree diff.
+
+    A rule inside a container only one sheet has is not counted: an [@media] or
+    [@container] block the two sheets spell differently comes and goes as a
+    pair, and reading its rules as surplus would report the spelling rather than
+    anything tw wrote twice. *)
+
+val check_no_surplus : test_name:string -> Cascade_diff.Css_compare.t -> unit
+(** [check_no_surplus ~test_name diff] fails when {!surplus} is non-empty,
+    naming every rule and declaration tw writes and Tailwind does not. *)
+
 val class_position : string -> string -> int option
 (** [class_position sheet cls] is the byte offset in [sheet] where the rule for
     class [cls] starts, or [None] when the sheet declares no such class. The

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -176,6 +176,126 @@ let test_order_gap_agreeing_sheets () =
     "nothing moves when the orders agree" (3, 0)
     (g.Test_helpers.pairs, g.Test_helpers.moves)
 
+(* Mode [`Tree] is the only mode that reports a rule written twice or a
+   custom-property binding nothing reads: mode [`Canonical] folds the second
+   copy away in its optimizer, and every caller of it prunes unreferenced
+   bindings off both sides first. The cases below feed {!Test_helpers.surplus}
+   sheets that carry one of those by construction, and sheets that carry only
+   the differences the check is not asking about. *)
+let surplus_of ~expected ~actual =
+  Test_helpers.surplus (Test_helpers.tree_diff_css ~expected ~actual)
+
+let test_surplus_reports_a_rule_written_twice () =
+  Alcotest.(check int)
+    "the second copy is surplus" 1
+    (List.length
+       (surplus_of ~expected:"@layer utilities{.a{color:red}.b{color:blue}}"
+          ~actual:"@layer utilities{.a{color:red}.b{color:blue}.a{color:red}}"))
+
+let test_surplus_reports_a_binding_nothing_reads () =
+  Alcotest.(check int)
+    "the dead binding is surplus" 1
+    (List.length
+       (surplus_of
+          ~expected:
+            "@layer theme{:root{--a:1px}}@layer utilities{.x{width:var(--a)}}"
+          ~actual:
+            "@layer theme{:root{--a:1px;--dead:2px}}@layer \
+             utilities{.x{width:var(--a)}}"))
+
+(* Two rules writing different properties can be emitted in either order without
+   changing what any element computes. That is a difference tree mode reports
+   and this check deliberately does not: ordering has its own oracles in
+   {!Test_helpers.check_class_order} and {!Test_helpers.sheet_order_gap}. *)
+let test_surplus_ignores_a_cascade_neutral_reorder () =
+  Alcotest.(check int)
+    "a reorder adds nothing" 0
+    (List.length
+       (surplus_of ~expected:"@layer utilities{.a{color:red}.b{width:1px}}"
+          ~actual:"@layer utilities{.b{width:1px}.a{color:red}}"))
+
+(* What respelling both sheets through one printer buys: the two minifiers write
+   this value differently and CSS reads the two spellings as the same tokens, so
+   the comparison must not see a difference here. Without the respelling it
+   does, and mode [`Tree] cannot gate anything against the real CLI. *)
+let test_respelling_settles_a_minifier_disagreement () =
+  let diff =
+    Test_helpers.tree_diff_css ~expected:":root{--c:oklch(63.7% .237 25.331)}"
+      ~actual:":root{--c:oklch(63.7%.237 25.331)}"
+  in
+  match diff.Cascade_diff.Css_compare.result with
+  | Cascade_diff.Css_compare.No_diff -> ()
+  | _ ->
+      let buf = Buffer.create 256 in
+      Cascade_diff.Css_compare.pp ~expected:"Tailwind" ~actual:"tw" buf diff;
+      Alcotest.failf "one value, two spellings, reported as a difference:\n%s"
+        (Buffer.contents buf)
+
+(* One class from every family tw implements, plus one of every variant shape,
+   so the sheet the check reads spans the generator rather than a corner of it.
+   Kept as class names because that is what both sides are asked for. *)
+let broad_class_set =
+  List.concat_map Tw_tools.Source_scan.split_whitespace
+    [
+      (* Layout, box model, sizing. *)
+      "p-4 px-2 m-4 -m-2 mt-8 gap-4 gap-x-2 block flex grid hidden w-4 h-8 \
+       max-w-4xl z-10 top-0 absolute relative container aspect-video columns-3 \
+       box-border isolate overflow-hidden overscroll-contain contain-layout";
+      (* Flex and grid. *)
+      "flex-col basis-1/2 grow shrink-0 order-2 items-center justify-between \
+       place-items-center content-center self-end justify-self-start \
+       grid-cols-2 col-span-2 row-start-2 auto-cols-fr grid-flow-col";
+      (* Borders, backgrounds, effects. *)
+      "border border-2 border-b border-gray-200 border-solid divide-x-2 \
+       divide-gray-200 rounded-sm rounded-t-lg bg-white bg-blue-600 shadow-md \
+       inset-shadow-sm ring-2 inset-ring-2 opacity-50 outline-none outline-2 \
+       mix-blend-multiply bg-blend-overlay mask-none";
+      (* Typography. *)
+      "text-lg text-gray-900 font-bold leading-relaxed tracking-wide indent-4 \
+       align-middle whitespace-nowrap break-words hyphens-auto antialiased \
+       list-disc underline uppercase truncate line-clamp-3 text-shadow-lg \
+       tab-4";
+      (* Filters and transforms. *)
+      "blur-sm brightness-125 contrast-50 grayscale invert saturate-150 sepia \
+       hue-rotate-90 drop-shadow-md backdrop-blur-sm translate-x-4 rotate-90 \
+       scale-50 skew-x-6 origin-top-left perspective-normal transform-3d \
+       backface-hidden";
+      (* Transitions, interactivity, tables, SVG, scrolling. *)
+      "transition-all duration-150 animate-spin will-change-transform \
+       cursor-pointer select-none appearance-none resize-none caret-red-500 \
+       accent-blue-500 field-sizing-content touch-pan-x scroll-mt-4 \
+       scroll-smooth table-fixed fill-current stroke-2 sr-only";
+      (* One of every variant shape. *)
+      "hover:bg-blue-500 focus:outline-none active:bg-blue-700 \
+       disabled:opacity-50 first:pt-0 last:pb-0 odd:bg-gray-50 before:block \
+       after:block marker:text-gray-500 placeholder:text-gray-400 \
+       dark:bg-gray-900 sm:p-2 md:grid-cols-2 lg:flex xl:hidden max-md:block \
+       min-lg:flex motion-safe:animate-pulse motion-reduce:transition-none \
+       contrast-more:border-4 group-hover:text-white peer-checked:bg-blue-500 \
+       peer-focus:ring-2 aria-checked:bg-blue-500 data-[state=open]:block \
+       not-hover:opacity-50 has-[:focus]:border-2 supports-grid:flex \
+       starting:opacity-0 @container @sm:flex dark:hover:bg-gray-800 \
+       dark:focus:outline-none md:hover:bg-blue-500 sm:dark:p-4 \
+       lg:group-hover:text-white";
+      (* Arbitrary values, including one holding a colon. *)
+      "bg-[color:var(--brand)] hover:bg-[color:var(--brand)] \
+       w-[calc(100%-1rem)] text-[14px] rotate-[10deg]";
+    ]
+
+let test_no_surplus_over_a_broad_class_set () =
+  let utilities =
+    List.map
+      (fun cls ->
+        match Tw.of_string cls with
+        | Ok u -> u
+        | Error (`Msg m) -> Alcotest.failf "%s does not parse: %s" cls m)
+      broad_class_set
+  in
+  let diff = Test_helpers.tree_diff utilities in
+  let test_name = "broad class set" in
+  Test_helpers.check_no_dropped_declarations ~test_name diff;
+  Test_helpers.check_no_surplus ~test_name diff
+
 let tests =
   [
     Alcotest.test_case "class position: continuing selector" `Quick
@@ -210,6 +330,16 @@ let tests =
       test_order_gap_drops_a_repeated_key;
     Alcotest.test_case "order gap: agreeing sheets" `Quick
       test_order_gap_agreeing_sheets;
+    Alcotest.test_case "surplus: a rule written twice" `Quick
+      test_surplus_reports_a_rule_written_twice;
+    Alcotest.test_case "surplus: a binding nothing reads" `Quick
+      test_surplus_reports_a_binding_nothing_reads;
+    Alcotest.test_case "surplus: a cascade-neutral reorder" `Quick
+      test_surplus_ignores_a_cascade_neutral_reorder;
+    Alcotest.test_case "respelling settles a minifier disagreement" `Quick
+      test_respelling_settles_a_minifier_disagreement;
+    Alcotest.test_case "no surplus over a broad class set" `Slow
+      test_no_surplus_over_a_broad_class_set;
   ]
 
 let suite = ("test_helpers", tests)


### PR DESCRIPTION
Normalize both sheets through the Cascade printer before tree diffing, removing spelling-only noise without merging, moving, or pruning rules. Gate representative classes on tw-only surplus so duplicate rules and unread custom properties remain visible despite canonical mode.