### PR TITLE
sort: close the align-content boundary

### DIFF
--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -242,7 +242,7 @@ module Handler = struct
     | Content_between -> ("content-between", content_between, 22)
     | Content_around -> ("content-around", content_around, 20)
     | Content_evenly -> ("content-evenly", content_evenly, 27)
-    | Content_stretch -> ("content-stretch", content_stretch, 31)
+    | Content_stretch -> ("content-stretch", content_stretch, 30)
     | Content_baseline -> ("content-baseline", content_baseline, 21)
     | Content_normal -> ("content-normal", content_normal, 28)
     | Content_center_safe -> ("content-center-safe", content_center_safe, 24)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 67, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 66, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_alignment.ml
+++ b/test/test_alignment.ml
@@ -118,12 +118,20 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"alignment suborder matches Tailwind" shuffled
 
+(* The last align-content candidate still precedes the first align-items
+   candidate at the shared property boundary. *)
+let content_stretch_boundary_matches_tailwind () =
+  Test_helpers.check_class_order ~test_name:"content stretch boundary"
+    [ "items-baseline"; "content-stretch" ]
+
 let tests =
   [
     test_case "alignment of_string - valid values" `Quick of_string_valid;
     test_case "alignment of_string - invalid values" `Quick of_string_invalid;
     test_case "alignment suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "content stretch boundary matches Tailwind" `Quick
+      content_stretch_boundary_matches_tailwind;
   ]
 
 let suite = ("alignment", tests)


### PR DESCRIPTION
Tailwind keeps content-stretch ahead of the first align-items candidate. Share the boundary suborder so the existing candidate-name tiebreak places content-stretch before items-baseline.\n\nAdds a focused Tailwind-backed regression and tightens the whole-sheet ceiling from 67 to 66 moves.