### PR TITLE
Place logical block margins before physical sides

### DIFF
--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -140,12 +140,12 @@ module Handler = struct
       | `Y -> 2
       | `S -> 3
       | `E -> 4
-      | `T -> 5
-      | `R -> 6
-      | `B -> 7
-      | `L -> 8
-      | `Bs -> 9
-      | `Be -> 10
+      | `Bs -> 5
+      | `Be -> 6
+      | `T -> 7
+      | `R -> 8
+      | `B -> 9
+      | `L -> 10
     in
     let sign_offset =
       match value with Negative _ -> 0 | Auto | Positive _ -> 200000

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 82, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 79, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_margin.ml
+++ b/test/test_margin.ml
@@ -104,6 +104,23 @@ let negative_suborder_matches_tailwind () =
     ~test_name:"negative margin suborder matches Tailwind"
     (Test_helpers.shuffle utilities)
 
+let margin_side_bands_match_tailwind () =
+  Test_helpers.check_class_order ~test_name:"margin side property bands"
+    [
+      "ml-2";
+      "mbs-8";
+      "mbe-2";
+      "mt-2";
+      "me-2";
+      "ms-2";
+      "my-2";
+      "mx-2";
+      "m-2";
+      "mr-2";
+      "mb-2";
+      "mbs-6";
+    ]
+
 (* m, mx and ml all write margin-left, so which one an element ends up with is
    decided by the order the two sheets emit them in. *)
 let rendering_matches_tailwind () =
@@ -208,6 +225,8 @@ let tests =
       suborder_matches_tailwind;
     test_case "negative margin suborder matches Tailwind" `Quick
       negative_suborder_matches_tailwind;
+    test_case "margin side bands match Tailwind" `Quick
+      margin_side_bands_match_tailwind;
     test_case "margin CSS values" `Quick test_css_values;
     test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
     test_case "margins render like Tailwind" `Slow rendering_matches_tailwind;


### PR DESCRIPTION
Tailwind orders margin-block-start and margin-block-end after the inline logical sides and before the physical top/right/bottom/left sides. Correct the margin side indices, add a focused property-band regression test, and tighten the whole-sheet utility ceiling from 82 to 79.