### PR TITLE
test: cover every utility family in the sort fuzzer

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -62,7 +62,29 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "arbitrary"
-  let priority _ = 37
+
+  (* Tailwind sorts an arbitrary property by the property it declares, not by
+     its name, so [[order:3]] lands with the [order-*] utilities and
+     [[mask-type:luminance]] with the masks. Every one of them sorted at the far
+     end of the layer instead. A property no family claims has no slot to take
+     and keeps that place. *)
+  let unclaimed = 37
+
+  let slot t =
+    let property, value =
+      match t with
+      | Color_opacity { property; value; _ } -> (property, value)
+      | Parsed_decl { property; value } -> (property, value)
+    in
+    match
+      Css.parse_declaration ~layer:"utilities" property
+        (Parse.decode_arbitrary_value value)
+    with
+    | None -> None
+    | Some decl -> Utility.order_of_property (Css.Declaration.property_key decl)
+
+  let priority t =
+    match slot t with Some (priority, _) -> priority | None -> unclaimed
 
   (* Render a known colour-property declaration ([color], [background-color],
      ...) with a parsed colour value and an /opacity modifier. *)
@@ -264,7 +286,7 @@ module Handler = struct
               | Some color -> color_opacity_render theme emit color inner
               | None -> style []))
 
-  let suborder _ = 0
+  let suborder t = match slot t with Some (_, sub) -> sub | None -> 0
 
   let to_class = function
     | Color_opacity { property; value; alpha_fn; opacity } ->

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -157,43 +157,21 @@ let rec filter_utility_properties props =
     props
 
 (* Recursively filter theme declarations from nested statements *)
-let rec filter_theme_from_statements statements =
+(* Theme tokens belong in the theme layer, so a utility rule that declares one
+   to make its own value available has it stripped here. [Css.map] reaches every
+   rule at any depth, [@starting-style] included, which the walk this replaces
+   did not descend into: [md:starting:p-4] declared [--spacing] inside the rule
+   as well as in the theme layer. A bare declarations block carries no selector,
+   so [Css.map] does not see one and the top level is filtered before it. *)
+let filter_theme_from_statements statements =
   List.map
     (fun stmt ->
       match Css.as_declarations stmt with
-      | Some decls ->
-          (* Bare declarations block - filter theme properties *)
-          let filtered_decls = filter_utility_properties decls in
-          Css.declarations filtered_decls
-      | None -> (
-          match Css.as_rule stmt with
-          | Some (selector, decls, nested) ->
-              let filtered_decls = filter_utility_properties decls in
-              let filtered_nested = filter_theme_from_statements nested in
-              Css.rule ~selector ~nested:filtered_nested filtered_decls
-          | None -> (
-              match Css.as_media stmt with
-              | Some (condition, content) ->
-                  Css.media ~condition (filter_theme_from_statements content)
-              | None -> (
-                  match Css.as_layer stmt with
-                  | Some (name, content) ->
-                      Css.layer ?name (filter_theme_from_statements content)
-                  | None -> (
-                      match Css.as_container stmt with
-                      | Some (name, condition, content) ->
-                          Css.container ?name ?condition
-                            (filter_theme_from_statements content)
-                      | None -> (
-                          (* An opacity colour's progressive-enhancement block
-                             carries the same theme declaration as the rule it
-                             sits beside; without this it is declared twice. *)
-                          match Css.as_supports stmt with
-                          | Some (condition, content) ->
-                              Css.supports ~condition
-                                (filter_theme_from_statements content)
-                          | None -> stmt))))))
+      | Some decls -> Css.declarations (filter_utility_properties decls)
+      | None -> stmt)
     statements
+  |> Css.map (fun selector decls ->
+      Css.rule ~selector (filter_utility_properties decls))
 
 (* Compute merge key from a base class name as a fallback when the utility
    handler does not provide a typed merge_key via Style.t. For bracket

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1350,25 +1350,25 @@ let has_pseudo_elements tw_classes =
   in
   List.exists check_utility tw_classes
 
-let has_transition_utility selector_props =
-  List.exists
-    (fun r ->
-      let bc =
-        match r with
-        | Regular { base_class; _ }
-        | Media_query { base_class; _ }
-        | Container_query { base_class; _ }
-        | Starting_style { base_class; _ }
-        | Supports_query { base_class; _ } ->
-            base_class
-      in
-      match bc with
-      | Some c ->
-          String.length c >= 10
-          && String.sub c 0 10 = "transition"
-          && c <> "transition-none"
-      | None -> false)
-    selector_props
+(* The default duration and timing function are theme declarations every
+   [transition-*] rule reads, so a sheet carrying one of those utilities needs
+   them however the utility is dressed. Reading the name off the emitted class
+   missed [hover:transition] and every other variant, whose class is
+   [hover:transition], and the rule then referenced a variable nothing
+   declared. *)
+let has_transition_utility tw_classes =
+  let rec check = function
+    | Utility.Base b ->
+        let c = Utility.class_of_base b in
+        String.length c >= 10
+        && String.sub c 0 10 = "transition"
+        && not (String.equal c "transition-none")
+    | Utility.Modified (_, u) | Utility.Important (_, u) | Utility.Aliased (_, u)
+      ->
+        check u
+    | Utility.Group us -> List.exists check us
+  in
+  List.exists check tw_classes
 
 (* Result of building individual layers *)
 type layers_result = {
@@ -1379,14 +1379,14 @@ type layers_result = {
   property_rules : Css.statement list;
 }
 
-let individual_layers ~theme ~layers ~include_base ~forms_base first_usage_order
-    selector_props all_property_statements statements =
+let individual_layers ~theme ~layers ~include_base ~forms_base ~has_transition
+    first_usage_order selector_props all_property_statements statements =
   let theme_defaults =
     let font_defaults =
       if include_base then Typography.default_font_family_declarations else []
     in
     let transition_defaults =
-      if include_base && has_transition_utility selector_props then
+      if include_base && has_transition then
         Transitions.default_transition_declarations
       else []
     in
@@ -1476,8 +1476,9 @@ let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
      flag, so utility presence must not auto-enable the global base. *)
   let forms_base = match forms with Some f -> f | None -> false in
   let individual =
-    individual_layers ~theme ~layers ~include_base ~forms_base first_usage_order
-      selector_props all_property_statements statements
+    individual_layers ~theme ~layers ~include_base ~forms_base
+      ~has_transition:(has_transition_utility tw_classes)
+      first_usage_order selector_props all_property_statements statements
   in
   let keyframes =
     List.fold_left collect_keyframes [] styles

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -375,39 +375,44 @@ module Handler = struct
     | Auto_rows_spacing n -> auto_rows_spacing n
     | Auto_rows_arbitrary (_, template) -> auto_rows_arbitrary template
 
+  (* Tailwind emits these five families in the alphabetical order of the CSS
+     property each declares: grid-auto-columns, grid-auto-flow, grid-auto-rows,
+     grid-template-columns, grid-template-rows. The bands below follow that, not
+     the template-before-auto reading they used to have, which put
+     [auto-rows-min] after [grid-cols-3] where Tailwind puts it before. *)
   let suborder = function
-    (* Grid template columns (10000-10999) *)
-    (* Order: numeric → arbitrary → keywords alphabetical *)
-    | Grid_cols n -> 10000 + n
-    | Grid_cols_arbitrary _ -> 10800
-    | Grid_cols_none -> 10900
-    | Grid_cols_subgrid -> 10901
-    (* Grid template rows (11000-11999) *)
-    | Grid_rows n -> 11000 + n
-    | Grid_rows_arbitrary _ -> 11800
-    | Grid_rows_none -> 11900
-    | Grid_rows_subgrid -> 11901
-    (* Grid auto flow (14000-14099) - alphabetical order *)
-    | Grid_flow_col -> 14000
-    | Grid_flow_col_dense -> 14001
-    | Grid_flow_dense -> 14002
-    | Grid_flow_row -> 14003
-    | Grid_flow_row_dense -> 14004
-    (* Grid auto columns (15000-15099) *)
+    (* Grid auto columns (10000-10099) *)
     (* Order: spacing (numeric) → arbitrary → keywords alphabetical *)
-    | Auto_cols_spacing _ -> 15000
-    | Auto_cols_arbitrary _ -> 15001
-    | Auto_cols_auto -> 15002
-    | Auto_cols_fr -> 15003
-    | Auto_cols_max -> 15004
-    | Auto_cols_min -> 15005
-    (* Grid auto rows (15100-15199) *)
-    | Auto_rows_spacing _ -> 15100
-    | Auto_rows_arbitrary _ -> 15101
-    | Auto_rows_auto -> 15102
-    | Auto_rows_fr -> 15103
-    | Auto_rows_max -> 15104
-    | Auto_rows_min -> 15105
+    | Auto_cols_spacing _ -> 10000
+    | Auto_cols_arbitrary _ -> 10001
+    | Auto_cols_auto -> 10002
+    | Auto_cols_fr -> 10003
+    | Auto_cols_max -> 10004
+    | Auto_cols_min -> 10005
+    (* Grid auto flow (10100-10199) - alphabetical order *)
+    | Grid_flow_col -> 10100
+    | Grid_flow_col_dense -> 10101
+    | Grid_flow_dense -> 10102
+    | Grid_flow_row -> 10103
+    | Grid_flow_row_dense -> 10104
+    (* Grid auto rows (10200-10299) *)
+    | Auto_rows_spacing _ -> 10200
+    | Auto_rows_arbitrary _ -> 10201
+    | Auto_rows_auto -> 10202
+    | Auto_rows_fr -> 10203
+    | Auto_rows_max -> 10204
+    | Auto_rows_min -> 10205
+    (* Grid template columns (11000-11999) *)
+    (* Order: numeric → arbitrary → keywords alphabetical *)
+    | Grid_cols n -> 11000 + n
+    | Grid_cols_arbitrary _ -> 11800
+    | Grid_cols_none -> 11900
+    | Grid_cols_subgrid -> 11901
+    (* Grid template rows (12000-12999) *)
+    | Grid_rows n -> 12000 + n
+    | Grid_rows_arbitrary _ -> 12800
+    | Grid_rows_none -> 12900
+    | Grid_rows_subgrid -> 12901
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -234,8 +234,8 @@ module Handler = struct
     | Clear_both | Clear_end | Clear_left | Clear_none | Clear_right
     | Clear_start ->
         1
-    (* object-fit / object-position (rank ~72): after svg fill/stroke (21),
-       before padding (23). *)
+    (* object-fit / object-position (rank ~72): after svg fill/stroke, which
+       shares this priority, and before padding (23). *)
     | Object_contain | Object_cover | Object_fill | Object_none
     | Object_scale_down | Object_center | Object_top | Object_bottom
     | Object_left | Object_right | Object_bottom_left | Object_bottom_right
@@ -292,27 +292,29 @@ module Handler = struct
     | Neg_z_arbitrary _ -> 20_000_000 + 560
     | Z_arbitrary _ -> 20_000_000 + 700
     | Z_auto -> 20_000_000 + 750
-    (* Object fit *)
-    | Object_contain -> 600
-    | Object_cover -> 601
-    | Object_fill -> 602
-    | Object_none -> 603
-    | Object_scale_down -> 604
+    (* Object fit, after every fill and stroke: svg.ml shares this priority and
+       Tailwind emits it first of the two, so the whole family starts past what
+       that handler assigns. *)
+    | Object_contain -> Svg.suborder_ceiling + 600
+    | Object_cover -> Svg.suborder_ceiling + 601
+    | Object_fill -> Svg.suborder_ceiling + 602
+    | Object_none -> Svg.suborder_ceiling + 603
+    | Object_scale_down -> Svg.suborder_ceiling + 604
     (* Object position - alphabetical: bottom, bottom-left, ..., top-right *)
-    | Object_bottom -> 700
-    | Object_bottom_left -> 701
-    | Object_bottom_right -> 702
-    | Object_center -> 703
-    | Object_left -> 704
-    | Object_left_bottom -> 705
-    | Object_left_top -> 706
-    | Object_right -> 707
-    | Object_right_bottom -> 708
-    | Object_right_top -> 709
-    | Object_top -> 710
-    | Object_top_left -> 711
-    | Object_top_right -> 712
-    | Object_arbitrary _ -> 650
+    | Object_bottom -> Svg.suborder_ceiling + 700
+    | Object_bottom_left -> Svg.suborder_ceiling + 701
+    | Object_bottom_right -> Svg.suborder_ceiling + 702
+    | Object_center -> Svg.suborder_ceiling + 703
+    | Object_left -> Svg.suborder_ceiling + 704
+    | Object_left_bottom -> Svg.suborder_ceiling + 705
+    | Object_left_top -> Svg.suborder_ceiling + 706
+    | Object_right -> Svg.suborder_ceiling + 707
+    | Object_right_bottom -> Svg.suborder_ceiling + 708
+    | Object_right_top -> Svg.suborder_ceiling + 709
+    | Object_top -> Svg.suborder_ceiling + 710
+    | Object_top_left -> Svg.suborder_ceiling + 711
+    | Object_top_right -> Svg.suborder_ceiling + 712
+    | Object_arbitrary _ -> Svg.suborder_ceiling + 650
     (* Float (priority 1) - after the grid-column/grid-row group (up to ~2.6K in
        grid_item.ml), before .container (9M). Alphabetical: end, left, none,
        right, start *)

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -408,24 +408,24 @@ let structural_selector cls modifier =
   | First_of_type -> cp "first-of-type" cls Css.Selector.First_of_type
   | Last_of_type -> cp "last-of-type" cls Css.Selector.Last_of_type
   | Only_of_type -> cp "only-of-type" cls Css.Selector.Only_of_type
-  | Nth expr ->
-      let nth, of_ = parse_nth_selector expr in
-      let prefix = Style.pp_nth "nth" expr in
+  | Nth n ->
+      let nth, of_ = parse_nth_selector n.Style.expr in
+      let prefix = Style.pp_nth "nth" n in
       Css.Selector.compound
         [ Css.Selector.Class (prefix ^ ":" ^ cls); Nth_child (nth, of_) ]
-  | Nth_last expr ->
-      let nth, of_ = parse_nth_selector expr in
-      let prefix = Style.pp_nth "nth-last" expr in
+  | Nth_last n ->
+      let nth, of_ = parse_nth_selector n.Style.expr in
+      let prefix = Style.pp_nth "nth-last" n in
       Css.Selector.compound
         [ Css.Selector.Class (prefix ^ ":" ^ cls); Nth_last_child (nth, of_) ]
-  | Nth_of_type expr ->
-      let nth, of_ = parse_nth_selector expr in
-      let prefix = Style.pp_nth "nth-of-type" expr in
+  | Nth_of_type n ->
+      let nth, of_ = parse_nth_selector n.Style.expr in
+      let prefix = Style.pp_nth "nth-of-type" n in
       Css.Selector.compound
         [ Css.Selector.Class (prefix ^ ":" ^ cls); Nth_of_type (nth, of_) ]
-  | Nth_last_of_type expr ->
-      let nth, of_ = parse_nth_selector expr in
-      let prefix = Style.pp_nth "nth-last-of-type" expr in
+  | Nth_last_of_type n ->
+      let nth, of_ = parse_nth_selector n.Style.expr in
+      let prefix = Style.pp_nth "nth-last-of-type" n in
       Css.Selector.compound
         [ Css.Selector.Class (prefix ^ ":" ^ cls); Nth_last_of_type (nth, of_) ]
   | Empty -> cp "empty" cls Css.Selector.Empty
@@ -710,8 +710,8 @@ let even styles = wrap Even styles
 let first_of_type styles = wrap First_of_type styles
 let last_of_type styles = wrap Last_of_type styles
 let only_of_type styles = wrap Only_of_type styles
-let nth expr styles = wrap (Nth expr) styles
-let nth_last expr styles = wrap (Nth_last expr) styles
+let nth expr styles = wrap (Nth (Style.nth_expr expr)) styles
+let nth_last expr styles = wrap (Nth_last (Style.nth_expr expr)) styles
 let empty styles = wrap Empty styles
 
 (* Form state variants *)
@@ -1255,6 +1255,12 @@ let is_valid_supports_condition cond =
       true
     with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> false
 
+(* Which spelling an [nth-*] argument was written in. A bare number reads both
+   ways and they are different classes, so the reader records the one it saw
+   rather than deciding again when it prints. *)
+let bracketed expr : Style.nth_expr = { expr; bracketed = true }
+let bare expr : Style.nth_expr = { expr; bracketed = false }
+
 (* Validate that an nth-*-[...] bracket holds an An+B expression (Selectors 4
    sec. 9.3). The reader raises on anything else, so the expression is checked
    where the modifier is parsed, like the has- selector above. *)
@@ -1324,10 +1330,11 @@ let bracket_value_patterns s =
       try_with "min-[" parse_css_length (fun l -> Min_arbitrary_length l));
     (fun () ->
       try_with "max-[" parse_css_length (fun l -> Max_arbitrary_length l));
-    (fun () -> try_nth "nth-last-of-type-[" (fun e -> Nth_last_of_type e));
-    (fun () -> try_nth "nth-of-type-[" (fun e -> Nth_of_type e));
-    (fun () -> try_nth "nth-last-[" (fun e -> Nth_last e));
-    (fun () -> try_nth "nth-[" (fun e -> Nth e));
+    (fun () ->
+      try_nth "nth-last-of-type-[" (fun e -> Nth_last_of_type (bracketed e)));
+    (fun () -> try_nth "nth-of-type-[" (fun e -> Nth_of_type (bracketed e)));
+    (fun () -> try_nth "nth-last-[" (fun e -> Nth_last (bracketed e)));
+    (fun () -> try_nth "nth-[" (fun e -> Nth (bracketed e)));
     (fun () ->
       let* cond = extract_bracket_content ~prefix:"supports-[" s in
       if is_valid_supports_condition cond then Some (Supports_condition cond)
@@ -1387,15 +1394,15 @@ let try_numeric_nth s =
       if Style.is_numeric rest then Some (make rest) else None
     else None
   in
-  match try_prefix "nth-last-of-type-" (fun n -> Nth_last_of_type n) with
+  match try_prefix "nth-last-of-type-" (fun n -> Nth_last_of_type (bare n)) with
   | Some _ as r -> r
   | None -> (
-      match try_prefix "nth-of-type-" (fun n -> Nth_of_type n) with
+      match try_prefix "nth-of-type-" (fun n -> Nth_of_type (bare n)) with
       | Some _ as r -> r
       | None -> (
-          match try_prefix "nth-last-" (fun n -> Nth_last n) with
+          match try_prefix "nth-last-" (fun n -> Nth_last (bare n)) with
           | Some _ as r -> r
-          | None -> try_prefix "nth-" (fun n -> Nth n)))
+          | None -> try_prefix "nth-" (fun n -> Nth (bare n))))
 
 (* Simple modifiers - direct string to modifier mapping *)
 let simple_modifiers =
