### PR TITLE
sort: group legacy gradient aliases

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -454,20 +454,21 @@ module Handler = struct
   let priority t = if property_rank t > mask_image_rank then 21 else 20
 
   (* Rules sharing a slot sort by declaration count, most first, then by class
-     name. In background-image's slot the linear directions and angles carry an
-     @supports fallback the other gradient functions do not, and the plain
-     images write nothing past background-image, so they close it. *)
+     name. In background-image's slot the native linear directions and angles
+     carry an @supports fallback. The legacy [bg-gradient-to-*] aliases join the
+     next group with conic, radial and bracket-linear gradients, while plain
+     images write nothing past background-image and close the property. *)
   let suborder t =
     let rank = property_rank t in
     if rank <> background_image_rank then Utility.Property_order.last rank
     else
       match t with
-      | Bg_gradient_to _ | Bg_linear_to _ | Bg_linear_to_interp _
-      | Bg_linear_angle _ | Bg_linear_angle_neg _ | Bg_linear_angle_interp _
+      | Bg_linear_to _ | Bg_linear_to_interp _ | Bg_linear_angle _
+      | Bg_linear_angle_neg _ | Bg_linear_angle_interp _
       | Bg_linear_angle_neg_interp _ ->
           Utility.Property_order.slot rank
-      | Bg_linear_bracket _ | Bg_linear_bracket_neg _ | Bg_conic
-      | Bg_conic_angle _ | Bg_conic_angle_neg _ | Bg_conic_interp _
+      | Bg_gradient_to _ | Bg_linear_bracket _ | Bg_linear_bracket_neg _
+      | Bg_conic | Bg_conic_angle _ | Bg_conic_angle_neg _ | Bg_conic_interp _
       | Bg_conic_angle_interp _ | Bg_conic_angle_neg_interp _ | Bg_radial
       | Bg_radial_interp _ | Bg_radial_bracket _ ->
           Utility.Property_order.slot rank + 1

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 66, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 64, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -303,6 +303,22 @@ let order_matches_tailwind () =
   Test_helpers.check_class_order
     ~test_name:"background and mask order matches Tailwind" classes
 
+(* The v3 bg-gradient-to-* spellings are compatibility aliases in the modern
+   linear-gradient band, after the native direction candidates. *)
+let legacy_gradient_alias_order_matches_tailwind () =
+  Test_helpers.check_class_order ~test_name:"legacy gradient alias order"
+    [
+      "bg-gradient-to-r";
+      "bg-linear-to-b";
+      "bg-linear-45";
+      "bg-gradient-to-t";
+      "bg-linear-to-r";
+      "bg-linear-to-t";
+      "bg-conic";
+      "bg-radial";
+      "bg-linear-[45deg]";
+    ]
+
 (* A gradient and a background colour both end up in background-image and
    background-color, and the gradient stops share the --tw-gradient-* slots.
    Palette colours are left out: tw declares the theme token as a hex where
@@ -582,6 +598,8 @@ let tests =
       suborder_matches_tailwind;
     test_case "background and mask order matches Tailwind" `Slow
       order_matches_tailwind;
+    test_case "legacy gradient alias order matches Tailwind" `Quick
+      legacy_gradient_alias_order_matches_tailwind;
     test_case "backgrounds render like Tailwind" `Slow
       rendering_matches_tailwind;
   ]


### PR DESCRIPTION
Tailwind places the v3 bg-gradient-to-* compatibility aliases after native linear directions, in the background-image group shared with conic, radial, and bracket-linear gradients. Move the aliases into that group.\n\nAdds a focused Tailwind-backed regression and tightens the whole-sheet ceiling from 66 to 64 moves.