### PR TITLE
sort: place gap candidate boundaries

### DIFF
--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -8,6 +8,7 @@ module Handler = struct
 
   type gap_value =
     | Standard of spacing
+    | Bare_var of string (* gap-(--value), raw kept for round-trip/order *)
     | Arbitrary of string * Css.length (* gap-[4px], raw kept for round-trip *)
     | Arbitrary_var of string (* gap-[var(--value)] *)
 
@@ -71,6 +72,12 @@ module Handler = struct
         | `All -> gap_standard ?theme s
         | `X -> gap_x_standard ?theme s
         | `Y -> gap_y_standard ?theme s)
+    | Bare_var raw -> (
+        let len = gap_var_ref ("var(" ^ Parse.bare_var_inner raw ^ ")") in
+        match axis with
+        | `All -> gap_arb len
+        | `X -> gap_x_arb len
+        | `Y -> gap_y_arb len)
     | Arbitrary (_, len) -> (
         match axis with
         | `All -> gap_arb len
@@ -330,9 +337,11 @@ module Handler = struct
     | Space_y_reverse -> space_y_reverse_style ()
 
   let gap_value_order = function
+    | Bare_var _ -> 0
+    | Standard `Px -> 2100
     | Standard s -> spacing_value_order s
     | Arbitrary _ -> 2000
-    | Arbitrary_var _ -> 2100
+    | Arbitrary_var _ -> 2000
 
   (* gap and space share priority 17 with the alignment utilities. Tailwind
      emits them in CSS-property registration order, which interleaves the two
@@ -361,6 +370,7 @@ module Handler = struct
 
   let pp_gap_value_suffix = function
     | Standard s -> Spacing.pp_spacing_suffix s
+    | Bare_var raw -> raw
     | Arbitrary (raw, _) -> "[" ^ raw ^ "]"
     | Arbitrary_var s -> "[" ^ s ^ "]"
 
@@ -400,7 +410,9 @@ module Handler = struct
      [gap-form] is a class Tailwind emits whenever the theme defines
      [--spacing-form]. *)
   let parse_gap_value ?theme value =
-    if String.length value > 0 && value.[0] = '[' then parse_gap_arbitrary value
+    if Parse.is_bare_var value then Some (Bare_var value)
+    else if String.length value > 0 && value.[0] = '[' then
+      parse_gap_arbitrary value
     else
       match Spacing.parse_value_string ?theme ~allow_auto:false value with
       | Some (#Style.spacing as s) -> Some (Standard s)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 73, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 71, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_gap.ml
+++ b/test/test_gap.ml
@@ -133,6 +133,12 @@ let test_arbitrary_length_grammar () =
   check "gap-[inherit]";
   check "gap-[4px]"
 
+(* The paren shorthand is Tailwind's first candidate value and literal px its
+   last; numeric and bracket values stay between those boundaries. *)
+let test_gap_candidate_boundaries () =
+  Test_helpers.check_class_order ~test_name:"gap candidate boundaries"
+    [ "space-y-2"; "gap-px"; "gap-[5cqw]"; "gap-10"; "gap-(--gap)"; "gap-1.5" ]
+
 (* gap'/gap_x'/gap_y' take a half-step float; space_x/space_y flipped from float
    to int with a [']-suffixed float sibling, same convention as [p]/[p']. *)
 let typed_prime () =
@@ -159,6 +165,7 @@ let tests =
     test_case "space-px CSS values" `Quick test_space_px_values;
     test_case "gap CSS values" `Quick test_css_values;
     test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
+    test_case "gap candidate boundaries" `Quick test_gap_candidate_boundaries;
   ]
 
 let suite = ("gap", tests)


### PR DESCRIPTION
Tailwind places the gap paren shorthand first and the literal px value last within the gap candidate. Parse the shorthand directly so it keeps a distinct order slot, and move px behind arbitrary values.\n\nAdds a focused Tailwind-backed regression and tightens the whole-sheet ceiling from 73 to 71 moves.