### PR TITLE
Split list-style property bands

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2358,18 +2358,15 @@ module Typography_late = struct
     | Align_text_top -> 1206
     | Align_top -> 1207
     (* List utilities (priority 11) - after resize (~1M), before appearance
-       (~3M). Alphabetical. *)
-    | List_bracket_var _ -> 2_000_000 + 8699
-    | List_bracket _ -> 2_000_000 + 8699
-    | List_decimal -> 2_000_000 + 8700
-    | List_disc -> 2_000_000 + 8701
-    | List_image_bracket_var _ -> 2_000_000 + 8698
-    | List_image_bracket _ -> 2_000_000 + 8698
-    | List_image_none -> 2_000_000 + 8702
-    | List_inside -> 2_000_000 + 8703
-    | List_none -> 2_000_000 + 8704
-    | List_outside -> 2_000_000 + 8705
-    | List_image_url _ -> 2_000_000 + 8706
+       (~3M). Position, type, and image form separate property bands; candidate
+       names settle ties inside each band. *)
+    | List_inside | List_outside -> 2_000_000
+    | List_bracket_var _ | List_bracket _ | List_decimal | List_disc | List_none
+      ->
+        2_010_000
+    | List_image_bracket_var _ | List_image_bracket _ | List_image_none
+    | List_image_url _ ->
+        2_020_000
     (* Underline offset — negatives first, then positives, then auto *)
     | Underline_offset_neg_px px -> 50000 + int_of_float px
     | Underline_offset_neg_arbitrary _ -> 59989

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,9 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [
-    ("utilities", `Moves 101, `Pairs 3800); ("components", `Moves 0, `Pairs 45);
-  ]
+  [ ("utilities", `Moves 95, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -827,6 +827,21 @@ let test_bracket_list_style () =
     "an unknown counter style is rejected" true
     (Result.is_error (Tw.of_string "list-[nonsense-style]"))
 
+(* List position, type, and image are three property bands; candidates inside
+   each band use their natural class-name order. *)
+let test_list_style_property_bands () =
+  Test_helpers.check_class_order ~test_name:"list-style property bands"
+    [
+      "list-image-none";
+      "list-image-[url(/carrot.png)]";
+      "list-none";
+      "list-disc";
+      "list-decimal";
+      "list-[square]";
+      "list-outside";
+      "list-inside";
+    ]
+
 (* CSS Fonts 4 sec. 6.4: a feature setting is a quoted four-character tag with
    an optional integer / on / off, so the docs' [<value>] placeholder is not
    one; the underscore in [font-features-["liga"_0]] is a space. *)
@@ -1172,6 +1187,7 @@ let tests =
     test_case "decoration shadeless opacity" `Quick
       test_decoration_shadeless_opacity;
     test_case "bracket list-style" `Quick test_bracket_list_style;
+    test_case "list-style property bands" `Slow test_list_style_property_bands;
     test_case "invalid font family" `Quick test_invalid_font_family;
     test_case "font bracket family quoted" `Quick
       test_font_bracket_family_quoted;


### PR DESCRIPTION
Sort list-style-position, list-style-type, and list-style-image as separate property bands with natural ordering inside each band. This reduces whole-sheet utility moves from 101 to 95.