### PR TITLE
Order named group and peer variants by state

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2576,9 +2576,15 @@ let slot_of_media_cond (cond : Css.Media.t) : Slot.t option =
    off the same table as the slot itself. *)
 let variant_inner_order token =
   let after n = String.sub token n (String.length token - n) in
+  let anchor_inner n =
+    let inner = after n in
+    (* A slash inside an arbitrary selector belongs to the selector. Named
+       simple states have no brackets, so their suffix can be removed here. *)
+    if String.contains inner '[' then inner else fst (split_name inner)
+  in
   let inner =
-    if String.starts_with ~prefix:"group-" token then Some (after 6)
-    else if String.starts_with ~prefix:"peer-" token then Some (after 5)
+    if String.starts_with ~prefix:"group-" token then Some (anchor_inner 6)
+    else if String.starts_with ~prefix:"peer-" token then Some (anchor_inner 5)
     else if String.starts_with ~prefix:"not-" token then Some (after 4)
     else
       (* [in-focus] names a state on an ancestor; [in-range] names one on the

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 49, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 44, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2427,6 +2427,18 @@ let test_repeated_child_variant_utility_order () =
   Test_helpers.check_class_order
     ~test_name:"repeated child variant follows utility order" classes
 
+let test_named_anchor_inner_order () =
+  (* Naming a group or peer changes the marker class, not the state the variant
+     wraps. The name must not make focus or checked fall into the zero/unknown
+     inner slot ahead of their unnamed forms. *)
+  Test_helpers.check_class_order ~test_name:"named anchor keeps inner state"
+    [
+      "group-open:hidden";
+      "group-focus/option:text-white";
+      "peer-checked:visible";
+      "peer-checked/draft:block";
+    ]
+
 let test_compound_variant_highest_component () =
   (* A stacked variant sorts into the group of its highest-order component,
      after that group's base rules, matching Tailwind. dark:md:block (dark > md)
@@ -2934,6 +2946,8 @@ let tests =
       test_variant_arbitrary_numeric_order;
     test_case "repeated child variant follows utility order" `Slow
       test_repeated_child_variant_utility_order;
+    test_case "named anchor keeps inner state" `Slow
+      test_named_anchor_inner_order;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
A group or peer marker name does not change the state its variant wraps. Strip the marker name before deriving the inner variant order so named focus and checked variants stay with their unnamed state.\n\nWhole-sheet utility moves: 49 to 44.