### PR TITLE
sort: align interaction and flow property bands

### DIFF
--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -32,11 +32,10 @@ module Handler = struct
 
   let name = "divide"
 
-  (* [divide-x-reverse] is the one member of the family Tailwind sorts after
-     everything else, borders included, while [divide-y-reverse] stays with the
-     rest. It sets only [--tw-divide-x-reverse], so the position is
-     cascade-neutral and the canonical differ cannot see it. *)
-  let priority = function X_reverse -> 39 | _ -> 5
+  (* The divide properties follow gap and precede self-alignment at priority 17.
+     [divide-x-reverse] alone sorts after everything else: it sets only an
+     unranked custom property, so the move is cascade-neutral. *)
+  let priority = function X_reverse -> 39 | _ -> 17
 
   (* CSS Variables for divide reverse. Property order 4/5 places these BEFORE
      --tw-border-style (order 6) in within-utility sorting, which determines
@@ -348,28 +347,27 @@ module Handler = struct
 
   (* Tailwind's order across the family, read off its own output: divide-x,
      divide-x-2, divide-y, divide-y-4, divide-y-reverse, the styles, the
-     colours, and divide-x-reverse last. The widths lead; the styles used to,
-     which put divide-dashed ahead of divide-y-4. Bands of 100000 keep the
-     arbitrary values inside their own width band. *)
+     colours, and divide-x-reverse last. The 60k-66k range fits after gap and
+     before self-alignment in the shared priority-17 band. *)
   let suborder = function
     (* The bare divide-x / divide-y (DEFAULT, n=1) sorts before the numbered
        variants: divide-x, divide-x-0, divide-x-4, ... The "-1" offset keeps the
        default ahead of divide-x-0 (n=0). *)
-    | X 1 -> -1
-    | X n -> n
-    | X_arb _ -> 50000
-    | Y 1 -> 100000 - 1
-    | Y n -> 100000 + n
-    | Y_arb _ -> 100000 + 50000
-    | Y_reverse -> 200000
-    | Line_style _ -> 300000
+    | X 1 -> 59_999
+    | X n -> 60_000 + min n 1_997
+    | X_arb _ -> 61_998
+    | Y 1 -> 61_999
+    | Y n -> 62_000 + min n 1_997
+    | Y_arb _ -> 63_998
+    | Y_reverse -> 64_000
+    | Line_style _ -> 65_000
     (* All divide color utilities use flat suborder for natural sort *)
