### PR TITLE
sort: place outline inherit after indigo

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -3191,8 +3191,8 @@ module Handler = struct
     | Outline_current ->
         3000 + (4 * 1000) (* c -> between cyan(4) and emerald(5) *)
     | Outline_current_opacity _ -> 3000 + (4 * 1000)
-    | Outline_inherit -> 3000 + (9 * 1000)
-    (* i -> between indigo(9) and lime(10) *)
+    | Outline_inherit -> 3000 + (9 * 1000) + 999
+    (* i -> after every indigo shade and before lime(10) *)
     | Outline_transparent -> 3000 + (22 * 1000)
     (* t -> between teal and violet *)
     | Outline_bracket_color _ -> 3000

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 58, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 57, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -273,6 +273,15 @@ let test_border_side_bracket_color_order () =
       "border-l-[#f00]";
     ]
 
+let test_outline_inherit_order () =
+  Test_helpers.check_class_order ~test_name:"outline inherit order"
+    [
+      "outline-lime-100";
+      "outline-inherit";
+      "outline-indigo-600";
+      "outline-indigo-500";
+    ]
+
 (* A CSS variable in a border color bracket, and its v4 paren shorthand, resolve
    to var(): border-[var(--x)] and border-(--x) both set border-color. *)
 let test_border_color_var () =
@@ -1018,6 +1027,7 @@ let tests =
     ( "Per-side border bracket color order",
       `Slow,
       test_border_side_bracket_color_order );
+    ("Outline inherit order", `Slow, test_outline_inherit_order);
     ("Bracket CSS colors", `Quick, test_bracket_css_colors);
     ("Bracket colour opacity", `Quick, test_bracket_colour_opacity);
     ("hsl hue units", `Quick, test_hsl_hue_units);


### PR DESCRIPTION
Tailwind places outline-inherit after all indigo shades and before lime. Move the keyword from the start of the indigo bucket into that open gap and pin both boundaries.

The whole-sheet utility move count drops from 58 to 57.