@@ -1645,7 +1652,7 @@ let try_not_shorthand inner =
     (* nth-X shorthand — :nth-child(X) *)
   else if String.length inner > 4 && String.sub inner 0 4 = "nth-" then
     let expr = String.sub inner 4 (String.length inner - 4) in
-    Some (Not (Nth expr))
+    Some (Not (Nth (Style.nth_expr expr)))
   else None
 
 (** Check if a modifier is compatible with not-* negation. Pseudo-elements,

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1312,6 +1312,8 @@ let bracket_named_patterns s =
       if is_valid_has_selector sel then Some (Has sel) else None);
   ]
 
+(* Every [nth-*-[...]] arm goes through [try_nth], so the bracket flag is set in
+   one place. *)
 let bracket_value_patterns s =
   let ( let* ) = Option.bind in
   let try_with prefix parse make =
@@ -1321,7 +1323,7 @@ let bracket_value_patterns s =
   in
   let try_nth prefix make =
     let* expr = extract_bracket_content ~prefix s in
-    if is_valid_nth_expr expr then Some (make expr) else None
+    if is_valid_nth_expr expr then Some (make (bracketed expr)) else None
   in
   [
     (fun () -> try_with "min-[" parse_px_value (fun px -> Min_arbitrary px));
@@ -1330,11 +1332,10 @@ let bracket_value_patterns s =
       try_with "min-[" parse_css_length (fun l -> Min_arbitrary_length l));
     (fun () ->
       try_with "max-[" parse_css_length (fun l -> Max_arbitrary_length l));
