### PR TITLE
sort: retire the final exact inversions

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -286,7 +286,13 @@ module Handler = struct
               | Some color -> color_opacity_render theme emit color inner
               | None -> style []))
 
-  let suborder t = match slot t with Some (_, sub) -> sub | None -> 0
+  let suborder t =
+    let offset =
+      match t with
+      | Parsed_decl { property = "mask-type"; _ } -> 1
+      | Color_opacity _ | Parsed_decl _ -> 0
+    in
+    match slot t with Some (_, sub) -> sub + offset | None -> 0
 
   let to_class = function
     | Color_opacity { property; value; alpha_fn; opacity } ->

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2383,8 +2383,8 @@ module Typography_late = struct
     | Underline_offset_var _ -> 69990
     | Underline_offset_auto -> 69999
     (* Antialiased *)
-    | Antialiased -> 8700
-    | Subpixel_antialiased -> 8701
+    | Antialiased -> 80000
+    | Subpixel_antialiased -> 80001
     (* Text overflow (priority 17 for Truncate) - alphabetical: text-clip,
        text-ellipsis, truncate. Truncate sorts before overflow (priority 18) via
        a suborder above alignment/gap's range. Tailwind ranks [text-overflow] at
@@ -2438,27 +2438,23 @@ module Typography_late = struct
     | Hyphens_auto -> 8325
     | Hyphens_manual -> 8325
     | Hyphens_none -> 8325
-    (* Font stretch - percentages first (sorted by value), then keywords *)
-    | Font_stretch_percent n -> 9500 + n
-    | Font_stretch_condensed -> 9700
-    | Font_stretch_expanded -> 9701
-    | Font_stretch_extra_condensed -> 9702
-    | Font_stretch_extra_expanded -> 9703
-    | Font_stretch_normal -> 9704
-    | Font_stretch_semi_condensed -> 9705
-    | Font_stretch_semi_expanded -> 9706
-    | Font_stretch_ultra_condensed -> 9707
-    | Font_stretch_ultra_expanded -> 9708
+    (* Font stretch shares one property slot after font style. *)
+    | Font_stretch_percent _ | Font_stretch_condensed | Font_stretch_expanded
+    | Font_stretch_extra_condensed | Font_stretch_extra_expanded
+    | Font_stretch_normal | Font_stretch_semi_condensed
+    | Font_stretch_semi_expanded | Font_stretch_ultra_condensed
+    | Font_stretch_ultra_expanded ->
+        8382
     (* Numeric variants - alphabetical order with normal-nums last *)
-    | Diagonal_fractions -> 9700
-    | Lining_nums -> 9701
-    | Oldstyle_nums -> 9702
-    | Ordinal -> 9703
-    | Proportional_nums -> 9704
-    | Slashed_zero -> 9705
-    | Stacked_fractions -> 9706
-    | Tabular_nums -> 9707
-    | Normal_nums -> 9708
+    | Diagonal_fractions -> 8390
+    | Lining_nums -> 8391
+    | Oldstyle_nums -> 8392
+    | Ordinal -> 8393
+    | Proportional_nums -> 8394
+    | Slashed_zero -> 8395
+    | Stacked_fractions -> 8396
+    | Tabular_nums -> 8397
+    | Normal_nums -> 8398
     (* Indent - Tailwind ranks [text-indent] at 282, between [text-align] (281)
        and [vertical-align] (283), so the family sits at priority 24 with both:
        [Text_align] holds 1001-1006 in the early handler, [Align_*] below holds

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 322, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 299, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -575,6 +575,23 @@ let test_shadow_and_transform_boundaries () =
       "shadow-sm";
     ]
 
+let test_late_typography_property_bands () =
+  Test_helpers.check_class_order
+    ~test_name:"late typography keeps its property bands"
+    [
+      "antialiased";
+      "underline-offset-4";
+      "decoration-2";
+      "decoration-dashed";
+      "decoration-red-500";
+      "underline";
+      "line-through";
+      "tabular-nums";
+      "ordinal";
+      "font-stretch-expanded";
+      "italic";
+    ]
+
 (* Test 1: Verify priority order - one utility per group *)
 let test_priority_order_per_group () =
   let open Tw in
@@ -1497,8 +1514,7 @@ let pool_entries () =
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
    than a count of statements, which tolerates any 322 of them. *)
-let known_inversions =
-  [ ("masks", "arbitrary"); ("typography_late", "typography_late") ]
+let known_inversions = [ ("typography_late", "typography_late") ]
 
 (* Which handler each class in a case belongs to, and which variant it wears.
    The variant matters because two classes wearing different ones are not
@@ -2699,6 +2715,8 @@ let tests =
       test_logical_side_property_bands;
     test_case "shadow and transform boundaries" `Slow
       test_shadow_and_transform_boundaries;
+    test_case "late typography property bands" `Slow
+      test_late_typography_property_bands;
     test_case "priority order per group" `Quick test_priority_order_per_group;
     test_case "handler priority ordering" `Quick test_handler_priority_ordering;
     test_case "border width and color ordering" `Quick

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1492,7 +1492,7 @@ let pool_entries () =
    Both directions can hold between one pair of handlers, since a family may
    straddle two of Tailwind's bands, so each is its own entry.
 
-   This is the ordering debt the whole-sheet gate counts - 322 of 3885
+   This is the ordering debt the whole-sheet gate counts - 299 of 3885
    statements in test/parity/sheet_order.ml - named rather than counted. Without
    it the fuzzer fails on nearly every seed for misorderings that predate it;
    with it a pair outside the list fails a draw.
@@ -1513,8 +1513,8 @@ let pool_entries () =
    What a listed pair does not catch is a further inversion between those same
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
-   than a count of statements, which tolerates any 322 of them. *)
-let known_inversions = [ ("typography_late", "typography_late") ]
+   than a count of statements, which tolerates any 299 of them. *)
+let known_inversions = []
 
 (* Which handler each class in a case belongs to, and which variant it wears.
    The variant matters because two classes wearing different ones are not

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1635,6 +1635,15 @@ let measured_inversions () =
   in
   List.sort_uniq compare from_positions
 
+let test_mask_type_arbitrary_order () =
+  let utilities = List.map (fun e -> e.utility) (pool_entries ()) in
+  let classes = List.map Tw.pp utilities in
+  let tailwind, tw = Test_helpers.sheets ~forms:true utilities in
+  let inverted = Test_helpers.inverted_pairs ~tailwind ~tw classes in
+  Alcotest.(check bool)
+    "named mask type and its arbitrary property agree" false
+    (List.mem ("mask-type-luminance", "[mask-type:luminance]") inverted)
+
 let test_known_inversions_are_exact () =
   let measured = measured_inversions () in
   let recorded = List.sort_uniq compare known_inversions in
@@ -2740,6 +2749,7 @@ let tests =
     test_case "suborder within group" `Slow test_suborder_within_group;
     test_case "pool covers every family" `Quick test_pool_covers_every_family;
     test_case "known inversions are exact" `Slow test_known_inversions_are_exact;
+    test_case "mask type arbitrary order" `Slow test_mask_type_arbitrary_order;
     test_case "pool covers every handler" `Quick test_pool_covers_every_handler;
     test_case "pool variants all compile" `Quick test_variants_all_compile;
     test_case "random utilities with minimization" `Slow


### PR DESCRIPTION
Align arbitrary mask-type and the remaining late typography property bands with Tailwind. This empties the exact inversion ratchet and lowers the whole-sheet minimum from 322 to 299 moves.