### PR TITLE
Interleave repeated element variants by utility order

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -941,12 +941,28 @@ let compare_nested_media r1 r2 =
       | _ -> 0)
   | _ -> 0
 
+(* Repeating an element variant changes the selector depth, but Tailwind still
+   sorts the candidate in the one element-variant slot. Keep the selector's
+   tokens intact and collapse only adjacent repetitions in the sort key. *)
+let collapse_repeated_element_variants modifiers =
+  let rec loop previous acc = function
+    | modifier :: rest
+      when (String.equal modifier "*" || String.equal modifier "**")
+           && Option.equal String.equal previous (Some modifier) ->
+        loop previous acc rest
+    | modifier :: rest -> loop (Some modifier) (modifier :: acc) rest
+    | [] -> List.rev acc
+  in
+  loop None [] modifiers
+
 (* Extract the modifier prefix from a base_class, e.g. "hover:p-4" -> "hover".
    Split with the modifier parser, not on the last ':': an arbitrary value can
    hold one, and [hover:bg-[color:var(--x)]] split naively yields the prefix
    [hover:bg-[color]. *)
 let variant_prefix = function
-  | Some s -> String.concat ":" (fst (Modifiers.of_string s))
+  | Some s ->
+      fst (Modifiers.of_string s)
+      |> collapse_repeated_element_variants |> String.concat ":"
   | None -> ""
 
 (* Compute variant order for a modifier prefix, stripping group-/peer-
@@ -1105,6 +1121,7 @@ let variant_order_list base_class variant_order breakpoint =
     | None -> []
     | Some bc ->
         let modifiers, _ = Modifiers.of_string bc in
+        let modifiers = collapse_repeated_element_variants modifiers in
         List.filter_map
           (fun m ->
             let key = token_order_key ~breakpoint m in

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 56, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 49, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2419,6 +2419,14 @@ let test_variant_arbitrary_numeric_order () =
   Test_helpers.check_ordering_matches
     ~test_name:"variant arbitrary values sort numerically" utilities
 
+let test_repeated_child_variant_utility_order () =
+  (* Repeating the direct-child variant changes which descendants match, but not
+     the variant slot. Tailwind still interleaves [*:*:] candidates with [*:],
+     according to the utility order inside the child-variant group. *)
+  let classes = [ "*:mb-4"; "*:*:max-w-full"; "*:rotate-180" ] in
+  Test_helpers.check_class_order
+    ~test_name:"repeated child variant follows utility order" classes
+
 let test_compound_variant_highest_component () =
   (* A stacked variant sorts into the group of its highest-order component,
      after that group's base rules, matching Tailwind. dark:md:block (dark > md)
@@ -2924,6 +2932,8 @@ let tests =
       test_variant_same_suborder_tiebreak;
     test_case "variant arbitrary values sort numerically" `Slow
       test_variant_arbitrary_numeric_order;
+    test_case "repeated child variant follows utility order" `Slow
+      test_repeated_child_variant_utility_order;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
Repeated child or descendant variants change selector depth without creating another cascade slot. Collapse adjacent repeated element tokens in the sort key so their candidates stay in the single element-variant group.\n\nWhole-sheet utility moves: 56 to 49.