### PR TITLE
Align perspective candidate ordering

### DIFF
--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1434,16 +1434,12 @@ module Handler = struct
     | Skew_x _ | Skew_x_arbitrary _ -> 1211
     | Skew_y n when n < 0 -> 1300
     | Skew_y _ | Skew_y_arbitrary _ -> 1301
-    (* Other transform utilities - arbitrary before named (alphabetical by
-       class) *)
-    | Perspective_arbitrary _ -> 1400
-    | Perspective_dramatic -> 1400
-    | Perspective_none -> 1401
-    | Perspective_theme _ -> 1402
-    | Perspective_normal -> 1402
-    | Perspective_near -> 1403
-    | Perspective_midrange -> 1404
-    | Perspective_distant -> 1405
+    (* Perspective depths are one candidate band; Tailwind orders their class
+       spellings rather than their semantic distance. *)
+    | Perspective_arbitrary _ | Perspective_dramatic | Perspective_none
+    | Perspective_theme _ | Perspective_normal | Perspective_near
+    | Perspective_midrange | Perspective_distant ->
+        1400
     | Perspective_origin_arbitrary _ -> 1499
     | Perspective_origin_bottom -> 1500
     | Perspective_origin_bottom_left -> 1501

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 93, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 90, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -68,6 +68,17 @@ let test_perspective_keywords () =
     (Astring.String.is_infix ~affix:"--perspective-distant:1200px"
        (css "perspective-distant"))
 
+let test_perspective_candidate_order () =
+  Test_helpers.check_class_order ~test_name:"perspective candidate order"
+    [
+      "perspective-none";
+      "perspective-near";
+      "perspective-dramatic";
+      "perspective-normal";
+      "perspective-distant";
+      "perspective-midrange";
+    ]
+
 let test_of_string_invalid () =
   (* Invalid transform utilities *)
   let test_invalid input =
@@ -432,6 +443,8 @@ let tests =
     test_case "translate spacing (both axes)" `Quick test_translate_spacing;
     test_case "translate+rotate" `Quick test_translate_rotate;
     test_case "perspective keywords" `Quick test_perspective_keywords;
+    test_case "perspective candidate order" `Quick
+      test_perspective_candidate_order;
     test_case "translate-px and negative arbitrary" `Quick
       test_translate_px_and_neg_arbitrary;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;


### PR DESCRIPTION
Tailwind orders perspective depth candidates by their class spelling rather than semantic distance. Put the depth candidates in one suborder band, add a focused ordering regression test, and tighten the whole-sheet utility ceiling from 93 to 90.