### PR TITLE
Align transform candidate bands

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -788,7 +788,7 @@ let compare_by_prio_sub_late r1 r2 kind1 kind2 =
            to the candidate name. *)
         let width_cmp = compare_declared_width r1 r2 in
         if width_cmp <> 0 then width_cmp
-        else natural_compare r1.selector_str r2.selector_str
+        else natural_compare r1.base_class_key r2.base_class_key
 
 let compare_cross_utility_regular r1 r2 =
   let p1, s1 = r1.order and p2, s2 = r2.order in

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1373,98 +1373,67 @@ module Handler = struct
     | Transform_cpu -> 2002
     | Transform_gpu -> 2003
     | Transform_none -> 2004
-    (* Combined translate (CSS `translate`): negatives first, positives second.
-       Within a sign Tailwind orders by class name, so one shared suborder plus
-       the string tiebreak already sorts fractions before small integers before
-       full/px. Positive integers need an explicit magnitude key (32 + n)
-       because lexical order puts translate-8 after translate-45; the spacing
-       scale on real sites keeps 32 + n below the translate-x band at 100. *)
-    | Neg_translate _ -> 20
-    | Neg_translate_arbitrary _ -> 20
-    | Neg_translate_full -> 20
-    | Neg_translate_px -> 20
-    | Neg_translate_x_px -> 20
-    | Neg_translate_y_px -> 20
-    | Neg_translate_fraction _ -> 20
-    | Translate_1_2 -> 31
-    | Translate_fraction _ -> 31
-    | Translate n -> 32 + n
-    | Translate_arbitrary _ -> 95
-    | Translate_full -> 96
-    | Translate_px -> 97
-    | Translate_none -> 98
-    (* Translate utilities come first *)
-    | Neg_translate_x_arbitrary _ -> 100
-    | Neg_translate_x_full -> 101
-    | Neg_translate_x_1_2 -> 102
-    | Neg_translate_x_fraction _ -> 102
-    | Translate_x n -> 110 + n
-    | Translate_x_fraction _ -> 125
-    | Translate_x_full -> 130
-    | Translate_x_px -> 131
-    | Translate_x_step f -> 100 + int_of_float (f *. 10.)
-    | Translate_x_arbitrary _ -> 199
-    | Neg_translate_y_arbitrary _ -> 200
-    | Neg_translate_y_full -> 201
-    | Neg_translate_y_1_2 -> 202
-    | Neg_translate_y_fraction _ -> 202
-    | Translate_y n -> 210 + n
-    | Translate_y_fraction _ -> 225
-    | Translate_y_full -> 230
-    | Translate_y_px -> 231
-    | Translate_y_step f -> 200 + int_of_float (f *. 10.)
-    | Translate_y_arbitrary _ -> 299
-    | Neg_translate_z_arbitrary _ -> 299
-    | Neg_translate_z_px -> 300
-    | Translate_z n -> 301 + n
-    | Translate_z_step f -> 300 + int_of_float (f *. 10.)
-    | Translate_z_px -> 320
-    | Translate_3d -> 320
-    (* Scale utilities *)
-    | Scale n -> 400 + n
-    | Scale_x n -> 500 + n
-    | Scale_x_arbitrary _ -> 599
-    | Scale_y n -> 600 + n
-    | Scale_y_arbitrary _ -> 699
-    | Scale_raw_1 _ -> 498
-    | Scale_raw_3 _ -> 499
-    | Scale_z n -> 700 + n
-    | Scale_z_arbitrary _ -> 799
-    | Scale_3d -> 750
-    | Scale_none -> 750
-    (* Rotate utilities - negative before positive, bare var before int/arb *)
-    | Neg_rotate_bare_var _ -> 750
-    | Neg_rotate_arbitrary _ -> 799
+    (* Candidate values share a slot within each sign/axis band. Tailwind uses
+       the natural candidate spelling inside that slot; baking the magnitude
+       into the suborder reverses negatives and lets a large value spill into
+       the next axis. *)
+    | Neg_translate _ | Neg_translate_arbitrary _ | Neg_translate_full
+    | Neg_translate_px | Neg_translate_fraction _ ->
+        20
+    | Translate _ | Translate_arbitrary _ | Translate_full | Translate_px
+    | Translate_1_2 | Translate_fraction _ ->
+        21
+    | Translate_x n when n < 0 -> 100
+    | Neg_translate_x_arbitrary _ | Neg_translate_x_full | Neg_translate_x_px
+    | Neg_translate_x_1_2 | Neg_translate_x_fraction _ ->
+        100
+    | Translate_x _ | Translate_x_fraction _ | Translate_x_full | Translate_x_px
+    | Translate_x_step _ | Translate_x_arbitrary _ ->
+        101
+    | Translate_y n when n < 0 -> 200
+    | Neg_translate_y_arbitrary _ | Neg_translate_y_full | Neg_translate_y_px
+    | Neg_translate_y_1_2 | Neg_translate_y_fraction _ ->
+        200
+    | Translate_y _ | Translate_y_fraction _ | Translate_y_full | Translate_y_px
+    | Translate_y_step _ | Translate_y_arbitrary _ ->
+        201
+    | Translate_z n when n < 0 -> 300
+    | Neg_translate_z_arbitrary _ | Neg_translate_z_px -> 300
+    | Translate_z _ | Translate_z_step _ | Translate_z_px -> 301
+    | Translate_3d | Translate_none -> 302
+    (* Scale utilities use the same sign/axis bands. *)
+    | Scale n when n < 0 -> 400
+    | Scale _ | Scale_raw_1 _ | Scale_raw_3 _ -> 401
+    | Scale_x n when n < 0 -> 500
+    | Scale_x _ | Scale_x_arbitrary _ -> 501
+    | Scale_y n when n < 0 -> 600
+    | Scale_y _ | Scale_y_arbitrary _ -> 601
+    | Scale_z n when n < 0 -> 700
+    | Scale_z _ | Scale_z_arbitrary _ -> 701
+    | Scale_3d | Scale_none -> 702
+    (* Rotate utilities: sign first, then a bare variable, named values and the
+       arbitrary/none tail. Axes each get their own sign pair. *)
+    | Rotate n when n < 0 -> 799
+    | Neg_rotate_bare_var _ | Neg_rotate_arbitrary _ -> 799
     | Rotate_bare_var _ -> 800
