### PR TITLE
Group compound variants by data predicate

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -31,11 +31,13 @@ type selector_kind =
    what separates two tokens that share it. A breakpoint token carries the width
    it names, so [sm] and [md] no longer collapse onto one key; a group-/ peer-
    token carries the state it wraps, so [group-focus] and [group-has] keep their
-   order. *)
+   order; a data token carries its predicate, so compounds stay with the named
+   or arbitrary data group they belong to. *)
 type variant_component = {
   slot : int;
   breakpoint : Css.Media.key option;
   wrapped : int;
+  data_key : string option;
 }
 
 (** Relationship between two rules being compared *)
@@ -1102,20 +1104,29 @@ let compare_variant_components a b =
       | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
       | Some _, None | None, Some _ | None, None -> 0
     in
-    if bp_cmp <> 0 then bp_cmp else Int.compare a.wrapped b.wrapped
+    if bp_cmp <> 0 then bp_cmp
+    else
+      let wrapped_cmp = Int.compare a.wrapped b.wrapped in
+      if wrapped_cmp <> 0 then wrapped_cmp
+      else Option.compare String.compare a.data_key b.data_key
 
 (* One modifier token's sort key. The slot alone leaves every breakpoint on one
    key and every group-/peer- spelling on another, so the component carries what
    separates two tokens inside a slot: the width for a breakpoint, read off the
    media query the rule renders as, and the wrapped state for group-/peer-, so
-   group-focus and group-has keep their focus-before-has order. *)
+   group-focus and group-has keep their focus-before-has order, and the
+   predicate spelling for data variants, so a lower-order compound component
+   does not push [data-focus:has-checked] past every other data predicate. *)
 let token_order_key ~breakpoint token =
   let slot = Modifiers.variant_order_of_prefix token in
   let wrapped = Modifiers.variant_inner_order token in
   let breakpoint =
     if slot = responsive_variant_order then breakpoint else None
   in
-  { slot; breakpoint; wrapped }
+  let data_key =
+    if String.starts_with ~prefix:"data-" token then Some token else None
+  in
+  { slot; breakpoint; wrapped; data_key }
 
 (* The variant order keys of a class's modifier stack, sorted descending.
    Tailwind sorts a candidate by this list compared lexicographically ascending,
@@ -1140,7 +1151,14 @@ let variant_order_list base_class variant_order breakpoint =
   in
   match from_bc with
   | [] when variant_order > 0 ->
-      [ { slot = variant_order; breakpoint = None; wrapped = 0 } ]
+      [
+        {
+          slot = variant_order;
+          breakpoint = None;
+          wrapped = 0;
+          data_key = None;
+        };
+      ]
   | l -> l
 
 (* Compare two descending variant-order-key lists lexicographically, ascending

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -31,6 +31,9 @@ type variant_component = {
   wrapped : int;
       (** The state a [group-]/[peer-] token wraps, so [group-focus] and
           [group-has] keep their order. [0] for every other token. *)
+  data_key : string option;
+      (** The data predicate spelling, so a compound stays with its named or
+          arbitrary data group. [None] for every other token. *)
 }
 (** One component of a rule's variant sort key: the slot a modifier token sorts
     in, plus what separates two tokens that share that slot. *)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 38, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 28, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2454,6 +2454,30 @@ let test_stacked_data_variant_slot () =
       "data-[focus]:border-sky-500";
     ]
 
+let test_compound_data_variant_group () =
+  (* A compound whose highest slot is data stays beside the data predicate it
+     names. The lower descendant, has, aria, or child slots order candidates
+     inside that predicate instead of pushing every compound after all data
+     variants. *)
+  Test_helpers.check_class_order ~test_name:"compound named data variant group"
+    [
+      "**:data-avatar:size-12";
+      "data-focus:ring-2";
+      "data-focus:has-checked:ring-2";
+      "aria-[current]:**:data-highlight:fill-gray-300";
+      "data-hover:bg-indigo-500";
+      "data-leave:duration-75";
+      "**:data-outline:stroke-gray-400";
+      "aria-[current]:**:data-outline:stroke-gray-950";
+    ];
+  Test_helpers.check_class_order
+    ~test_name:"compound arbitrary data variant group"
+    [
+      "data-[size=large]:p-8";
+      "data-[slot=description]:*:mt-4";
+      "data-[state=open]:overflow-hidden";
+    ]
+
 let test_compound_variant_highest_component () =
   (* A stacked variant sorts into the group of its highest-order component,
      after that group's base rules, matching Tailwind. dark:md:block (dark > md)
@@ -2964,6 +2988,8 @@ let tests =
     test_case "named anchor keeps inner state" `Slow
       test_named_anchor_inner_order;
     test_case "stacked data variant slot" `Slow test_stacked_data_variant_slot;
+    test_case "compound data variant group" `Slow
+      test_compound_data_variant_group;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
A compound whose highest slot is a data variant belongs beside that named or arbitrary data predicate. Carry the predicate on the variant component so lower descendant, has, aria, and child slots order within the group instead of pushing every compound after all data variants.\n\nWhole-sheet utility moves: 38 to 28.