### PR TITLE
sort: lead text-overflow with the legacy alias

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2383,14 +2383,14 @@ module Typography_late = struct
     (* Antialiased *)
     | Antialiased -> 80000
     | Subpixel_antialiased -> 80001
-    (* Text overflow (priority 17 for Truncate) - alphabetical: text-clip,
-       text-ellipsis, truncate. Truncate sorts before overflow (priority 18) via
-       a suborder above alignment/gap's range. Tailwind ranks [text-overflow] at
-       293, between the word-wrapping families (291/292) below and hyphens (294)
+    (* The legacy overflow-ellipsis alias leads the canonical text-overflow
+       candidates. Truncate sorts before overflow (priority 18) via a suborder
+       above alignment/gap's range. Tailwind ranks [text-overflow] at 293,
+       between the word-wrapping families (291/292) below and hyphens (294)
        above - it already lands there without adjustment. *)
+    | Overflow_ellipsis -> 8319
     | Text_clip -> 8320
     | Text_ellipsis -> 8321
-    | Overflow_ellipsis -> 8321
     | Truncate -> 9_000_000 (* priority 17, after alignment/gap (max ~2100) *)
     (* Text wrap - Tailwind ranks [text-wrap] at 290, right after letter-spacing
        (289, Tracking's suborder tops out at 8306) and before overflow-wrap

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 61, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 60, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -174,6 +174,10 @@ let test_text_overflow_wrap () =
   check "text-balance";
   check "text-pretty"
 
+let test_text_overflow_order () =
+  Test_helpers.check_class_order ~test_name:"text-overflow order"
+    [ "text-ellipsis"; "overflow-ellipsis"; "text-clip" ]
+
 let test_word_overflow_wrap () =
   check "break-normal";
   check "break-words";
@@ -1215,6 +1219,7 @@ let tests =
     test_case "line-clamp-none theme override" `Quick
       test_line_clamp_none_theme_override;
     test_case "text overflow/wrap" `Quick test_text_overflow_wrap;
+    test_case "text overflow order" `Slow test_text_overflow_order;
     test_case "word/overflow wrap" `Quick test_word_overflow_wrap;
     test_case "hyphens" `Quick test_hyphens;
     test_case "list style" `Quick test_list_style;


### PR DESCRIPTION
Tailwind places the legacy overflow-ellipsis alias before text-clip and text-ellipsis. Give that alias the leading slot and pin the three-class boundary.

The whole-sheet utility move count drops from 61 to 60.