-    | Named_color _ | Named_color_opacity _ -> 400000
-    | Bracket_color _ | Bracket_color_opacity _ -> 400000
-    | Current | Current_opacity _ -> 400000
-    | Inherit -> 400000
-    | Transparent -> 400000
-    | X_reverse -> 500000
+    | Named_color _ | Named_color_opacity _ -> 66_000
+    | Bracket_color _ | Bracket_color_opacity _ -> 66_000
+    | Current | Current_opacity _ -> 66_000
+    | Inherit -> 66_000
+    | Transparent -> 66_000
+    | X_reverse -> 0
 
   (* The bracket spelling of an arbitrary width, for the typed constructors,
      which are handed a width rather than the text an author wrote. cascade

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -65,15 +65,16 @@ module Handler = struct
 
   let name = "interactivity"
 
-  (* Most interactivity utilities (user-select, will-change, scroll-snap, ...)
-     sort late (priority 31). resize (canonical rank 47) and appearance (rank
-     49) belong right after cursor (priority 11), around list-style (rank 48);
-     they return priority 11 with a suborder above cursor's range (<1000),
-     leaving a gap for list-style at ~2M. *)
+  (* Interaction controls from resize through appearance share priority 11 so
+     they can sit between cursor and columns. Scroll behavior follows overflow
+     and overscroll at priority 18; user-select and will-change sort late. *)
   let priority = function
     | Resize | Resize_none | Resize_x | Resize_y | Appearance_auto
-    | Appearance_none ->
+    | Appearance_none | Snap_start | Snap_end | Snap_center | Snap_none | Snap_x
+    | Snap_y | Snap_both | Snap_mandatory | Snap_proximity | Snap_align_none
+    | Snap_normal | Snap_always ->
         11
+    | Scroll_auto | Scroll_smooth -> 18
     (* Tailwind's utility order opens with the container utilities and then
        pointer-events, before the layout group. *)
     | Pointer_events_none | Pointer_events_auto -> -1
@@ -221,25 +222,18 @@ module Handler = struct
     | Scheme_only_light -> scheme_only_light_s
 
   let suborder = function
-    (* Alphabetical order: scroll before select *)
-    | Scroll_auto -> 0
-    | Scroll_smooth -> 1
+    | Scroll_auto -> 700
+    | Scroll_smooth -> 701
     | Select_all -> 2
     | Select_auto -> 3
     | Select_none -> 4
     | Select_text -> 5
-    | Snap_align_none -> 10
-    | Snap_always -> 11
-    | Snap_both -> 12
-    | Snap_center -> 13
-    | Snap_end -> 14
-    | Snap_mandatory -> 15
-    | Snap_none -> 16
-    | Snap_normal -> 17
-    | Snap_proximity -> 18
-    | Snap_start -> 19
-    | Snap_x -> 20
-    | Snap_y -> 21
+    (* Snap utilities are grouped by their property-order key. Candidate names
+       settle ties inside each property band. *)
+    | Snap_both | Snap_none | Snap_x | Snap_y -> 1_100_000
+    | Snap_mandatory | Snap_proximity -> 1_110_000
+    | Snap_align_none | Snap_center | Snap_end | Snap_start -> 1_120_000
+    | Snap_always | Snap_normal -> 1_130_000
     (* resize (priority 11) - after cursor (<1000), before list-style (~2M) *)
     | Resize -> 1_000_000 + 22
     | Resize_none -> 1_000_000 + 23

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -216,11 +216,9 @@ module Handler = struct
 
   let name = "layout"
 
-  (* Most layout utilities are the display family (priority 4). Visibility and
-     z-index occupy distinct canonical positions in Tailwind's order, so they
-     return their own priority: visibility comes first (rank 0), z-index right
-     after inset (rank 12) via priority 0 with a suborder above inset's range
-     (position.ml uses up to ~13M) and below container (priority 1). *)
+  (* Most layout utilities are the display family (priority 4). Visibility,
+     z-index, break controls, box decoration, and object controls occupy their
+     own property bands. *)
   let priority = function
     | Collapse | Invisible | Visible -> 0
     | Neg_z _ | Z_0 | Z _ | Z_10 | Z_20 | Z_30 | Z_40 | Z_50 | Neg_z_arbitrary _
@@ -243,6 +241,17 @@ module Handler = struct
     | Object_right_top | Object_top_left | Object_top_right | Object_arbitrary _
       ->
         22
+    | Break_before_all | Break_before_auto | Break_before_avoid
+    | Break_before_avoid_page | Break_before_column | Break_before_left
+    | Break_before_page | Break_before_right | Break_inside_auto
+    | Break_inside_avoid | Break_inside_avoid_column | Break_inside_avoid_page
+    | Break_after_all | Break_after_auto | Break_after_avoid
+    | Break_after_avoid_page | Break_after_column | Break_after_left
+    | Break_after_page | Break_after_right ->
+        14
+    | Box_decoration_clone | Box_decoration_slice | Decoration_clone
+    | Decoration_slice ->
+        21
     | _ -> 4
 
   let suborder = function
@@ -331,11 +340,12 @@ module Handler = struct
     | Clear_none -> 3_000_103
     | Clear_right -> 3_000_104
     | Clear_start -> 3_000_105
-    (* Box decoration break - alphabetical: clone, slice *)
-    | Box_decoration_clone -> 1000
-    | Box_decoration_slice -> 1001
-    | Decoration_clone -> 1000
-    | Decoration_slice -> 1001
+    (* Box decoration break (priority 21) sits after mask-image and its gradient
+       variables, before background-size. *)
+    | Box_decoration_clone -> Utility.Property_order.last 250
+    | Box_decoration_slice -> Utility.Property_order.last 250
+    | Decoration_clone -> Utility.Property_order.last 250
+    | Decoration_slice -> Utility.Property_order.last 250
     (* Break before - alphabetical order (Tailwind: break-before < break-inside
        < break-after) *)
     | Break_before_all -> 1100

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -38,7 +38,10 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "scroll"
-  let priority _ = 2
+
+  (* Scroll margin and padding follow the snap controls in the shared
+     interaction band and precede scrollbar/list/appearance. *)
+  let priority _ = 11
 
   (** Get (declaration, length) for spacing value using Theme.spacing_calc_float
   *)
@@ -117,7 +120,8 @@ module Handler = struct
         style [ scroll_prop kind axis len ]
 
   let suborder { kind; negative; axis; value } =
-    let kind_offset = match kind with Margin -> 0 | Padding -> 10000000 in
+    let interaction_offset = 1_200_000 in
+    let kind_offset = match kind with Margin -> 0 | Padding -> 110_000 in
     (* Side decides first and the sign is a tie-break inside the side, which is
        the order Tailwind emits: the negative of a side sits with that side, not
        ahead of every positive. The logical sides come before the physical
@@ -125,27 +129,27 @@ module Handler = struct
     let axis_offset =
       match axis with
       | All -> 0
-      | X -> 100000
-      | Y -> 200000
-      | S -> 300000
-      | E -> 400000
-      | Bs -> 500000
-      | Be -> 600000
-      | T -> 700000
-      | R -> 800000
-      | B -> 900000
-      | L -> 1000000
+      | X -> 10_000
+      | Y -> 20_000
+      | S -> 30_000
+      | E -> 40_000
+      | Bs -> 50_000
+      | Be -> 60_000
+      | T -> 70_000
+      | R -> 80_000
+      | B -> 90_000
+      | L -> 100_000
     in
-    let neg_offset = if negative then 0 else 50000 in
+    let neg_offset = if negative then 0 else 5_000 in
     (* Half the axis band each, so a value can never carry a rule across the
        sign boundary: the arbitrary spellings sit at the top of their half. *)
     let value_order =
       match value with
-      | Spacing n -> int_of_float (n *. 10.)
-      | Arbitrary _ -> 49000
-      | Arbitrary_var _ -> 49001
+      | Spacing n -> min 4_997 (int_of_float (n *. 10.))
+      | Arbitrary _ -> 4_998
+      | Arbitrary_var _ -> 4_999
     in
-    kind_offset + neg_offset + axis_offset + value_order
+    interaction_offset + kind_offset + neg_offset + axis_offset + value_order
 
   let axis_suffix = function
     | All -> ""

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -35,41 +35,14 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "scrollbar"
-  let priority _ = 2
 
-  let alpha_order s =
-    let v = ref 0 in
-    for i = 0 to min 3 (String.length s - 1) do
-      v := (!v * 256) + Char.code s.[i]
-    done;
-    !v
+  (* Scrollbar properties follow scroll padding and precede list style. *)
+  let priority _ = 11
 
-  let color_suffix color shade =
-    if Color.is_shadeless color then Color.color_to_string color
-    else Color.color_to_string color ^ "-" ^ string_of_int shade
-
-  (* Bracket values sort first, then keywords/theme colours alphabetically (ties
-     broken by the framework on the full class name), matching Tailwind. *)
-  let spec_detail = function
-    | Bracket _ -> 0
-    | Theme (color, shade, _) -> alpha_order (color_suffix color shade)
-    | Current -> alpha_order "current"
-    | Inherit -> alpha_order "inherit"
-    | Transparent -> alpha_order "transparent"
-
-  let suborder t =
-    let group, detail =
-      match t with
-      | Width_auto -> (0, 0)
-      | Width_none -> (0, 1)
-      | Width_thin -> (0, 2)
-      | Gutter_auto -> (1, 0)
-      | Gutter_both -> (1, 1)
-      | Gutter_stable -> (1, 2)
-      | Thumb s -> (2, spec_detail s)
-      | Track s -> (3, spec_detail s)
-    in
-    (group lsl 32) + detail
+  let suborder = function
+    | Width_auto | Width_none | Width_thin -> 1_450_000
+    | Thumb _ | Track _ -> 1_460_000
+    | Gutter_auto | Gutter_both | Gutter_stable -> 1_470_000
 
   let spec_class = function
     | Theme (color, shade, op) ->

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -29,7 +29,9 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "touch"
-  let priority _ = 14
+
+  (* Touch-action follows cursor and opens the shared interaction band. *)
+  let priority _ = 11
 
   (* CSS Variables for composable touch-action values *)
   let tw_pan_x_var =
@@ -60,23 +62,20 @@ module Handler = struct
     let decl, _ = Var.binding var value in
     style ~property_rules:touch_props [ decl; composable_touch_action () ]
 
-  (* Class suffix, style and cascade suborder of one utility, alphabetical
-     except that the x-axis pans come before the y-axis ones. One match covers
-     all three, so a constructor added to [t] without an entry here is a compile
-     error. *)
-  let data : t -> string * Style.t * int = function
-    | Auto -> ("auto", style [ touch_action Css.Auto ], 0)
-    | Manipulation ->
-        ("manipulation", style [ touch_action Css.Manipulation ], 1)
-    | No_action -> ("none", style [ touch_action Css.None ], 2)
-    | Pan_left -> ("pan-left", composable_style tw_pan_x_var Css.Pan_left, 3)
-    | Pan_right -> ("pan-right", composable_style tw_pan_x_var Css.Pan_right, 4)
-    | Pan_x -> ("pan-x", composable_style tw_pan_x_var Css.Pan_x, 5)
-    | Pan_down -> ("pan-down", composable_style tw_pan_y_var Css.Pan_down, 6)
-    | Pan_up -> ("pan-up", composable_style tw_pan_y_var Css.Pan_up, 7)
-    | Pan_y -> ("pan-y", composable_style tw_pan_y_var Css.Pan_y, 8)
+  (* Class suffix and style of one utility. One match covers both, so a
+     constructor added to [t] without an entry here is a compile error. *)
+  let data : t -> string * Style.t = function
+    | Auto -> ("auto", style [ touch_action Css.Auto ])
+    | Manipulation -> ("manipulation", style [ touch_action Css.Manipulation ])
+    | No_action -> ("none", style [ touch_action Css.None ])
+    | Pan_left -> ("pan-left", composable_style tw_pan_x_var Css.Pan_left)
+    | Pan_right -> ("pan-right", composable_style tw_pan_x_var Css.Pan_right)
+    | Pan_x -> ("pan-x", composable_style tw_pan_x_var Css.Pan_x)
+    | Pan_down -> ("pan-down", composable_style tw_pan_y_var Css.Pan_down)
+    | Pan_up -> ("pan-up", composable_style tw_pan_y_var Css.Pan_up)
+    | Pan_y -> ("pan-y", composable_style tw_pan_y_var Css.Pan_y)
     | Pinch_zoom ->
-        ("pinch-zoom", composable_style tw_pinch_zoom_var Css.Pinch_zoom, 9)
+        ("pinch-zoom", composable_style tw_pinch_zoom_var Css.Pinch_zoom)
 
   (* Every value a class names, for the class-name lookup. *)
   let all =
@@ -94,16 +93,20 @@ module Handler = struct
     ]
 
   let to_class v =
-    let suffix, _, _ = data v in
+    let suffix, _ = data v in
     "touch-" ^ suffix
 
   let to_style _theme v =
-    let _, s, _ = data v in
+    let _, s = data v in
     s
 
-  let suborder v =
-    let _, _, o = data v in
-    o
+  let suborder = function
+    (* Composed values carry a second property-order key, so they precede the
+       direct touch-action values. Candidate names settle ties within a key. *)
+    | Pan_left | Pan_right | Pan_x -> 500_000
+    | Pan_down | Pan_up | Pan_y -> 500_001
+    | Pinch_zoom -> 500_002
+    | Auto | Manipulation | No_action -> 500_003
 
   let of_class_map = List.map (fun v -> (to_class v, v)) all
 

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 533, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 421, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -442,6 +442,35 @@ let test_scrolling_property_bands () =
       "cursor-pointer";
     ]
 
