### PR TITLE
Group drop-shadow size candidates

### DIFF
--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1291,16 +1291,13 @@ module Handler = struct
     | Drop_shadow_opacity _ -> 2690
     | Drop_shadow_size_opacity _ -> 2692
     | Drop_shadow -> 2700
-    | Drop_shadow_arbitrary _ -> 2701
-    | Drop_shadow_multi -> 2702
-    (* The named sizes share one slot: Tailwind orders them by class name, and
-       the alphabetical tie-break puts xl before xs where a per-size number had
-       them the other way round. *)
-    | Drop_shadow_2xl | Drop_shadow_lg | Drop_shadow_md | Drop_shadow_sm
+    (* All size candidates share one slot: Tailwind orders them by class name,
+       including arbitrary and project-defined values. *)
+    | Drop_shadow_2xl | Drop_shadow_arbitrary _ | Drop_shadow_lg
+    | Drop_shadow_md | Drop_shadow_multi | Drop_shadow_named _ | Drop_shadow_sm
     | Drop_shadow_xs | Drop_shadow_xl ->
         2703
     | Drop_shadow_none -> 2708
-    | Drop_shadow_named _ -> 2701
     (* Every drop-shadow colour shares one slot, after the sizes: Tailwind
        orders them among themselves by class name, which the alphabetical
        tie-break already does. *)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 57, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 56, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -121,6 +121,15 @@ let drop_shadow_slot_order () =
     (List.sort Int.compare positions)
     positions
 
+let drop_shadow_candidate_order () =
+  Test_helpers.check_class_order ~test_name:"drop-shadow candidate order"
+    [
+      "drop-shadow-lg";
+      "drop-shadow-[0_3px_1px_rgba(0,0,0,.15)]";
+      "drop-shadow-2xl";
+      "drop-shadow";
+    ]
+
 let suborder_matches_tailwind () =
   let open Tw in
   let shuffled =
@@ -429,6 +438,7 @@ let tests =
       suborder_matches_tailwind;
     test_case "filter candidate order" `Slow candidate_order_matches_tailwind;
     test_case "drop-shadow slot order" `Quick drop_shadow_slot_order;
+    test_case "drop-shadow candidate order" `Slow drop_shadow_candidate_order;
     test_case "project blur token" `Quick test_project_blur_token;
   ]
 


### PR DESCRIPTION
Arbitrary and project-defined drop-shadow sizes now share the built-in size candidate slot. This lets the existing raw candidate tie-break match Tailwind order and lowers the whole-sheet ceiling from 57 to 56.