### PR TITLE
sort: place aspect ratio before dimensions

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -102,7 +102,9 @@ module Handler = struct
 
   (* Family bases are 10M apart so the interleaved spacing/fraction range (< 5M)
      and the arbitrary/keyword offsets never overflow into the next family. *)
-  (* size-* (width+height) sorts first in Tailwind, before h/w/max/min. *)
+  let aspect_base = -10_000_000
+
+  (* Within the dimension families, size-* sorts before h/w/max/min. *)
   let size_base = 0
   let h_base = 10_000_000
   let max_h_base = 20_000_000
@@ -110,7 +112,6 @@ module Handler = struct
   let w_base = 40_000_000
   let max_w_base = 50_000_000
   let min_w_base = 60_000_000
-  let aspect_base = 70_000_000
 
   (* Tailwind registers the logical sizing utilities after every other one, so
      they sort last rather than beside w-* and h-*; [logical_priority] carries

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 371, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 349, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -330,6 +330,19 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"sizing suborder matches Tailwind" shuffled
 
+let aspect_precedes_dimensions () =
+  Test_helpers.check_class_order ~test_name:"aspect ratio precedes dimensions"
+    [
+      "min-w-0";
+      "max-w-4xl";
+      "w-4";
+      "min-h-0";
+      "max-h-96";
+      "h-8";
+      "size-10";
+      "aspect-square";
+    ]
+
 (* Tailwind interleaves spacing and fractions by magnitude: w-0.5, w-1, w-1.5,
    w-1/2, w-1/3, w-2, w-2/3, w-3/4. tw used to sort all fractions ahead of all
    spacing (a flat offset), reversing conflicting rules (both set width). *)
@@ -588,6 +601,7 @@ let tests =
       test_arbitrary_aspect_rejects_non_ratio;
     test_case "sizing fraction interleave matches Tailwind" `Quick
       fraction_interleave_matches_tailwind;
+    test_case "aspect precedes dimensions" `Quick aspect_precedes_dimensions;
   ]
 
 let suite = ("sizing", tests)

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1421,7 +1421,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 371 of 3885
+   This is the ordering debt the whole-sheet gate counts - 349 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1442,7 +1442,7 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 371 of them. *)
+   than a count of statements, which tolerates any 349 of them. *)
 let known_inversions =
   [
     ("divide", "text_shadow");
@@ -1451,7 +1451,6 @@ let known_inversions =
     ("masks", "arbitrary");
     ("padding", "padding");
     ("position", "position");
-    ("sizing", "sizing");
     ("tables", "tables");
     ("typography_late", "typography_late");
   ]


### PR DESCRIPTION
Move aspect-ratio ahead of size, height, and width utilities, matching Tailwind's property order. This retires the sizing self-inversion and lowers the whole-sheet minimum from 371 to 349 moves.