### PR TITLE
sort: compare padding candidates naturally

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -676,10 +676,10 @@ let natural_compare s1 s2 =
   in
   compare_at 0 0
 
-(* Tailwind orders the values of sizing and flex-basis candidates by the raw
-   candidate spelling. This naturally interleaves digit-led theme names with
-   numeric values (2, 2xl, 10), and puts the [(--var)] shorthand before both.
-   The handler suborders still separate the property families themselves. *)
+(* Tailwind orders the values of dynamic candidates by the raw candidate
+   spelling. This naturally interleaves digit-led theme names with numeric
+   values (2, 2xl, 10), and puts the [(--var)] shorthand before both. The
+   handler suborders still separate the property families themselves. *)
 let candidate_value_family base_class =
   let _, base = Modifiers.of_string base_class in
   List.find_opt
@@ -687,6 +687,17 @@ let candidate_value_family base_class =
       let n = String.length prefix in
       String.length base > n && String.starts_with ~prefix:(prefix ^ "-") base)
     [
+      "pbs";
+      "pbe";
+      "px";
+      "py";
+      "ps";
+      "pe";
+      "pt";
+      "pr";
+      "pb";
+      "pl";
+      "p";
       "min-inline";
       "max-inline";
       "min-block";

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 63, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 61, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_padding.ml
+++ b/test/test_padding.ml
@@ -52,6 +52,10 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"padding suborder matches Tailwind" shuffled
 
+let candidate_order () =
+  Test_helpers.check_class_order ~test_name:"padding candidate order"
+    [ "py-2"; "py-1.25"; "py-1.5"; "py-1" ]
+
 (** Test that CSS values use the correct spacing multiplier. p-64 should
     generate calc(var(--spacing)*64), not calc(var(--spacing)*16) *)
 let test_css_values () =
@@ -134,6 +138,7 @@ let tests =
     test_case "padding of_string - invalid values" `Quick of_string_invalid;
     test_case "padding suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
+    test_case "padding candidate order" `Quick candidate_order;
     test_case "padding CSS values" `Quick test_css_values;
     test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
     test_case "typed constructors: half-step" `Quick typed_prime;


### PR DESCRIPTION
Tailwind orders values within a dynamic padding candidate by the raw, natural candidate spelling. Reuse the existing candidate comparator for every padding axis and pin the multi-part decimal boundary.

The whole-sheet utility move count drops from 63 to 61.