### PR TITLE
sort: align shadow and transform boundaries

### DIFF
--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -32,10 +32,10 @@ module Handler = struct
 
   let name = "divide"
 
-  (* The divide properties follow gap and precede self-alignment at priority 17.
-     [divide-x-reverse] alone sorts after everything else: it sets only an
-     unranked custom property, so the move is cascade-neutral. *)
-  let priority = function X_reverse -> 43 | _ -> 17
+  (* The divide properties follow gap and precede self-alignment. The unranked
+     [divide-x-reverse] custom property sits between backface and
+     perspective. *)
+  let priority = function X_reverse -> 39 | _ -> 17
 
   (* CSS Variables for divide reverse. Property order 4/5 places these BEFORE
      --tw-border-style (order 6) in within-utility sorting, which determines
@@ -367,7 +367,7 @@ module Handler = struct
     | Current | Current_opacity _ -> 66_000
     | Inherit -> 66_000
     | Transparent -> 66_000
-    | X_reverse -> 0
+    | X_reverse -> 1_700
 
   (* The bracket spelling of an arbitrary width, for the typed constructors,
      which are handed a width rather than the text an author wrote. cascade

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -204,7 +204,7 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "effects"
-  let priority _ = 27
+  let priority = function Ring_inset -> 40 | _ -> 27
 
   (* Shadow variables with property registration. Order: translate (0-2), scale
      (3-5), border-style (6), gradients (7-15), font-weight (16), shadows
@@ -3147,7 +3147,7 @@ module Handler = struct
     | Shadow_transparent_opacity _ | Shadow_bracket_color _
     | Shadow_bracket_color_opacity _ | Shadow_bracket_color_var _
     | Shadow_bracket_color_var_opacity _ ->
-        35000
+        40000
     (* Inset shadow opacity utilities — same relative scheme as shadow *)
     | Inset_shadow_arbitrary_opacity (arb, _) ->
         let len = String.length arb in
@@ -3161,23 +3161,23 @@ module Handler = struct
           then true
           else has_var (i + 1)
         in
-        if has_var 0 then 30988
-        else if String.contains arb '#' then 30990
-        else 30989
-    | Inset_shadow_shape_opacity _ -> 30991
+        if has_var 0 then 31988
+        else if String.contains arb '#' then 31990
+        else 31989
+    | Inset_shadow_shape_opacity _ -> 31991
     (* Inset shadow shape utilities — all same suborder, natural_compare
        decides *)
     | Inset_shadow | Inset_shadow_2xs | Inset_shadow_xs | Inset_shadow_none
     | Inset_shadow_sm | Inset_shadow_arbitrary _ | Inset_shadow_bracket_shadow _
     | Inset_shadow_bracket_var _ | Inset_shadow_theme _ ->
-        31000
+        32000
     (* Inset shadow color utilities *)
     | Inset_shadow_color _ | Inset_shadow_color_opacity _ | Inset_shadow_current
     | Inset_shadow_current_opacity _ | Inset_shadow_inherit
     | Inset_shadow_transparent | Inset_shadow_bracket_color _
     | Inset_shadow_transparent_opacity _ | Inset_shadow_bracket_color_opacity _
     | Inset_shadow_bracket_color_var _ | Inset_shadow_bracket_cvar_opacity _ ->
-        36000
+        42000
     (* Background blend modes come after opacity, before mix-blend *)
     | Bg_blend_color -> 22000
     | Bg_blend_color_burn -> 22001
@@ -3214,43 +3214,40 @@ module Handler = struct
     | Mix_blend_saturation -> 24015
     | Mix_blend_screen -> 24016
     | Mix_blend_soft_light -> 24017
-    (* Ring utilities come after shadows. Ordered to match Tailwind: 1. ring
-       widths, 2. ring-color, 3. inset-ring-color, 4. ring-offset-width, 5.
-       ring-offset-color, 6. ring-inset *)
-    | Ring_md -> 40000
-    | Ring_none -> 40001
-    | Ring_xs -> 40002
-    | Ring_sm -> 40003
-    | Ring_lg -> 40004
-    | Ring_xl -> 40005
-    | Ring_width _ -> 40005
-    | Ring_bracket_length _ -> 40010
+    | Ring_md -> 31000
+    | Ring_none -> 31001
+    | Ring_xs -> 31002
+    | Ring_sm -> 31003
+    | Ring_lg -> 31004
+    | Ring_xl -> 31005
+    | Ring_width _ -> 31005
+    | Ring_bracket_length _ -> 31010
     | Ring_color _ | Ring_color_opacity _ | Ring_keyword_opacity _
     | Ring_transparent | Ring_current | Ring_current_opacity _ | Ring_inherit
     | Ring_bracket_color _ | Ring_bracket_color_opacity _
     | Ring_bracket_color_var _ | Ring_bracket_color_var_opacity _
     | Ring_bracket_var _ | Ring_bracket_var_opacity _ ->
-        50000
-    | Ring_inset -> 51000
-    | Inset_ring_default -> 55000
-    | Inset_ring_width n -> 55001 + n
-    | Inset_ring_bracket_length _ -> 55100
+        41000
+    | Ring_inset -> 2000
+    | Inset_ring_default -> 33000
+    | Inset_ring_width n -> 33001 + n
+    | Inset_ring_bracket_length _ -> 33100
     | Inset_ring_color _ | Inset_ring_color_opacity _
     | Inset_ring_keyword_opacity _ | Inset_ring_transparent | Inset_ring_current
     | Inset_ring_current_opacity _ | Inset_ring_inherit
     | Inset_ring_bracket_color _ | Inset_ring_bracket_color_opacity _
     | Inset_ring_bracket_color_var _ | Inset_ring_bracket_cvar_opacity _
     | Inset_ring_bracket_var _ | Inset_ring_bracket_var_opacity _ ->
-        60000
-    | Ring_offset_width n -> 80000 + n
-    | Ring_offset_bracket_length _ -> 80100
+        43000
+    | Ring_offset_width n -> 50000 + n
+    | Ring_offset_bracket_length _ -> 50100
     | Ring_offset_color _ | Ring_offset_color_opacity _
     | Ring_offset_keyword_opacity _ | Ring_offset_transparent
     | Ring_offset_current | Ring_offset_current_opacity _ | Ring_offset_inherit
     | Ring_offset_bracket_color _ | Ring_offset_bracket_color_opacity _
     | Ring_offset_bracket_color_var _ | Ring_offset_bracket_cvar_opacity _
     | Ring_offset_bracket_var _ | Ring_offset_bracket_var_opacity _ ->
-        100000
+        51000
 
   let examples =
     [

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 331, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 322, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1475,7 +1475,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 331 of 3885
+   This is the ordering debt the whole-sheet gate counts - 322 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1496,15 +1496,9 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 331 of them. *)
+   than a count of statements, which tolerates any 322 of them. *)
 let known_inversions =
-  [
-    ("divide", "text_shadow");
-    ("divide", "transforms");
-    ("effects", "effects");
-    ("masks", "arbitrary");
-    ("typography_late", "typography_late");
-  ]
+  [ ("masks", "arbitrary"); ("typography_late", "typography_late") ]
 
 (* Which handler each class in a case belongs to, and which variant it wears.
    The variant matters because two classes wearing different ones are not

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -551,6 +551,30 @@ let test_logical_side_property_bands () =
       "inset-0";
     ]
 
+let test_shadow_and_transform_boundaries () =
+  Test_helpers.check_class_order
+    ~test_name:"shadow and transform boundaries keep their property bands"
+    [
+      "transform-3d";
+      "text-shadow-sm";
+      "perspective-normal";
+      "divide-x-reverse";
+      "backface-hidden";
+      "select-none";
+      "outline-hidden";
+      "ring-inset";
+      "ring-offset-red-500";
+      "ring-offset-2";
+      "inset-ring-red-500";
+      "inset-shadow-red-500";
+      "ring-red-500";
+      "shadow-red-500";
+      "inset-ring-2";
+      "inset-shadow-sm";
+      "ring-2";
+      "shadow-sm";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -2670,6 +2694,8 @@ let tests =
       test_late_control_property_bands;
     test_case "logical side property bands" `Slow
       test_logical_side_property_bands;
+    test_case "shadow and transform boundaries" `Slow
+      test_shadow_and_transform_boundaries;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick


### PR DESCRIPTION
Interleave shadow and ring shape/color bands, move ring-inset into its late slot, and place divide-x-reverse between backface and perspective. This retires three exact inversions and lowers the whole-sheet minimum from 331 to 322 moves.