### PR TITLE
Use natural aspect candidate order

### DIFF
--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -862,17 +862,12 @@ module Handler = struct
     | Sized (prop, v) ->
         let f = family prop in
         f.base + value_order f v
-    (* Aspect: ratios -> brackets -> keywords *)
-    | Aspect_ratio (rw, rh) ->
-        aspect_base + int_of_float (rw *. 10.) + int_of_float rh
-    | Aspect_bracket (_, rw, rh) ->
-        aspect_base + 1000 + int_of_float (rw *. 10.) + int_of_float rh
-    | Aspect_bracket_num s ->
-        aspect_base + 1000 + int_of_float (float_of_string s *. 10.) + 1
-    | Aspect_auto -> aspect_base + 2000
-    | Aspect_square -> aspect_base + 2001
-    | Aspect_video -> aspect_base + 2002
-    | Aspect_theme _ -> aspect_base + 1500
+    (* Every aspect candidate writes the same property. One slot lets the
+       natural class-name tie-break order numeric ratios, then brackets and
+       keywords without large numerators spilling past the tail. *)
+    | Aspect_ratio _ | Aspect_bracket _ | Aspect_bracket_num _ | Aspect_auto
+    | Aspect_square | Aspect_video | Aspect_theme _ ->
+        aspect_base
 
   (** Priority 6: sizing utilities (w-*, h-*, max-w-*, ...) come before
       flex-1/flex-col in Tailwind's order. The logical ones are registered after

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 163, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 151, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -343,6 +343,26 @@ let aspect_precedes_dimensions () =
       "aspect-square";
     ]
 
+(* Every aspect ratio writes the same property. Tailwind keeps the family in
+   natural candidate order, including large site-derived ratios, before the
+   bracket and keyword tails. *)
+let aspect_candidate_order_matches_tailwind () =
+  Test_helpers.check_class_order ~test_name:"aspect candidate order"
+    [
+      "aspect-video";
+      "aspect-square";
+      "aspect-auto";
+      "aspect-[7/9]";
+      "aspect-[1.333]";
+      "aspect-971/879";
+      "aspect-971/349";
+      "aspect-970/975";
+      "aspect-970/922";
+      "aspect-3/4";
+      "aspect-3/2";
+      "aspect-2/1";
+    ]
+
 (* Tailwind interleaves spacing and fractions by magnitude: w-0.5, w-1, w-1.5,
    w-1/2, w-1/3, w-2, w-2/3, w-3/4. tw used to sort all fractions ahead of all
    spacing (a flat offset), reversing conflicting rules (both set width). *)
@@ -602,6 +622,8 @@ let tests =
     test_case "sizing fraction interleave matches Tailwind" `Quick
       fraction_interleave_matches_tailwind;
     test_case "aspect precedes dimensions" `Quick aspect_precedes_dimensions;
+    test_case "aspect candidate order" `Slow
+      aspect_candidate_order_matches_tailwind;
   ]
 
 let suite = ("sizing", tests)


### PR DESCRIPTION
Place every aspect-ratio candidate in one property slot and let the natural class-name tie-break order values. Large numeric ratios now stay before bracket and keyword candidates, matching Tailwind.\n\nThe whole-sheet utility-order ratchet drops from 163 to 151 moves.