### PR TITLE
Order compound variants by recursive inner path

### DIFF
--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2571,10 +2571,11 @@ let slot_of_media_cond (cond : Css.Media.t) : Slot.t option =
       Some Slot.Inverted_colors
   | _ -> None
 
-(* What separates two tokens that share a slot: a [group-]/[peer-] token sorts
-   by the state it wraps and a [not-] token by the variant it negates, both read
-   off the same table as the slot itself. *)
-let variant_inner_order token =
+(* The variant wrapped by one compound token, if any. Keeping this extraction in
+   one place lets ordering follow group-not-has-peer-not-data-active all the way
+   to its data predicate instead of stopping at the first [not] or [has]
+   slot. *)
+let variant_inner_token token =
   let after n = String.sub token n (String.length token - n) in
   let anchor_inner n =
     let inner = after n in
@@ -2582,21 +2583,29 @@ let variant_inner_order token =
        simple states have no brackets, so their suffix can be removed here. *)
     if String.contains inner '[' then inner else fst (split_name inner)
   in
-  let inner =
-    if String.starts_with ~prefix:"group-" token then Some (anchor_inner 6)
-    else if String.starts_with ~prefix:"peer-" token then Some (anchor_inner 5)
-    else if String.starts_with ~prefix:"not-" token then Some (after 4)
-    else
-      (* [in-focus] names a state on an ancestor; [in-range] names one on the
-         element itself, and the table matches that by name. *)
-      match slot_of_prefix token with
-      | Some Slot.Ancestor -> Some (after 3)
-      | Some _ | None -> None
-  in
-  match inner with
+  if String.starts_with ~prefix:"group-" token then Some (anchor_inner 6)
+  else if String.starts_with ~prefix:"peer-" token then Some (anchor_inner 5)
+  else if String.starts_with ~prefix:"not-" token then Some (after 4)
+  else if String.starts_with ~prefix:"has-" token then Some (after 4)
+  else
+    (* [in-focus] names a state on an ancestor; [in-range] names one on the
+       element itself, and the table matches that by name. *)
+    match slot_of_prefix token with
+    | Some Slot.Ancestor -> Some (after 3)
+    | Some _ | None -> None
+
+let rec variant_inner_order_path token =
+  match variant_inner_token token with
+  | None -> []
   | Some inner -> (
-      match slot_of_prefix inner with Some slot -> Slot.rank slot | None -> 0)
-  | None -> 0
+      match slot_of_prefix inner with
+      | Some slot -> Slot.rank slot :: variant_inner_order_path inner
+      | None -> [])
+
+(* The first wrapped slot retained for callers that only need the immediate
+   compound variant. *)
+let variant_inner_order token =
+  match variant_inner_order_path token with order :: _ -> order | [] -> 0
 
 let not_variant_order m = Slot.rank (slot_of_modifier m)
 

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -756,6 +756,11 @@ val variant_inner_order : string -> int
     on the scale {!val-variant_order_of_prefix} returns. [0] for every other
     token. *)
 
+val variant_inner_order_path : string -> int list
+(** [variant_inner_order_path token] recursively returns every wrapped variant
+    position, outermost first. For example, [group-has-focus] yields the [has]
+    and [focus] positions. *)
+
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as
     {!val-variant_order_of_prefix} for the corresponding CSS media condition.

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -36,7 +36,7 @@ type selector_kind =
 type variant_component = {
   slot : int;
   breakpoint : Css.Media.key option;
-  wrapped : int;
+  wrapped : int list;
   value_key : string option;
 }
 
@@ -1106,7 +1106,7 @@ let compare_variant_components a b =
     in
     if bp_cmp <> 0 then bp_cmp
     else
-      let wrapped_cmp = Int.compare a.wrapped b.wrapped in
+      let wrapped_cmp = List.compare Int.compare a.wrapped b.wrapped in
       if wrapped_cmp <> 0 then wrapped_cmp
       else Option.compare String.compare a.value_key b.value_key
 
@@ -1138,7 +1138,7 @@ let arbitrary_variant_selector_key token =
    does not push [data-focus:has-checked] past every other data predicate. *)
 let token_order_key ~breakpoint token =
   let slot = Modifiers.variant_order_of_prefix token in
-  let wrapped = Modifiers.variant_inner_order token in
+  let wrapped = Modifiers.variant_inner_order_path token in
   let breakpoint =
     if slot = responsive_variant_order then breakpoint else None
   in
@@ -1177,7 +1177,7 @@ let variant_order_list base_class variant_order breakpoint =
         {
           slot = variant_order;
           breakpoint = None;
-          wrapped = 0;
+          wrapped = [];
           value_key = None;
         };
       ]

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -28,9 +28,10 @@ type variant_component = {
   breakpoint : Css.Media.key option;
       (** The width a breakpoint token names, so [sm] and [md] do not collapse
           onto one key. [None] for every other token. *)
-  wrapped : int;
-      (** The state a [group-]/[peer-] token wraps, so [group-focus] and
-          [group-has] keep their order. [0] for every other token. *)
+  wrapped : int list;
+      (** The recursive path of variants a compound token wraps, so
+          [group-has-indeterminate] and [group-has-focus] keep their inner state
+          order. [[]] for a non-compound token. *)
   value_key : string option;
       (** A data predicate spelling or the decoded selector denoted by an
           arbitrary variant, including its implicit [&:is(...)] anchor. [None]

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 12, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 8, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2499,6 +2499,31 @@ let test_arbitrary_variant_selector_order () =
       "[html:has(&)]:bg-blue-500";
     ]
 
+let test_recursive_compound_variant_order () =
+  (* Compound variants compare their wrapped variant recursively. The outer
+     group/not slot alone cannot distinguish group-has-indeterminate from
+     group-has-focus, or not-group-open from not-group-has-data-lg. *)
+  Test_helpers.check_class_order
+    ~test_name:"recursive group compound variant order"
+    [
+      "group-focus:opacity-100";
+      "group-has-checked:opacity-100";
+      "group-has-indeterminate:opacity-100";
+      "group-has-focus:opacity-100";
+      "group-has-disabled:stroke-gray-950/25";
+      "group-has-[&:focus]:opacity-100";
+      "group-has-[a]:block";
+      "group-aria-selected:block";
+    ];
+  Test_helpers.check_class_order
+    ~test_name:"recursive negation compound variant order"
+    [
+      "not-group-open:hidden";
+      "not-group-has-data-lg:opacity-40";
+      "not-peer-has-checked:opacity-0";
+      "not-last:border-b";
+    ]
+
 let test_compound_variant_highest_component () =
   (* A stacked variant sorts into the group of its highest-order component,
      after that group's base rules, matching Tailwind. dark:md:block (dark > md)
@@ -3013,6 +3038,8 @@ let tests =
       test_compound_data_variant_group;
     test_case "arbitrary variant selector order" `Slow
       test_arbitrary_variant_selector_order;
+    test_case "recursive compound variant order" `Slow
+      test_recursive_compound_variant_order;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
Compound variants compare the variant they wrap recursively. Carry the full inner slot path through group, peer, not, in, and has so deeply nested states keep Tailwind's order instead of tying at the first compound slot.\n\nWhole-sheet utility moves: 12 to 8.