-    (fun () ->
-      try_nth "nth-last-of-type-[" (fun e -> Nth_last_of_type (bracketed e)));
-    (fun () -> try_nth "nth-of-type-[" (fun e -> Nth_of_type (bracketed e)));
-    (fun () -> try_nth "nth-last-[" (fun e -> Nth_last (bracketed e)));
-    (fun () -> try_nth "nth-[" (fun e -> Nth (bracketed e)));
+    (fun () -> try_nth "nth-last-of-type-[" (fun e -> Nth_last_of_type e));
+    (fun () -> try_nth "nth-of-type-[" (fun e -> Nth_of_type e));
+    (fun () -> try_nth "nth-last-[" (fun e -> Nth_last e));
+    (fun () -> try_nth "nth-[" (fun e -> Nth e));
     (fun () ->
       let* cond = extract_bracket_content ~prefix:"supports-[" s in
       if is_valid_supports_condition cond then Some (Supports_condition cond)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1992,7 +1992,9 @@ let rec apply_modifier_to_rule ?theme modifier = function
   | Container_query { condition; selector; props; base_class; nested } ->
       apply_modifier_to_container_query ?theme modifier ~condition ~selector
         ~props ~base_class ~nested
-  | other -> [ other ]
+  | Starting_style { selector; props; base_class; nested } ->
+      apply_modifier_to_starting_style ?theme modifier ~selector ~props
+        ~base_class ~nested
 
 (* Apply a modifier to a [@container] rule, the way the [@supports] case does:
    run it on the inner rule so all the selector and media machinery applies,
@@ -2053,6 +2055,33 @@ and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
     | Media_query { condition = outer; selector; props; base_class; nested; _ }
       ->
         wrap_supports_in_media outer selector props base_class nested
+    | other -> other)
+
+(* An outer variant on a [@starting-style] rule, the way the [@supports] case
+   does it: run the modifier on the inner rule so all the selector and media
+   machinery applies, then put each result back inside the at-rule. With no arm
+   of its own the rule fell through the catch-all and the variant went with it,
+   so [hover:starting:p-4] named its rule [.starting\:p-4] and matched nothing
+   in the markup. *)
+and apply_modifier_to_starting_style ?theme modifier ~selector ~props
+    ~base_class ~nested =
+  let inner = regular ~selector ~props ?base_class ~nested () in
+  let started sel p = Css.starting_style [ Css.rule ~selector:sel p ] in
+  apply_modifier_to_rule ?theme modifier inner
+  |> List.map (function
+    | Regular { selector; props; base_class; has_hover; nested; _ } ->
+        (* A bare hover: rule carries [has_hover] rather than an outer media, so
+           the at-rule goes inside [@media (hover:hover)] to match. *)
+        if has_hover then
+          media_query ~condition:hover_media ~selector ~props:[] ?base_class
+            ~nested:(started selector props :: nested)
+            ()
+        else starting_style ~selector ~props ?base_class ~nested ()
+    | Media_query { condition = outer; selector; props; base_class; nested; _ }
+      ->
+        media_query ~condition:outer ~selector ~props:[] ?base_class
+          ~nested:(started selector props :: nested)
+          ()
     | other -> other)
 
 (* Handle Modified style by recursively extracting and applying modifier *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -327,6 +327,12 @@ let selector_with_data_key selector key value =
 let nested_hover ~selector ~props =
   [ Css.media ~condition:hover_media [ Css.rule ~selector props ] ]
 
+(* At-rule variants carry their rule in [nested] when an inner hover-gated
+   variant is present. Keeping the declarations on the wrapper would discard
+   [has_hover], because only [Regular] outputs retain that flag. *)
+let at_rule_body ~inner_has_hover ~selector ~props =
+  if inner_has_hover then ([], nested_hover ~selector ~props) else (props, [])
+
 let media_rule_with_prefix ?(inner_has_hover = false) prefix condition
     base_class selector props =
   let modified_class = prefix ^ ":" ^ base_class in
@@ -853,26 +859,34 @@ let normalize_supports_condition = Modifiers.normalize_supports_condition
 
 (** Handle [supports-<property>] modifier: builds the shorthand class name and
     emits [\@supports (prop: var(--tw))] directly, typed. *)
-let handle_supports_property_modifier prop base_class selector props =
+let handle_supports_property_modifier ?(inner_has_hover = false) prop base_class
+    selector props =
   let modified_class = "supports-" ^ prop ^ ":" ^ base_class in
   let new_selector =
     Rules_selector.replace_class_in_selector ~old_class:base_class
       ~new_class:modified_class selector
   in
   let condition = Css.Supports.property prop "var(--tw)" in
-  supports_query ~condition ~selector:new_selector ~props
+  let props, nested =
+    at_rule_body ~inner_has_hover ~selector:new_selector ~props
+  in
+  supports_query ~condition ~selector:new_selector ~props ~nested
     ~base_class:modified_class ()
 
 (** Handle [supports-[condition]] modifier: builds the bracket class name,
     normalizes the author's condition text, and emits a supports query rule. *)
-let handle_supports_condition_modifier condition_str base_class selector props =
+let handle_supports_condition_modifier ?(inner_has_hover = false) condition_str
+    base_class selector props =
   let modified_class = "supports-[" ^ condition_str ^ "]:" ^ base_class in
   let new_selector =
     Rules_selector.replace_class_in_selector ~old_class:base_class
       ~new_class:modified_class selector
   in
   let condition = normalize_supports_condition condition_str in
-  supports_query ~condition ~selector:new_selector ~props
+  let props, nested =
+    at_rule_body ~inner_has_hover ~selector:new_selector ~props
+  in
+  supports_query ~condition ~selector:new_selector ~props ~nested
     ~base_class:modified_class ()
 
 (** Map a media-like modifier to its corresponding Css.Media.t condition.
@@ -1538,18 +1552,21 @@ let arbitrary_selector_rule content base_class selector props =
 (* An at-rule written in brackets: [[@supports(display:grid)]] wraps the utility
    in that query, [[@starting-style]] in [@starting-style]. The class name keeps
    the brackets, so it cannot go through the [supports-] spelling. *)
-let at_rule_variant content ~selector base_class props =
+let at_rule_variant ?(inner_has_hover = false) content ~selector base_class
+    props =
   let modified_class = "[" ^ content ^ "]:" ^ base_class in
   let selector =
     Rules_selector.transform_selector_with_modifier
       (Css.Selector.Class modified_class) base_class modified_class selector
   in
+  let props, nested = at_rule_body ~inner_has_hover ~selector ~props in
   if content = "@starting-style" then
-    starting_style ~selector ~props ~base_class:modified_class ()
+    starting_style ~selector ~props ~nested ~base_class:modified_class ()
   else
     let cond = String.trim (String.sub content 9 (String.length content - 9)) in
     let condition = normalize_supports_condition cond in
-    supports_query ~condition ~selector ~props ~base_class:modified_class ()
+    supports_query ~condition ~selector ~props ~nested
+      ~base_class:modified_class ()
 
 (* A [matchVariant]-registered custom variant. The class name is the token
    ([is-data-foo]); the selector is the template with [&] replaced by the
@@ -1610,6 +1627,30 @@ let prose_element_rule name ~base_class ~selector props =
     ~base_class:("prose-" ^ name ^ ":" ^ base_class)
     ()
 
+let starting_rule ~inner_has_hover base_class selector props =
+  let modified_class = "starting:" ^ base_class in
+  (* Rebuilding the selector from the bare class would drop what an inner
+     variant put on it, as [open:]'s [:is([open], :popover-open, :open)]. *)
+  let selector =
+    Rules_selector.transform_selector_with_modifier
+      (Css.Selector.Class modified_class) base_class modified_class selector
+  in
+  let props, nested = at_rule_body ~inner_has_hover ~selector ~props in
+  starting_style ~selector ~props ~nested ~base_class:modified_class ()
+
+let container_style_rule ~inner_has_hover token condition base_class selector
+    props =
+  (* A [@custom-variant] whose body is a container query wraps the utility in
+     its structural condition. *)
+  let modified_class = token ^ ":" ^ base_class in
+  let selector =
+    Rules_selector.replace_class_in_selector ~old_class:base_class
+      ~new_class:modified_class selector
+  in
+  let props, nested = at_rule_body ~inner_has_hover ~selector ~props in
+  container_query ~condition ~selector ~props ~nested ~base_class:modified_class
+    ()
+
 let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
     selector props =
   match modifier with
@@ -1626,9 +1667,11 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
         selector props
   (* Supports feature query *)
   | Style.Supports_property prop ->
-      handle_supports_property_modifier prop base_class selector props
+      handle_supports_property_modifier ~inner_has_hover prop base_class
+        selector props
   | Style.Supports_condition condition_str ->
-      handle_supports_condition_modifier condition_str base_class selector props
+      handle_supports_condition_modifier ~inner_has_hover condition_str
+        base_class selector props
   (* Responsive and container *)
   | Style.Responsive breakpoint ->
       responsive_rule ?theme ~inner_has_hover breakpoint base_class selector
@@ -1683,15 +1726,7 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
   | Style.Data_bracket _ | Style.Group_data _ | Style.Peer_data _ ->
       route_data_bracket_modifier modifier ~selector base_class props
   (* Starting style - selector includes starting: prefix *)
-  | Style.Starting ->
-      let modified_class = "starting:" ^ base_class in
-      (* Rebuilding the selector from the bare class would drop what an inner
-         variant put on it, as [open:]'s [:is([open], :popover-open, :open)]. *)
-      let new_selector =
-        Rules_selector.transform_selector_with_modifier
-          (Css.Selector.Class modified_class) base_class modified_class selector
-      in
-      starting_style ~selector:new_selector ~props ~base_class:modified_class ()
+  | Style.Starting -> starting_rule ~inner_has_hover base_class selector props
   (* Interactive pseudo-classes *)
   | Style.Hover | Style.Focus | Style.Active | Style.Focus_within
   | Style.Focus_visible | Style.Disabled ->
@@ -1702,20 +1737,13 @@ let dispatch_modifier ?theme ?(inner_has_hover = false) modifier base_class
       handle_pseudo_element_modifier modifier base_class props
   | Style.Arbitrary_selector content ->
       arbitrary_selector_rule content base_class selector props
-  | Style.At_rule content -> at_rule_variant content ~selector base_class props
+  | Style.At_rule content ->
+      at_rule_variant ~inner_has_hover content ~selector base_class props
   | Style.Custom_variant (token, template) ->
       custom_variant_rule token template base_class props
   | Style.Container_style (token, condition) ->
-      (* A [@custom-variant] whose body is a container query: wrap the utility
-         in [@container <condition>], like [container_rule] but with a
-         structural condition supplied by the variant. *)
-      let modified_class = token ^ ":" ^ base_class in
-      let new_selector =
-        Rules_selector.replace_class_in_selector ~old_class:base_class
-          ~new_class:modified_class selector
-      in
-      container_query ~condition ~selector:new_selector ~props
-        ~base_class:modified_class ()
+      container_style_rule ~inner_has_hover token condition base_class selector
+        props
   (* Prose element variants — descendant selector with element filter *)
   | Style.Prose_element name ->
       prose_element_rule name ~base_class ~selector props
@@ -1775,23 +1803,23 @@ let arbitrary_selector_in_media content bc selector props ~inner_condition
 (** Apply a modifier to a Media_query rule by wrapping it in an outer media
     query. Handles media-like modifiers, responsive modifiers, and falls back to
     returning the rule unchanged. *)
-let rec rename_class_in_stmt ~old_class ~new_class stmt =
-  let recurse = rename_class_in_stmt ~old_class ~new_class in
-  match Css.as_rule stmt with
-  | Some (selector, decls, nested) ->
-      Css.rule
-        ~selector:
-          (Rules_selector.replace_class_in_selector ~old_class ~new_class
-             selector)
-        ~nested:(List.map recurse nested) decls
-  | None -> (
-      match Css.as_media stmt with
-      | Some (condition, stmts) -> Css.media ~condition (List.map recurse stmts)
-      | None -> (
-          match Css.as_supports stmt with
-          | Some (condition, stmts) ->
-              Css.supports ~condition (List.map recurse stmts)
-          | None -> stmt))
+let rec map_selectors_in_stmt f (stmt : Css.statement) =
+  let recurse = map_selectors_in_stmt f in
+  let open Cascade.Stylesheet in
+  match stmt with
+  | Rule r ->
+      Rule
+        { r with selector = f r.selector; nested = List.map recurse r.nested }
+  | Media (condition, stmts) -> Media (condition, List.map recurse stmts)
+  | Container (name, condition, stmts) ->
+      Container (name, condition, List.map recurse stmts)
+  | Supports (condition, stmts) -> Supports (condition, List.map recurse stmts)
+  | Starting_style stmts -> Starting_style (List.map recurse stmts)
+  | other -> other
+
+let rename_class_in_stmt ~old_class ~new_class =
+  map_selectors_in_stmt
+    (Rules_selector.replace_class_in_selector ~old_class ~new_class)
 
 let apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
     ~props ~base_class ~nested =
@@ -1903,6 +1931,32 @@ let nest_inside_at_rule inner = function
       Output.Media_query { r with nested = inner :: nested }
   | other -> other
 
+(* Rewrite every rule in an at-rule's finished body with the same selector
+   transformation its outer variant applied to the wrapper's selector. The
+   exact-selector case also covers arbitrary selector variants, whose spelling
+   cannot be reconstructed through [Modifiers.to_selector]. *)
+let rewrite_at_rule_body modifier ~base_class ~selector ~modified_class
+    ~modified_selector nested =
+  let modified_base_selector =
+    if wraps_in_at_rule modifier then None
+    else
+      match Modifiers.to_selector modifier base_class with
+      | selector -> Some selector
+      | exception Invalid_argument _ -> None
+  in
+  let rewrite inner_selector =
+    if Css.Selector.equal inner_selector selector then modified_selector
+    else
+      match modified_base_selector with
+      | Some modified_base_selector ->
+          Rules_selector.transform_selector_with_modifier modified_base_selector
+            base_class modified_class inner_selector
+      | None ->
+          Rules_selector.replace_class_in_selector ~old_class:base_class
+            ~new_class:modified_class inner_selector
+  in
+  List.map (map_selectors_in_stmt rewrite) nested
+
 (* Extract selector and properties from a single Utility *)
 (* Apply modifier to extracted rule *)
 let rec apply_modifier_to_rule ?theme modifier = function
@@ -1986,6 +2040,11 @@ let rec apply_modifier_to_rule ?theme modifier = function
       { condition = inner_condition; selector; props; base_class; nested; _ } ->
       apply_modifier_to_media_query ?theme modifier ~inner_condition ~selector
         ~props ~base_class ~nested
+  | ( Supports_query { nested; _ }
+    | Container_query { nested; _ }
+    | Starting_style { nested; _ } ) as output
+    when nested <> [] ->
+      apply_modifier_to_nested_output ?theme modifier output
   | Supports_query { condition; selector; props; base_class; merge_key; _ } ->
       apply_modifier_to_supports_query ?theme modifier ~condition ~selector
         ~props ~base_class ~merge_key
@@ -1995,6 +2054,68 @@ let rec apply_modifier_to_rule ?theme modifier = function
   | Starting_style { selector; props; base_class; nested } ->
       apply_modifier_to_starting_style ?theme modifier ~selector ~props
         ~base_class ~nested
+
+and apply_modifier_to_nested_output ?theme modifier = function
+  | Supports_query { condition; selector; props; base_class; merge_key; nested }
+    ->
+      apply_nested_at_rule ?theme modifier ~selector ~props ~base_class ~nested
+        ~wrap_statement:(fun body -> Css.supports ~condition body)
+        ~wrap_output:(fun ~selector ~base_class ~nested ->
+          supports_query ~condition ~selector ~props:[] ?base_class ?merge_key
+            ~nested ())
+  | Container_query { condition; selector; props; base_class; nested } ->
+      apply_nested_at_rule ?theme modifier ~selector ~props ~base_class ~nested
+        ~wrap_statement:(fun body -> Css.container ~condition body)
+        ~wrap_output:(fun ~selector ~base_class ~nested ->
+          container_query ~condition ~selector ~props:[] ?base_class ~nested ())
+  | Starting_style { selector; props; base_class; nested } ->
+      apply_nested_at_rule ?theme modifier ~selector ~props ~base_class ~nested
+        ~wrap_statement:Css.starting_style
+        ~wrap_output:(fun ~selector ~base_class ~nested ->
+          starting_style ~selector ~props:[] ?base_class ~nested ())
+  | _ -> invalid_arg "nested at-rule output"
+
+(* A hover-gated at-rule has a finished body in [nested] and no declarations on
+   the wrapper itself. Apply the outer variant to a plain rule to obtain its
+   selector/query, rewrite the finished body with that same selector change,
+   then put the original at-rule at the correct depth. *)
+and apply_nested_at_rule ?theme modifier ~selector ~props ~base_class ~nested
+    ~wrap_statement ~wrap_output =
+  let bc = Option.value base_class ~default:"" in
+  apply_modifier_to_rule ?theme modifier
+    (regular ~selector ~props ?base_class ())
+  |> List.map (fun outer ->
+      let modified_selector, modified_props, modified_base_class =
+        match outer with
+        | Regular { selector; props; base_class; _ }
+        | Media_query { selector; props; base_class; _ }
+        | Container_query { selector; props; base_class; _ }
+        | Starting_style { selector; props; base_class; _ }
+        | Supports_query { selector; props; base_class; _ } ->
+            (selector, props, base_class)
+      in
+      let modified_class = Option.value modified_base_class ~default:bc in
+      let nested =
+        rewrite_at_rule_body modifier ~base_class:bc ~selector ~modified_class
+          ~modified_selector nested
+      in
+      let body =
+        (if modified_props = [] then []
+         else [ Css.rule ~selector:modified_selector modified_props ])
+        @ nested
+      in
+      let inner = wrap_statement body in
+      match outer with
+      | Regular { has_hover = true; _ } ->
+          media_query ~condition:hover_media ~selector:modified_selector
+            ~props:[] ?base_class:modified_base_class ~nested:[ inner ] ()
+      | Regular _ ->
+          wrap_output ~selector:modified_selector
+            ~base_class:modified_base_class ~nested:body
+      | Media_query ({ nested; _ } as r) ->
+          Media_query { r with props = []; nested = inner :: nested }
+      | (Container_query _ | Starting_style _ | Supports_query _) as wrapper ->
+          nest_inside_at_rule inner wrapper)
 
 (* Apply a modifier to a [@container] rule, the way the [@supports] case does:
    run it on the inner rule so all the selector and media machinery applies,

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -1959,57 +1959,69 @@ let rewrite_at_rule_body modifier ~base_class ~selector ~modified_class
 
 (* Extract selector and properties from a single Utility *)
 (* Apply modifier to extracted rule *)
+let preserve_hover_gate has_hover rules =
+  if has_hover then
+    List.map
+      (function
+        | Output.Regular r -> Output.Regular { r with has_hover = true }
+        | rule -> rule)
+      rules
+  else rules
+
 let rec apply_modifier_to_rule ?theme modifier = function
-  | Regular { selector; props; base_class; has_hover; _ } -> (
+  | Regular { selector; props; base_class; has_hover; _ } ->
       let bc = Option.value base_class ~default:"" in
       let rebase ~selector rules =
         rebase_on_selector ~base_class:bc ~selector rules
       in
-      match modifier with
-      | Style.Pseudo_marker ->
-          let open Css.Selector in
-          pseudo_element_rules
-            ~pseudo_selectors:[ Marker; Webkit_details_marker ]
-            bc props "marker"
-      | Style.Pseudo_selection ->
-          let open Css.Selector in
-          pseudo_element_rules ~pseudo_selectors:[ Selection ] bc props
-            "selection"
-      | Style.Not inner_modifier -> (
-          match inner_modifier with
-          | Style.In_bracket content -> handle_not_in_bracket content bc props
-          | Style.In_data attr -> handle_not_in_data attr bc props
-          | _ -> handle_not_modifier ?theme inner_modifier bc selector props)
-      | Style.Not_bracket content ->
-          rebase ~selector (handle_not_bracket content bc props)
-      | Style.In_bracket content ->
-          rebase ~selector (handle_in_bracket content bc props)
-      | Style.In_data attr -> rebase ~selector (handle_in_data attr bc props)
-      | Style.In_state (inner, name) ->
-          rebase ~selector (handle_in_state inner name bc props)
-      | Style.Group_not (inner, name_opt) ->
-          rebase ~selector (handle_group_not_modifier inner name_opt bc props)
-      | Style.Peer_not (inner, name_opt) ->
-          rebase ~selector (handle_peer_not_modifier inner name_opt bc props)
-      | Style.Named_group (inner, name) ->
-          rebase ~selector (handle_named_group inner name bc props)
-      | Style.Named_peer (inner, name) ->
-          rebase ~selector (handle_named_peer inner name bc props)
-      | Style.Not_named_group (inner, name) ->
-          rebase ~selector (handle_not_named_group inner name bc props)
-      | Style.Has_named_group (inner, name) ->
-          rebase ~selector (handle_has_named_group inner name bc props)
-      | Style.In_named_group (inner, name) ->
-          rebase ~selector (handle_in_named_group inner name bc props)
-      | Style.Group_peer_named (inner, name) ->
-          rebase ~selector (handle_group_peer_named inner name bc props)
-      | _ -> (
-          try
-            [
-              modifier_to_rule_themed ?theme ~inner_has_hover:has_hover modifier
-                bc selector props;
-            ]
-          with Invalid_argument _ -> []))
+      let rules =
+        match modifier with
+        | Style.Pseudo_marker ->
+            let open Css.Selector in
+            pseudo_element_rules
+              ~pseudo_selectors:[ Marker; Webkit_details_marker ]
+              bc props "marker"
+        | Style.Pseudo_selection ->
+            let open Css.Selector in
+            pseudo_element_rules ~pseudo_selectors:[ Selection ] bc props
+              "selection"
+        | Style.Not inner_modifier -> (
+            match inner_modifier with
+            | Style.In_bracket content -> handle_not_in_bracket content bc props
+            | Style.In_data attr -> handle_not_in_data attr bc props
+            | _ -> handle_not_modifier ?theme inner_modifier bc selector props)
+        | Style.Not_bracket content ->
+            rebase ~selector (handle_not_bracket content bc props)
+        | Style.In_bracket content ->
+            rebase ~selector (handle_in_bracket content bc props)
+        | Style.In_data attr -> rebase ~selector (handle_in_data attr bc props)
+        | Style.In_state (inner, name) ->
+            rebase ~selector (handle_in_state inner name bc props)
+        | Style.Group_not (inner, name_opt) ->
+            rebase ~selector (handle_group_not_modifier inner name_opt bc props)
+        | Style.Peer_not (inner, name_opt) ->
+            rebase ~selector (handle_peer_not_modifier inner name_opt bc props)
+        | Style.Named_group (inner, name) ->
+            rebase ~selector (handle_named_group inner name bc props)
+        | Style.Named_peer (inner, name) ->
+            rebase ~selector (handle_named_peer inner name bc props)
+        | Style.Not_named_group (inner, name) ->
+            rebase ~selector (handle_not_named_group inner name bc props)
+        | Style.Has_named_group (inner, name) ->
+            rebase ~selector (handle_has_named_group inner name bc props)
+        | Style.In_named_group (inner, name) ->
+            rebase ~selector (handle_in_named_group inner name bc props)
+        | Style.Group_peer_named (inner, name) ->
+            rebase ~selector (handle_group_peer_named inner name bc props)
+        | _ -> (
+            try
+              [
+                modifier_to_rule_themed ?theme ~inner_has_hover:has_hover
+                  modifier bc selector props;
+              ]
+            with Invalid_argument _ -> [])
+      in
+      preserve_hover_gate has_hover rules
   | Media_query
       { condition = inner_condition; selector; props; base_class; nested; _ }
     when wraps_in_at_rule modifier ->

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -74,6 +74,12 @@ type arbitrary_px = { px : float; text : string }
    respelling the number. The class is named after [text]. *)
 type arbitrary_length = { len : Css.length; text : string }
 
+(* An [nth-*] argument with the bracket flag: [nth-3] and [nth-[3]] both read
+   and are different classes, so re-printing from the expression alone renamed
+   the second to the first and the rule named a class the source never
+   carried. *)
+type nth_expr = { expr : string; bracketed : bool }
+
 type modifier =
   | Hover
   | Focus
@@ -124,10 +130,10 @@ type modifier =
   | First_of_type
   | Last_of_type
   | Only_of_type
-  | Nth of string
-  | Nth_last of string
-  | Nth_of_type of string
-  | Nth_last_of_type of string
+  | Nth of nth_expr
+  | Nth_last of nth_expr
+  | Nth_of_type of nth_expr
+  | Nth_last_of_type of nth_expr
   | Empty
   | Checked
   | Indeterminate
@@ -383,8 +389,12 @@ let rec map_important = function
 
 let is_numeric s = s <> "" && String.for_all (fun c -> c >= '0' && c <= '9') s
 
-let pp_nth prefix expr =
-  if is_numeric expr then prefix ^ "-" ^ expr else prefix ^ "-[" ^ expr ^ "]"
+(* A bare number is the only expression that can go unbracketed, so that is what
+   the DSL constructor writes; the reader records what it saw instead. *)
+let nth_expr expr = { expr; bracketed = not (is_numeric expr) }
+
+let pp_nth prefix n =
+  if n.bracketed then prefix ^ "-[" ^ n.expr ^ "]" else prefix ^ "-" ^ n.expr
 
 let container_cmp_prefix = function Min -> "min-" | Max -> "max-"
 

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -52,6 +52,15 @@ type arbitrary_length = {
     the first thing it cannot use, so re-printing the length respells the number
     and drops any remainder, leaving a selector the markup does not carry. *)
 
+type nth_expr = {
+  expr : string;  (** the An+B expression, e.g. ["3"] or ["2n+1"] *)
+  bracketed : bool;  (** whether the author wrote it inside [[...]] *)
+}
+(** An [nth-*] argument. Both [nth-3] and [nth-[3]] read, and they name two
+    different classes, so which one was written has to survive: deciding the
+    bracket again when printing, on whether the expression is a bare number,
+    gave [nth-[3]:p-4] a rule named after [nth-3:p-4] and it matched nothing. *)
+
 type modifier =
   | Hover
   | Focus
@@ -104,10 +113,10 @@ type modifier =
   | First_of_type
   | Last_of_type
   | Only_of_type
-  | Nth of string
-  | Nth_last of string
-  | Nth_of_type of string
-  | Nth_last_of_type of string
+  | Nth of nth_expr
+  | Nth_last of nth_expr
+  | Nth_of_type of nth_expr
+  | Nth_last_of_type of nth_expr
   | Empty
   | Checked
   | Indeterminate
@@ -323,9 +332,13 @@ type shadow = [ size | `Inner ]
 val is_numeric : string -> bool
 (** [is_numeric s] returns true if [s] is a non-empty string of digits. *)
 
-val pp_nth : string -> string -> string
-(** [pp_nth prefix expr] formats an nth modifier, using numeric or bracket form.
-*)
+val nth_expr : string -> nth_expr
+(** [nth_expr expr] is [expr] with the bracket flag the DSL constructor implies:
+    a bare number is the only expression that can be written unbracketed. *)
+
+val pp_nth : string -> nth_expr -> string
+(** [pp_nth prefix n] is the class-name prefix of an [nth-*] modifier, bracketed
+    or not as {!nth_expr.bracketed} says the author wrote it. *)
 
 val group_state_modifiers : (string * modifier) list
 (** [group_state_modifiers] maps a state name (["focus"], ["first"]) to the

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -5,6 +5,12 @@ module Css = Cascade.Css
 (** Error helper *)
 let err_not_utility = Error (`Msg "Not an SVG utility")
 
+(* How wide one of the three suborder groups below is. A suborder is a plain
+   [int], 32 bits under js_of_ocaml, so a name packs seven bits per character
+   rather than eight: a byte each left no room for the group above it. *)
+let alpha_span = 1 lsl 28
+let suborder_ceiling = 3 * alpha_span
+
 module Handler = struct
   open Style
 
@@ -180,11 +186,13 @@ module Handler = struct
         style ~merge_key:"stroke-width-"
           [ Css.stroke_width (Var (Var.bracket bare_name)) ]
 
-  (* Alphabetical suborder from first 4 chars of a string *)
+  (* Alphabetical suborder from the first four characters of a name. [-] is the
+     lowest byte one of these carries, so seven bits hold a character and four
+     of them stay inside {!alpha_span}. *)
   let alpha_order s =
     let v = ref 0 in
     for i = 0 to min 3 (String.length s - 1) do
-      v := (!v * 256) + Char.code s.[i]
+      v := (!v * 128) + max 0 (Char.code s.[i] - Char.code '-')
     done;
     !v
 
@@ -225,9 +233,7 @@ module Handler = struct
       | Stroke_width_bracket _ -> (2, 100)
       | Stroke_width_typed_var _ -> (2, 100)
     in
-    (* alpha_order returns at most 4 bytes = 0x7F7F7F7F on ASCII, so multiply
-       group by 0x100000000 to ensure no overlap. *)
-    (group lsl 32) + detail
+    (group * alpha_span) + detail
 
   let to_class = function
     | Fill_none -> "fill-none"

--- a/lib/svg.mli
+++ b/lib/svg.mli
@@ -5,6 +5,11 @@
 
 open Utility
 
+val suborder_ceiling : int
+(** One past every suborder this handler assigns. [object-fit] and
+    [object-position] share its priority and Tailwind emits them after every
+    fill and stroke, so {!Layout} starts their suborders here. *)
+
 (** {1 Fill Utilities} *)
 
 val fill_none : t

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1141,24 +1141,18 @@ module Handler = struct
 
   let transform_none = style [ Css.transform None ]
 
-  (* transform-cpu is an alias for transform *)
+  (* [transform-cpu] writes what [transform] writes. The [@property] block for
+     the five channels belongs to [transform] alone, though: Tailwind declares
+     them there and neither of the two below carries them, so asking for the
+     rules here put a whole [@layer properties] in a sheet whose only transform
+     utility was this one. *)
   let transform_cpu =
     let rotate_x_ref = Var.reference_with_empty_fallback tw_rotate_x_var in
     let rotate_y_ref = Var.reference_with_empty_fallback tw_rotate_y_var in
     let rotate_z_ref = Var.reference_with_empty_fallback tw_rotate_z_var in
     let skew_x_ref = Var.reference_with_empty_fallback tw_skew_x_var in
     let skew_y_ref = Var.reference_with_empty_fallback tw_skew_y_var in
-    let property_rules =
-      collect_property_rules
-        [
-          tw_rotate_x_var;
-          tw_rotate_y_var;
-          tw_rotate_z_var;
-          tw_skew_x_var;
-          tw_skew_y_var;
-        ]
-    in
-    style ~property_rules
+    style
       [
         transforms
           [
@@ -1170,24 +1164,15 @@ module Handler = struct
           ];
       ]
 
-  (* transform-gpu adds translateZ(0) for GPU acceleration plus all var refs *)
+  (* transform-gpu adds translateZ(0) for GPU acceleration plus all var refs. No
+     [@property] block here either; see [transform_cpu]. *)
   let transform_gpu =
     let rotate_x_ref = Var.reference_with_empty_fallback tw_rotate_x_var in
     let rotate_y_ref = Var.reference_with_empty_fallback tw_rotate_y_var in
     let rotate_z_ref = Var.reference_with_empty_fallback tw_rotate_z_var in
     let skew_x_ref = Var.reference_with_empty_fallback tw_skew_x_var in
     let skew_y_ref = Var.reference_with_empty_fallback tw_skew_y_var in
-    let property_rules =
-      collect_property_rules
-        [
-          tw_rotate_x_var;
-          tw_rotate_y_var;
-          tw_rotate_z_var;
-          tw_skew_x_var;
-          tw_skew_y_var;
-        ]
-    in
-    style ~property_rules
+    style
       [
         transforms
           [

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -9,8 +9,13 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "zoom"
-  let priority _ = 2
-  let suborder = function Percent _ -> 0 | Arbitrary _ -> 1
+
+  (* Tailwind emits [zoom-*] between the transforms and the animations. It
+     shares the transforms' priority rather than taking one of its own, there
+     being no integer left between the two, and starts past every suborder
+     transforms.ml assigns (2004 at the time of writing). *)
+  let priority _ = 9
+  let suborder = function Percent _ -> 3000 | Arbitrary _ -> 3001
 
   let num_to_string n =
     if Float.is_integer n then string_of_int (int_of_float n) else Pp.float n

--- a/test/dune
+++ b/test/dune
@@ -12,4 +12,6 @@
   cascade.diff
   test_helpers
   upstream_fixture)
- (deps upstream/utilities.txt upstream/variants.txt))
+ ; test_sort reads tw.ml's include list back to check that the fuzzer pool has
+ ; an entry for every family it lists.
+ (deps upstream/utilities.txt upstream/variants.txt ../lib/tw.ml))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -205,11 +205,15 @@ let interacting_pairs classes =
    only output is an unreferenced binding - check_rendering_matches covers that
    class now, and agreeing on one predicate is worth more than the extra
    sensitivity here. *)
-let ordering_diff ?(forms = false) utilities =
-  let classnames = List.map Tw.pp utilities in
-  Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
-    (tailwind_css ~forms classnames)
-    (our_css utilities)
+(* Both sheets for one case. [ordering_faults] needs the text as well as the
+   diff, and generating them here keeps one description of what is compared. *)
+let sheets ?(forms = false) utilities =
+  (tailwind_css ~forms (List.map Tw.pp utilities), our_css utilities)
+
+let canonical_diff (tailwind, tw) =
+  Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true tailwind tw
+
+let ordering_diff ?forms utilities = canonical_diff (sheets ?forms utilities)
 
 (* [Css_compare] drops a declaration its reader rejects from that side's AST
    before the comparison runs, so a real difference can surface as a phantom
@@ -813,6 +817,66 @@ let sheet_order_gap ~layer ~tailwind ~tw =
     moves = Array.length common - Array.length keep;
     moved = List.rev !moved;
   }
+
+(* The order oracle the fuzzer minimises and asserts on. [ordering_diff] runs
+   canonically, which folds away a reorder among utilities writing disjoint
+   properties, so a family emitted in the wrong band is invisible to it: the
+   fuzzer could not fail on the one bug class a sort fuzzer exists to find.
+   Reading the statement order out of the bytes is what sees that. *)
+let order_faults ~tailwind ~tw layer =
+  let gap = sheet_order_gap ~layer ~tailwind ~tw in
+  if gap.moves = 0 then []
+  else
+    let shown = List.filteri (fun i _ -> i < 20) gap.moved in
+    let line (key, tailwind_rank, tw_rank) =
+      Fmt.str "    %-50s Tailwind #%d, tw #%d" key tailwind_rank tw_rank
+    in
+    let hidden = List.length gap.moved - List.length shown in
+    let tail =
+      if hidden = 0 then [] else [ Fmt.str "    ... and %d more" hidden ]
+    in
+    [
+      String.concat "\n"
+        (Fmt.str "@layer %s: %d of %d statements are out of Tailwind's order"
+           layer gap.moves gap.pairs
+         :: List.map line shown
+        @ tail);
+    ]
+
+let ordering_faults ?forms utilities =
+  let tailwind, tw = sheets ?forms utilities in
+  let diff = canonical_diff (tailwind, tw) in
+  let dropped = dropped_declarations diff in
+  let unread =
+    if dropped = [] then []
+    else
+      [
+        Fmt.str
+          "the comparison could not read %d declaration(s) and dropped them, \
+           so it compared less than it appears to:\n\
+           %s"
+          (List.length dropped)
+          (String.concat "\n" (List.map Cascade.Error.to_string dropped));
+      ]
+  in
+  let differs =
+    match diff.Css_compare.result with
+    | Css_compare.No_diff -> []
+    | _ ->
+        let buf = Buffer.create 1024 in
+        Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
+        [ Buffer.contents buf ]
+  in
+  unread @ differs
+  @ List.concat_map (order_faults ~tailwind ~tw) [ "utilities"; "components" ]
+
+let check_sheet_order_fails ?forms utilities =
+  ordering_faults ?forms utilities <> []
+
+let check_sheet_order_matches ?forms ~test_name utilities =
+  match ordering_faults ?forms utilities with
+  | [] -> ()
+  | faults -> Alcotest.failf "%s\n%s" test_name (String.concat "\n" faults)
 
 (** CSS Test Helpers *)
 

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -717,17 +717,17 @@ let selector_branches sel =
   emit hi;
   List.rev !out
 
-let layer_statement_keys sheet ~layer =
+let layer_body sheet ~layer =
   let wanted = "@layer " ^ layer in
-  let body =
-    List.find_map
-      (fun (prelude, body) ->
-        match body with
-        | Some span when normalize_prelude prelude = wanted -> Some span
-        | _ -> None)
-      (statements_between sheet 0 (String.length sheet))
-  in
-  match body with
+  List.find_map
+    (fun (prelude, body) ->
+      match body with
+      | Some span when normalize_prelude prelude = wanted -> Some span
+      | _ -> None)
+    (statements_between sheet 0 (String.length sheet))
+
+let layer_statement_keys sheet ~layer =
+  match layer_body sheet ~layer with
   | None -> []
   | Some (lo, hi) ->
       List.concat_map
@@ -818,65 +818,113 @@ let sheet_order_gap ~layer ~tailwind ~tw =
     moved = List.rev !moved;
   }
 
+(* Where one class's rule sits: the layer, the at-rule it is nested in - empty
+   at the layer's own top level - and its rank there. Two rules under different
+   at-rules are not comparable, and neither are two in different layers: the
+   position of a [@media] block says where the block sits, not where a utility
+   inside it sorts, and tw emits one block per rule where Tailwind merges. *)
+type slot = { container : string; rank : int * int }
+
+(* Does [selector] name class [cls]? The same match [class_position] makes. *)
+let names_class selector cls = class_position selector cls <> None
+
+let class_slots sheet ~layer classes =
+  match layer_body sheet ~layer with
+  | None -> []
+  | Some (lo, hi) ->
+      let found container rank selector =
+        List.filter_map
+          (fun cls ->
+            if names_class selector cls then Some (cls, { container; rank })
+            else None)
+          classes
+      in
+      statements_between sheet lo hi
+      |> List.mapi (fun i (prelude, body) ->
+          let p = normalize_prelude prelude in
+          if p = "" then []
+          else if p.[0] <> '@' then found "" (i, 0) p
+          else
+            match body with
+            | None -> []
+            (* One level down is enough: Tailwind nests a rule inside a media or
+               supports block and no deeper. *)
+            | Some (blo, bhi) ->
+                statements_between sheet blo bhi
+                |> List.mapi (fun j (inner, _) ->
+                    let sel = normalize_prelude inner in
+                    if sel = "" || sel.[0] = '@' then [] else found p (i, j) sel)
+                |> List.concat)
+      |> List.concat
+
 (* The order oracle the fuzzer minimises and asserts on. [ordering_diff] runs
    canonically, which folds away a reorder among utilities writing disjoint
    properties, so a family emitted in the wrong band is invisible to it: the
    fuzzer could not fail on the one bug class a sort fuzzer exists to find.
-   Reading the statement order out of the bytes is what sees that. *)
-let order_faults ~tailwind ~tw layer =
-  let gap = sheet_order_gap ~layer ~tailwind ~tw in
-  if gap.moves = 0 then []
-  else
-    let shown = List.filteri (fun i _ -> i < 20) gap.moved in
-    let line (key, tailwind_rank, tw_rank) =
-      Fmt.str "    %-50s Tailwind #%d, tw #%d" key tailwind_rank tw_rank
-    in
-    let hidden = List.length gap.moved - List.length shown in
-    let tail =
-      if hidden = 0 then [] else [ Fmt.str "    ... and %d more" hidden ]
-    in
-    [
-      String.concat "\n"
-        (Fmt.str "@layer %s: %d of %d statements are out of Tailwind's order"
-           layer gap.moves gap.pairs
-         :: List.map line shown
-        @ tail);
-    ]
+   Reading the order off the bytes is what sees it.
 
-let ordering_faults ?forms utilities =
-  let tailwind, tw = sheets ?forms utilities in
-  let diff = canonical_diff (tailwind, tw) in
-  let dropped = dropped_declarations diff in
-  let unread =
-    if dropped = [] then []
-    else
-      [
-        Fmt.str
-          "the comparison could not read %d declaration(s) and dropped them, \
-           so it compared less than it appears to:\n\
-           %s"
-          (List.length dropped)
-          (String.concat "\n" (List.map Cascade.Error.to_string dropped));
-      ]
+   A pair rather than a count, because a pair is a property of the two classes
+   and nothing else: both sheets order their utilities by a key of their own, so
+   two classes that disagree here disagree in every sheet holding both, whatever
+   else is drawn. That is what a recorded set of known disagreements can be
+   written against; the count {!sheet_order_gap} reports moves with the draw. *)
+let inverted_pairs ~tailwind ~tw classes =
+  let first_slot sheet layer =
+    let tbl = Hashtbl.create 64 in
+    List.iter
+      (fun (cls, slot) ->
+        if not (Hashtbl.mem tbl cls) then Hashtbl.add tbl cls slot)
+      (class_slots sheet ~layer classes);
+    tbl
   in
-  let differs =
-    match diff.Css_compare.result with
-    | Css_compare.No_diff -> []
-    | _ ->
-        let buf = Buffer.create 1024 in
-        Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
-        [ Buffer.contents buf ]
+  let per_layer layer =
+    let theirs = first_slot tailwind layer and ours = first_slot tw layer in
+    let placed =
+      List.filter (fun c -> Hashtbl.mem theirs c && Hashtbl.mem ours c) classes
+    in
+    let rec pairs acc = function
+      | [] | [ _ ] -> acc
+      | a :: rest ->
+          let acc =
+            List.fold_left
+              (fun acc b ->
+                let ta = Hashtbl.find theirs a and tb = Hashtbl.find theirs b in
+                let oa = Hashtbl.find ours a and ob = Hashtbl.find ours b in
+                (* Only a pair sitting under the same at-rule on both sides is
+                   one whose order the two sheets actually disagree about. *)
+                if
+                  String.equal ta.container tb.container
+                  && String.equal oa.container ob.container
+                  && String.equal ta.container oa.container
+                then
+                  let theirs_first = compare ta.rank tb.rank < 0 in
+                  let ours_first = compare oa.rank ob.rank < 0 in
+                  if theirs_first = ours_first then acc
+                  else if theirs_first then (a, b) :: acc
+                  else (b, a) :: acc
+                else acc)
+              acc rest
+          in
+          pairs acc rest
+    in
+    pairs [] placed
   in
-  unread @ differs
-  @ List.concat_map (order_faults ~tailwind ~tw) [ "utilities"; "components" ]
+  List.concat_map per_layer [ "utilities"; "components" ]
 
-let check_sheet_order_fails ?forms utilities =
-  ordering_faults ?forms utilities <> []
+let sheet_diff ~tailwind ~tw = canonical_diff (tailwind, tw)
 
-let check_sheet_order_matches ?forms ~test_name utilities =
-  match ordering_faults ?forms utilities with
-  | [] -> ()
-  | faults -> Alcotest.failf "%s\n%s" test_name (String.concat "\n" faults)
+let describe_diff diff =
+  let buf = Buffer.create 1024 in
+  Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
+  Buffer.contents buf
+
+let describe_dropped dropped =
+  Fmt.str
+    "the comparison could not read %d declaration(s) and dropped them, so it \
+     compared less than it appears to:\n\
+     %s"
+    (List.length dropped)
+    (String.concat "\n" (List.map Cascade.Error.to_string dropped))
 
 (** CSS Test Helpers *)
 

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -176,6 +176,31 @@ val sheet_order_gap : layer:string -> tailwind:string -> tw:string -> order_gap
     form: it sees a family placed in the wrong band even when no two utilities
     it reorders share a property. *)
 
+val ordering_faults : ?forms:bool -> Tw.t list -> string list
+(** [ordering_faults ?forms utilities] is everything separating tw's sheet for
+    [utilities] from the pinned Tailwind CLI's: a declaration either reader
+    dropped, what the canonical differ reports, and every statement the two put
+    in a different place in [@layer utilities] or [@layer components], read off
+    the bytes by {!sheet_order_gap}. Empty when the two agree.
+
+    The differ alone cannot see a reorder among utilities writing disjoint
+    properties, canonical mode folding one away by design, so a fuzzer
+    minimising on {!check_ordering_fails} can never fail on a family emitted in
+    the wrong band - the one bug class a sort fuzzer exists to find. The byte
+    positions are what see it. *)
+
+val check_sheet_order_fails : ?forms:bool -> Tw.t list -> bool
+(** [check_sheet_order_fails ?forms utilities] is [true] when {!ordering_faults}
+    reports anything. The fuzzer's minimisation predicate. *)
+
+val check_sheet_order_matches :
+  ?forms:bool -> test_name:string -> Tw.t list -> unit
+(** [check_sheet_order_matches ?forms ~test_name utilities] fails with whatever
+    {!ordering_faults} reports. The same function drives it and
+    {!check_sheet_order_fails}, so a minimal case the fuzzer prints is one this
+    assertion also rejects; two predicates that disagree let a fuzzer report a
+    failing case and pass anyway. *)
+
 val render_elements : string list -> string list
 (** [render_elements classnames] is the element list {!check_rendering_matches}
     renders: each class on its own, then one element per {!interacting_pairs}

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -176,30 +176,42 @@ val sheet_order_gap : layer:string -> tailwind:string -> tw:string -> order_gap
     form: it sees a family placed in the wrong band even when no two utilities
     it reorders share a property. *)
 
-val ordering_faults : ?forms:bool -> Tw.t list -> string list
-(** [ordering_faults ?forms utilities] is everything separating tw's sheet for
-    [utilities] from the pinned Tailwind CLI's: a declaration either reader
-    dropped, what the canonical differ reports, and every statement the two put
-    in a different place in [@layer utilities] or [@layer components], read off
-    the bytes by {!sheet_order_gap}. Empty when the two agree.
+val sheets : ?forms:bool -> Tw.t list -> string * string
+(** [sheets ?forms utilities] is the pinned Tailwind CLI's sheet for [utilities]
+    and tw's, both minified. Generating the pair once is what lets {!sheet_diff}
+    and {!inverted_pairs} read the same two sheets. *)
 
-    The differ alone cannot see a reorder among utilities writing disjoint
-    properties, canonical mode folding one away by design, so a fuzzer
-    minimising on {!check_ordering_fails} can never fail on a family emitted in
-    the wrong band - the one bug class a sort fuzzer exists to find. The byte
-    positions are what see it. *)
+val sheet_diff : tailwind:string -> tw:string -> Cascade_diff.Css_compare.t
+(** [sheet_diff ~tailwind ~tw] compares the two sheets canonically, with dead
+    custom properties pruned, the way {!ordering_diff} does. Returning the
+    comparison rather than a verdict is what lets a caller read its structure:
+    the differ reports a reorder as a {!Cascade_diff.Tree_diff.Reordered} node
+    whenever the two rules are cascade-significant, which a caller carrying a
+    set of known misorderings has to be able to recognise. *)
 
-val check_sheet_order_fails : ?forms:bool -> Tw.t list -> bool
-(** [check_sheet_order_fails ?forms utilities] is [true] when {!ordering_faults}
-    reports anything. The fuzzer's minimisation predicate. *)
+val describe_diff : Cascade_diff.Css_compare.t -> string
+(** [describe_diff diff] is [diff] rendered for a failure message. *)
 
-val check_sheet_order_matches :
-  ?forms:bool -> test_name:string -> Tw.t list -> unit
-(** [check_sheet_order_matches ?forms ~test_name utilities] fails with whatever
-    {!ordering_faults} reports. The same function drives it and
-    {!check_sheet_order_fails}, so a minimal case the fuzzer prints is one this
-    assertion also rejects; two predicates that disagree let a fuzzer report a
-    failing case and pass anyway. *)
+val describe_dropped : Error.t list -> string
+(** [describe_dropped dropped] says that the comparison read less than it
+    appears to, and which declarations it could not read. *)
+
+val inverted_pairs :
+  tailwind:string -> tw:string -> string list -> (string * string) list
+(** [inverted_pairs ~tailwind ~tw classes] is every pair of [classes] the two
+    sheets put in opposite orders, each written [(a, b)] with [a] the one
+    Tailwind emits first. Only a pair whose two rules sit under the same at-rule
+    in the same layer on both sides is compared: the position of a [@media]
+    block says where the block sits rather than where a utility inside it sorts,
+    and tw emits one block per rule where Tailwind merges. A class naming
+    several rules is taken at the first.
+
+    A pair, not a count. Both sheets order their utilities by a key of their
+    own, so two classes that disagree here disagree in every sheet holding both,
+    whatever else was drawn - which is what lets a set of known disagreements be
+    recorded and a new one still fail. {!sheet_order_gap} answers the
+    whole-sheet question instead, and its count moves with what is in the sheet.
+*)
 
 val render_elements : string list -> string list
 (** [render_elements classnames] is the element list {!check_rendering_matches}

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 575, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 542, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -300,8 +300,19 @@ let test_invalid_hex_value () =
     "[color:#ff0000] still emits the colour" true
     (Astring.String.is_infix ~affix:"color: #ff0000" (css "[color:#ff0000]"))
 
+(* An arbitrary property sorts where the property it declares sorts, which is
+   the same rule a project's own [@utility] follows. They all shared one slot
+   near the end of the layer instead, so [[order:3]] came after the margins it
+   belongs in front of. No two of these write a common property, so no canonical
+   comparison could see it; the positions in the sheet can. *)
+let test_sorts_by_declared_property () =
+  Test_helpers.check_class_order ~test_name:"arbitrary property slots"
+    [ "[order:3]"; "m-4"; "[display:grid]"; "p-4"; "[color:red]" ]
+
 let tests =
   [
+    test_case "sorts by the property it declares" `Quick
+      test_sorts_by_declared_property;
     test_case "invalid hex value" `Quick test_invalid_hex_value;
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
     test_case "arbitrary of_string - invalid values" `Quick of_string_invalid;

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -1075,6 +1075,26 @@ let test_removed_family_drops_derived_default () =
   check bool "--default-mono-font-family stays" true
     (List.mem "--default-mono-font-family" vars)
 
+(* A theme token a utility declares to make its own value available belongs in
+   the theme layer and nowhere else. The walk that strips it descended into
+   [@media], [@supports], [@container] and [@layer] by name and knew nothing of
+   [@starting-style], so [md:starting:p-4] declared [--spacing] inside the rule
+   as well, where Tailwind declares it once. *)
+let test_theme_tokens_stripped_at_every_depth () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u ->
+          let css =
+            Tw.to_css ~base:true [ u ] |> Tw.Css.to_string ~minify:true
+          in
+          let occurrences =
+            List.length (Astring.String.cuts ~sep:"--spacing:" css) - 1
+          in
+          Alcotest.(check int) (cls ^ " declares --spacing once") 1 occurrences)
+    [ "p-4"; "starting:p-4"; "md:starting:p-4"; "hover:starting:p-4" ]
+
 let tests =
   [
     test_case "starting-style blocks merge" `Quick test_starting_style_merges;
@@ -1145,6 +1165,8 @@ let tests =
       test_extra_keeps_plain_order;
     test_case "style with rules and props ordering" `Quick
       test_style_rules_props;
+    test_case "theme tokens stripped at every depth" `Quick
+      test_theme_tokens_stripped_at_every_depth;
   ]
 
 let suite = ("build", tests)

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -366,6 +366,30 @@ let test_arbitrary_breakpoint_spelling () =
       "min-[0.5rem]:flex";
     ]
 
+(* [nth-3] and [nth-[3]] are two spellings of one selector and two different
+   classes, so the one the author wrote has to come back out. Deciding the
+   bracket again when printing, on whether the expression is a bare number,
+   named [nth-[3]:p-4] as [.nth-3\\:p-4] and the rule matched nothing. *)
+let test_nth_spelling () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u -> Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u))
+    [
+      "nth-3:flex";
+      "nth-[3]:flex";
+      "nth-[2n+1]:flex";
+      "nth-last-2:flex";
+      "nth-last-[2]:flex";
+      "nth-of-type-3:flex";
+      "nth-of-type-[3]:flex";
+      "nth-last-of-type-4:flex";
+      "nth-last-of-type-[4]:flex";
+      "not-nth-3:flex";
+      "not-nth-[3]:flex";
+    ]
+
 (* The bracket holds a length, so a word is not a breakpoint at all. *)
 let test_arbitrary_breakpoint_rejects_non_length () =
   List.iter
@@ -1409,6 +1433,7 @@ let tests =
         test_not_has_shorthand_selector;
       test_case "arbitrary breakpoint spelling" `Quick
         test_arbitrary_breakpoint_spelling;
+      test_case "nth spelling" `Quick test_nth_spelling;
       test_case "arbitrary breakpoint rejects non-length" `Quick
         test_arbitrary_breakpoint_rejects_non_length;
       test_case "custom variant is theme-local" `Quick

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -200,6 +200,34 @@ let test_hover_dark_media_wrapper () =
     (Astring.String.is_infix ~affix:"prefers-color-scheme:dark" s
     || Astring.String.is_infix ~affix:"prefers-color-scheme: dark" s)
 
+(* An at-rule variant outside [group-hover:] must keep the inner variant's
+   pointer-capability gate inside its own block. These wrappers used to consume
+   the selector and declarations but not [has_hover], so the style matched on
+   touch devices. Both named and bracketed spellings take the same route. *)
+let test_at_rule_keeps_inner_hover_gate () =
+  let cases =
+    [
+      ( "supports-grid:group-hover:flex-row",
+        "@supports(grid:var(--tw)){@media(hover:hover){" );
+      ( "supports-[display:grid]:group-hover:flex-row",
+        "@supports(display:grid){@media(hover:hover){" );
+      ( "[@supports(display:grid)]:group-hover:flex-row",
+        "@supports(display:grid){@media(hover:hover){" );
+      ("starting:group-hover:flex-row", "@starting-style{@media(hover:hover){");
+      ( "[@starting-style]:group-hover:flex-row",
+        "@starting-style{@media(hover:hover){" );
+    ]
+  in
+  List.iter
+    (fun (cls, nesting) ->
+      let css =
+        match Tw.of_string cls with
+        | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+        | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      in
+      check bool cls true (Astring.String.is_infix ~affix:nesting css))
+    cases
+
 (* An outer variant has to find the class the inner one produced. The child
    variant buries it inside an [:is] with a child combinator and the
    pseudo-element variants report the class they prefixed, so both used to be
@@ -537,6 +565,8 @@ let tests =
       test_opacity_color_variant_no_leak;
     test_case "hover:dark keeps hover media wrapper" `Quick
       test_hover_dark_media_wrapper;
+    test_case "at-rule keeps inner hover media wrapper" `Quick
+      test_at_rule_keeps_inner_hover_gate;
     test_case "attribute variant keeps the inner selector" `Quick
       test_attribute_variant_keeps_inner;
     test_case "not- variant keeps the inner selector" `Quick

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -247,6 +247,30 @@ let test_at_rule_keeps_inner_hover_gate () =
       check bool cls true (Astring.String.is_infix ~affix:nesting css))
     cases
 
+(* A selector-building outer variant must retain the capability gate carried by
+   an inner peer-hover rule. [not-[:hover]] takes a dedicated multi-rule route,
+   which used to keep the transformed selector but drop [has_hover]. *)
+let test_selector_variant_keeps_inner_hover_gate () =
+  List.iter
+    (fun cls ->
+      let css =
+        match Tw.of_string cls with
+        | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+        | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      in
+      check bool cls true
+        (Astring.String.is_infix ~affix:"@media(hover:hover){" css))
+    [
+      "not-[:hover]:peer-hover:touch-pan-x";
+      "not-focus:peer-hover:touch-pan-x";
+      "in-[.parent]:peer-hover:touch-pan-x";
+      "in-data-open:peer-hover:touch-pan-x";
+      "group-not-focus:peer-hover:touch-pan-x";
+      "peer-not-focus:peer-hover:touch-pan-x";
+      "group-focus/foo:peer-hover:touch-pan-x";
+      "peer-focus/foo:peer-hover:touch-pan-x";
+    ]
+
 (* An outer variant has to find the class the inner one produced. The child
    variant buries it inside an [:is] with a child combinator and the
    pseudo-element variants report the class they prefixed, so both used to be
@@ -586,6 +610,8 @@ let tests =
       test_hover_dark_media_wrapper;
     test_case "at-rule keeps inner hover media wrapper" `Quick
       test_at_rule_keeps_inner_hover_gate;
+    test_case "selector variant keeps inner hover media wrapper" `Quick
+      test_selector_variant_keeps_inner_hover_gate;
     test_case "attribute variant keeps the inner selector" `Quick
       test_attribute_variant_keeps_inner;
     test_case "not- variant keeps the inner selector" `Quick

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -485,6 +485,36 @@ let test_prose_element_over_media () =
   variant_has "prose-p:md:text-lg" ".prose-p\\:md\\:text-lg :where(p)";
   variant_has "prose-a:dark:text-white" ".prose-a\\:dark\\:text-white :where(a)"
 
+(* [apply_modifier_to_rule] had no arm for a [@starting-style] rule, so an outer
+   variant fell through the catch-all and went with it: [hover:starting:p-4]
+   named its rule [.starting\\:p-4], a class the source never carries, and the
+   rule matched nothing. Every other at-rule wrapper had an arm already. *)
+let test_variant_outside_starting_style () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok u ->
+          let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string in
+          Alcotest.(check bool)
+            (cls ^ " keeps its own class")
+            true
+            (Astring.String.is_infix
+               ~affix:(Tw.Css.Selector.to_string (Tw.Css.Selector.class_ cls))
+               css);
+          Alcotest.(check bool)
+            (cls ^ " stays inside @starting-style")
+            true
+            (Astring.String.is_infix ~affix:"@starting-style" css))
+    [
+      "starting:p-4";
+      "hover:starting:p-4";
+      "md:starting:p-4";
+      "first:starting:p-4";
+      "nth-3:starting:p-4";
+      "dark:starting:opacity-50";
+    ]
+
 let tests =
   [
     test_case "arbitrary selector combinator variants" `Quick
@@ -541,6 +571,8 @@ let tests =
     test_case "escape class name hex escapes" `Quick
       check_escape_class_name_hex_escapes;
     test_case "modifier_to_rule" `Quick test_modifier_to_rule;
+    test_case "a variant outside starting-style survives" `Quick
+      test_variant_outside_starting_style;
   ]
 
 let suite = ("rule", tests)

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -216,6 +216,25 @@ let test_at_rule_keeps_inner_hover_gate () =
       ("starting:group-hover:flex-row", "@starting-style{@media(hover:hover){");
       ( "[@starting-style]:group-hover:flex-row",
         "@starting-style{@media(hover:hover){" );
+      ( "sm:supports-[display:grid]:group-hover:flex-row",
+        "@supports(display:grid){@media(hover:hover){" );
+      ( "first:supports-[display:grid]:group-hover:flex-row",
+        "@supports(display:grid){@media(hover:hover){" );
+      ( "sm:starting:group-hover:flex-row",
+        "@starting-style{@media(hover:hover){" );
+      ( "first:[@starting-style]:group-hover:flex-row",
+        "@starting-style{@media(hover:hover){" );
+      ( "first:@sm:group-hover:flex-row",
+        "@container(width>=24rem){@media(hover:hover){" );
+      ( "sm:@sm:group-hover:flex-row",
+        "@container(width>=24rem){@media(hover:hover){" );
+      ( "supports-[display:grid]:starting:group-hover:flex-row",
+        "@supports(display:grid){@starting-style{@media(hover:hover){" );
+      ( "starting:supports-[display:grid]:group-hover:flex-row",
+        "@starting-style{@supports(display:grid){@media(hover:hover){" );
+      ( "supports-[display:grid]:@sm:group-hover:flex-row",
+        "@supports(display:grid){@container(width>=24rem){@media(hover:hover){"
+      );
     ]
   in
   List.iter

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -705,311 +705,649 @@ let test_suborder_within_group () =
       Test_helpers.check_ordering_matches ~forms ~test_name shuffled)
     test_groups
 
