### PR TITLE
var: give tail theme tokens distinct bands

### DIFF
--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -67,11 +67,11 @@ let font_variation =
 
 let mono_font_feature =
   Var.theme Css.Font_feature_settings "default-mono-font-feature-settings"
-    ~order:(8, 42)
+    ~order:(8, 43)
 
 let mono_font_variation =
   Var.theme Css.Font_variation_settings "default-mono-font-variation-settings"
-    ~order:(8, 43)
+    ~order:(8, 44)
 
 (** Helper for creating variable references in preflight context
 

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -73,7 +73,7 @@ module Handler = struct
   (* Theme variable for transition-property-opacity *)
   let transition_property_opacity_var =
     Var.theme Css.Transition_property_value "transition-property-opacity"
-      ~order:(8, 2)
+      ~order:(8, 32)
 
   let transition_none = style [ Css.transition_property [ Css.None ] ]
 
@@ -170,7 +170,7 @@ module Handler = struct
   (* Theme variable for transition-property-colors *)
   let transition_property_colors_var =
     Var.theme Css.Transition_property_value "transition-property-colors"
-      ~order:(8, 3)
+      ~order:(8, 33)
 
   let transition_colors ?theme () =
     let gradient_from_name =

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -279,10 +279,10 @@ let font_mono_var = Var.theme Css.Font_family "font-mono" ~order:(1, 2)
 
 (* Default font family variables that reference the base font variables *)
 let default_font_family_var =
-  Var.theme Css.Font_family "default-font-family" ~order:(9, 0)
+  Var.theme Css.Font_family "default-font-family" ~order:(8, 39)
 
 let default_mono_font_family_var =
-  Var.theme Css.Font_family "default-mono-font-family" ~order:(9, 1)
+  Var.theme Css.Font_family "default-mono-font-family" ~order:(8, 42)
 
 (* Tailwind v4.3.2 replaced the [ui-sans-serif, system-ui, ...] default with the
    platform system-font stack. *)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 581, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 575, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -174,7 +174,16 @@ let order_of_family_bands () =
   expect "blur-xs" (8, 0);
   expect "perspective-dramatic" (8, 10);
   expect "aspect-video" (8, 20);
-  expect "default-transition-duration" (8, 30)
+  expect "default-transition-duration" (8, 30);
+  expect "default-transition-timing-function" (8, 31);
+  expect "transition-property-opacity" (8, 32);
+  expect "transition-property-colors" (8, 33);
+  expect "default-font-family" (8, 39);
+  expect "default-font-feature-settings" (8, 40);
+  expect "default-font-variation-settings" (8, 41);
+  expect "default-mono-font-family" (8, 42);
+  expect "default-mono-font-feature-settings" (8, 43);
+  expect "default-mono-font-variation-settings" (8, 44)
 
 (* A project [@theme] may name font families of its own; they all sit at (1,
    100). Rendering one must not decide the answer for the others. *)


### PR DESCRIPTION
Tw assigned transition-property theme variables to blur slots and placed derived font-family defaults after the feature and variation settings they should bracket. Give each token a distinct position matching Tailwind’s theme order; the whole-sheet order metric improves from 581 to 575 movable pairs.

The regression pins the transition and font-default bands directly so future changes cannot silently recreate these cascade-neutral collisions.