### PR TITLE
Keep routed custom-variant candidates together

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -420,6 +420,40 @@ let add_index ?(declared = fun _ -> false) triples =
         : Sort.indexed_rule))
     triples
 
+(* The entrypoint expands one routed candidate into finished CSS before it hands
+   the result to the regular build. That candidate can contain several top-level
+   rules -- for example a selector branch, its [@supports] companion and a media
+   branch. Tailwind keeps those rules together. Preserve their source order as
+   one sortable block instead of letting the rule comparator interleave a later
+   candidate between the branches. *)
+let sort_indexed_blocks indexed =
+  let groups = Hashtbl.create 8 in
+  List.iter
+    (fun (r : Sort.indexed_rule) ->
+      match (r.declared, r.base_class) with
+      | true, Some cls ->
+          let previous =
+            Option.value ~default:[] (Hashtbl.find_opt groups cls)
+          in
+          Hashtbl.replace groups cls (r :: previous)
+      | _ -> ())
+    indexed;
+  let emitted = Hashtbl.create 8 in
+  let blocks =
+    List.filter_map
+      (fun (r : Sort.indexed_rule) ->
+        match (r.declared, r.base_class) with
+        | true, Some cls when Hashtbl.mem emitted cls -> None
+        | true, Some cls ->
+            Hashtbl.add emitted cls ();
+            Some (r, List.rev (Hashtbl.find groups cls))
+        | _ -> Some (r, [ r ]))
+      indexed
+  in
+  blocks
+  |> List.sort (fun (r1, _) (r2, _) -> Sort.compare_indexed_rules r1 r2)
+  |> List.concat_map snd
+
 (* Convert selector/props pairs to CSS rules. *)
 (* Internal: build rule sets from pre-extracted outputs. *)
 let rule_sets_from_selector_props order_map all_rules =
@@ -431,7 +465,7 @@ let rule_sets_from_selector_props order_map all_rules =
     |> List.filter_map (rule_to_triple order_map)
     |> deduplicate_typed_triples |> add_index
   in
