### PR TITLE
Sort late arbitrary property bands

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -66,9 +66,10 @@ module Handler = struct
   (* Tailwind sorts an arbitrary property by the property it declares, not by
      its name, so [[order:3]] lands with the [order-*] utilities and
      [[mask-type:luminance]] with the masks. Every one of them sorted at the far
-     end of the layer instead. A property no family claims has no slot to take
-     and keeps that place. *)
-  let unclaimed = 37
+     end of the layer instead. A property no family claims shares Tailwind's
+     late arbitrary-property band, after alpha text shadows and before backface
+     visibility. *)
+  let unclaimed = 38
 
   let slot t =
     let property, value =
@@ -292,7 +293,7 @@ module Handler = struct
       | Parsed_decl { property = "mask-type"; _ } -> 1
       | Color_opacity _ | Parsed_decl _ -> 0
     in
-    match slot t with Some (_, sub) -> sub + offset | None -> 0
+    match slot t with Some (_, sub) -> sub + offset | None -> 10
 
   let to_class = function
     | Color_opacity { property; value; alpha_fn; opacity } ->

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -45,7 +45,14 @@ module Handler = struct
   type Utility.base += Self of t
 
   let name = "text_shadow"
-  let priority _ = 41
+
+  (* An opacity-bearing shadow writes the alpha channel before text-shadow, so
+     Tailwind places it after user-select and before backface visibility. The
+     ordinary shape and colour utilities remain in the later text-shadow
+     band. *)
+  let priority = function
+    | Text_shadow_shape_opacity _ | Text_shadow_arbitrary_opacity _ -> 38
+    | _ -> 41
 
   let text_shadow_color_var =
     Var.channel ~needs_property:true ~property_order:35 ~family:`Text_shadow
@@ -934,11 +941,11 @@ module Handler = struct
   let suborder = function
     | Text_shadow_arbitrary_opacity (arb, _) -> (
         match parse_arbitrary_shadow arb with
-        | Some (_, _, _, Var_ref _) -> -3 (* @supports lab *)
-        | Some (_, _, _, No_color) -> -2 (* @supports color-mix *)
-        | Some (_, _, _, (Hex _ | Css_color _)) -> -1 (* no @supports *)
-        | Stdlib.Option.None -> 0)
-    | Text_shadow_shape_opacity _ -> -1 (* no @supports *)
+        | Some (_, _, _, Var_ref _) -> 6 (* @supports lab *)
+        | Some (_, _, _, No_color) -> 7 (* @supports color-mix *)
+        | Some (_, _, _, (Hex _ | Css_color _)) -> 8 (* no @supports *)
+        | Stdlib.Option.None -> 9)
+    | Text_shadow_shape_opacity _ -> 8 (* no @supports *)
     | _ -> 0
 
   let examples = [ Text_shadow_shape S_sm; Text_shadow_current ]

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 126, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 114, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -568,6 +568,27 @@ let test_late_control_property_bands () =
       "scheme-dark";
     ]
 
+(* The outline-style, user-select and alpha-bearing text-shadow candidates form
+   three consecutive bands after backdrop-filter. The ordinary text-shadow
+   shapes still live in their later text-shadow band. *)
+let test_outline_select_shadow_property_bands () =
+  Test_helpers.check_class_order
+    ~test_name:"outline, select and alpha text-shadow property bands"
+    [
+      "text-shadow-sm";
+      "transform-3d";
+      "perspective-normal";
+      "backface-hidden";
+      "text-shadow-lg/20";
+      "select-none";
+      "select-all";
+      "outline-solid";
+      "outline-dashed";
+      "backdrop-filter-none";
+      "filter-none";
+      "outline-inherit";
+    ]
+
 let test_logical_side_property_bands () =
   Test_helpers.check_class_order
     ~test_name:"logical sides keep their property bands"
@@ -2782,6 +2803,8 @@ let tests =
     test_case "field sizing property band" `Slow test_field_sizing_property_band;
     test_case "late control property bands" `Slow
       test_late_control_property_bands;
+    test_case "outline, select and alpha shadow bands" `Slow
+      test_outline_select_shadow_property_bands;
     test_case "logical side property bands" `Slow
       test_logical_side_property_bands;
     test_case "shadow and transform boundaries" `Slow

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -578,6 +578,9 @@ let test_outline_select_shadow_property_bands () =
       "text-shadow-sm";
       "transform-3d";
       "perspective-normal";
+      "divide-x-reverse";
+      "[hanging-punctuation:first_last]";
+      "[animation-name:move-x]";
       "backface-hidden";
       "text-shadow-lg/20";
       "select-none";


### PR DESCRIPTION
Move alpha-bearing text shadows and unclaimed arbitrary properties into their Tailwind property bands. This restores the outline, user-select, alpha-shadow, arbitrary-property, and backface sequence while reducing whole-sheet utility moves from 126 to 114.