+(* Columns and break controls open the flow block; grid/flex/alignment/gap and
+   divide follow before self-alignment, overflow and scroll behavior. *)
+let test_flow_property_bands () =
+  Test_helpers.check_class_order ~test_name:"flow controls keep their bands"
+    [
+      "rounded-lg";
+      "scroll-smooth";
+      "overscroll-contain";
+      "overflow-hidden";
+      "place-self-center";
+      "divide-red-500";
+      "divide-dashed";
+      "divide-y-reverse";
+      "divide-x-2";
+      "gap-4";
+      "justify-center";
+      "items-center";
+      "place-content-center";
+      "flex-wrap";
+      "flex-row";
+      "grid-cols-3";
+      "grid-flow-col";
+      "auto-cols-fr";
+      "break-after-page";
+      "break-inside-avoid";
+      "break-before-page";
+      "columns-2";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -2706,6 +2735,7 @@ let tests =
     test_case "text-indent family order" `Quick test_indent_family_order;
     test_case "transform control bands" `Slow test_transform_control_bands;
     test_case "scrolling property bands" `Slow test_scrolling_property_bands;
+    test_case "flow property bands" `Slow test_flow_property_bands;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -418,6 +418,30 @@ let test_transform_control_bands () =
       "table-fixed";
     ]
 
