### PR TITLE
sort: share the mask-type property slot

### DIFF
--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -287,13 +287,7 @@ module Handler = struct
               | Some color -> color_opacity_render theme emit color inner
               | None -> style []))
 
-  let suborder t =
-    let offset =
-      match t with
-      | Parsed_decl { property = "mask-type"; _ } -> 1
-      | Color_opacity _ | Parsed_decl _ -> 0
-    in
-    match slot t with Some (_, sub) -> sub + offset | None -> 10
+  let suborder t = match slot t with Some (_, sub) -> sub | None -> 10
 
   let to_class = function
     | Color_opacity { property; value; alpha_fn; opacity } ->

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 64, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 63, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1737,13 +1737,13 @@ let measured_inversions () =
   List.sort_uniq compare from_positions
 
 let test_mask_type_arbitrary_order () =
-  let utilities = List.map (fun e -> e.utility) (pool_entries ()) in
-  let classes = List.map Tw.pp utilities in
-  let tailwind, tw = Test_helpers.sheets ~forms:true utilities in
-  let inverted = Test_helpers.inverted_pairs ~tailwind ~tw classes in
-  Alcotest.(check bool)
-    "named mask type and its arbitrary property agree" false
-    (List.mem ("mask-type-luminance", "[mask-type:luminance]") inverted)
+  Test_helpers.check_class_order ~test_name:"arbitrary mask-type order"
+    [
+      "mask-auto";
+      "mask-type-luminance";
+      "[mask-type:luminance]";
+      "mask-type-alpha";
+    ]
 
 let test_known_inversions_are_exact () =
   let measured = measured_inversions () in

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1599,7 +1599,7 @@ let pool_entries () =
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
    than a count of statements, which tolerates any 299 of them. *)
-let known_inversions = []
+let known_inversions = [ ("masks", "arbitrary") ]
 
 (* Which handler each class in a case belongs to, and which variant it wears.
    The variant matters because two classes wearing different ones are not


### PR DESCRIPTION
Arbitrary mask-type declarations belong in the same property slot as the named utilities. Remove the special-case offset and pin the exact candidate order.

The whole-sheet utility move count drops from 64 to 63.