### PR TITLE
Use natural filter candidate order

### DIFF
--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1280,23 +1280,14 @@ module Handler = struct
   let err_not_utility = Error (`Msg "Not a filter utility")
 
   let suborder = function
-    (* Non-backdrop filters come first, then backdrop filters. Order matches
-       Tailwind v4: alphabetical by class name within each filter type. *)
-    | Blur -> 0
-    | Blur_2xl -> 1
-    | Blur_3xl -> 2
-    | Blur_arbitrary _ -> 3
-    | Blur_lg -> 4
-    | Blur_md -> 5
-    | Blur_none -> 6
-    | Blur_sm -> 7
-    | Blur_theme _ -> 14
-    | Blur_xl -> 8
-    | Blur_xs -> 9
-    | Brightness n -> 1000 + n
-    | Brightness_arbitrary _ -> 1500
-    | Contrast n -> 2000 + n
-    | Contrast_arbitrary _ -> 2500
+    (* Each filter kind is one property slot. Tailwind uses the natural
+       candidate spelling inside it, which handles bare defaults, numeric
+       values, arbitrary values and negative angles without per-value keys. *)
+    | Blur | Blur_2xl | Blur_3xl | Blur_arbitrary _ | Blur_lg | Blur_md
+    | Blur_none | Blur_sm | Blur_theme _ | Blur_xl | Blur_xs ->
+        0
+    | Brightness _ | Brightness_arbitrary _ -> 1000
+    | Contrast _ | Contrast_arbitrary _ -> 2000
     | Drop_shadow_opacity _ -> 2690
     | Drop_shadow_size_opacity _ -> 2692
     | Drop_shadow -> 2700
@@ -1316,54 +1307,29 @@ module Handler = struct
     | Drop_shadow_keyword_color _ | Drop_shadow_keyword_color_opacity _
     | Drop_shadow_inherit | Drop_shadow_color _ | Drop_shadow_color_opacity _ ->
         2710
-    | Filter -> 9000
-    | Filter_arbitrary _ -> 9001
-    | Filter_none -> 9002
-    | Grayscale n -> 4000 + (100 - n)
-    | Grayscale_arbitrary _ -> 4500
-    | Hue_rotate n -> 5000 + n
-    | Hue_rotate_arbitrary _ -> 5500
-    | Neg_hue_rotate_arbitrary _ -> 4990
-    | Invert n -> 6000 + (100 - n)
-    | Invert_arbitrary _ -> 6500
-    | Saturate n -> 7000 + n
-    | Saturate_arbitrary _ -> 7500
-    | Sepia n -> 8000 + (100 - n)
-    | Sepia_arbitrary _ -> 8500
-    (* Backdrop filters come after regular filters. Order: backdrop-blur,
-       brightness, contrast, filter, grayscale, hue-rotate (neg then pos),
-       invert, opacity, saturate, sepia. Within each: arbitrary first, then
-       none, then named values. *)
-    | Backdrop_blur_arbitrary _ -> 10000
-    | Backdrop_blur_none -> 10001
-    | Backdrop_blur_xs -> 10002
-    | Backdrop_blur_sm -> 10003
-    | Backdrop_blur -> 10004
-    | Backdrop_blur_md -> 10005
-    | Backdrop_blur_lg -> 10006
-    | Backdrop_blur_xl -> 10007
-    | Backdrop_blur_2xl -> 10008
-    | Backdrop_blur_3xl -> 10009
-    | Backdrop_brightness n -> 11000 + n
-    | Backdrop_brightness_arbitrary _ -> 11500
-    | Backdrop_contrast n -> 12000 + n
-    | Backdrop_contrast_arbitrary _ -> 12500
-    | Backdrop_filter -> 21000
-    | Backdrop_filter_arbitrary _ -> 21001
-    | Backdrop_filter_none -> 21002
-    | Backdrop_grayscale n -> 14000 + (100 - n)
-    | Backdrop_grayscale_arbitrary _ -> 14500
-    | Neg_backdrop_hue_rotate_arbitrary _ -> 14990
-    | Backdrop_hue_rotate n -> 15000 + n
-    | Backdrop_hue_rotate_arbitrary _ -> 15500
-    | Backdrop_invert n -> 16000 + (100 - n)
-    | Backdrop_invert_arbitrary _ -> 16500
-    | Backdrop_opacity n -> 17000 + Float.to_int (n *. 10.)
-    | Backdrop_opacity_arbitrary _ -> 18100
-    | Backdrop_saturate n -> 19000 + n
-    | Backdrop_saturate_arbitrary _ -> 19500
-    | Backdrop_sepia n -> 20000 + (100 - n)
-    | Backdrop_sepia_arbitrary _ -> 20500
+    | Grayscale _ | Grayscale_arbitrary _ -> 4000
+    | Hue_rotate _ | Hue_rotate_arbitrary _ | Neg_hue_rotate_arbitrary _ -> 5000
+    | Invert _ | Invert_arbitrary _ -> 6000
+    | Saturate _ | Saturate_arbitrary _ -> 7000
+    | Sepia _ | Sepia_arbitrary _ -> 8000
+    | Filter | Filter_arbitrary _ | Filter_none -> 9000
+    (* Backdrop filters follow the same one-slot-per-kind rule. *)
+    | Backdrop_blur_arbitrary _ | Backdrop_blur_none | Backdrop_blur_xs
+    | Backdrop_blur_sm | Backdrop_blur | Backdrop_blur_md | Backdrop_blur_lg
+    | Backdrop_blur_xl | Backdrop_blur_2xl | Backdrop_blur_3xl ->
+        10000
+    | Backdrop_brightness _ | Backdrop_brightness_arbitrary _ -> 11000
+    | Backdrop_contrast _ | Backdrop_contrast_arbitrary _ -> 12000
+    | Backdrop_grayscale _ | Backdrop_grayscale_arbitrary _ -> 14000
+    | Neg_backdrop_hue_rotate_arbitrary _ | Backdrop_hue_rotate _
+    | Backdrop_hue_rotate_arbitrary _ ->
+        15000
+    | Backdrop_invert _ | Backdrop_invert_arbitrary _ -> 16000
+    | Backdrop_opacity _ | Backdrop_opacity_arbitrary _ -> 17000
+    | Backdrop_saturate _ | Backdrop_saturate_arbitrary _ -> 19000
+    | Backdrop_sepia _ | Backdrop_sepia_arbitrary _ -> 20000
+    | Backdrop_filter | Backdrop_filter_arbitrary _ | Backdrop_filter_none ->
+        21000
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 151, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 131, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -131,6 +131,64 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"filters suborder matches Tailwind" shuffled
 
+(* A filter kind is one property slot; Tailwind orders its candidate spellings
+   naturally. Per-value arithmetic reverses negative angles and the
+   grayscale/invert/sepia tails, while hand-numbered blur sizes disagree with
+   candidate order. *)
+let candidate_order_matches_tailwind () =
+  Test_helpers.check_class_order ~test_name:"filter candidate order"
+    [
+      "sepia-0";
+      "sepia";
+      "invert-65";
+      "invert-0";
+      "invert";
+      "hue-rotate-270";
+      "hue-rotate-0";
+      "-hue-rotate-180";
+      "-hue-rotate-90";
+      "-hue-rotate-15";
+      "grayscale-200";
+      "grayscale-50";
+      "grayscale-0";
+      "grayscale";
+      "blur-xs";
+      "blur-xl";
+      "blur-sm";
+      "blur-none";
+      "blur-md";
+      "blur-lg";
+      "blur-3xl";
+      "blur-2xl";
+      "blur";
+      "backdrop-filter-none";
+      "backdrop-filter";
+      "backdrop-sepia-50";
+      "backdrop-sepia-0";
+      "backdrop-sepia";
+      "backdrop-invert-65";
+      "backdrop-invert-0";
+      "backdrop-invert";
+      "backdrop-hue-rotate-270";
+      "backdrop-hue-rotate-0";
+      "-backdrop-hue-rotate-180";
+      "-backdrop-hue-rotate-90";
+      "-backdrop-hue-rotate-15";
+      "backdrop-grayscale-200";
+      "backdrop-grayscale-50";
+      "backdrop-grayscale-0";
+      "backdrop-grayscale";
+      "backdrop-blur-xs";
+      "backdrop-blur-xl";
+      "backdrop-blur-sm";
+      "backdrop-blur-none";
+      "backdrop-blur-md";
+      "backdrop-blur-lg";
+      "backdrop-blur-3xl";
+      "backdrop-blur-2xl";
+      "backdrop-blur";
+    ]
+
 (* backdrop-blur-N must reference the unified v4 --blur-N token (not the dropped
    --backdrop-blur-N) and emit the shipped --blur-N decl. *)
 let test_backdrop_blur_token () =
@@ -369,6 +427,7 @@ let tests =
     test_case "backdrop-blur token" `Quick test_backdrop_blur_token;
     test_case "filters suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "filter candidate order" `Slow candidate_order_matches_tailwind;
     test_case "drop-shadow slot order" `Quick drop_shadow_slot_order;
     test_case "project blur token" `Quick test_project_blur_token;
   ]


### PR DESCRIPTION
Place each regular and backdrop filter kind in one property slot, using the natural class-name tie-break for its candidates. This fixes negative angles, bare defaults, arbitrary values, and grayscale/invert/sepia tails.\n\nThe whole-sheet utility-order ratchet drops from 151 to 131 moves.