### PR TITLE
sort: align the late control property bands

### DIFF
--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -19,7 +19,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "accessibility"
-  let priority _ = 29
+  let priority _ = 36
 
   let to_class = function
     | Auto -> "forced-color-adjust-auto"

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1023,7 +1023,7 @@ module Outline_style_handler = struct
   type Utility.base += Self of t
 
   let name = "outline_style"
-  let priority _ = 28
+  let priority _ = 37
 
   let to_style _theme = function
     | Dashed ->
@@ -1042,9 +1042,7 @@ module Outline_style_handler = struct
         let decl, _ = Var.binding Handler.outline_style_var Css.Solid in
         style [ decl; Css.outline_style Css.Solid ]
 
-  (* outline-style closes the outline family at priority 28, after the widths
-     and offsets here and after color.ml's outline colors (3000-28000);
-     alphabetical: dashed, dotted, double, none, solid. *)
+  (* These outline-style utilities form a late property band. *)
   let suborder = function
     | Dashed -> 30000
     | Dotted -> 30001

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -35,7 +35,7 @@ module Handler = struct
   (* The divide properties follow gap and precede self-alignment at priority 17.
      [divide-x-reverse] alone sorts after everything else: it sets only an
      unranked custom property, so the move is cascade-neutral. *)
-  let priority = function X_reverse -> 39 | _ -> 17
+  let priority = function X_reverse -> 43 | _ -> 17
 
   (* CSS Variables for divide reverse. Property order 4/5 places these BEFORE
      --tw-border-style (order 6) in within-utility sorting, which determines

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -75,6 +75,13 @@ module Handler = struct
     | Snap_normal | Snap_always ->
         11
     | Scroll_auto | Scroll_smooth -> 18
+    | Scheme_dark | Scheme_light | Scheme_light_dark | Scheme_normal
+    | Scheme_only_dark | Scheme_only_light ->
+        27
+    | Will_change_auto | Will_change_scroll | Will_change_contents
+    | Will_change_transform | Will_change_arbitrary _ ->
+        33
+    | Select_none | Select_text | Select_all | Select_auto -> 38
     (* Tailwind's utility order opens with the container utilities and then
        pointer-events, before the layout group. *)
     | Pointer_events_none | Pointer_events_auto -> -1
@@ -251,12 +258,12 @@ module Handler = struct
     | Will_change_arbitrary _ -> 30
     | Group -> 35
     | Peer -> 36
-    | Scheme_dark -> 40
-    | Scheme_light -> 41
-    | Scheme_light_dark -> 42
-    | Scheme_normal -> 43
-    | Scheme_only_dark -> 44
-    | Scheme_only_light -> 45
+    | Scheme_dark -> -100
+    | Scheme_light -> -99
+    | Scheme_light_dark -> -98
+    | Scheme_normal -> -97
+    | Scheme_only_dark -> -96
+    | Scheme_only_light -> -95
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -45,7 +45,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "text_shadow"
-  let priority _ = 36
+  let priority _ = 41
 
   let text_shadow_color_var =
     Var.channel ~needs_property:true ~property_order:35 ~family:`Text_shadow

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -152,14 +152,14 @@ module Handler = struct
 
   (* The transform chain sits before animations. Controls that Tailwind sorts
      through a later property band must not travel with it: origin precedes the
-     chain, backface follows selection, perspective follows containment, and
+     chain, backface follows selection, perspective follows backface, and
      transform box/style follow text-shadow. *)
   let priority = function
     | Origin_center | Origin_top | Origin_bottom | Origin_left | Origin_right
     | Origin_top_left | Origin_top_right | Origin_bottom_left
     | Origin_bottom_right | Origin_arbitrary _ ->
         8
-    | Backface_visible | Backface_hidden -> 31
+    | Backface_visible | Backface_hidden -> 39
     | Perspective_none | Perspective_theme _ | Perspective_dramatic
     | Perspective_near | Perspective_normal | Perspective_midrange
     | Perspective_distant | Perspective_arbitrary _ | Perspective_origin_center
@@ -168,11 +168,11 @@ module Handler = struct
     | Perspective_origin_top_left | Perspective_origin_top_right
     | Perspective_origin_bottom_left | Perspective_origin_bottom_right
     | Perspective_origin_arbitrary _ ->
-        35
+        40
     | Transform_style_3d | Transform_style_flat | Transform_box_border
     | Transform_box_content | Transform_box_fill | Transform_box_stroke
     | Transform_box_view ->
-        37
+        42
     | _ -> 9
 
   (* Tailwind v4 uses rotate-x/y/z and skew-x/y variables for the transform

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1770,6 +1770,9 @@ module Typography_late = struct
     | Align_bottom | Align_sub | Align_super | Align_text_top
     | Align_text_bottom | Align_arbitrary_var _ ->
         24
+    | Content_none | Content _ | Content_squote _ | Content_raw _
+    | Content_named _ ->
+        35
     | _ -> 26
 
   let ( >|= ) = Parse.( >|= )

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 411, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 371, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1421,7 +1421,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 411 of 3885
+   This is the ordering debt the whole-sheet gate counts - 371 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1442,34 +1442,17 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 411 of them. *)
+   than a count of statements, which tolerates any 371 of them. *)
 let known_inversions =
   [
-    ("accessibility", "outline_style");
-    ("contain", "accessibility");
-    ("contain", "interactivity");
-    ("contain", "outline_style");
-    ("contain", "transforms");
     ("divide", "text_shadow");
     ("divide", "transforms");
     ("effects", "effects");
-    ("filters", "accessibility");
-    ("filters", "outline_style");
-    ("interactivity", "accessibility");
-    ("interactivity", "borders");
-    ("interactivity", "effects");
-    ("interactivity", "filters");
-    ("interactivity", "interactivity");
-    ("interactivity", "outline_style");
     ("masks", "arbitrary");
     ("padding", "padding");
     ("position", "position");
     ("sizing", "sizing");
     ("tables", "tables");
-    ("transitions", "accessibility");
-    ("transitions", "interactivity");
-    ("transitions", "outline_style");
-    ("transitions", "transforms");
     ("typography_late", "typography_late");
   ]
 

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -501,6 +501,26 @@ let test_field_sizing_property_band () =
       "m-4";
     ]
 
+let test_late_control_property_bands () =
+  Test_helpers.check_class_order
+    ~test_name:"late controls keep their property bands"
+    [
+      "transform-3d";
+      "text-shadow-sm";
+      "perspective-normal";
+      "backface-hidden";
+      "select-none";
+      "outline-solid";
+      "forced-color-adjust-auto";
+      "content-none";
+      "contain-layout";
+      "will-change-auto";
+      "transition";
+      "blur-sm";
+      "outline-hidden";
+      "scheme-dark";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -2637,6 +2657,8 @@ let tests =
     test_case "flow property bands" `Slow test_flow_property_bands;
     test_case "tab property band" `Slow test_tab_property_band;
     test_case "field sizing property band" `Slow test_field_sizing_property_band;
+    test_case "late control property bands" `Slow
+      test_late_control_property_bands;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick


### PR DESCRIPTION
Align color scheme, transitions, containment, accessibility, selection, and late transform controls with Tailwind's emitted order. This retires 17 handler inversions and lowers the whole-sheet minimum from 411 to 371 moves.