### PR TITLE
sort: keep ring widths in numeric order

### DIFF
--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -3218,9 +3218,9 @@ module Handler = struct
     | Ring_none -> 31001
     | Ring_xs -> 31002
     | Ring_sm -> 31003
-    | Ring_lg -> 31004
-    | Ring_xl -> 31005
-    | Ring_width _ -> 31005
+    | Ring_width n -> 31001 + n
+    | Ring_lg -> 31005
+    | Ring_xl -> 31009
     | Ring_bracket_length _ -> 31010
     | Ring_color _ | Ring_color_opacity _ | Ring_keyword_opacity _
     | Ring_transparent | Ring_current | Ring_current_opacity _ | Ring_inherit

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 59, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 58, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -49,6 +49,10 @@ let test_ring_of_string_valid () =
   check "inset-ring-black";
   check "inset-ring-white/10"
 
+let test_ring_width_order () =
+  Test_helpers.check_class_order ~test_name:"ring width order"
+    [ "ring-8"; "ring-4"; "ring-3"; "ring-2"; "ring-1"; "ring-0"; "ring" ]
+
 (* ring-black / ring-white (shadeless theme colours) parse with an optional
    /opacity; a shaded colour without a shade (ring-red) stays rejected. *)
 let test_ring_shadeless_color () =
@@ -591,6 +595,7 @@ let tests =
     test_case "effects of_string - valid values" `Quick of_string_valid;
     test_case "effects of_string - invalid values" `Quick of_string_invalid;
     test_case "ring of_string - valid values" `Quick test_ring_of_string_valid;
+    test_case "ring width order" `Slow test_ring_width_order;
     test_case "ring-inset @property family" `Quick
       test_ring_inset_property_rules;
     test_case "ring shadeless color opacity" `Quick test_ring_shadeless_color;


### PR DESCRIPTION
Tailwind interleaves non-built-in integer ring widths with the fixed scale. Map every width to its numeric position instead of placing arbitrary integers in the ring-8 slot, and pin the open band.

The whole-sheet utility move count drops from 59 to 58.