### PR TITLE
Order arbitrary variants by decoded selector

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -31,13 +31,13 @@ type selector_kind =
    what separates two tokens that share it. A breakpoint token carries the width
    it names, so [sm] and [md] no longer collapse onto one key; a group-/ peer-
    token carries the state it wraps, so [group-focus] and [group-has] keep their
-   order; a data token carries its predicate, so compounds stay with the named
-   or arbitrary data group they belong to. *)
+   order; data and arbitrary tokens carry the value that distinguishes groups
+   inside their slot. *)
 type variant_component = {
   slot : int;
   breakpoint : Css.Media.key option;
   wrapped : int;
-  data_key : string option;
+  value_key : string option;
 }
 
 (** Relationship between two rules being compared *)
@@ -1108,7 +1108,26 @@ let compare_variant_components a b =
     else
       let wrapped_cmp = Int.compare a.wrapped b.wrapped in
       if wrapped_cmp <> 0 then wrapped_cmp
-      else Option.compare String.compare a.data_key b.data_key
+      else Option.compare String.compare a.value_key b.value_key
+
+(* Tailwind compares arbitrary variants by the selector they denote, after
+   decoding bracket-space underscores. A bare compound is implicitly anchored on
+   the candidate, while a selector with [&], a relative selector, or an at-rule
+   already carries its own context. *)
+let arbitrary_variant_selector_key token =
+  if not (Parse.is_bracket_value token) then None
+  else
+    let selector =
+      token |> Parse.bracket_inner |> Parse.decode_underscores |> String.trim
+    in
+    if selector = "" then None
+    else
+      let first = selector.[0] in
+      if
+        first <> '>' && first <> '+' && first <> '~' && first <> '@'
+        && not (String.contains selector '&')
+      then Some ("&:is(" ^ selector ^ ")")
+      else Some selector
 
 (* One modifier token's sort key. The slot alone leaves every breakpoint on one
    key and every group-/peer- spelling on another, so the component carries what
@@ -1123,10 +1142,13 @@ let token_order_key ~breakpoint token =
   let breakpoint =
     if slot = responsive_variant_order then breakpoint else None
   in
-  let data_key =
-    if String.starts_with ~prefix:"data-" token then Some token else None
+  let value_key =
+    match arbitrary_variant_selector_key token with
+    | Some _ as key -> key
+    | None when String.starts_with ~prefix:"data-" token -> Some token
+    | None -> None
   in
-  { slot; breakpoint; wrapped; data_key }
+  { slot; breakpoint; wrapped; value_key }
 
 (* The variant order keys of a class's modifier stack, sorted descending.
    Tailwind sorts a candidate by this list compared lexicographically ascending,
@@ -1156,7 +1178,7 @@ let variant_order_list base_class variant_order breakpoint =
           slot = variant_order;
           breakpoint = None;
           wrapped = 0;
-          data_key = None;
+          value_key = None;
         };
       ]
   | l -> l

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -31,9 +31,10 @@ type variant_component = {
   wrapped : int;
       (** The state a [group-]/[peer-] token wraps, so [group-focus] and
           [group-has] keep their order. [0] for every other token. *)
-  data_key : string option;
-      (** The data predicate spelling, so a compound stays with its named or
-          arbitrary data group. [None] for every other token. *)
+  value_key : string option;
+      (** A data predicate spelling or the decoded selector denoted by an
+          arbitrary variant, including its implicit [&:is(...)] anchor. [None]
+          for slots whose variants compare only by rank. *)
 }
 (** One component of a rule's variant sort key: the slot a modifier token sorts
     in, plus what separates two tokens that share that slot. *)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 28, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 12, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2478,6 +2478,27 @@ let test_compound_data_variant_group () =
       "data-[state=open]:overflow-hidden";
     ]
 
+let test_arbitrary_variant_selector_order () =
+  (* Tailwind orders arbitrary variants by the selector they denote: underscores
+     decode to spaces and a bare selector is anchored as [&:is(...)]. Compound
+     lower slots then order inside that selector's group. *)
+  Test_helpers.check_class_order ~test_name:"arbitrary variant selector order"
+    [
+      "[&_p]:mt-4";
+      "[&.is-dragging]:active:cursor-grabbing";
+      "**:[.line]:not-last:min-h-lh";
+      "[&:is([open],:popover-open)]:opacity-100";
+      "**:[svg]:first:size-5";
+      "[&:nth-child(3)]:py-0";
+      "[&>*]:rounded-lg";
+      "[&>*]:bg-white";
+      "[&>*]:p-4";
+      "[&>*]:shadow";
+      "[&>[data-active]+span]:text-blue-600";
+      "[:where(&_.line)]:pl-4";
+      "[html:has(&)]:bg-blue-500";
+    ]
+
 let test_compound_variant_highest_component () =
   (* A stacked variant sorts into the group of its highest-order component,
      after that group's base rules, matching Tailwind. dark:md:block (dark > md)
@@ -2990,6 +3011,8 @@ let tests =
     test_case "stacked data variant slot" `Slow test_stacked_data_variant_slot;
     test_case "compound data variant group" `Slow
       test_compound_data_variant_group;
+    test_case "arbitrary variant selector order" `Slow
+      test_arbitrary_variant_selector_order;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
Tailwind compares arbitrary variants by the selector they denote, not the raw bracket token. Decode underscore spaces and add the implicit &:is(...) anchor for bare compounds, then carry that selector as the variant component value key.\n\nWhole-sheet utility moves: 28 to 12.