### PR TITLE
sort: place field sizing after display

### DIFF
--- a/lib/field_sizing.ml
+++ b/lib/field_sizing.ml
@@ -10,7 +10,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "field_sizing"
-  let priority _ = 2
+  let priority _ = 5
   let suborder = function Content -> 0 | Fixed -> 1
 
   let to_class = function

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 413, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 411, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -486,6 +486,21 @@ let test_tab_property_band () =
       "text-wrap";
     ]
 
+let test_field_sizing_property_band () =
+  Test_helpers.check_class_order
+    ~test_name:"field sizing keeps its property band"
+    [
+      "cursor-pointer";
+      "w-4";
+      "field-sizing-content";
+      "grid";
+      "flex";
+      "block";
+      "line-clamp-2";
+      "box-border";
+      "m-4";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -2627,6 +2642,7 @@ let tests =
     test_case "scrolling property bands" `Slow test_scrolling_property_bands;
     test_case "flow property bands" `Slow test_flow_property_bands;
     test_case "tab property band" `Slow test_tab_property_band;
+    test_case "field sizing property band" `Slow test_field_sizing_property_band;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1401,7 +1401,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 413 of 3885
+   This is the ordering debt the whole-sheet gate counts - 411 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1422,11 +1422,10 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 413 of them. *)
+   than a count of statements, which tolerates any 411 of them. *)
 let known_inversions =
   [
     ("accessibility", "outline_style");
-    ("box_sizing", "field_sizing");
     ("contain", "accessibility");
     ("contain", "interactivity");
     ("contain", "outline_style");
@@ -1436,16 +1435,12 @@ let known_inversions =
     ("effects", "effects");
     ("filters", "accessibility");
     ("filters", "outline_style");
-    ("flex", "field_sizing");
-    ("grid", "field_sizing");
     ("interactivity", "accessibility");
     ("interactivity", "borders");
     ("interactivity", "effects");
     ("interactivity", "filters");
     ("interactivity", "interactivity");
     ("interactivity", "outline_style");
-    ("layout", "field_sizing");
-    ("margin", "field_sizing");
     ("masks", "arbitrary");
     ("padding", "padding");
     ("position", "position");
@@ -1455,7 +1450,6 @@ let known_inversions =
     ("transitions", "interactivity");
     ("transitions", "outline_style");
     ("transitions", "transforms");
-    ("typography_late", "field_sizing");
     ("typography_late", "typography_late");
   ]
 


### PR DESCRIPTION
Move field-sizing between Tailwind's display and sizing property bands. This retires six handler inversions and lowers the whole-sheet minimum from 413 to 411 moves.