### PR TITLE
Sort bracket font sizes after 9xl

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -911,8 +911,9 @@ module Typography_early = struct
     | Font_named _ -> 1504
     | Font_weight_theme _ -> 4201
     | Leading_theme _ -> 3206
-    (* Bracket font-size with line-height modifier — before named sizes *)
-    | Text_bracket_fs_lh _ -> 2000
+    (* Bracket font-size/line-height candidates follow 9xl in the shared slot;
+       the candidate-name tiebreak keeps 9xl first. *)
+    | Text_bracket_fs_lh _ -> 2008
     (* Font sizes come second - alphabetical order *)
     | Text_2xl -> 2001
     | Text_3xl -> 2002

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -33,7 +33,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    that as a pass. *)
 let pinned =
   [
-    ("utilities", `Moves 114, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
+    ("utilities", `Moves 101, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
   ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -863,6 +863,12 @@ let test_font_feature_property_band () =
       "font-sans";
     ]
 
+(* A bracket font-size carrying a line-height modifier follows the large named
+   sizes and precedes the base size in Tailwind's candidate order. *)
+let test_bracket_font_size_candidate_band () =
+  Test_helpers.check_class_order ~test_name:"bracket font-size candidate band"
+    [ "text-base"; "text-[13px]/6"; "text-9xl"; "text-2xl" ]
+
 (* A font family is idents or quoted strings; the docs' [<value>] placeholder
    used to be quoted into font-family: "<value>". *)
 let test_invalid_font_family () =
@@ -1173,6 +1179,8 @@ let tests =
       test_font_bracket_family_comma_list;
     test_case "font-features value" `Quick test_font_features_value;
     test_case "font-feature property band" `Slow test_font_feature_property_band;
+    test_case "bracket font-size candidate band" `Slow
+      test_bracket_font_size_candidate_band;
     test_case "tracking-normal unit" `Quick test_tracking_normal_unit;
     test_case "numeric leading from spacing" `Quick test_numeric_leading_spacing;
     test_case "leading half-step" `Quick test_leading_prime;


### PR DESCRIPTION
Place bracket font-size candidates with line-height modifiers after the large named sizes and before text-base. This matches Tailwind candidate order and reduces whole-sheet utility moves from 114 to 101.