### PR TITLE
Place font features before font size

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -976,9 +976,9 @@ module Typography_early = struct
     | Font_semibold -> 4800
     | Font_thin -> 4900
     (* Font feature settings *)
-    | Font_features_quoted _ -> 5000
-    | Font_features_var _ -> 5000
-    | Font_features_bare_var _ -> 5000
+    | Font_features_quoted _ -> 1600
+    | Font_features_var _ -> 1600
+    | Font_features_bare_var _ -> 1600
     (* Italic *)
     | Italic -> 8380
     | Not_italic -> 8381

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 131, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 126, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -847,6 +847,22 @@ let test_font_features_value () =
     (Astring.String.is_infix ~affix:"font-feature-settings:\"liga\" 0"
        (css "font-features-[\"liga\"_0]"))
 
+(* font-feature-settings follows font-family and precedes font-size in
+   Tailwind's property table. Keeping it after the weight band displaces both
+   the feature rules and every larger text size in a full sheet. *)
+let test_font_feature_property_band () =
+  Test_helpers.check_class_order ~test_name:"font feature property band"
+    [
+      "font-bold";
+      "leading-tight";
+      "text-9xl";
+      "text-2xl";
+      "font-features-[\"tnum\"]";
+      "font-features-(--my-features)";
+      "font-serif";
+      "font-sans";
+    ]
+
 (* A font family is idents or quoted strings; the docs' [<value>] placeholder
    used to be quoted into font-family: "<value>". *)
 let test_invalid_font_family () =
@@ -1156,6 +1172,7 @@ let tests =
     test_case "font bracket family comma list" `Quick
       test_font_bracket_family_comma_list;
     test_case "font-features value" `Quick test_font_features_value;
+    test_case "font-feature property band" `Slow test_font_feature_property_band;
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;
     test_case "leading half-step" `Quick test_leading_prime;


### PR DESCRIPTION
Move font-feature-settings into its Tailwind property band after font-family and before font-size. Feature utilities no longer trail the size, leading, and weight families.\n\nThe whole-sheet utility-order ratchet drops from 131 to 126 moves.