-    | Rotate n -> 801 + n
-    (* An arbitrary rotate sorts after every named rotate ('[' > any digit), so
-       it must sit past the largest [Rotate n] (rotate-180 -> 801 + 180 = 981),
-       not mid-range. *)
-    | Rotate_3d_arbitrary _ -> 982
-    | Rotate_arbitrary _ -> 983
-    | Rotate_none -> 983
-    | Neg_rotate_x_bare_var _ -> 900
-    | Neg_rotate_x_arbitrary _ -> 949
-    | Rotate_x_bare_var _ -> 950
-    | Rotate_x n -> 951 + n
-    | Rotate_x_arbitrary _ -> 999
-    | Neg_rotate_y_bare_var _ -> 1000
-    | Neg_rotate_y_arbitrary _ -> 1049
-    | Rotate_y_bare_var _ -> 1050
-    | Rotate_y n -> 1051 + n
-    | Rotate_y_arbitrary _ -> 1099
-    | Neg_rotate_z_bare_var _ -> 1100
-    | Neg_rotate_z_arbitrary _ -> 1149
-    | Rotate_z_bare_var _ -> 1150
-    | Rotate_z n -> 1151 + n
-    | Rotate_z_arbitrary _ -> 1199
-    (* Skew utilities *)
-    | Skew_x n -> 1200 + n
-    | Skew_x_arbitrary _ -> 1299
-    | Skew_y n -> 1300 + n
-    | Skew_y_arbitrary _ -> 1398
-    | Skew n -> 1200 + n (* Combined skew, same order as skew-x *)
-    | Skew_arbitrary _ -> 1250
+    | Rotate _ -> 801
+    | Rotate_3d_arbitrary _ | Rotate_arbitrary _ | Rotate_none -> 802
+    | Rotate_x n when n < 0 -> 900
+    | Neg_rotate_x_bare_var _ | Neg_rotate_x_arbitrary _ -> 900
+    | Rotate_x _ | Rotate_x_bare_var _ | Rotate_x_arbitrary _ -> 901
+    | Rotate_y n when n < 0 -> 1000
+    | Neg_rotate_y_bare_var _ | Neg_rotate_y_arbitrary _ -> 1000
+    | Rotate_y _ | Rotate_y_bare_var _ | Rotate_y_arbitrary _ -> 1001
+    | Rotate_z n when n < 0 -> 1100
+    | Neg_rotate_z_bare_var _ | Neg_rotate_z_arbitrary _ -> 1100
+    | Rotate_z _ | Rotate_z_bare_var _ | Rotate_z_arbitrary _ -> 1101
+    (* Combined skew precedes skew-x, then skew-y. *)
+    | Skew n when n < 0 -> 1200
+    | Skew _ | Skew_arbitrary _ -> 1201
+    | Skew_x n when n < 0 -> 1210
+    | Skew_x _ | Skew_x_arbitrary _ -> 1211
+    | Skew_y n when n < 0 -> 1300
+    | Skew_y _ | Skew_y_arbitrary _ -> 1301
     (* Other transform utilities - arbitrary before named (alphabetical by
        class) *)
     | Perspective_arbitrary _ -> 1400

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 299, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 252, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -418,6 +418,53 @@ let test_transform_control_bands () =
       "table-fixed";
     ]
 