-  let sorted = List.sort Sort.compare_indexed_rules indexed in
+  let sorted = sort_indexed_blocks indexed in
   if Sort.debug_compare_enabled () then
     List.iter
       (fun (r : Sort.indexed_rule) ->
@@ -474,8 +508,7 @@ let statements_of_sorted_rules ?verbatim sorted_rules =
 let sorted_indexed_rules ?declared order_map all_rules =
   all_rules
   |> List.filter_map (rule_to_triple order_map)
-  |> deduplicate_typed_triples |> add_index ?declared
-  |> List.sort Sort.compare_indexed_rules
+  |> deduplicate_typed_triples |> add_index ?declared |> sort_indexed_blocks
 
 (* Sort var names by property_order. Names include -- prefix. *)
 let sort_vars_by_property_order vars =

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2268,6 +2268,24 @@ let test_rounded_position_order () =
   check_before ".rounded-r-full" ".rounded-b-full";
   check_before ".rounded-b-full" ".rounded-bl-full"
 
+let substring_occurrences ~needle haystack =
+  let n = String.length needle and h = String.length haystack in
+  let rec go i acc =
+    if i + n > h then List.rev acc
+    else if String.sub haystack i n = needle then go (i + 1) (i :: acc)
+    else go (i + 1) acc
+  in
+  go 0 []
+
+let emitted_classes css classes =
+  classes
+  |> List.concat_map (fun cls ->
+      let selector = Css.Selector.to_string (Css.Selector.class_ cls) in
+      substring_occurrences ~needle:selector css
+      |> List.map (fun position -> (position, cls)))
+  |> List.sort (fun (a, _) (b, _) -> Int.compare a b)
+  |> List.map snd
+
 let test_color_mix_supports_companion_order () =
   (* A colour with an opacity modifier emits a hex fallback plus an @supports
      block carrying the color-mix version, and the fallback has to come first or
@@ -2285,34 +2303,12 @@ let test_color_mix_supports_companion_order () =
   in
   let utilities = List.map (fun c -> Result.get_ok (Tw.of_string c)) classes in
   let css = Css.to_string ~minify:true (Tw.to_css ~base:false utilities) in
-  let occurrences needle =
-    let n = String.length needle and h = String.length css in
-    let rec go i acc =
-      if i + n > h then List.rev acc
-      else if String.sub css i n = needle then go (i + 1) (i :: acc)
-      else go (i + 1) acc
-    in
-    go 0 []
-  in
-  let escape c =
-    String.concat ""
-      (List.map
-         (fun ch ->
-           match ch with
-           | ':' | '/' -> "\\" ^ String.make 1 ch
-           | ch -> String.make 1 ch)
-         (List.init (String.length c) (String.get c)))
-  in
   (* Every occurrence of every selector, in emitted order. Each utility writes
      exactly two -- the fallback and its @supports companion -- so the sequence
      has to read as adjacent identical pairs. *)
   let emitted =
-    classes
-    |> List.concat_map (fun c ->
-        occurrences ("." ^ escape c ^ "[data-checked]")
-        |> List.map (fun pos -> (pos, c)))
-    |> List.sort (fun (a, _) (b, _) -> Int.compare a b)
-    |> List.map snd
+    emitted_classes css classes
+    |> List.filter (fun cls -> String.starts_with ~prefix:"data-checked:" cls)
   in
   let rec paired = function
     | [] -> true
@@ -2322,6 +2318,40 @@ let test_color_mix_supports_companion_order () =
   Alcotest.check Alcotest.bool
     "each fallback is immediately followed by its own @supports companion" true
     (List.length emitted = 2 * List.length classes && paired emitted)
+
+(* A custom variant may put the same utility into a selector branch and a media
+   branch. Tailwind keeps all branches of one candidate together, including a
+   colour's progressive-enhancement [@supports] rules, before starting the next
+   candidate. Sorting the nested media branch on its wrapper instead split one
+   candidate around the following colour. *)
+let test_custom_variant_supports_companion_order () =
+  let defs =
+    [
+      ( "dark",
+        "&:where(.dark,.dark \
+         *){@slot;}@media(prefers-color-scheme:dark){&:where(.system,.system \
+         *){@slot;}}" );
+    ]
+  in
+  let classes = [ "dark:border-black/10"; "dark:border-fuchsia-500" ] in
+  let _, extra, _ =
+    Tw_tools.Entrypoint.custom_routed_utilities ~theme:Tw.Scheme.default ~defs
+      ~udefs:[] classes
+  in
+  let css =
+    Tw.Build.to_css ~extra [] |> Css.to_string ~minify:true ~lossless:true
+  in
+  Alcotest.(check (list string))
+    "every branch stays with its candidate"
+    [
+      "dark:border-black/10";
+      "dark:border-black/10";
+      "dark:border-black/10";
+      "dark:border-black/10";
+      "dark:border-fuchsia-500";
+      "dark:border-fuchsia-500";
+    ]
+    (emitted_classes css classes)
 
 let test_margin_value_order () =
   (* Margin values sort by raw suffix: numeric, then arbitrary ('['), then
@@ -2886,6 +2916,8 @@ let tests =
     test_case "rounded position order" `Slow test_rounded_position_order;
     test_case "color-mix @supports companion order" `Slow
       test_color_mix_supports_companion_order;
+    test_case "custom variant branches stay with their candidate" `Quick
+      test_custom_variant_supports_companion_order;
     test_case "margin value order" `Slow test_margin_value_order;
     test_case "prose margin order" `Slow test_prose_margin_order;
     test_case "variant same-suborder tiebreak" `Slow


### PR DESCRIPTION
Custom variants can expand one candidate into selector, supports, and media branches. Preserve those branches as a single sortable block so a later candidate cannot split them.