-(* Test 3: Random utilities with minimization *)
+(* Test 3: Random utilities with minimization.
+
+   The pool is keyed by the lib/ module that exports its entries, and
+   [test_pool_covers_every_family] reads tw.ml's include list back and fails on
+   a module with nothing under it. A hand-written list nothing checks drifts:
+   the one this replaces reached 103 constructors of tw.mli's 1030, and no seed
+   could compile a [hover:] or an [md:] rule at all, modifiers exporting 210
+   constructors the pool never touched. *)
+
+(* An entry is written as the class a user types, which is what the reader takes
+   back, so a typo fails inside a test rather than at module initialisation. The
+   families with no reader are built from their constructor instead. *)
+let cls name =
+  match Tw.of_string name with
+  | Ok u -> u
+  | Error (`Msg m) -> Alcotest.failf "pool entry %S does not parse: %s" name m
+
+let pool_families () =
+  let c names = List.map cls names in
+  [
+    ( "accessibility",
+      c [ "forced-color-adjust-none"; "forced-color-adjust-auto" ] );
+    ( "alignment",
+      c
+        [
+          "items-center";
+          "items-start";
+          "justify-between";
+          "justify-center";
+          "self-end";
+          "content-around";
+          "place-items-center";
+          "place-content-between";
+          "justify-items-start";
+          "justify-self-end";
+          "place-self-center";
+        ] );
+    ("animations", c [ "animate-spin"; "animate-pulse"; "animate-none" ]);
+    (* [[property:value]] takes any property, so it sorts into whichever band
+       the property it declares belongs to. *)
+    ("arbitrary", c [ "[color:red]"; "[mask-type:luminance]"; "[order:3]" ]);
+    ( "backgrounds",
+      c
+        [
+          "bg-red-500";
+          "bg-white";
+          "bg-cover";
+          "bg-center";
+          "bg-no-repeat";
+          "bg-fixed";
+          "bg-clip-text";
+          "bg-origin-content";
+          "bg-linear-to-r";
+          "from-blue-500";
+          "via-purple-500";
+          "to-pink-500";
+        ] );
+    ( "borders",
+      c
+        [
+          "border";
+          "border-2";
+          "border-t-4";
+          "border-x-2";
+          "border-dashed";
+          "rounded-lg";
+          "rounded-t-md";
+          "rounded-full";
+          "outline-2";
+          "outline-dashed";
+          "outline-offset-2";
+        ] );
+    ("box_sizing", c [ "box-border"; "box-content" ]);
+    ( "color",
+      c
+        [
+          "text-red-500";
+          "text-white";
+          "accent-pink-500";
+          "caret-blue-500";
+          "placeholder-gray-400";
+        ] );
+    ("columns", c [ "columns-3"; "columns-md"; "columns-auto" ]);
+    ("contain", c [ "contain-layout"; "contain-strict"; "contain-content" ]);
+    ("containers", c [ "container"; "@container" ]);
+    ("cursor", c [ "cursor-pointer"; "cursor-not-allowed"; "cursor-grab" ]);
+    ( "divide",
+      c
+        [
+          "divide-x";
+          "divide-y-2";
+          "divide-gray-300";
+          "divide-dashed";
+          "divide-x-reverse";
+        ] );
+    ( "effects",
+      c
+        [
+          "shadow-md";
+          "shadow-none";
+          "opacity-50";
+          "mix-blend-multiply";
+          "bg-blend-multiply";
+          "inset-shadow-sm";
+          "ring-2";
+          "ring-offset-4";
+          "inset-ring-2";
+        ] );
+    ("field_sizing", c [ "field-sizing-content"; "field-sizing-fixed" ]);
+    ( "filters",
+      c
+        [
+          "filter-none";
+          "blur-sm";
+          "brightness-125";
+          "grayscale";
+          "hue-rotate-90";
+          "invert";
+          "backdrop-blur-md";
+          "backdrop-saturate-150";
+          "drop-shadow-lg";
+        ] );
+    ("flex", c [ "flex"; "inline-flex" ]);
+    ( "flex_layout",
+      c
+        [
+          "flex-row";
+          "flex-col";
+          "flex-row-reverse";
+          "flex-col-reverse";
+          "flex-wrap";
+          "flex-nowrap";
+        ] );
+    ( "flex_props",
+      c
+        [
+          "flex-1";
+          "flex-auto";
+          "grow";
+          "shrink-0";
+          "basis-1/2";
+          "order-2";
+          "order-first";
+        ] );
+    (* The plugin's own utilities. A draw holding one is compared with the
+       plugin loaded, which is what [~forms] switches on. *)
+    ("forms", c [ "form-input"; "form-select"; "form-checkbox" ]);
+    ("gap", c [ "gap-4"; "gap-x-2"; "gap-y-8" ]);
+    ("grid", c [ "grid"; "inline-grid" ]);
+    ( "grid_item",
+      c [ "col-span-2"; "row-span-3"; "col-start-2"; "row-end-4"; "col-auto" ]
+    );
+    ( "grid_template",
+      c
+        [
+          "grid-cols-3";
+          "grid-cols-none";
+          "grid-rows-2";
+          "grid-rows-subgrid";
+          "grid-flow-col";
+          "auto-cols-fr";
+          "auto-rows-min";
+        ] );
+    ( "interactivity",
+      c
+        [
+          "select-none";
+          "resize-y";
+          "pointer-events-none";
+          "appearance-none";
+          "will-change-transform";
+          "snap-center";
+          "snap-x";
+          "scroll-smooth";
+          "scheme-dark";
+          "group";
+          "peer";
+        ] );
+    ( "layout",
+      c
+        [
+          "block";
+          "inline-block";
+          "hidden";
+          "table";
+          "contents";
+          "float-left";
+          "clear-both";
+          "isolate";
+          "object-cover";
+          "object-center";
+          "z-10";
+          "break-after-page";
+          "box-decoration-clone";
+          "sr-only";
+          "not-sr-only";
+        ] );
+    ( "margin",
+      c [ "m-4"; "mx-2"; "my-8"; "mt-1"; "mb-6"; "ml-auto"; "-mt-4"; "ms-2" ] );
+    ( "mask_gradient",
+      c
+        [
+          "mask-t-from-50%";
+          "mask-r-to-90%";
+          "mask-radial-from-20%";
+          "mask-conic-from-30%";
+          "mask-linear-from-40%";
+          "mask-x-from-10%";
+        ] );
+    ( "masks",
+      c
+        [
+          "mask-none";
+          "mask-alpha";
+          "mask-cover";
+          "mask-center";
+          "mask-repeat-x";
+          "mask-clip-content";
+          "mask-origin-padding";
+          "mask-add";
+          "mask-type-luminance";
+        ] );
+    ("overflow", c [ "overflow-hidden"; "overflow-x-auto"; "overflow-y-scroll" ]);
+    ("overflow_wrap", c [ "wrap-break-word"; "wrap-anywhere"; "wrap-normal" ]);
+    ( "overscroll",
+      c [ "overscroll-contain"; "overscroll-x-none"; "overscroll-y-auto" ] );
+    ( "padding",
+      c [ "p-4"; "px-2"; "py-8"; "pt-1"; "pb-6"; "pl-3"; "pr-5"; "ps-2" ] );
+    ( "position",
+      c
+        [
+          "relative";
+          "absolute";
+          "sticky";
+          "static";
+          "top-0";
+          "inset-x-4";
+          "left-1/2";
+          "start-0";
+          "inset-0";
+        ] );
+    ("prose", c [ "prose"; "prose-lg"; "prose-invert"; "prose-slate" ]);
+    ("scroll", c [ "scroll-m-4"; "scroll-px-2"; "scroll-mt-8"; "scroll-pb-6" ]);
+    ( "scrollbar",
+      c
+        [
+          "scrollbar-thin";
+          "scrollbar-gutter-stable";
+          "scrollbar-thumb-gray-400";
+          "scrollbar-track-gray-100";
+        ] );
+    ( "sizing",
+      c
+        [
+          "w-4";
+          "w-full";
+          "h-8";
+          "h-screen";
+          "min-w-0";
+          "max-w-4xl";
+          "max-h-96";
+          "size-10";
+          "aspect-video";
+          "aspect-square";
+          "aspect-auto";
+          "aspect-[4/3]";
+        ] );
+    ("svg", c [ "fill-none"; "fill-red-500"; "stroke-current"; "stroke-2" ]);
+    ("tab", c [ "tab-4"; "tab-2" ]);
+    ( "tables",
+      c
+        [
+          "border-collapse"; "border-spacing-2"; "table-fixed"; "caption-bottom";
+        ] );
+    ("text_shadow", c [ "text-shadow-sm"; "text-shadow-lg"; "text-shadow-none" ]);
+    ("touch", c [ "touch-pan-x"; "touch-manipulation"; "touch-none" ]);
+    ( "transforms",
+      c
+        [
+          "rotate-45";
+          "scale-95";
+          "translate-x-4";
+          "skew-y-3";
+          "origin-top-left";
+          "transform-gpu";
+          "transform-none";
+          "transform-3d";
+          "perspective-dramatic";
+          "backface-hidden";
+          "rotate-x-30";
+          "translate-z-4";
+        ] );
+    ( "transitions",
+      c
+        [
+          "transition";
+          "transition-colors";
+          "duration-300";
+          "ease-in-out";
+          "delay-150";
+        ] );
+    ( "typography",
+      c
+        [
+          "text-xs";
+          "text-2xl";
+          "font-bold";
+          "font-sans";
+          "leading-relaxed";
+          "tracking-wide";
+          "italic";
+          "uppercase";
+          "underline";
+          "line-through";
+          "text-ellipsis";
+          "indent-4";
+          "align-middle";
+          "whitespace-nowrap";
+          "list-disc";
+          "line-clamp-3";
+          "antialiased";
+          "tabular-nums";
+          "hyphens-auto";
+          "decoration-2";
+          "decoration-sky-400";
+          "underline-offset-4";
+        ] );
+    ("zoom", c [ "zoom-50"; "zoom-100" ]);
+  ]
+
+(* [Responsive] nests a media query, and two of those on one class is a spelling
+   Tailwind refuses, so a stack takes at most one. [Element] ends the compound
+   selector with a pseudo-element, which nothing may follow: Tailwind writes
+   [marker:last:x] as [::marker:last-child] and its own minifier then drops what
+   it cannot parse, so only the innermost of a stack may be one. *)
+type variant_kind = Plain | Responsive | Element
+
+(* modifiers exports 210 constructors and no utility of its own, so a seed
+   reaches the family only by dressing one: this list is what puts a [hover:]
+   rule or an [@media] block in front of the comparator at all. Written as the
+   prefix rather than as the constructor, since tw.mli re-exports only about a
+   fifth of them and the reader takes every spelling. *)
+let pool_variants =
+  [
+    ("hover", Plain);
+    ("focus", Plain);
+    ("active", Plain);
+    ("disabled", Plain);
+    ("focus-within", Plain);
+    ("focus-visible", Plain);
+    ("first", Plain);
+    ("last", Plain);
+    ("only", Plain);
+    ("odd", Plain);
+    ("even", Plain);
+    ("first-of-type", Plain);
+    ("last-of-type", Plain);
+    ("empty", Plain);
+    ("checked", Plain);
+    ("indeterminate", Plain);
+    ("default", Plain);
+    ("required", Plain);
+    ("valid", Plain);
+    ("invalid", Plain);
+    ("in-range", Plain);
+    ("placeholder-shown", Plain);
+    ("autofill", Plain);
+    ("read-only", Plain);
+    ("optional", Plain);
+    ("open", Plain);
+    ("enabled", Plain);
+    ("target", Plain);
+    ("visited", Plain);
+    ("inert", Plain);
+    ("user-valid", Plain);
+    ("before", Element);
+    ("after", Element);
+    ("marker", Element);
+    ("selection", Element);
+    ("placeholder", Element);
+    ("backdrop", Element);
+    ("file", Element);
+    ("first-letter", Element);
+    ("first-line", Element);
+    ("details-content", Element);
+    ("*", Plain);
+    ("**", Plain);
+    ("group-hover", Plain);
+    ("group-focus", Plain);
+    ("group-first", Plain);
+    ("group-last", Plain);
+    ("group-odd", Plain);
+    ("group-open", Plain);
+    ("group-checked", Plain);
+    ("group-disabled", Plain);
+    ("group-focus-within", Plain);
+    ("peer-hover", Plain);
+    ("peer-focus", Plain);
+    ("peer-checked", Plain);
+    ("peer-disabled", Plain);
+    ("peer-first", Plain);
+    ("peer-last", Plain);
+    ("peer-invalid", Plain);
+    ("aria-checked", Plain);
+    ("aria-expanded", Plain);
+    ("aria-selected", Plain);
+    ("aria-disabled", Plain);
+    ("data-[state=open]", Plain);
+    ("data-active", Plain);
+    ("data-inactive", Plain);
+    ("nth-3", Plain);
+    ("nth-last-2", Plain);
+    (* A class rather than a type selector: Tailwind wraps a [has-[...]] bracket
+       in [:is()] and tw does not, which is a difference of spelling alone and
+       one the canonical differ folds away for every argument but a bare type
+       selector. Kept out of the pool so the fuzzer reports order rather than
+       that. *)
+    ("has-[.x]", Plain);
+    ("group-has-[.x]", Plain);
+    ("peer-has-[.x]", Plain);
+    ("not-[:hover]", Plain);
+    ("in-[.x]", Plain);
+    ("ltr", Plain);
+    ("rtl", Plain);
+    ("starting", Plain);
+    ("sm", Responsive);
+    ("md", Responsive);
+    ("lg", Responsive);
+    ("xl", Responsive);
+    ("2xl", Responsive);
+    ("max-sm", Responsive);
+    ("max-md", Responsive);
+    ("max-lg", Responsive);
+    ("min-[600px]", Responsive);
+    ("max-[900px]", Responsive);
+    ("dark", Responsive);
+    ("motion-safe", Responsive);
+    ("motion-reduce", Responsive);
+    ("contrast-more", Responsive);
+    ("contrast-less", Responsive);
+    ("print", Responsive);
+    ("portrait", Responsive);
+    ("landscape", Responsive);
+    ("forced-colors", Responsive);
+    ("supports-[display:grid]", Responsive);
+  ]
+
+let pick_variant rng kinds =
+  let candidates = List.filter (fun (_, k) -> List.mem k kinds) pool_variants in
+  List.nth candidates (Random.State.int rng (List.length candidates))
+
+(* A variant is applied by spelling it onto the class, which is the one form
+   every one of them has; [clip-*] has no reader and stays bare, and any other
+   refusal is a finding rather than a case to skip. *)
+let prefix name u =
+  let bare = Tw.pp u in
+  let dressed = name ^ ":" ^ bare in
+  match Tw.of_string dressed with
+  | Ok v -> v
+  | Error (`Msg m) ->
+      if Result.is_error (Tw.of_string bare) then u
+      else Alcotest.failf "%S does not read back: %s" dressed m
+
+(* How much of a draw wears a variant. All of it would compare one media block
+   against another and never a plain rule against one, and none of it is where
+   the pool was. *)
+let dress rng u =
+  match Random.State.int rng 6 with
+  | 0 | 1 | 2 -> u
+  | 3 | 4 ->
+      let name, _ = pick_variant rng [ Plain; Responsive; Element ] in
+      prefix name u
+  | _ ->
+      (* Stacked: the pseudo-element innermost, since it ends the selector, and
+         the media query outermost, which is how [md:hover:] is written. *)
+      let inner, _ = pick_variant rng [ Plain; Element ] in
+      let outer, _ = pick_variant rng [ Plain; Responsive ] in
+      prefix outer (prefix inner u)
+
+(* Without replacement. Drawing 30 from 252 with replacement left about 28
+   distinct, and each duplicate cost a comparison and covered nothing. *)
+let draw rng n entries =
+  let arr = Array.of_list entries in
+  let len = Array.length arr in
+  for i = len - 1 downto 1 do
+    let j = Random.State.int rng (i + 1) in
+    let t = arr.(i) in
+    arr.(i) <- arr.(j);
+    arr.(j) <- t
+  done;
+  Array.to_list (Array.sub arr 0 (min n len))
+
+let sample_size = 30
+let samples = 6
+
 let test_random_utilities_with_minimization () =
