### PR TITLE
Order compound variants by recursive inner value

### DIFF
--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -756,6 +756,10 @@ val variant_inner_order : string -> int
     on the scale {!val-variant_order_of_prefix} returns. [0] for every other
     token. *)
 
+val variant_inner_token : string -> string option
+(** [variant_inner_token token] is the variant immediately wrapped by a
+    [group-], [peer-], [not-], [in-], or [has-] compound token. *)
+
 val variant_inner_order_path : string -> int list
 (** [variant_inner_order_path token] recursively returns every wrapped variant
     position, outermost first. For example, [group-has-focus] yields the [has]

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -1129,6 +1129,12 @@ let arbitrary_variant_selector_key token =
       then Some ("&:is(" ^ selector ^ ")")
       else Some selector
 
+let rec variant_value_key token =
+  match arbitrary_variant_selector_key token with
+  | Some _ as key -> key
+  | None when String.starts_with ~prefix:"data-" token -> Some token
+  | None -> Option.bind (Modifiers.variant_inner_token token) variant_value_key
+
 (* One modifier token's sort key. The slot alone leaves every breakpoint on one
    key and every group-/peer- spelling on another, so the component carries what
    separates two tokens inside a slot: the width for a breakpoint, read off the
@@ -1142,12 +1148,7 @@ let token_order_key ~breakpoint token =
   let breakpoint =
     if slot = responsive_variant_order then breakpoint else None
   in
-  let value_key =
-    match arbitrary_variant_selector_key token with
-    | Some _ as key -> key
-    | None when String.starts_with ~prefix:"data-" token -> Some token
-    | None -> None
-  in
+  let value_key = variant_value_key token in
   { slot; breakpoint; wrapped; value_key }
 
 (* The variant order keys of a class's modifier stack, sorted descending.

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 8, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 6, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2524,6 +2524,25 @@ let test_recursive_compound_variant_order () =
       "not-last:border-b";
     ]
 
+let test_compound_variant_inner_value_order () =
+  (* Recursive slot paths still tie for two arbitrary variants. Tailwind then
+     compares the decoded selector at the inner variant, so [&:is(.foo)] sorts
+     before a selector beginning with [:nth-*]. *)
+  Test_helpers.check_class_order
+    ~test_name:"group arbitrary inner selector order"
+    [
+      "group-data-[tooltip-hover=true]:opacity-100";
+      "group-[.is-published]:block";
+      "group-[:nth-of-type(3)_&]:block";
+    ];
+  Test_helpers.check_class_order
+    ~test_name:"peer arbitrary inner selector order"
+    [
+      "peer-has-checked:block";
+      "peer-[.is-dirty]:peer-required:block";
+      "peer-[:nth-of-type(3)_&]:block";
+    ]
+
 let test_compound_variant_highest_component () =
   (* A stacked variant sorts into the group of its highest-order component,
      after that group's base rules, matching Tailwind. dark:md:block (dark > md)
@@ -3040,6 +3059,8 @@ let tests =
       test_arbitrary_variant_selector_order;
     test_case "recursive compound variant order" `Slow
       test_recursive_compound_variant_order;
+    test_case "compound variant inner value order" `Slow
+      test_compound_variant_inner_value_order;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
Carry the innermost arbitrary-selector or data value into compound variant sort keys.\n\nThis orders nested group and peer arbitrary selectors like Tailwind and tightens the whole-sheet utility move ceiling from 8 to 6.