### PR TITLE
sort: place transition resets after block sizing

### DIFF
--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -33,8 +33,8 @@ module Handler = struct
   let name = "divide"
 
   (* The divide properties follow gap and precede self-alignment. The unranked
-     [divide-x-reverse] custom property sits between backface and
-     perspective. *)
+     [divide-x-reverse] custom property sits between logical block and inline
+     sizing. *)
   let priority = function X_reverse -> 38 | _ -> 17
 
   (* CSS Variables for divide reverse. Property order 4/5 places these BEFORE
@@ -367,7 +367,7 @@ module Handler = struct
     | Current | Current_opacity _ -> 66_000
     | Inherit -> 66_000
     | Transparent -> 66_000
-    | X_reverse -> 1_700
+    | X_reverse -> 89_000_000
 
   (* The bracket spelling of an arbitrary width, for the typed constructors,
      which are handed a width rather than the text an author wrote. cascade

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -46,8 +46,11 @@ module Handler = struct
 
   let name = "transitions"
 
-  let priority _ =
-    32 (* Transition utilities come after all other styling utilities *)
+  let priority = function
+    (* Tailwind registers these late channel resets after divide-x-reverse and
+       before the logical inline sizing candidates. *)
+    | Duration_initial | Ease_initial -> 38
+    | _ -> 32 (* Transition utilities come after all other styling utilities *)
 
   (* Theme variables for default transition settings. Duration has lower order
      (8,0) so it appears before timing-function (8,1) in the theme layer output,
@@ -544,7 +547,7 @@ module Handler = struct
        key supplies their natural order without mixing duration values in. *)
     | Delay _ | Delay_arbitrary _ -> 100
     | Duration n -> 200 + n
-    | Duration_initial -> 200001
+    | Duration_initial -> 89_000_001
     | Duration_arbitrary _ -> 200000
     (* Ease utilities come after Duration. Tailwind orders: duration then ease.
        Use a high base to ensure even duration-5000 (suborder 5200) < ease.
@@ -553,7 +556,7 @@ module Handler = struct
     | Ease_in_out -> 100001
     | Ease_linear -> 100002
     | Ease_out -> 100003
-    | Ease_initial -> 100004
+    | Ease_initial -> 89_000_002
     | Ease_arbitrary _ -> 99999
     | Ease_theme _ -> 100005
 

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 76, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 73, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -171,6 +171,21 @@ let test_delay_candidate_band () =
       "delay-300";
     ]
 
+(* Tailwind registers the channel resets near the end of its utility list, after
+   logical block sizing and divide-x-reverse, but before logical inline sizing
+   and perspective. *)
+let test_initial_reset_boundary () =
+  Test_helpers.check_class_order ~test_name:"initial reset boundary"
+    [
+      "perspective-normal";
+      "duration-initial";
+      "inline-full";
+      "block-full";
+      "divide-x-reverse";
+      "backface-hidden";
+      "ease-initial";
+    ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -185,6 +200,8 @@ let tests =
       Alcotest.test_case "default transition theme survives a variant" `Quick
         test_default_transition_theme_survives_a_variant;
       Alcotest.test_case "delay candidate band" `Quick test_delay_candidate_band;
+      Alcotest.test_case "initial reset boundary" `Quick
+        test_initial_reset_boundary;
     ]
 
 let suite = ("transitions", tests)


### PR DESCRIPTION
Tailwind places divide-x-reverse and the duration/ease initial resets between logical block and inline sizing. Move that three-rule band to the same boundary.\n\nAdds a focused Tailwind-backed boundary regression and tightens the whole-sheet ceiling from 76 to 73 moves.