### PR TITLE
test: ignore grouped selectors in inversion checks

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -891,16 +891,19 @@ let inverted_pairs ~tailwind ~tw classes =
                 let ta = Hashtbl.find theirs a and tb = Hashtbl.find theirs b in
                 let oa = Hashtbl.find ours a and ob = Hashtbl.find ours b in
                 (* Only a pair sitting under the same at-rule on both sides is
-                   one whose order the two sheets actually disagree about. *)
+                   one whose order the two sheets can disagree about. Two
+                   branches in one selector list have the same statement rank
+                   and therefore no order relative to each other. *)
                 if
                   String.equal ta.container tb.container
                   && String.equal oa.container ob.container
                   && String.equal ta.container oa.container
                 then
-                  let theirs_first = compare ta.rank tb.rank < 0 in
-                  let ours_first = compare oa.rank ob.rank < 0 in
-                  if theirs_first = ours_first then acc
-                  else if theirs_first then (a, b) :: acc
+                  let theirs_order = compare ta.rank tb.rank in
+                  let ours_order = compare oa.rank ob.rank in
+                  if theirs_order = 0 || ours_order = 0 then acc
+                  else if theirs_order < 0 = (ours_order < 0) then acc
+                  else if theirs_order < 0 then (a, b) :: acc
                   else (b, a) :: acc
                 else acc)
               acc rest

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -1639,7 +1639,7 @@ let pool_entries () =
    two handlers. The handler is as fine as the key gets, and a family spanning
    two of Tailwind's bands answers one name for both. That is still far finer
    than a count of statements, which tolerates any 299 of them. *)
-let known_inversions = [ ("masks", "arbitrary") ]
+let known_inversions = []
 
 (* Which handler each class in a case belongs to, and which variant it wears.
    The variant matters because two classes wearing different ones are not

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -176,6 +176,22 @@ let test_order_gap_agreeing_sheets () =
     "nothing moves when the orders agree" (3, 0)
     (g.Test_helpers.pairs, g.Test_helpers.moves)
 
+(* Two branches in one selector list occupy one statement and therefore have no
+   order relative to each other. If either sheet merges them, the pairwise
+   oracle must not turn their equal ranks into an inversion. *)
+let test_inversions_ignore_a_grouped_selector () =
+  let separate = utilities_layer [ ".a"; ".b" ] in
+  let grouped = utilities_layer [ ".a,.b" ] in
+  let inverted tailwind tw =
+    Test_helpers.inverted_pairs ~tailwind ~tw [ "a"; "b" ]
+  in
+  Alcotest.(check (list (pair string string)))
+    "tw groups the pair" []
+    (inverted separate grouped);
+  Alcotest.(check (list (pair string string)))
+    "Tailwind groups the pair" []
+    (inverted grouped separate)
+
 (* Mode [`Tree] is the only mode that reports a rule written twice or a
    custom-property binding nothing reads: mode [`Canonical] folds the second
    copy away in its optimizer, and every caller of it prunes unreferenced
@@ -330,6 +346,8 @@ let tests =
       test_order_gap_drops_a_repeated_key;
     Alcotest.test_case "order gap: agreeing sheets" `Quick
       test_order_gap_agreeing_sheets;
+    Alcotest.test_case "inversions: grouped selector is unordered" `Quick
+      test_inversions_ignore_a_grouped_selector;
     Alcotest.test_case "surplus: a rule written twice" `Quick
       test_surplus_reports_a_rule_written_twice;
     Alcotest.test_case "surplus: a binding nothing reads" `Quick


### PR DESCRIPTION
`inverted_pairs` treated two branches of one selector list as ordered and reported a false mask-type inversion. Equal statement ranks on either sheet are now left unordered.