-  let open Tw in
-  (* Large pool of utilities from all groups *)
-  let all_utilities =
-    [
-      (* Margin: priority 2 *)
-      m 0;
-      m 1;
-      m 2;
-      m 3;
-      m 4;
-      m 5;
-      m 6;
-      m 8;
-      m 10;
-      m 12;
-      m 16;
-      m 20;
-      mx 0;
-      mx 1;
-      mx 2;
-      mx 4;
-      mx 8;
-      my 0;
-      my 1;
-      my 2;
-      my 4;
-      my 8;
-      mt 0;
-      mt 1;
-      mt 2;
-      mt 4;
-      mt 6;
-      mt 8;
-      mb 0;
-      mb 1;
-      mb 2;
-      mb 3;
-      mb 4;
-      mb 6;
-      ml 0;
-      ml 1;
-      ml 2;
-      ml 4;
-      mr 0;
-      mr 1;
-      mr 2;
-      mr 4;
-      mr 5;
-      mr 8;
-      (* Display: priority 10 *)
-      block;
-      inline;
-      inline_block;
-      flex;
-      inline_flex;
-      grid;
-      inline_grid;
-      hidden;
-      (* Position: priority 11 *)
-      static;
-      fixed;
-      absolute;
-      relative;
-      sticky;
-      (* Sizing: priority 12 *)
-      w 0;
-      w 1;
-      w 2;
-      w 4;
-      w 6;
-      w 8;
-      w 10;
-      w 12;
-      w 16;
-      w 20;
-      w 24;
-      h 0;
-      h 1;
-      h 2;
-      h 4;
-      h 6;
-      h 8;
-      h 10;
-      h 12;
-      h 16;
-      h 20;
-      min_w 0;
-      min_h 0;
-      max_w_2xl;
-      max_w_3xl;
-      max_w_4xl;
-      max_w_5xl;
-      (* Grid layout: priority 13 *)
-      grid_cols 1;
-      grid_cols 2;
-      grid_cols 3;
-      grid_cols 4;
-      grid_cols 6;
-      grid_cols 12;
-      grid_rows 1;
-      grid_rows 2;
-      grid_rows 3;
-      grid_rows 4;
-      col_span 1;
-      col_span 2;
-      col_span 3;
-      col_span 4;
-      row_span 1;
-      row_span 2;
-      row_span 3;
-      (* Flex layout: priority 14 *)
-      flex_row;
-      flex_col;
-      (* Container alignment: priority 15, suborder 0-999 *)
-      items_start;
-      items_center;
-      items_end;
-      items_baseline;
-      items_stretch;
-      justify_start;
-      justify_center;
-      justify_end;
-      justify_between;
-      justify_around;
-      content_start;
-      content_center;
-      content_end;
-      (* Gap: priority 15, suborder 25000+ *)
-      gap 0;
-      gap 1;
-      gap 2;
-      gap 3;
-      gap 4;
-      gap 6;
-      gap 8;
-      gap 10;
-      gap 12;
-      gap_x 0;
-      gap_x 2;
-      gap_x 4;
-      gap_y 0;
-      gap_y 2;
-      gap_y 4;
-      (* Self alignment: priority 15, suborder 50000+ *)
-      self_auto;
-      self_start;
-      self_center;
-      (* Border: priority 17 *)
-      rounded;
-      rounded_md;
-      rounded_lg;
-      rounded_full;
-      border;
-      (* Background: priority 18 *)
-      bg white;
-      bg black;
-      bg ~shade:50 gray;
-      bg ~shade:100 gray;
-      bg ~shade:200 gray;
-      bg ~shade:300 gray;
-      bg gray;
-      bg ~shade:900 gray;
-      bg ~shade:50 red;
-      bg ~shade:100 red;
-      bg red;
-      bg ~shade:600 red;
-      bg ~shade:900 red;
-      bg ~shade:50 blue;
-      bg ~shade:100 blue;
-      bg blue;
-      bg ~shade:600 blue;
-      bg ~shade:900 blue;
-      bg ~shade:50 green;
-      bg green;
-      bg ~shade:600 green;
-      bg ~shade:50 yellow;
-      bg yellow;
-      bg purple;
-      bg pink;
-      (* Padding: priority 19 *)
-      p 0;
-      p 1;
-      p 2;
-      p 3;
-      p 4;
-      p 5;
-      p 6;
-      p 8;
-      p 10;
-      p 12;
-      p 16;
-      px 0;
-      px 1;
-      px 2;
-      px 4;
-      px 6;
-      px 8;
-      py 0;
-      py 1;
-      py 2;
-      py 4;
-      py 6;
-      py 8;
-      pt 0;
-      pt 1;
-      pt 2;
-      pt 3;
-      pt 4;
-      pt 6;
-      pt 8;
-      pb 0;
-      pb 1;
-      pb 2;
-      pb 4;
-      pb 6;
-      pb 8;
-      pl 0;
-      pl 1;
-      pl 2;
-      pl 4;
-      pl 6;
-      pl 8;
-      pr 0;
-      pr 1;
-      pr 2;
-      pr 4;
-      pr 6;
-      pr 8;
-      (* Text align: priority 20 *)
-      text_left;
-      text_center;
-      text_right;
-      text_justify;
-      (* Typography: priority 100 *)
-      text_xs;
-      text_sm;
-      text_base;
-      text_lg;
-      text_xl;
-      text_2xl;
-      text_3xl;
-      font_thin;
-      font_normal;
-      font_medium;
-      font_semibold;
-      font_bold;
-      leading_tight;
-      leading_snug;
-      leading_normal;
-      leading_relaxed;
-      (* Effects: priority 700 *)
-      shadow;
-      shadow_sm;
-      shadow_md;
-      shadow_lg;
-      shadow_xl;
-      shadow_none;
-      opacity 0;
-      opacity 50;
-      opacity 75;
-      opacity 100;
-      (* Interactivity: priority 800 *)
-      cursor_pointer;
-      cursor_default;
-      cursor_wait;
-      cursor_not_allowed;
-      select_none;
-      select_text;
-      select_all;
-      (* Container/Prose: priority 1000 *)
-      prose;
-      prose_sm;
-      prose_lg;
-    ]
+  let entries =
+    List.concat_map
+      (fun (family, us) -> List.map (fun u -> (family, u)) us)
+      (pool_families ())
   in
