### PR TITLE
sort: place zoom paren shorthand first

### DIFF
--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -5,7 +5,11 @@ module Css = Cascade.Css
 module Handler = struct
   open Style
 
-  type t = Percent of float | Arbitrary of string * Css.zoom
+  type t =
+    | Percent of float
+    | Bare_var of string
+    | Arbitrary of string * Css.zoom
+
   type Utility.base += Self of t
 
   let name = "zoom"
@@ -15,17 +19,27 @@ module Handler = struct
      being no integer left between the two, and starts past every suborder
      transforms.ml assigns (2004 at the time of writing). *)
   let priority _ = 9
-  let suborder = function Percent _ -> 3000 | Arbitrary _ -> 3001
+
+  let suborder = function
+    | Bare_var _ -> 2999
+    | Percent _ -> 3000
+    | Arbitrary _ -> 3001
 
   let num_to_string n =
     if Float.is_integer n then string_of_int (int_of_float n) else Pp.float n
 
   let to_class = function
     | Percent n -> "zoom-" ^ num_to_string n
+    | Bare_var raw -> "zoom-" ^ raw
     | Arbitrary (raw, _) -> "zoom-" ^ raw
 
   let to_style _theme = function
     | Percent n -> style [ Css.zoom (Pct n) ]
+    | Bare_var raw ->
+        let name =
+          Parse.extract_var_name ("var(" ^ Parse.bare_var_inner raw ^ ")")
+        in
+        style [ Css.zoom (Var (Var.bracket name)) ]
     | Arbitrary (_, v) -> style [ Css.zoom v ]
 
   (* [zoom-[var(--zoom)]] references a var; other bracket values parse as a
@@ -47,6 +61,7 @@ module Handler = struct
 
   let of_class _theme class_name =
     match Parse.split_class class_name with
+    | [ "zoom"; value ] when Parse.is_bare_var value -> Ok (Bare_var value)
     | [ "zoom"; n ] -> (
         match int_of_string_opt n with
         | Some i -> Ok (Percent (float_of_int i))

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 68, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 67, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_zoom.ml
+++ b/test/test_zoom.ml
@@ -27,11 +27,19 @@ let test_zoom_sorts_after_the_transforms () =
       "p-4";
     ]
 
+(* The paren shorthand is Tailwind's first zoom candidate, before the numeric
+   scale and bracket-arbitrary values. *)
+let test_zoom_candidate_boundary () =
+  Test_helpers.check_class_order ~test_name:"zoom candidate boundary"
+    [ "zoom-125"; "zoom-(--preview-zoom)"; "zoom-[1.1]"; "zoom-75"; "zoom-100" ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "sorts after the transforms" `Quick
         test_zoom_sorts_after_the_transforms;
+      Alcotest.test_case "candidate boundary" `Quick
+        test_zoom_candidate_boundary;
     ]
 
 let suite = ("zoom", tests)


### PR DESCRIPTION
Tailwind places the zoom paren shorthand before numeric and bracket-arbitrary values. Parse it natively in the zoom handler so it keeps its own first-candidate suborder instead of passing through the arbitrary-value alias fallback.\n\nAdds a focused Tailwind-backed regression and tightens the whole-sheet ceiling from 68 to 67 moves.