+(* Tailwind orders transform candidates by sign, axis, then the natural class
+   spelling inside each band. Numeric suborders invert negative magnitudes and
+   eventually spill a large value into the following axis. *)
+let test_transform_candidate_bands () =
+  Test_helpers.check_class_order
+    ~test_name:"transform candidates keep their sign and axis bands"
+    [
+      "translate-none";
+      "translate-z-12";
+      "-translate-z-8";
+      "translate-y-20";
+      "translate-y-1/2";
+      "-translate-y-12";
+      "-translate-y-1";
+      "translate-x-12";
+      "translate-x-1/2";
+      "-translate-x-12";
+      "-translate-x-1";
+      "translate-45";
+      "-translate-6";
+      "scale-none";
+      "scale-y-150";
+      "-scale-y-125";
+      "scale-x-125";
+      "-scale-x-75";
+      "scale-150";
+      "-scale-125";
+      "-scale-100";
+      "rotate-z-45";
+      "-rotate-z-45";
+      "rotate-y-180";
+      "-rotate-y-90";
+      "rotate-x-90";
+      "-rotate-x-90";
+      "rotate-none";
+      "rotate-225";
+      "-rotate-210";
+      "-rotate-12";
+      "skew-y-12";
+      "-skew-y-3";
+      "skew-x-12";
+      "-skew-x-10";
+      "skew-12";
+      "-skew-12";
+      "-skew-3";
+    ]
+
 (* Cursor opens the interaction block, followed by touch, resize, snap,
    scrolling, scrollbar, list, appearance and columns property bands. *)
 let test_scrolling_property_bands () =
@@ -2705,6 +2752,7 @@ let tests =
       test_indent_within_early_typography;
     test_case "text-indent family order" `Quick test_indent_family_order;
     test_case "transform control bands" `Slow test_transform_control_bands;
+    test_case "transform candidate bands" `Slow test_transform_candidate_bands;
     test_case "scrolling property bands" `Slow test_scrolling_property_bands;
     test_case "flow property bands" `Slow test_flow_property_bands;
     test_case "tab property band" `Slow test_tab_property_band;


### PR DESCRIPTION
Group transform candidates by sign and axis, then use the natural class-name tie-break within each band. This matches Tailwind for large and negative values without letting one axis spill into the next.\n\nThe whole-sheet utility-order ratchet drops from 299 to 252 moves.