### PR TITLE
Preserve property bands around custom variants

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1560,47 +1560,53 @@ let output_base_class_and_props = function
 let normalize_declared_property_families order_map builtins extra_outputs =
   List.iter
     (fun (class_name, (priority, _), outputs) ->
-      match
-        List.find_map
-          (fun output ->
-            let _, props = output_base_class_and_props output in
-            Utility.ordering_property props)
-          outputs
-      with
-      | None -> ()
-      | Some property ->
-          let family =
-            List.filter_map
-              (fun output ->
-                let base_class, props = output_base_class_and_props output in
-                match (base_class, Utility.ordering_property props) with
-                | Some cls, Some key
-                  when Css.Declaration.equal_prop_key key property ->
-                    let base = extract_base_utility cls in
-                    Option.map
-                      (fun order -> (base, order))
-                      (Hashtbl.find_opt order_map base)
-                | _ -> None)
-              builtins
-          in
-          let suborder =
-            List.fold_left
-              (fun acc (_, (p, s)) ->
-                if p <> priority then acc
-                else Some (Option.fold ~none:s ~some:(Int.min s) acc))
-              None family
-          in
-          Option.iter
-            (fun suborder ->
-              List.iter
-                (fun (base, (p, _)) ->
-                  if p = priority then
-                    Hashtbl.replace order_map base (priority, suborder))
-                family;
-              Hashtbl.replace order_map
-                (extract_base_utility class_name)
-                (priority, suborder))
-            suborder)
+      let modifiers, _ = Modifiers.of_string class_name in
+      (* A custom-variant expansion also arrives through [extra], already
+         carrying the order of the built-in it wraps. It is not a new utility
+         joining that property family, so flattening the family around it
+         destroys the built-ins' property walk. *)
+      if modifiers = [] then
+        match
+          List.find_map
+            (fun output ->
+              let _, props = output_base_class_and_props output in
+              Utility.ordering_property props)
+            outputs
+        with
+        | None -> ()
+        | Some property ->
+            let family =
+              List.filter_map
+                (fun output ->
+                  let base_class, props = output_base_class_and_props output in
+                  match (base_class, Utility.ordering_property props) with
+                  | Some cls, Some key
+                    when Css.Declaration.equal_prop_key key property ->
+                      let base = extract_base_utility cls in
+                      Option.map
+                        (fun order -> (base, order))
+                        (Hashtbl.find_opt order_map base)
+                  | _ -> None)
+                builtins
+            in
+            let suborder =
+              List.fold_left
+                (fun acc (_, (p, s)) ->
+                  if p <> priority then acc
+                  else Some (Option.fold ~none:s ~some:(Int.min s) acc))
+                None family
+            in
+            Option.iter
+              (fun suborder ->
+                List.iter
+                  (fun (base, (p, _)) ->
+                    if p = priority then
+                      Hashtbl.replace order_map base (priority, suborder))
+                  family;
+                Hashtbl.replace order_map
+                  (extract_base_utility class_name)
+                  (priority, suborder))
+              suborder)
     extra_outputs
 
 let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 252, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 163, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2423,6 +2423,27 @@ let check_before what sheet first second =
   in
   check bool what true (position first < position second)
 
+(* A custom-variant expansion arrives through [extra], but it is not a declared
+   utility joining the property family. Treating it as one flattens every
+   built-in mask-image suborder onto the first slot. *)
+let test_mask_gradient_property_walk () =
+  let variant = "dark:mask-[linear-gradient(black,transparent)]" in
+  let extra =
+    ( variant,
+      (21, 0),
+      [
+        Css.rule
+          ~selector:(Css.Selector.class_ variant)
+          [ Css.mask_image Css.None ];
+      ] )
+  in
+  let sheet =
+    Tw.Build.to_css ~extra:[ extra ]
+      [ builtin "mask-t-from-50%"; builtin "mask-y-from-70%" ]
+  in
+  check_before "variant extras preserve mask-image property order" sheet
+    ".mask-y-from-70\\%" ".mask-t-from-50\\%"
+
 let test_declared_utility_after_wider_builtin () =
   let sheet =
     Tw.Build.to_css
@@ -2753,6 +2774,8 @@ let tests =
     test_case "text-indent family order" `Quick test_indent_family_order;
     test_case "transform control bands" `Slow test_transform_control_bands;
     test_case "transform candidate bands" `Slow test_transform_candidate_bands;
+    test_case "mask-gradient property walk" `Slow
+      test_mask_gradient_property_walk;
     test_case "scrolling property bands" `Slow test_scrolling_property_bands;
     test_case "flow property bands" `Slow test_flow_property_bands;
     test_case "tab property band" `Slow test_tab_property_band;


### PR DESCRIPTION
Restrict declared-utility family normalization to unmodified utility declarations. Custom-variant expansions already carry their built-in order and must not flatten the surrounding property family.\n\nThe whole-sheet utility-order ratchet drops from 252 to 163 moves.