### PR TITLE
sort: keep delay candidates together

### DIFF
--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -540,8 +540,9 @@ module Handler = struct
     | Transition_none -> 6
     | Transition_behavior_allow_discrete -> 7 (* transition-discrete *)
     | Transition_behavior_normal -> 8 (* transition-normal *)
-    | Delay n -> 100 + n
-    | Delay_arbitrary _ -> 100000
+    (* Candidate values share Tailwind's one registration slot; the raw class
+       key supplies their natural order without mixing duration values in. *)
+    | Delay _ | Delay_arbitrary _ -> 100
     | Duration n -> 200 + n
     | Duration_initial -> 200001
     | Duration_arbitrary _ -> 200000

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 79, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 76, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -157,6 +157,20 @@ let test_default_transition_theme_survives_a_variant () =
       Alcotest.(check bool) (cls ^ " needs no defaults") false (declares cls))
     [ "transition-none"; "hover:transition-none"; "p-4" ]
 
+(* Values of one candidate are one registration slot in Tailwind. A numeric
+   suborder per delay value used to let duration rules leak between them. *)
+let test_delay_candidate_band () =
+  Test_helpers.check_class_order ~test_name:"delay candidate band"
+    [
+      "duration-150";
+      "delay-700";
+      "ease-in";
+      "delay-150";
+      "transition";
+      "duration-300";
+      "delay-300";
+    ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -170,6 +184,7 @@ let tests =
       Alcotest.test_case "project ease token" `Quick test_project_ease_token;
       Alcotest.test_case "default transition theme survives a variant" `Quick
         test_default_transition_theme_survives_a_variant;
+      Alcotest.test_case "delay candidate band" `Quick test_delay_candidate_band;
     ]
 
 let suite = ("transitions", tests)


### PR DESCRIPTION
Tailwind assigns every value of the delay candidate to one registration slot. Flatten tw's delay suborder so duration values cannot interleave the band.\n\nAdds a focused Tailwind-backed order regression and tightens the whole-sheet ceiling from 79 to 76 moves.