+(* Cursor opens the interaction block, followed by touch, resize, snap,
+   scrolling, scrollbar, list, appearance and columns property bands. *)
+let test_scrolling_property_bands () =
+  Test_helpers.check_class_order
+    ~test_name:"scrolling controls keep their property bands"
+    [
+      "columns-2";
+      "appearance-none";
+      "list-disc";
+      "scrollbar-gutter-stable";
+      "scrollbar-thumb-red-500";
+      "scrollbar-auto";
+      "scroll-p-4";
+      "scroll-m-4";
+      "snap-always";
+      "snap-start";
+      "snap-mandatory";
+      "snap-x";
+      "resize";
+      "touch-auto";
+      "touch-pan-x";
+      "cursor-pointer";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -2681,6 +2705,7 @@ let tests =
       test_indent_within_early_typography;
     test_case "text-indent family order" `Quick test_indent_family_order;
     test_case "transform control bands" `Slow test_transform_control_bands;
+    test_case "scrolling property bands" `Slow test_scrolling_property_bands;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1371,7 +1371,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 561 of 3885
+   This is the ordering debt the whole-sheet gate counts - 421 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1392,165 +1392,74 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 561 of them. *)
+   than a count of statements, which tolerates any 421 of them. *)
 let known_inversions =
   [
     ("accessibility", "outline_style");
-    ("alignment", "divide");
-    ("alignment", "layout");
     ("alignment", "tab");
-    ("animations", "divide");
-    ("animations", "layout");
-    ("animations", "scroll");
-    ("animations", "scrollbar");
     ("animations", "tab");
     ("arbitrary", "tab");
-    ("backgrounds", "layout");
     ("backgrounds", "tab");
-    ("borders", "layout");
     ("borders", "tab");
     ("box_sizing", "field_sizing");
-    ("box_sizing", "scroll");
-    ("box_sizing", "scrollbar");
     ("box_sizing", "tab");
-    ("columns", "divide");
-    ("columns", "layout");
     ("columns", "tab");
     ("contain", "accessibility");
     ("contain", "interactivity");
     ("contain", "outline_style");
     ("contain", "transforms");
-    ("cursor", "divide");
-    ("cursor", "layout");
-    ("cursor", "scroll");
-    ("cursor", "scrollbar");
     ("cursor", "tab");
-    ("divide", "layout");
     ("divide", "tab");
     ("divide", "text_shadow");
     ("divide", "transforms");
     ("effects", "effects");
     ("filters", "accessibility");
     ("filters", "outline_style");
-    ("flex_layout", "divide");
-    ("flex_layout", "layout");
     ("flex_layout", "tab");
-    ("flex_props", "divide");
-    ("flex_props", "layout");
-    ("flex_props", "scroll");
-    ("flex_props", "scrollbar");
     ("flex_props", "tab");
     ("flex", "field_sizing");
-    ("flex", "scroll");
-    ("flex", "scrollbar");
     ("flex", "tab");
-    ("gap", "divide");
-    ("gap", "layout");
     ("gap", "tab");
-    ("grid_template", "divide");
-    ("grid_template", "layout");
     ("grid_template", "tab");
     ("grid", "field_sizing");
-    ("grid", "scroll");
-    ("grid", "scrollbar");
     ("grid", "tab");
     ("interactivity", "accessibility");
-    ("interactivity", "alignment");
-    ("interactivity", "arbitrary");
-    ("interactivity", "backgrounds");
     ("interactivity", "borders");
-    ("interactivity", "color");
-    ("interactivity", "columns");
-    ("interactivity", "divide");
     ("interactivity", "effects");
     ("interactivity", "filters");
-    ("interactivity", "flex_layout");
-    ("interactivity", "gap");
-    ("interactivity", "grid_template");
     ("interactivity", "interactivity");
-    ("interactivity", "layout");
-    ("interactivity", "mask_gradient");
-    ("interactivity", "masks");
     ("interactivity", "outline_style");
-    ("interactivity", "overflow_wrap");
-    ("interactivity", "overflow");
-    ("interactivity", "overscroll");
-    ("interactivity", "padding");
-    ("interactivity", "scroll");
-    ("interactivity", "scrollbar");
-    ("interactivity", "svg");
     ("interactivity", "tab");
-    ("interactivity", "typography_early");
-    ("interactivity", "typography_late");
     ("layout", "field_sizing");
-    ("layout", "layout");
-    ("layout", "scroll");
-    ("layout", "scrollbar");
     ("layout", "tab");
     ("margin", "field_sizing");
-    ("margin", "scroll");
-    ("margin", "scrollbar");
     ("margin", "tab");
-    ("mask_gradient", "layout");
     ("mask_gradient", "tab");
     ("masks", "arbitrary");
-    ("masks", "layout");
     ("masks", "tab");
     ("overflow_wrap", "tab");
-    ("overflow", "layout");
     ("overflow", "tab");
-    ("overscroll", "layout");
     ("overscroll", "tab");
     ("padding", "padding");
     ("padding", "tab");
     ("position", "position");
-    ("scroll", "scrollbar");
     ("scroll", "tab");
-    ("scrollbar", "scrollbar");
     ("scrollbar", "tab");
-    ("sizing", "divide");
-    ("sizing", "layout");
-    ("sizing", "scroll");
-    ("sizing", "scrollbar");
     ("sizing", "sizing");
     ("sizing", "tab");
     ("svg", "tab");
-    ("tables", "divide");
-    ("tables", "layout");
-    ("tables", "scroll");
-    ("tables", "scrollbar");
     ("tables", "tab");
     ("tables", "tables");
-    ("touch", "columns");
-    ("touch", "divide");
-    ("touch", "interactivity");
-    ("touch", "layout");
-    ("touch", "scroll");
-    ("touch", "scrollbar");
     ("touch", "tab");
-    ("touch", "touch");
-    ("touch", "typography_late");
-    ("transforms", "divide");
-    ("transforms", "layout");
-    ("transforms", "scroll");
-    ("transforms", "scrollbar");
     ("transforms", "tab");
     ("transitions", "accessibility");
     ("transitions", "interactivity");
     ("transitions", "outline_style");
     ("transitions", "transforms");
     ("typography_early", "tab");
-    ("typography_late", "divide");
     ("typography_late", "field_sizing");
-    ("typography_late", "layout");
-    ("typography_late", "scroll");
-    ("typography_late", "scrollbar");
     ("typography_late", "tab");
     ("typography_late", "typography_late");
-    ("zoom", "divide");
-    ("zoom", "layout");
-    ("zoom", "scroll");
-    ("zoom", "scrollbar");
     ("zoom", "tab");
   ]
 


### PR DESCRIPTION
Align touch, scrolling, breaks, and divide utilities with Tailwind's middle property bands. This retires 91 handler inversions and lowers the whole-sheet minimum from 533 to 421 moves.