### PR TITLE
sort: preserve declared position prelude

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1556,7 +1556,9 @@ let output_base_class_and_props = function
    Built-in values carry distinct numeric suborders in TW, so when a declared
    utility joins one of those property families, normalize that family's
    suborder for this render and let the existing candidate-name tiebreaker
-   interleave both kinds of utility. *)
+   interleave both kinds of utility. A negative minimum is a built-in prelude,
+   such as [sr-only]/[not-sr-only] before ordinary position utilities. Preserve
+   that walk and put the declared utility in the preceding property slot. *)
 let normalize_declared_property_families order_map builtins extra_outputs =
   List.iter
     (fun (class_name, (priority, _), outputs) ->
@@ -1598,14 +1600,19 @@ let normalize_declared_property_families order_map builtins extra_outputs =
             in
             Option.iter
               (fun suborder ->
-                List.iter
-                  (fun (base, (p, _)) ->
-                    if p = priority then
-                      Hashtbl.replace order_map base (priority, suborder))
-                  family;
-                Hashtbl.replace order_map
-                  (extract_base_utility class_name)
-                  (priority, suborder))
+                if suborder < 0 then
+                  Hashtbl.replace order_map
+                    (extract_base_utility class_name)
+                    (priority, suborder - 1)
+                else (
+                  List.iter
+                    (fun (base, (p, _)) ->
+                      if p = priority then
+                        Hashtbl.replace order_map base (priority, suborder))
+                    family;
+                  Hashtbl.replace order_map
+                    (extract_base_utility class_name)
+                    (priority, suborder)))
               suborder)
     extra_outputs
 

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 71, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 68, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2514,6 +2514,33 @@ let test_declared_utility_ties_by_name () =
   check_before "the declared utility keeps its alphabetical place" sheet
     ".aaa-pad" ".p-4"
 
+(* Position starts with two multi-property screen-reader utilities. A declared
+   utility writing [position] occupies the preceding property slot without
+   collapsing that built-in prelude onto the ordinary position candidates. *)
+let test_declared_position_before_screen_reader_prelude () =
+  let order =
+    match Tw.Utility.order_of_property (Key Position) with
+    | Some order -> order
+    | None -> Alcotest.fail "position has no utility slot"
+  in
+  let sheet =
+    Tw.Build.to_css
+      ~extra:
+        [
+          ( "line-y",
+            order,
+            [
+              Css.rule
+                ~selector:(Css.Selector.class_ "line-y")
+                [ Css.position Relative ];
+            ] );
+        ]
+      [ builtin "sr-only"; builtin "not-sr-only"; builtin "absolute" ]
+  in
+  check (list string) "declared position and built-in prelude"
+    [ ".line-y"; ".sr-only"; ".not-sr-only"; ".absolute" ]
+    (utility_selectors sheet)
+
 let test_regular_before_media () =
   (* Test that regular rules ALWAYS come before media queries, regardless of their priorities.
    * Example: max-w-4xl (regular, priority 8) and md:grid-cols-2 (media, priority 12).
@@ -2875,6 +2902,8 @@ let tests =
       test_declared_utility_after_wider_builtin;
     test_case "declared utility ties by candidate name" `Quick
       test_declared_utility_ties_by_name;
+    test_case "declared position precedes the screen-reader prelude" `Quick
+      test_declared_position_before_screen_reader_prelude;
     test_case "rules_of_grouped prose merging bug" `Quick
       rules_of_grouped_prose_bug;
     test_case "suborder within group" `Slow test_suborder_within_group;


### PR DESCRIPTION
Tailwind places a declared position utility before the screen-reader prelude without reversing or flattening the built-in position walk. Preserve negative built-in suborders and assign the declared utility the preceding property slot.\n\nAdds a focused regression and tightens the whole-sheet ceiling from 71 to 68 moves.