### PR TITLE
Place backface before logical sizing

### DIFF
--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -35,7 +35,7 @@ module Handler = struct
   (* The divide properties follow gap and precede self-alignment. The unranked
      [divide-x-reverse] custom property sits between backface and
      perspective. *)
-  let priority = function X_reverse -> 39 | _ -> 17
+  let priority = function X_reverse -> 38 | _ -> 17
 
   (* CSS Variables for divide reverse. Property order 4/5 places these BEFORE
      --tw-border-style (order 6) in within-utility sorting, which determines

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -159,7 +159,7 @@ module Handler = struct
     | Origin_top_left | Origin_top_right | Origin_bottom_left
     | Origin_bottom_right | Origin_arbitrary _ ->
         8
-    | Backface_visible | Backface_hidden -> 39
+    | Backface_visible | Backface_hidden -> 38
     | Perspective_none | Perspective_theme _ | Perspective_dramatic
     | Perspective_near | Perspective_normal | Perspective_midrange
     | Perspective_distant | Perspective_arbitrary _ | Perspective_origin_center

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 95, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 93, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -592,6 +592,20 @@ let test_outline_select_shadow_property_bands () =
       "outline-inherit";
     ]
 
+(* Backface visibility and divide-x-reverse precede the logical sizing block;
+   perspective follows it. *)
+let test_backface_logical_sizing_boundary () =
+  Test_helpers.check_class_order ~test_name:"backface/logical sizing boundary"
+    [
+      "perspective-normal";
+      "max-block-full";
+      "inline-full";
+      "divide-x-reverse";
+      "backface-visible";
+      "[animation-name:move-x]";
+      "text-shadow-lg/20";
+    ]
+
 let test_logical_side_property_bands () =
   Test_helpers.check_class_order
     ~test_name:"logical sides keep their property bands"
@@ -2808,6 +2822,8 @@ let tests =
       test_late_control_property_bands;
     test_case "outline, select and alpha shadow bands" `Slow
       test_outline_select_shadow_property_bands;
+    test_case "backface/logical sizing boundary" `Slow
+      test_backface_logical_sizing_boundary;
     test_case "logical side property bands" `Slow
       test_logical_side_property_bands;
     test_case "shadow and transform boundaries" `Slow


### PR DESCRIPTION
Place backface visibility and divide-x-reverse before the logical sizing property block while keeping perspective after it. This reduces whole-sheet utility moves from 95 to 93.