-
-  let pick_random n lst =
-    let arr = Array.of_list lst in
-    let len = Array.length arr in
-    let picked = ref [] in
-    for _ = 1 to min n len do
-      let idx = Random.State.int Test_helpers.test_rng len in
-      picked := arr.(idx) :: !picked
-    done;
-    !picked
+  let rng = Test_helpers.test_rng in
+  (* The forms plugin is loaded on both sides only when the case holds one of
+     its utilities, and minimisation can take the last one out, so each element
+     carries whether it is one rather than the draw deciding once. *)
+  let utilities cases = List.map snd cases in
+  let forms cases = List.exists fst cases in
+  let sample i =
+    let initial =
+      List.map
+        (fun (family, u) -> (String.equal family "forms", dress rng u))
+        (draw rng sample_size entries)
+    in
+    Fmt.epr "Sample %d/%d: %d utilities@." i samples (List.length initial);
+    let fails cases =
+      Test_helpers.check_sheet_order_fails ~forms:(forms cases)
+        (utilities cases)
+    in
+    match Test_helpers.minimize_failing_case fails initial with
+    | None -> ()
+    | Some final ->
+        Fmt.epr "@.Minimal failing case (%d utilities): %a@."
+          (List.length final)
+          Fmt.(list ~sep:(const string " ") string)
+          (List.map Tw.pp (utilities final));
+        Test_helpers.check_sheet_order_matches ~forms:(forms final)
+          ~test_name:"random utilities ordering matches Tailwind"
+          (utilities final)
   in
+  for i = 1 to samples do
+    sample i
+  done
 
-  let initial = pick_random 30 all_utilities in
-  Fmt.epr "Testing with %d utilities@." (List.length initial);
+(* Every module tw.ml includes exports utilities, and one with no pool entry is
+   a family no seed can reach. Reading the include list back is what makes a new
+   family a failure rather than a hole nobody thinks to look for. *)
+let rec dir_containing name dir =
+  if Sys.file_exists (Filename.concat dir name) then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else dir_containing name parent
 
-  match
-    Test_helpers.minimize_failing_case Test_helpers.check_ordering_fails initial
-  with
-  | None -> () (* Test passes *)
-  | Some final ->
-      let final_classes = List.map Tw.pp final in
-      Fmt.epr "@.Minimal failing case (%d utilities): %a@." (List.length final)
-        Fmt.(list ~sep:(const string " ") string)
-        final_classes;
+let included_modules () =
+  let path = "lib/tw.ml" in
+  let root =
+    match dir_containing path (Sys.getcwd ()) with
+    | Some r -> r
+    | None -> Alcotest.failf "cannot find %s from %s" path (Sys.getcwd ())
+  in
+  let ic = open_in_bin (Filename.concat root path) in
+  let text =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  String.split_on_char '\n' text
+  |> List.filter_map (fun line ->
+      match Astring.String.cut ~sep:"include " (String.trim line) with
+      | Some ("", m) when m <> "" && m.[0] >= 'A' && m.[0] <= 'Z' ->
+          Some (String.uncapitalize_ascii m)
+      | _ -> None)
+  |> List.sort_uniq String.compare
 
