### PR TITLE
tailwind_gen: invoke the pinned CLI without npx

### DIFF
--- a/lib/tools/tailwind_gen.ml
+++ b/lib/tools/tailwind_gen.ml
@@ -159,22 +159,53 @@ let describe_candidate cmd present =
     | Some v -> cmd ^ ": v" ^ v
     | None -> cmd ^ ": unknown version"
 
+let rec dir_containing name dir =
+  if Sys.file_exists (Filename.concat dir name) then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else dir_containing name parent
+
+(* Worktrees can safely share an installed node_modules tree: the packages are
+   read-only while tests run. Do not put npx between the harness and the pinned
+   binary, because concurrent npx processes coordinate through npm's shared
+   cache and can starve one another for minutes. *)
+let project_tailwindcss_command () =
+  let relative = "node_modules/.bin/tailwindcss" in
+  match dir_containing relative (Sys.getcwd ()) with
+  | None -> None
+  | Some root ->
+      let path = Filename.concat root relative in
+      let executable =
+        try
+          Unix.access path [ Unix.X_OK ];
+          true
+        with Unix.Unix_error _ -> false
+      in
+      if executable then Some (Filename.quote path) else None
+
 let tailwindcss_command () =
   let have cmd = Sys.command ("which " ^ cmd ^ " > /dev/null 2>&1") = 0 in
+  let project = project_tailwindcss_command () in
   let native = have "tailwindcss" in
   let npx = have "npx" in
-  if native && command_is_required "tailwindcss" then "tailwindcss"
-  else if npx && command_is_required "npx tailwindcss" then "npx tailwindcss"
-  else
-    failwith
-      ("tailwindcss v"
-      ^ version_string required_version
-      ^ " is required ("
-      ^ describe_candidate "tailwindcss" native
-      ^ ", "
-      ^ describe_candidate "npx tailwindcss" npx
-      ^ ").\nInstall it with: npm install -g @tailwindcss/cli@"
-      ^ version_string required_version)
+  match project with
+  | Some cmd when command_is_required cmd -> cmd
+  | _ when native && command_is_required "tailwindcss" -> "tailwindcss"
+  | _ when npx && command_is_required "npx tailwindcss" -> "npx tailwindcss"
+  | _ ->
+      failwith
+        ("tailwindcss v"
+        ^ version_string required_version
+        ^ " is required ("
+        ^ describe_candidate
+            (Option.value ~default:"node_modules/.bin/tailwindcss" project)
+            (Option.is_some project)
+        ^ ", "
+        ^ describe_candidate "tailwindcss" native
+        ^ ", "
+        ^ describe_candidate "npx tailwindcss" npx
+        ^ ").\nInstall it with: npm install -g @tailwindcss/cli@"
+        ^ version_string required_version)
 
 let check_tailwindcss_available () =
   match !availability_result with

--- a/lib/tools/tailwind_gen.mli
+++ b/lib/tools/tailwind_gen.mli
@@ -24,6 +24,10 @@ val check_tailwindcss_available : unit -> unit
 (** [check_tailwindcss_available ()] checks if Tailwind CSS v4 is available.
     @raise Failure if Tailwind CSS is not available or not v4. *)
 
+val tailwindcss_command : unit -> string
+(** [tailwindcss_command ()] is the shell command for the pinned Tailwind CLI.
+    @raise Failure if Tailwind CSS is unavailable or has the wrong version. *)
+
 val availability : unit -> (unit, string) result
 (** [availability ()] is [Ok ()] iff the required tailwindcss CLI is installed
     and could be identified. It is [Error reason] when the CLI is missing,

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -10,6 +10,26 @@ let test_check_available () =
   check_tailwindcss_available ();
   check bool "tailwindcss available" true true
 
+let rec dir_containing name dir =
+  if Sys.file_exists (Filename.concat dir name) then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else dir_containing name parent
+
+(* Every worktree points node_modules at the same installed tree. Going through
+   npx makes concurrent gates coordinate through npm's shared cache even though
+   the exact executable is already present and immutable. *)
+let test_prefers_project_tailwindcss () =
+  let relative = "node_modules/.bin/tailwindcss" in
+  let root =
+    match dir_containing relative (Sys.getcwd ()) with
+    | Some root -> root
+    | None -> Alcotest.skip ()
+  in
+  let expected = Filename.quote (Filename.concat root relative) in
+  check string "uses the pinned executable directly" expected
+    (tailwindcss_command ())
+
 let test_generate_simple () =
   Test_helpers.require_tailwind_cli ();
   let css = generate ~minify:true [ "p-4"; "bg-blue-500" ] in
@@ -83,6 +103,8 @@ let test_arbitrary_url_matches_cli () =
 let tests =
   [
     test_case "check tailwindcss available" `Quick test_check_available;
+    test_case "prefer the project Tailwind executable" `Quick
+      test_prefers_project_tailwindcss;
     test_case "generate simple CSS" `Quick test_generate_simple;
     test_case "arbitrary colour opacity matches live CLI" `Quick
       test_arbitrary_color_opacity_matches_cli;


### PR DESCRIPTION
Resolve the pinned Tailwind CLI from the nearest project node_modules before falling back to native or npx discovery. This avoids npm-cache coordination starving concurrent @runtest jobs while preserving exact version checking.