### PR TITLE
Keep variant antialiasing before placeholders

### DIFF
--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2380,10 +2380,11 @@ module Typography_late = struct
     | Underline_offset_arbitrary _ -> 69989
     | Underline_offset_var _ -> 69990
     | Underline_offset_auto -> 69999
-    (* Both simple smoothing rules lead the placeholder pseudo-element band;
-       their class names keep antialiased first inside the shared slot. *)
-    | Antialiased -> 80000
-    | Subpixel_antialiased -> 80000
+    (* Both simple smoothing rules lead the placeholder pseudo-element band.
+       Keep them in their own slot: variant rules use their selector to settle
+       ties, while base rules retain handler order. *)
+    | Antialiased -> 79999
+    | Subpixel_antialiased -> 79999
     (* The legacy overflow-ellipsis alias leads the canonical text-overflow
        candidates. Truncate sorts before overflow (priority 18) via a suborder
        above alignment/gap's range. Tailwind ranks [text-overflow] at 293,

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -187,6 +187,14 @@ let test_antialiasing_order () =
       "antialiased";
     ]
 
+let test_variant_antialiasing_order () =
+  Test_helpers.check_class_order ~test_name:"variant antialiasing order"
+    [
+      "hover:placeholder-gray-400";
+      "hover:subpixel-antialiased";
+      "hover:antialiased";
+    ]
+
 let test_word_overflow_wrap () =
   check "break-normal";
   check "break-words";
@@ -1230,6 +1238,7 @@ let tests =
     test_case "text overflow/wrap" `Quick test_text_overflow_wrap;
     test_case "text overflow order" `Slow test_text_overflow_order;
     test_case "antialiasing order" `Slow test_antialiasing_order;
+    test_case "variant antialiasing order" `Slow test_variant_antialiasing_order;
     test_case "word/overflow wrap" `Quick test_word_overflow_wrap;
     test_case "hyphens" `Quick test_hyphens;
     test_case "list style" `Quick test_list_style;


### PR DESCRIPTION
Antialiasing utilities now use a distinct slot immediately before placeholder colours. This preserves the existing base order and prevents variant selector tie-breaking from moving `subpixel-antialiased` after placeholders.

The whole-sheet corpus has no variant-wrapped antialiasing candidate, so its ceiling remains 56.