-      (* Now run the actual test with minimal case *)
-      Test_helpers.check_ordering_matches
-        ~test_name:"random utilities ordering matches Tailwind" final
+(* A family whose utilities cannot go through the comparator, and why. Never a
+   silent omission: the coverage check subtracts this list and nothing else. *)
+let unfuzzable =
+  [
+    ( "modifiers",
+      "exports variants rather than utilities; [pool_variants] carries it, and \
+       [test_variants_all_compile] checks that list" );
+    ( "clipping",
+      "[clip_polygon] names its class [clip-[polygon(...)]], which Tailwind \
+       does not read and emits nothing for, and which tw's own reader rejects \
+       too: there is no comparison to make" );
+  ]
+
+let test_pool_covers_every_family () =
+  let covered = List.map fst (pool_families ()) in
+  let expected = included_modules () in
+  (* A read that returned nothing would report every family as covered. *)
+  if List.length expected < 40 then
+    Alcotest.failf "read only %d includes out of lib/tw.ml, expected the lot"
+      (List.length expected);
+  let missing =
+    List.filter
+      (fun m -> (not (List.mem m covered)) && not (List.mem_assoc m unfuzzable))
+      expected
+  in
+  if missing <> [] then
+    Alcotest.failf
+      "the fuzzer pool has no entry for %d of tw.ml's families: %s.\n\
+       Add utilities under that key in [pool_families], or list the family in \
+       [unfuzzable] with why it cannot go through the comparator."
+      (List.length missing)
+      (String.concat ", " missing);
+  let stale = List.filter (fun m -> not (List.mem m expected)) covered in
+  if stale <> [] then
+    Alcotest.failf "the pool is keyed by %s, which tw.ml no longer includes"
+      (String.concat ", " stale)
+
+(* The module list above is what tw.ml says exists; this is what the registry
+   says. A family can be keyed correctly and still hold nothing of its own -
+   [flex] carried six [flex-row]-style classes, every one of them
+   [flex_layout]'s - and only the handler each class actually resolves to sees
+   that. Each registered handler offers a few of its own utilities as
+   {!Tw.Utility.examples_classes}, so the expected set comes out of the registry
+   rather than out of a second hand-written list. *)
+let handler_of cls =
+  match Tw.Utility.base_of_class Tw.Scheme.default cls with
+  | Ok base -> Some (Tw.Utility.name_of_base base)
+  | Error (`Msg _) -> None
+
+let test_pool_covers_every_handler () =
+  let names classes = List.filter_map handler_of classes in
+  let covered =
+    names
+      (List.concat_map (fun (_, us) -> List.map Tw.pp us) (pool_families ()))
+  in
+  let expected =
+    List.sort_uniq String.compare (names (Tw.Utility.examples_classes ()))
+  in
+  if List.length expected < 40 then
+    Alcotest.failf "the registry offered only %d handlers to compare against"
+      (List.length expected);
+  let missing = List.filter (fun h -> not (List.mem h covered)) expected in
+  if missing <> [] then
+    Alcotest.failf
+      "no pool entry resolves to %d registered handler(s): %s.\n\
+       A class keyed under one family but claimed by another leaves the family \
+       it is keyed under with nothing of its own."
+      (List.length missing)
+      (String.concat ", " missing)
+
+(* Every variant has to read back onto a class and to change it, or a draw that
+   reaches one fails on the spelling rather than on the order. *)
+let test_variants_all_compile () =
+  List.iter
+    (fun (name, _) ->
+      let u = prefix name (cls "p-4") in
+      if Tw.pp u = "p-4" then
+        Alcotest.failf "variant %s left the class it wraps unchanged" name;
+      ignore (Tw.to_css ~base:false [ u ]))
+    pool_variants
 
 let test_border_width_color_ordering () =
   (* Test that border width utilities (borders.ml, priority 16) come before
@@ -1962,6 +2300,9 @@ let tests =
     test_case "rules_of_grouped prose merging bug" `Quick
       rules_of_grouped_prose_bug;
     test_case "suborder within group" `Slow test_suborder_within_group;
+    test_case "pool covers every family" `Quick test_pool_covers_every_family;
+    test_case "pool covers every handler" `Quick test_pool_covers_every_handler;
+    test_case "pool variants all compile" `Quick test_variants_all_compile;
     test_case "random utilities with minimization" `Slow
       test_random_utilities_with_minimization;
     test_case "variant families sort as Tailwind" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1034,7 +1034,10 @@ let pool_families () =
 (* What a variant may sit next to in a stack.
 
    [Responsive] nests a media query, and two of those on one class is a spelling
-   Tailwind refuses, so a stack takes at most one and it goes outermost.
+   Tailwind refuses, so a stack takes at most one and it goes outermost. [Hover]
+   nests [\@media (hover: hover)], and a stack takes at most one of those too:
+   Tailwind nests the query once per hover-gated variant and tw emits it once,
+   so [group-hover:hover:x] differs by a redundant wrapper.
 
    [Innermost] may not wrap another variant. [starting] is here because
    [starting:hover:x] loses the [@media (hover:hover)] the inner variant asked
@@ -1049,7 +1052,7 @@ let pool_families () =
    which no reader accepts, and its own minifier then empties what it cannot
    parse. It also needs a utility whose rules stop at the element; see
    {!reaches_past_the_element}. *)
-type variant_kind = Plain | Responsive | Innermost | Element
+type variant_kind = Plain | Responsive | Hover | Innermost | Element
 
 (* modifiers exports 210 constructors and no utility of its own, so a seed
    reaches the family only by dressing one: this list is what puts a [hover:]
@@ -1058,7 +1061,7 @@ type variant_kind = Plain | Responsive | Innermost | Element
    fifth of them and the reader takes every spelling. *)
 let pool_variants =
   [
-    ("hover", Plain);
+    ("hover", Hover);
     ("focus", Plain);
     ("active", Plain);
     ("disabled", Plain);
@@ -1101,7 +1104,7 @@ let pool_variants =
     ("details-content", Element);
     ("*", Plain);
     ("**", Plain);
-    ("group-hover", Plain);
+    ("group-hover", Hover);
     ("group-focus", Plain);
     ("group-first", Plain);
     ("group-last", Plain);
@@ -1110,7 +1113,7 @@ let pool_variants =
     ("group-checked", Plain);
     ("group-disabled", Plain);
     ("group-focus-within", Plain);
-    ("peer-hover", Plain);
+    ("peer-hover", Hover);
     ("peer-focus", Plain);
     ("peer-checked", Plain);
     ("peer-disabled", Plain);
@@ -1210,8 +1213,8 @@ let dressing_of cls =
 let dress rng ~dressing u =
   let alone =
     match dressing with
-    | Any -> [ Plain; Responsive; Innermost; Element ]
-    | No_pseudo_element -> [ Plain; Responsive; Innermost ]
+    | Any -> [ Plain; Responsive; Hover; Innermost; Element ]
+    | No_pseudo_element -> [ Plain; Responsive; Hover; Innermost ]
     | Bare -> []
   in
   let innermost =
@@ -1229,10 +1232,13 @@ let dress rng ~dressing u =
         (name, prefix name u)
     | _ ->
         (* Stacked: the pseudo-element innermost, since it ends the selector,
-           and the media query outermost, which is how [md:hover:] is
-           written. *)
-        let inner, _ = pick_variant rng innermost in
-        let outer, _ = pick_variant rng [ Plain; Responsive ] in
+           and the media query outermost, which is how [md:hover:] is written.
+           At most one hover-gated variant, wherever it lands. *)
+        let outer, outer_kind = pick_variant rng [ Plain; Responsive; Hover ] in
+        let inner_kinds =
+          if outer_kind = Hover then innermost else Hover :: innermost
+        in
+        let inner, _ = pick_variant rng inner_kinds in
         (outer ^ ":" ^ inner, prefix outer (prefix inner u))
 
 (* Without replacement. Drawing 30 from 252 with replacement left about 28
@@ -1530,22 +1536,22 @@ let case_index cases =
 
    A [Reordered] node with no [swapped_with] is a reorder inside one rule rather
    than of the rules, and is not this. *)
-let rec only_reorders (d : Cascade_diff.Tree_diff.t) =
-  d.layer_order = None
-  && List.for_all rule_is_reorder d.rules
-  && List.for_all container_is_reorder d.containers
-
-and rule_is_reorder (r : Cascade_diff.Tree_diff.rule_diff) =
+let rule_is_reorder (r : Cascade_diff.Tree_diff.rule_diff) =
   match r with
   | Cascade_diff.Tree_diff.Reordered { swapped_with = Some _; _ } -> true
   | _ -> false
 
-and container_is_reorder (c : Cascade_diff.Tree_diff.container_diff) =
+let rec container_is_reorder (c : Cascade_diff.Tree_diff.container_diff) =
   match c with
   | Cascade_diff.Tree_diff.Modified { rule_changes; container_changes; _ } ->
       List.for_all rule_is_reorder rule_changes
       && List.for_all container_is_reorder container_changes
   | _ -> false
+
+let only_reorders (d : Cascade_diff.Tree_diff.t) =
+  d.layer_order = None
+  && List.for_all rule_is_reorder d.rules
+  && List.for_all container_is_reorder d.containers
 
 (* One reading of a case, for both minimisation and the assertion: two
    predicates that disagree let a fuzzer print a failing case and pass anyway.
@@ -1570,12 +1576,12 @@ let case_faults cases =
         match (entry a, entry b) with
         | Some (ha, va), Some (hb, vb)
           when String.equal va vb && not (List.mem (ha, hb) known_inversions) ->
-            Some
-              (Fmt.str
-                 "%s comes before %s in Tailwind and after it in tw. Fix the \
-                  order, or record (%S, %S) in [known_inversions] if it is \
-                  debt this branch does not close."
-                 a b ha hb)
+            Fmt.kstr
+              (fun m -> Some m)
+              "%s comes before %s in Tailwind and after it in tw. Fix the \
+               order, or record (%S, %S) in [known_inversions] if it is debt \
+               this branch does not close."
+              a b ha hb
         | _ -> None)
   in
   let structural =

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -849,9 +849,6 @@ let pool_families () =
           "order-2";
           "order-first";
         ] );
-    (* The plugin's own utilities. A draw holding one is compared with the
-       plugin loaded, which is what [~forms] switches on. *)
-    ("forms", c [ "form-input"; "form-select"; "form-checkbox" ]);
     ("gap", c [ "gap-4"; "gap-x-2"; "gap-y-8" ]);
     ("grid", c [ "grid"; "inline-grid" ]);
     ( "grid_item",
@@ -946,7 +943,6 @@ let pool_families () =
           "start-0";
           "inset-0";
         ] );
-    ("prose", c [ "prose"; "prose-lg"; "prose-invert"; "prose-slate" ]);
     ("scroll", c [ "scroll-m-4"; "scroll-px-2"; "scroll-mt-8"; "scroll-pb-6" ]);
     ( "scrollbar",
       c
@@ -1035,12 +1031,25 @@ let pool_families () =
     ("zoom", c [ "zoom-50"; "zoom-100" ]);
   ]
 
-(* [Responsive] nests a media query, and two of those on one class is a spelling
-   Tailwind refuses, so a stack takes at most one. [Element] ends the compound
-   selector with a pseudo-element, which nothing may follow: Tailwind writes
-   [marker:last:x] as [::marker:last-child] and its own minifier then drops what
-   it cannot parse, so only the innermost of a stack may be one. *)
-type variant_kind = Plain | Responsive | Element
+(* What a variant may sit next to in a stack.
+
+   [Responsive] nests a media query, and two of those on one class is a spelling
+   Tailwind refuses, so a stack takes at most one and it goes outermost.
+
+   [Innermost] may not wrap another variant. [starting] is here because
+   [starting:hover:x] loses the [@media (hover:hover)] the inner variant asked
+   for, a bug of its own rather than an ordering question. [in-[...]] is out of
+   the list altogether: composed with anything - an inner variant, or a utility
+   carrying its own pseudo-element - it wraps the ancestor selector in [:is()]
+   where Tailwind appends to that selector's last compound, which is the same
+   CSS spelled differently and reads as a difference every time.
+
+   [Element] is [Innermost] and ends the compound with a pseudo-element, which
+   nothing may follow: Tailwind writes [marker:last:x] as [::marker:last-child],
+   which no reader accepts, and its own minifier then empties what it cannot
+   parse. It also needs a utility whose rules stop at the element; see
+   {!reaches_past_the_element}. *)
+type variant_kind = Plain | Responsive | Innermost | Element
 
 (* modifiers exports 210 constructors and no utility of its own, so a seed
    reaches the family only by dressing one: this list is what puts a [hover:]
@@ -1126,10 +1135,9 @@ let pool_variants =
     ("group-has-[.x]", Plain);
     ("peer-has-[.x]", Plain);
     ("not-[:hover]", Plain);
-    ("in-[.x]", Plain);
     ("ltr", Plain);
     ("rtl", Plain);
-    ("starting", Plain);
+    ("starting", Innermost);
     ("sm", Responsive);
     ("md", Responsive);
     ("lg", Responsive);
@@ -1168,21 +1176,64 @@ let prefix name u =
       if Result.is_error (Tw.of_string bare) then u
       else Alcotest.failf "%S does not read back: %s" dressed m
 
+(* How much of a variant a utility can wear. Every restriction here is a bug or
+   a gap of its own rather than an ordering question, which is what this fuzzer
+   is for, and each is named with why. *)
+type dressing =
+  | Any
+  | No_pseudo_element
+      (** Its rules reach past the element they are named for - a descendant, a
+          child, or a pseudo-element of its own - so a pseudo-element variant
+          cannot dress it. [before:divide-x] would have to mean
+          [::before > :not(:last-child)] and tw writes [::before] alone,
+          dropping the child part; [details-content:placeholder-gray-400] puts
+          two pseudo-elements in one compound, which no reader accepts. *)
+  | Bare
+      (** It emits a companion block - an [@supports] beside the rule, or a
+          nested [@media] - and a variant puts each in a [@media] of its own.
+          Tailwind merges consecutive blocks and cascade does not (CLAUDE.md
+          section 8), so the split reads as a missing declaration rather than as
+          the merge gap it is. *)
+
+let dressing_of cls =
+  let has prefixes =
+    List.exists (fun p -> Astring.String.is_prefix ~affix:p cls) prefixes
+  in
+  if has [ "bg-linear-to-"; "container"; "@container" ] then Bare
+  else if has [ "divide-"; "space-"; "placeholder-"; "group"; "peer" ] then
+    No_pseudo_element
+  else Any
+
 (* How much of a draw wears a variant. All of it would compare one media block
    against another and never a plain rule against one, and none of it is where
    the pool was. *)
-let dress rng u =
-  match Random.State.int rng 6 with
-  | 0 | 1 | 2 -> u
-  | 3 | 4 ->
-      let name, _ = pick_variant rng [ Plain; Responsive; Element ] in
-      prefix name u
-  | _ ->
-      (* Stacked: the pseudo-element innermost, since it ends the selector, and
-         the media query outermost, which is how [md:hover:] is written. *)
-      let inner, _ = pick_variant rng [ Plain; Element ] in
-      let outer, _ = pick_variant rng [ Plain; Responsive ] in
-      prefix outer (prefix inner u)
+let dress rng ~dressing u =
+  let alone =
+    match dressing with
+    | Any -> [ Plain; Responsive; Innermost; Element ]
+    | No_pseudo_element -> [ Plain; Responsive; Innermost ]
+    | Bare -> []
+  in
+  let innermost =
+    match dressing with
+    | Any -> [ Plain; Element ]
+    | No_pseudo_element -> [ Plain ]
+    | Bare -> []
+  in
+  if alone = [] then ("", u)
+  else
+    match Random.State.int rng 6 with
+    | 0 | 1 | 2 -> ("", u)
+    | 3 | 4 ->
+        let name, _ = pick_variant rng alone in
+        (name, prefix name u)
+    | _ ->
+        (* Stacked: the pseudo-element innermost, since it ends the selector,
+           and the media query outermost, which is how [md:hover:] is
+           written. *)
+        let inner, _ = pick_variant rng innermost in
+        let outer, _ = pick_variant rng [ Plain; Responsive ] in
+        (outer ^ ":" ^ inner, prefix outer (prefix inner u))
 
 (* Without replacement. Drawing 30 from 252 with replacement left about 28
    distinct, and each duplicate cost a comparison and covered nothing. *)
@@ -1200,43 +1251,417 @@ let draw rng n entries =
 let sample_size = 30
 let samples = 6
 
-let test_random_utilities_with_minimization () =
-  let entries =
-    List.concat_map
-      (fun (family, us) -> List.map (fun u -> (family, u)) us)
-      (pool_families ())
+(* An entry the fuzzer draws. [handler] is the registered handler that claims
+   the undressed class, which is the key {!known_inversions} is written in;
+   dressing the utility in a variant does not change it. *)
+type entry = {
+  utility : Tw.t;
+  handler : string;
+  forms : bool;
+  dressing : dressing;
+  variant : string;  (** the prefixes it was dressed in, [""] undressed *)
+}
+
+(* Which handler a class resolves to. Finer than the lib/ module a family is
+   keyed by: typography answers early or late, borders answers outline_style for
+   its outline utilities. *)
+let handler_of cls =
+  match Tw.Utility.base_of_class Tw.Scheme.default cls with
+  | Ok base -> Some (Tw.Utility.name_of_base base)
+  | Error (`Msg _) -> None
+
+let pool_entries () =
+  List.concat_map
+    (fun (family, us) ->
+      List.map
+        (fun u ->
+          {
+            utility = u;
+            handler =
+              (match handler_of (Tw.pp u) with Some h -> h | None -> family);
+            forms = String.equal family "forms";
+            dressing = dressing_of (Tw.pp u);
+            variant = "";
+          })
+        us)
+    (pool_families ())
+
+(* Handler pairs tw orders the other way round from Tailwind. [(a, b)] reads:
+   Tailwind emits some a-utility before some b-utility, and tw emits it after.
+   Both directions can hold between one pair of handlers, since a family may
+   straddle two of Tailwind's bands, so each is its own entry.
+
+   This is the ordering debt the whole-sheet gate counts - 561 of 3885
+   statements in test/parity/sheet_order.ml - named rather than counted. Without
+   it the fuzzer fails on nearly every seed for misorderings that predate it;
+   with it a pair outside the list fails a draw.
+   [test_known_inversions_are_exact] measures the set over the whole pool and
+   fails when it grows and when one of these is fixed, so the list can only
+   shrink, and closing a bug is what forces an entry out of it. Both oracles
+   consult it: the byte positions {!Test_helpers.inverted_pairs} reads, and the
+   canonical differ, which reports a reorder of its own whenever the two rules
+   are cascade-significant.
+
+   A pair rather than a family: 18 families explain all 188 entries, and naming
+   the families instead would tolerate every disagreement either of them has,
+   including one against a family that is itself correctly placed. A pair is
+   also a property of the two classes and nothing else - both sheets order their
+   utilities by a key of their own - so it is measurable once and means the same
+   in every draw.
+
+   What a listed pair does not catch is a further inversion between those same
+   two handlers. The handler is as fine as the key gets, and a family spanning
+   two of Tailwind's bands answers one name for both. That is still far finer
+   than a count of statements, which tolerates any 561 of them. *)
+let known_inversions =
+  [
+    ("accessibility", "outline_style");
+    ("accessibility", "transforms");
+    ("alignment", "divide");
+    ("alignment", "layout");
+    ("alignment", "tab");
+    ("alignment", "transforms");
+    ("animations", "divide");
+    ("animations", "layout");
+    ("animations", "scroll");
+    ("animations", "scrollbar");
+    ("animations", "tab");
+    ("animations", "transforms");
+    ("arbitrary", "tab");
+    ("arbitrary", "transforms");
+    ("backgrounds", "layout");
+    ("backgrounds", "tab");
+    ("backgrounds", "transforms");
+    ("borders", "layout");
+    ("borders", "tab");
+    ("borders", "transforms");
+    ("box_sizing", "field_sizing");
+    ("box_sizing", "scroll");
+    ("box_sizing", "scrollbar");
+    ("box_sizing", "tab");
+    ("color", "transforms");
+    ("columns", "divide");
+    ("columns", "layout");
+    ("columns", "tab");
+    ("columns", "transforms");
+    ("contain", "accessibility");
+    ("contain", "interactivity");
+    ("contain", "outline_style");
+    ("contain", "transforms");
+    ("cursor", "divide");
+    ("cursor", "layout");
+    ("cursor", "scroll");
+    ("cursor", "scrollbar");
+    ("cursor", "tab");
+    ("cursor", "transforms");
+    ("divide", "layout");
+    ("divide", "tab");
+    ("divide", "text_shadow");
+    ("divide", "transforms");
+    ("effects", "effects");
+    ("effects", "transforms");
+    ("filters", "accessibility");
+    ("filters", "outline_style");
+    ("filters", "transforms");
+    ("flex_layout", "divide");
+    ("flex_layout", "layout");
+    ("flex_layout", "tab");
+    ("flex_layout", "transforms");
+    ("flex_props", "divide");
+    ("flex_props", "layout");
+    ("flex_props", "scroll");
+    ("flex_props", "scrollbar");
+    ("flex_props", "tab");
+    ("flex", "field_sizing");
+    ("flex", "scroll");
+    ("flex", "scrollbar");
+    ("flex", "tab");
+    ("gap", "divide");
+    ("gap", "layout");
+    ("gap", "tab");
+    ("gap", "transforms");
+    ("grid_template", "divide");
+    ("grid_template", "layout");
+    ("grid_template", "tab");
+    ("grid_template", "transforms");
+    ("grid", "field_sizing");
+    ("grid", "scroll");
+    ("grid", "scrollbar");
+    ("grid", "tab");
+    ("interactivity", "accessibility");
+    ("interactivity", "alignment");
+    ("interactivity", "arbitrary");
+    ("interactivity", "backgrounds");
+    ("interactivity", "borders");
+    ("interactivity", "color");
+    ("interactivity", "columns");
+    ("interactivity", "divide");
+    ("interactivity", "effects");
+    ("interactivity", "filters");
+    ("interactivity", "flex_layout");
+    ("interactivity", "gap");
+    ("interactivity", "grid_template");
+    ("interactivity", "interactivity");
+    ("interactivity", "layout");
+    ("interactivity", "mask_gradient");
+    ("interactivity", "masks");
+    ("interactivity", "outline_style");
+    ("interactivity", "overflow_wrap");
+    ("interactivity", "overflow");
+    ("interactivity", "overscroll");
+    ("interactivity", "padding");
+    ("interactivity", "scroll");
+    ("interactivity", "scrollbar");
+    ("interactivity", "svg");
+    ("interactivity", "tab");
+    ("interactivity", "transforms");
+    ("interactivity", "typography_early");
+    ("interactivity", "typography_late");
+    ("layout", "field_sizing");
+    ("layout", "layout");
+    ("layout", "scroll");
+    ("layout", "scrollbar");
+    ("layout", "tab");
+    ("layout", "transforms");
+    ("margin", "field_sizing");
+    ("margin", "scroll");
+    ("margin", "scrollbar");
+    ("margin", "tab");
+    ("mask_gradient", "layout");
+    ("mask_gradient", "tab");
+    ("mask_gradient", "transforms");
+    ("masks", "arbitrary");
+    ("masks", "layout");
+    ("masks", "tab");
+    ("masks", "transforms");
+    ("outline_style", "transforms");
+    ("overflow_wrap", "tab");
+    ("overflow_wrap", "transforms");
+    ("overflow", "layout");
+    ("overflow", "tab");
+    ("overflow", "transforms");
+    ("overscroll", "layout");
+    ("overscroll", "tab");
+    ("overscroll", "transforms");
+    ("padding", "padding");
+    ("padding", "tab");
+    ("padding", "transforms");
+    ("position", "position");
+    ("scroll", "scrollbar");
+    ("scroll", "tab");
+    ("scrollbar", "scrollbar");
+    ("scrollbar", "tab");
+    ("sizing", "divide");
+    ("sizing", "layout");
+    ("sizing", "scroll");
+    ("sizing", "scrollbar");
+    ("sizing", "sizing");
+    ("sizing", "tab");
+    ("svg", "tab");
+    ("svg", "transforms");
+    ("tables", "divide");
+    ("tables", "layout");
+    ("tables", "scroll");
+    ("tables", "scrollbar");
+    ("tables", "tab");
+    ("tables", "tables");
+    ("text_shadow", "transforms");
+    ("touch", "columns");
+    ("touch", "divide");
+    ("touch", "interactivity");
+    ("touch", "layout");
+    ("touch", "scroll");
+    ("touch", "scrollbar");
+    ("touch", "tab");
+    ("touch", "touch");
+    ("touch", "transforms");
+    ("touch", "typography_late");
+    ("transforms", "divide");
+    ("transforms", "layout");
+    ("transforms", "scroll");
+    ("transforms", "scrollbar");
+    ("transforms", "tab");
+    ("transforms", "transforms");
+    ("transitions", "accessibility");
+    ("transitions", "interactivity");
+    ("transitions", "outline_style");
+    ("transitions", "transforms");
+    ("typography_early", "tab");
+    ("typography_early", "transforms");
+    ("typography_late", "divide");
+    ("typography_late", "field_sizing");
+    ("typography_late", "layout");
+    ("typography_late", "scroll");
+    ("typography_late", "scrollbar");
+    ("typography_late", "tab");
+    ("typography_late", "transforms");
+    ("typography_late", "typography_early");
+    ("typography_late", "typography_late");
+    ("zoom", "divide");
+    ("zoom", "layout");
+    ("zoom", "scroll");
+    ("zoom", "scrollbar");
+    ("zoom", "tab");
+    ("zoom", "transforms");
+  ]
+
+(* Which handler each class in a case belongs to, and which variant it wears.
+   The variant matters because two classes wearing different ones are not
+   comparable here: a variant changes the sort key by design, and where Tailwind
+   puts [hover:a] relative to [md:b] is its variant order rather than the
+   utility order this measures. The differ still reads that pair. *)
+let case_index cases =
+  let tbl = Hashtbl.create (List.length cases) in
+  List.iter
+    (fun e ->
+      let cls = Tw.pp e.utility in
+      if not (Hashtbl.mem tbl cls) then
+        Hashtbl.add tbl cls (e.handler, e.variant))
+    cases;
+  tbl
+
+(* Is every change in the differ's tree a reorder of whole rules? The differ
+   answers what kind of difference there is; which pairs disagree is
+   {!Test_helpers.inverted_pairs}'s question, and it is the one that can be
+   recorded. Splitting them that way is deliberate: the differ picks which of
+   several rotated rules to call moved from the context it is given, so a pair
+   it names in a three-class draw is not the pair it names over the pool, while
+   two byte positions read the same wherever they are read.
+
+   A [Reordered] node with no [swapped_with] is a reorder inside one rule rather
+   than of the rules, and is not this. *)
+let rec only_reorders (d : Cascade_diff.Tree_diff.t) =
+  d.layer_order = None
+  && List.for_all rule_is_reorder d.rules
+  && List.for_all container_is_reorder d.containers
+
+and rule_is_reorder (r : Cascade_diff.Tree_diff.rule_diff) =
+  match r with
+  | Cascade_diff.Tree_diff.Reordered { swapped_with = Some _; _ } -> true
+  | _ -> false
+
+and container_is_reorder (c : Cascade_diff.Tree_diff.container_diff) =
+  match c with
+  | Cascade_diff.Tree_diff.Modified { rule_changes; container_changes; _ } ->
+      List.for_all rule_is_reorder rule_changes
+      && List.for_all container_is_reorder container_changes
+  | _ -> false
+
+(* One reading of a case, for both minimisation and the assertion: two
+   predicates that disagree let a fuzzer print a failing case and pass anyway.
+   The canonical differ answers what the two sheets declare differently, and the
+   pairwise order answers what they emit in a different order, which the differ
+   folds away whenever the two utilities write disjoint properties. Both consult
+   [known_inversions]. *)
+let case_faults cases =
+  let utilities = List.map (fun e -> e.utility) cases in
+  let forms = List.exists (fun e -> e.forms) cases in
+  let tailwind, tw = Test_helpers.sheets ~forms utilities in
+  let index = case_index cases in
+  let entry cls = Hashtbl.find_opt index cls in
+  let diff = Test_helpers.sheet_diff ~tailwind ~tw in
+  let dropped = Test_helpers.dropped_declarations diff in
+  let unread =
+    if dropped = [] then [] else [ Test_helpers.describe_dropped dropped ]
   in
