### PR TITLE
sort: place tab size in the typography band

### DIFF
--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -9,8 +9,8 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "tab"
-  let priority _ = 2
-  let suborder = function Tab n -> n | Tab_arbitrary _ -> 1000
+  let priority _ = 26
+  let suborder _ = 8340
 
   let to_class = function
     | Tab n -> "tab-" ^ string_of_int n

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 421, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 413, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -471,6 +471,21 @@ let test_flow_property_bands () =
       "columns-2";
     ]
 
+(* Tab size follows white-space and precedes text color and transforms. *)
+let test_tab_property_band () =
+  Test_helpers.check_class_order ~test_name:"tab size keeps its property band"
+    [
+      "uppercase";
+      "text-red-500";
+      "tab-4";
+      "whitespace-nowrap";
+      "hyphens-auto";
+      "text-ellipsis";
+      "break-all";
+      "break-words";
+      "text-wrap";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -2645,6 +2660,7 @@ let tests =
     test_case "transform control bands" `Slow test_transform_control_bands;
     test_case "scrolling property bands" `Slow test_scrolling_property_bands;
     test_case "flow property bands" `Slow test_flow_property_bands;
+    test_case "tab property band" `Slow test_tab_property_band;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1386,7 +1386,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 421 of 3885
+   This is the ordering debt the whole-sheet gate counts - 413 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1407,75 +1407,41 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 421 of them. *)
+   than a count of statements, which tolerates any 413 of them. *)
 let known_inversions =
   [
     ("accessibility", "outline_style");
-    ("alignment", "tab");
-    ("animations", "tab");
-    ("arbitrary", "tab");
-    ("backgrounds", "tab");
-    ("borders", "tab");
     ("box_sizing", "field_sizing");
-    ("box_sizing", "tab");
-    ("columns", "tab");
     ("contain", "accessibility");
     ("contain", "interactivity");
     ("contain", "outline_style");
     ("contain", "transforms");
-    ("cursor", "tab");
-    ("divide", "tab");
     ("divide", "text_shadow");
     ("divide", "transforms");
     ("effects", "effects");
     ("filters", "accessibility");
     ("filters", "outline_style");
-    ("flex_layout", "tab");
-    ("flex_props", "tab");
     ("flex", "field_sizing");
-    ("flex", "tab");
-    ("gap", "tab");
-    ("grid_template", "tab");
     ("grid", "field_sizing");
-    ("grid", "tab");
     ("interactivity", "accessibility");
     ("interactivity", "borders");
     ("interactivity", "effects");
     ("interactivity", "filters");
     ("interactivity", "interactivity");
     ("interactivity", "outline_style");
-    ("interactivity", "tab");
     ("layout", "field_sizing");
-    ("layout", "tab");
     ("margin", "field_sizing");
-    ("margin", "tab");
-    ("mask_gradient", "tab");
     ("masks", "arbitrary");
-    ("masks", "tab");
-    ("overflow_wrap", "tab");
-    ("overflow", "tab");
-    ("overscroll", "tab");
     ("padding", "padding");
-    ("padding", "tab");
     ("position", "position");
-    ("scroll", "tab");
-    ("scrollbar", "tab");
     ("sizing", "sizing");
-    ("sizing", "tab");
-    ("svg", "tab");
-    ("tables", "tab");
     ("tables", "tables");
-    ("touch", "tab");
-    ("transforms", "tab");
     ("transitions", "accessibility");
     ("transitions", "interactivity");
     ("transitions", "outline_style");
     ("transitions", "transforms");
-    ("typography_early", "tab");
     ("typography_late", "field_sizing");
-    ("typography_late", "tab");
     ("typography_late", "typography_late");
-    ("zoom", "tab");
   ]
 
 (* Which handler each class in a case belongs to, and which variant it wears.


### PR DESCRIPTION
Move tab-size after white-space and before text color, matching Tailwind's property order. This retires 34 handler inversions and lowers the whole-sheet minimum from 421 to 413 moves.