### PR TITLE
sort: keep antialiasing ahead of placeholders

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2380,9 +2380,10 @@ module Typography_late = struct
     | Underline_offset_arbitrary _ -> 69989
     | Underline_offset_var _ -> 69990
     | Underline_offset_auto -> 69999
-    (* Antialiased *)
+    (* Both simple smoothing rules lead the placeholder pseudo-element band;
+       their class names keep antialiased first inside the shared slot. *)
     | Antialiased -> 80000
-    | Subpixel_antialiased -> 80001
+    | Subpixel_antialiased -> 80000
     (* The legacy overflow-ellipsis alias leads the canonical text-overflow
        candidates. Truncate sorts before overflow (priority 18) via a suborder
        above alignment/gap's range. Tailwind ranks [text-overflow] at 293,

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 60, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 59, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -178,6 +178,15 @@ let test_text_overflow_order () =
   Test_helpers.check_class_order ~test_name:"text-overflow order"
     [ "text-ellipsis"; "overflow-ellipsis"; "text-clip" ]
 
+let test_antialiasing_order () =
+  Test_helpers.check_class_order ~test_name:"antialiasing order"
+    [
+      "caret-red-500";
+      "placeholder-gray-400";
+      "subpixel-antialiased";
+      "antialiased";
+    ]
+
 let test_word_overflow_wrap () =
   check "break-normal";
   check "break-words";
@@ -1220,6 +1229,7 @@ let tests =
       test_line_clamp_none_theme_override;
     test_case "text overflow/wrap" `Quick test_text_overflow_wrap;
     test_case "text overflow order" `Slow test_text_overflow_order;
+    test_case "antialiasing order" `Slow test_antialiasing_order;
     test_case "word/overflow wrap" `Quick test_word_overflow_wrap;
     test_case "hyphens" `Quick test_hyphens;
     test_case "list style" `Quick test_list_style;


### PR DESCRIPTION
Tailwind keeps both font-smoothing utilities before the placeholder pseudo-element colour band. Give them the same suborder so the existing simple/pseudo and natural tiebreaks preserve that boundary.

The whole-sheet utility move count drops from 60 to 59.