+  let unrecorded =
+    Test_helpers.inverted_pairs ~tailwind ~tw (List.map Tw.pp utilities)
+    |> List.filter_map (fun (a, b) ->
+        match (entry a, entry b) with
+        | Some (ha, va), Some (hb, vb)
+          when String.equal va vb && not (List.mem (ha, hb) known_inversions) ->
+            Some
+              (Fmt.str
+                 "%s comes before %s in Tailwind and after it in tw. Fix the \
+                  order, or record (%S, %S) in [known_inversions] if it is \
+                  debt this branch does not close."
+                 a b ha hb)
+        | _ -> None)
+  in
+  let structural =
+    match diff.Cascade_diff.Css_compare.result with
+    | Cascade_diff.Css_compare.No_diff -> []
+    (* Only order differs, and every pair that disagrees is recorded. *)
+    | Cascade_diff.Css_compare.Tree_diff d
+      when only_reorders d && unrecorded = [] ->
+        []
+    | _ -> [ Test_helpers.describe_diff diff ]
+  in
+  unread @ structural @ unrecorded
+
+let test_random_utilities_with_minimization () =
+  let entries = pool_entries () in
   let rng = Test_helpers.test_rng in
-  (* The forms plugin is loaded on both sides only when the case holds one of
-     its utilities, and minimisation can take the last one out, so each element
-     carries whether it is one rather than the draw deciding once. *)
-  let utilities cases = List.map snd cases in
-  let forms cases = List.exists fst cases in
   let sample i =
     let initial =
       List.map
-        (fun (family, u) -> (String.equal family "forms", dress rng u))
+        (fun e ->
+          let variant, utility = dress rng ~dressing:e.dressing e.utility in
+          { e with utility; variant })
         (draw rng sample_size entries)
     in
     Fmt.epr "Sample %d/%d: %d utilities@." i samples (List.length initial);
-    let fails cases =
-      Test_helpers.check_sheet_order_fails ~forms:(forms cases)
-        (utilities cases)
-    in
-    match Test_helpers.minimize_failing_case fails initial with
+    match
+      Test_helpers.minimize_failing_case
+        (fun cases -> case_faults cases <> [])
+        initial
+    with
     | None -> ()
-    | Some final ->
+    | Some final -> (
         Fmt.epr "@.Minimal failing case (%d utilities): %a@."
           (List.length final)
           Fmt.(list ~sep:(const string " ") string)
-          (List.map Tw.pp (utilities final));
-        Test_helpers.check_sheet_order_matches ~forms:(forms final)
-          ~test_name:"random utilities ordering matches Tailwind"
-          (utilities final)
+          (List.map (fun e -> Tw.pp e.utility) final);
+        match case_faults final with
+        | [] -> ()
+        | faults ->
+            Alcotest.failf "random utilities ordering matches Tailwind\n%s"
+              (String.concat "\n" faults))
   in
   for i = 1 to samples do
     sample i
   done
+
+(* The set {!known_inversions} records, measured over the whole pool at once.
+   Measured rather than collected from failing seeds: every pair the fuzzer can
+   draw is in this one comparison, so the list describes the debt instead of
+   whichever part of it a seed happened to hit. *)
+let measured_inversions () =
+  let entries = pool_entries () in
+  let utilities = List.map (fun e -> e.utility) entries in
+  let tailwind, tw = Test_helpers.sheets ~forms:true utilities in
+  let index = case_index entries in
+  let handler cls =
+    match Hashtbl.find_opt index cls with Some (h, _) -> h | None -> cls
+  in
+  let from_positions =
+    Test_helpers.inverted_pairs ~tailwind ~tw (List.map Tw.pp utilities)
+    |> List.map (fun (a, b) -> (handler a, handler b))
+  in
+  List.sort_uniq compare from_positions
+
+let test_known_inversions_are_exact () =
+  let measured = measured_inversions () in
+  let recorded = List.sort_uniq compare known_inversions in
+  let show pairs =
+    String.concat "\n"
+      (List.map (fun (a, b) -> Fmt.str "    (%S, %S);" a b) pairs)
+  in
+  let unrecorded = List.filter (fun p -> not (List.mem p recorded)) measured in
+  if unrecorded <> [] then
+    Alcotest.failf
+      "%d handler pair(s) are out of Tailwind's order and not recorded:\n\
+       %s\n\
+       Fix the order, or add them to [known_inversions] in test/test_sort.ml."
+      (List.length unrecorded) (show unrecorded);
+  let closed = List.filter (fun p -> not (List.mem p measured)) recorded in
+  if closed <> [] then
+    Alcotest.failf
+      "%d recorded pair(s) are in Tailwind's order now:\n\
+       %s\n\
+       Delete them from [known_inversions] in test/test_sort.ml. The list is a \
+       ratchet: it only shrinks."
+      (List.length closed) (show closed)
 
 (* Every module tw.ml includes exports utilities, and one with no pool entry is
    a family no seed can reach. Reading the include list back is what makes a new
@@ -1275,6 +1700,18 @@ let unfuzzable =
     ( "modifiers",
       "exports variants rather than utilities; [pool_variants] carries it, and \
        [test_variants_all_compile] checks that list" );
+    ( "forms",
+      "drawn beside [ring-offset-*] it emits a property rule for \
+       [--tw-ring-offset-shadow] and a properties layer Tailwind does not, \
+       neither utility doing so on its own: the plugin's own writes register \
+       as setting the variable where Tailwind's do not. A bug about which \
+       variables need a property rule, not about order" );
+    ( "prose",
+      "emits a block of about ninety descendant rules, and where another \
+       utility falls inside that block is not a question about a pair of \
+       classes: the two sheets order prose's own rules differently, so pairing \
+       them by position says nothing and only the differ sees it. Covered by \
+       test_prose.ml" );
     ( "clipping",
       "[clip_polygon] names its class [clip-[polygon(...)]], which Tailwind \
        does not read and emits nothing for, and which tw's own reader rejects \
@@ -1312,11 +1749,6 @@ let test_pool_covers_every_family () =
    that. Each registered handler offers a few of its own utilities as
    {!Tw.Utility.examples_classes}, so the expected set comes out of the registry
    rather than out of a second hand-written list. *)
-let handler_of cls =
-  match Tw.Utility.base_of_class Tw.Scheme.default cls with
-  | Ok base -> Some (Tw.Utility.name_of_base base)
-  | Error (`Msg _) -> None
-
 let test_pool_covers_every_handler () =
   let names classes = List.filter_map handler_of classes in
   let covered =
@@ -2301,6 +2733,7 @@ let tests =
       rules_of_grouped_prose_bug;
     test_case "suborder within group" `Slow test_suborder_within_group;
     test_case "pool covers every family" `Quick test_pool_covers_every_family;
+    test_case "known inversions are exact" `Slow test_known_inversions_are_exact;
     test_case "pool covers every handler" `Quick test_pool_covers_every_handler;
     test_case "pool variants all compile" `Quick test_variants_all_compile;
     test_case "random utilities with minimization" `Slow

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1501,7 +1501,6 @@ let known_inversions =
     ("typography_late", "scrollbar");
     ("typography_late", "tab");
     ("typography_late", "transforms");
-    ("typography_late", "typography_early");
     ("typography_late", "typography_late");
     ("zoom", "divide");
     ("zoom", "layout");

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -124,9 +124,30 @@ let bracket_named_color () =
     "stroke-[notacolour] is not a class" true
     (Result.is_error (Tw.of_string "stroke-[notacolour]"))
 
+(* fill and stroke share a priority with object-fit and object-position, and
+   Tailwind emits them first of the two. They sorted last instead, the whole svg
+   family landing after the object utilities, and no canonical comparison could
+   see it: the two write disjoint properties, so nothing about the pair is
+   cascade-significant and the differ folds the reorder away. Reading the
+   positions back out of the sheet is what catches it. *)
+let svg_sorts_before_object () =
+  Test_helpers.check_class_order ~test_name:"fill and stroke before object"
+    [
+      "bg-cover";
+      "mask-cover";
+      "fill-blue-200";
+      "fill-none";
+      "stroke-current";
+      "stroke-2";
+      "object-cover";
+      "object-center";
+      "p-4";
+    ]
+
 let tests =
   [
     test_case "basic svg" `Quick basic_svg;
+    test_case "svg sorts before object" `Quick svg_sorts_before_object;
     test_case "bracket named colour" `Quick bracket_named_color;
     test_case "stroke shadeless colors" `Quick stroke_shadeless_colors;
     test_case "stroke light-dark color" `Quick stroke_light_dark_color;

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -387,8 +387,37 @@ let test_project_perspective_token () =
     "an undeclared perspective name is rejected" true
     (Result.is_error (Tw.of_string ~theme "perspective-nope"))
 
+(* The [@property] block for the five rotate/skew channels belongs to
+   [transform]. [transform-cpu] and [transform-gpu] only read them, and asking
+   for the rules there put a whole [@layer properties] and five [@property]
+   rules in a sheet whose one transform utility was either of those two. *)
+let test_property_rules_belong_to_transform () =
+  let property_rules cls =
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u ->
+        let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string in
+        List.length
+          (List.filter
+             (fun l -> Astring.String.is_prefix ~affix:"@property" l)
+             (String.split_on_char '\n' css))
+  in
+  Alcotest.(check int) "transform declares them" 5 (property_rules "transform");
+  Alcotest.(check int)
+    "transform-cpu does not" 0
+    (property_rules "transform-cpu");
+  Alcotest.(check int)
+    "transform-gpu does not" 0
+    (property_rules "transform-gpu");
+  (* A utility that sets one of the channels still brings its rule along. *)
+  Alcotest.(check bool)
+    "rotate-x-30 declares its own" true
+    (property_rules "rotate-x-30" > 0)
+
 let tests =
   [
+    test_case "property rules belong to transform" `Quick
+      test_property_rules_belong_to_transform;
     test_case "invalid arbitrary transform" `Quick
       test_invalid_arbitrary_transform;
     test_case "perspective-none theme override" `Quick

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -125,6 +125,38 @@ let test_project_ease_token () =
     "an undeclared ease name is rejected" true
     (Result.is_error (Tw.of_string ~theme "ease-nope"))
 
+(* Every transition rule reads [--default-transition-duration] and
+   [--default-transition-timing-function] through a fallback, so the theme has
+   to declare them whenever one is emitted. Which classes need them was read off
+   the name of the emitted class, and a variant renames that class, so
+   [hover:transition] left both undeclared: the rule then fell back to a
+   variable nothing set and the element did not animate at all. *)
+let test_default_transition_theme_survives_a_variant () =
+  let declares cls =
+    match Tw.of_string cls with
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+    | Ok u ->
+        let css = Tw.to_css ~base:true [ u ] |> Tw.Css.to_string in
+        Astring.String.is_infix ~affix:"--default-transition-duration:" css
+        && Astring.String.is_infix
+             ~affix:"--default-transition-timing-function:" css
+  in
+  List.iter
+    (fun cls ->
+      Alcotest.(check bool) (cls ^ " declares the defaults") true (declares cls))
+    [
+      "transition";
+      "hover:transition";
+      "md:transition";
+      "before:transition";
+      "hover:transition-colors";
+    ];
+  (* [transition-none] animates nothing, so it needs neither, dressed or not. *)
+  List.iter
+    (fun cls ->
+      Alcotest.(check bool) (cls ^ " needs no defaults") false (declares cls))
+    [ "transition-none"; "hover:transition-none"; "p-4" ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -136,6 +168,8 @@ let tests =
       Alcotest.test_case "arbitrary ease steps default position" `Quick
         test_arbitrary_ease_steps_default_position;
       Alcotest.test_case "project ease token" `Quick test_project_ease_token;
+      Alcotest.test_case "default transition theme survives a variant" `Quick
+        test_default_transition_theme_survives_a_variant;
     ]
 
 let suite = ("transitions", tests)

--- a/test/test_zoom.ml
+++ b/test/test_zoom.ml
@@ -10,7 +10,28 @@ let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-1.5";
   Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-unknown"
 
+(* Tailwind emits [zoom-*] between the transforms and the animations. It sorted
+   with the margins instead, at the priority a family gets when nobody has
+   placed it, and no canonical comparison could see that: [zoom] shares a
+   property with none of them. *)
+let test_zoom_sorts_after_the_transforms () =
+  Test_helpers.check_class_order ~test_name:"zoom band"
+    [
+      "m-4";
+      "translate-x-4";
+      "rotate-45";
+      "transform-gpu";
+      "zoom-50";
+      "animate-spin";
+      "cursor-pointer";
+      "p-4";
+    ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "sorts after the transforms" `Quick
+        test_zoom_sorts_after_the_transforms;
+    ]
 
 let suite = ("zoom", tests)


### PR DESCRIPTION
Expand the sort fuzzer across every utility family and use Tailwind byte positions to expose ordering and routing defects. Fix the resulting variant-composition regressions, including preserving inner hover capability gates through at-rule and selector variants.