### PR TITLE
Respect exact custom variant sort slots

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -278,8 +278,24 @@ let native_stylesheet ~(opts : gen_opts) ~include_base all_classes =
   let routed_count, routed_extra, routed_stmts =
     Entrypoint.custom_routed_utilities ~theme:opts.theme ~defs ~udefs routed
   in
+  (* Routed custom variants no longer pass through the typed modifier parser,
+     but the sorter still needs their exact names so a declaration such as
+     [not-dark] is not mistaken for the built-in [not-] compound slot. Dummy
+     selector values are sufficient here: routed candidates already carry the
+     expanded author CSS in [extra], and only the registered names are read. *)
+  let sort_theme =
+    let custom = Tw.Scheme.{ values = [ ("", "&") ]; template = "{}" } in
+    let custom_variants =
+      List.fold_left
+        (fun variants (name, _) ->
+          if List.mem_assoc name variants then variants
+          else (name, custom) :: variants)
+        opts.theme.custom_variants defs
+    in
+    { opts.theme with custom_variants }
+  in
   let stylesheet =
-    Tw.to_css ~theme:opts.theme ~base:include_base ~extra:routed_extra
+    Tw.to_css ~theme:sort_theme ~base:include_base ~extra:routed_extra
       (List.map snd known)
   in
   let stylesheet = Entrypoint.place_routed routed_stmts stylesheet in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -383,7 +383,7 @@ let rec declaration_count props nested =
                     | None -> 0))))
       0 nested
 
-let add_index ?(declared = fun _ -> false) triples =
+let add_index ?theme ?(declared = fun _ -> false) triples =
   let buf = Buffer.create 256 in
   List.mapi
     (fun i (typ, sel, props, order, nested, base_class, merge_key) ->
@@ -411,7 +411,8 @@ let add_index ?(declared = fun _ -> false) triples =
          variant_order;
          variant_key = Sort.variant_sort_key base_class nested;
          variant_orders =
-           Sort.variant_order_list base_class variant_order responsive_media_key;
+           Sort.variant_order_list ?theme base_class variant_order
+             responsive_media_key;
          base_class_key = Option.value ~default:"" base_class;
          media_key;
          nested_media_key;
@@ -505,10 +506,11 @@ let statements_of_sorted_rules ?verbatim sorted_rules =
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)
-let sorted_indexed_rules ?declared order_map all_rules =
+let sorted_indexed_rules ?theme ?declared order_map all_rules =
   all_rules
   |> List.filter_map (rule_to_triple order_map)
-  |> deduplicate_typed_triples |> add_index ?declared |> sort_indexed_blocks
+  |> deduplicate_typed_triples |> add_index ?theme ?declared
+  |> sort_indexed_blocks
 
 (* Sort var names by property_order. Names include -- prefix. *)
 let sort_vars_by_property_order vars =
@@ -1690,7 +1692,7 @@ let to_css ?(theme = Scheme.default) ?(config = default_config) ?(extra = [])
     fun cls -> Hashtbl.mem names cls
   in
   let sorted_rules =
-    sorted_indexed_rules ~declared:verbatim order_map selector_props
+    sorted_indexed_rules ~theme ~declared:verbatim order_map selector_props
   in
   let statements = statements_of_sorted_rules ~verbatim sorted_rules in
   let layer_results =

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2594,13 +2594,19 @@ let variant_inner_token token =
     | Some Slot.Ancestor -> Some (after 3)
     | Some _ | None -> None
 
-let rec variant_inner_order_path token =
+let variant_order_of_prefix ?theme prefix =
+  match theme with
+  | Some theme when Option.is_some (try_custom_variant theme prefix) ->
+      Slot.rank Slot.Custom
+  | Some _ | None -> (
+      match slot_of_prefix prefix with Some slot -> Slot.rank slot | None -> 0)
+
+let rec variant_inner_order_path ?theme token =
   match variant_inner_token token with
   | None -> []
-  | Some inner -> (
-      match slot_of_prefix inner with
-      | Some slot -> Slot.rank slot :: variant_inner_order_path inner
-      | None -> [])
+  | Some inner ->
+      let order = variant_order_of_prefix ?theme inner in
+      if order = 0 then [] else order :: variant_inner_order_path ?theme inner
 
 (* The first wrapped slot retained for callers that only need the immediate
    compound variant. *)
@@ -2608,9 +2614,6 @@ let variant_inner_order token =
   match variant_inner_order_path token with order :: _ -> order | [] -> 0
 
 let not_variant_order m = Slot.rank (slot_of_modifier m)
-
-let variant_order_of_prefix prefix =
-  match slot_of_prefix prefix with Some slot -> Slot.rank slot | None -> 0
 
 let variant_order_of_media_cond cond =
   match slot_of_media_cond cond with Some slot -> Slot.rank slot | None -> 0

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -742,11 +742,13 @@ val not_variant_order : modifier -> int
     for the inner modifier of a [not-*], which sorts where the variant it
     negates sorts. Never 0: every modifier has a position. *)
 
-val variant_order_of_prefix : string -> int
-(** [variant_order_of_prefix prefix] returns the position of a modifier prefix
-    string in the Tailwind v4 variant cascade. The prefix is one modifier of a
-    class name, the part between two ":" (e.g. ["hover"], ["group-has-checked"],
-    ["@min-[64rem]"]). Returns 0 for a token that names no variant, which
+val variant_order_of_prefix : ?theme:Scheme.t -> string -> int
+(** [variant_order_of_prefix ?theme prefix] returns the position of a modifier
+    prefix string in the Tailwind v4 variant cascade. The prefix is one modifier
+    of a class name, the part between two ":" (e.g. ["hover"],
+    ["group-has-checked"], ["@min-[64rem]"]). When [theme] is supplied, its
+    exact custom-variant names take precedence over the built-in prefix grammar.
+    Returns 0 for a token that names no variant, which
     {!Sort.compare_indexed_rules} reads as "this rule carries no variant". *)
 
 val variant_inner_order : string -> int
@@ -760,10 +762,10 @@ val variant_inner_token : string -> string option
 (** [variant_inner_token token] is the variant immediately wrapped by a
     [group-], [peer-], [not-], [in-], or [has-] compound token. *)
 
-val variant_inner_order_path : string -> int list
-(** [variant_inner_order_path token] recursively returns every wrapped variant
-    position, outermost first. For example, [group-has-focus] yields the [has]
-    and [focus] positions. *)
+val variant_inner_order_path : ?theme:Scheme.t -> string -> int list
+(** [variant_inner_order_path ?theme token] recursively returns every wrapped
+    variant position, outermost first. For example, [group-has-focus] yields the
+    [has] and [focus] positions. [theme] resolves wrapped custom variants. *)
 
 val variant_order_of_media_cond : Css.Media.t -> int
 (** [variant_order_of_media_cond cond] returns the same sort key as

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -1142,9 +1142,9 @@ let rec variant_value_key token =
    group-focus and group-has keep their focus-before-has order, and the
    predicate spelling for data variants, so a lower-order compound component
    does not push [data-focus:has-checked] past every other data predicate. *)
-let token_order_key ~breakpoint token =
-  let slot = Modifiers.variant_order_of_prefix token in
-  let wrapped = Modifiers.variant_inner_order_path token in
+let token_order_key ?theme ~breakpoint token =
+  let slot = Modifiers.variant_order_of_prefix ?theme token in
+  let wrapped = Modifiers.variant_inner_order_path ?theme token in
   let breakpoint =
     if slot = responsive_variant_order then breakpoint else None
   in
@@ -1158,7 +1158,7 @@ let token_order_key ~breakpoint token =
    (group:hover vs hover:group) get identical keys. Falls back to the scalar
    [variant_order] for selector-derived variants (before:/after:) that carry no
    order-bearing prefix in the base class. *)
-let variant_order_list base_class variant_order breakpoint =
+let variant_order_list ?theme base_class variant_order breakpoint =
   let from_bc =
     match base_class with
     | None -> []
@@ -1167,7 +1167,7 @@ let variant_order_list base_class variant_order breakpoint =
         let modifiers, _ = collapse_repeated_variant_slots modifiers in
         List.filter_map
           (fun m ->
-            let key = token_order_key ~breakpoint m in
+            let key = token_order_key ?theme ~breakpoint m in
             if key.slot > 0 then Some key else None)
           modifiers
         |> List.sort (fun a b -> compare_variant_components b a)

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -103,13 +103,19 @@ val variant_sort_key : string option -> Css.statement list -> string * int * int
     triple stored in {!field-variant_key}. *)
 
 val variant_order_list :
-  string option -> int -> Css.Media.key option -> variant_component list
-(** [variant_order_list base_class variant_order breakpoint] is the descending
-    list of variant order keys stored in {!field-variant_orders}.
-    [variant_order] is the scalar fallback for selector-derived variants with no
-    order-bearing prefix. [breakpoint] is the rule's {!val-responsive_media_key}
-    and becomes the {!field-variant_component.breakpoint} of whichever token
-    names a breakpoint. *)
+  ?theme:Scheme.t ->
+  string option ->
+  int ->
+  Css.Media.key option ->
+  variant_component list
+(** [variant_order_list ?theme base_class variant_order breakpoint] is the
+    descending list of variant order keys stored in {!field-variant_orders}.
+    [theme] resolves exact custom-variant names before the built-in prefix
+    grammar. [variant_order] is the scalar fallback for selector-derived
+    variants with no order-bearing prefix. [breakpoint] is the rule's
+    {!val-responsive_media_key} and becomes the
+    {!field-variant_component.breakpoint} of whichever token names a breakpoint.
+*)
 
 val media_sort_keys :
   [ `Regular

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 6, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 5, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2615,6 +2615,53 @@ let check_before what sheet first second =
   in
   check bool what true (position first < position second)
 
+(* A project's exact [@custom-variant] name wins over the built-in prefix
+   grammar. In particular, [not-dark] is one custom slot; it is not the built-in
+   [not-] compound wrapped around [dark]. *)
+let test_theme_custom_variant_shadows_prefix_slot () =
+  let selector =
+    "&:not(:where(.dark, .dark *)):not(:where(.system, .system *))"
+  in
+  let theme : Tw.Scheme.t =
+    {
+      Tw.Scheme.default with
+      custom_variants =
+        [
+          ( "not-dark",
+            Tw.Scheme.{ values = [ ("", selector) ]; template = "{}" } );
+        ];
+    }
+  in
+  let hidden =
+    match Tw.Utility.base_of_class theme "hidden" with
+    | Ok base -> Tw.Utility.base base
+    | Error (`Msg m) -> Alcotest.failf "hidden: %s" m
+  in
+  let custom =
+    Tw.Utility.Modified (Tw.Style.Custom_variant ("not-dark", selector), hidden)
+  in
+  let classes = [ "dark:hidden"; "not-dark:hidden"; "[&:empty]:hidden" ] in
+  let utilities =
+    [
+      Tw.Utility.Modified (Tw.Style.Dark, hidden);
+      custom;
+      Tw.Utility.Modified (Tw.Style.Arbitrary_selector "&:empty", hidden);
+    ]
+  in
+  let sheet =
+    let config = { Tw.Build.base = false; forms = None; layers = true } in
+    Css.to_string ~minify:true (Tw.Build.to_css ~theme ~config utilities)
+  in
+  let position cls =
+    let needle = Css.Selector.to_string (Css.Selector.class_ cls) in
+    match Astring.String.find_sub ~sub:needle sheet with
+    | Some i -> (i, cls)
+    | None -> Alcotest.failf "%s missing from %s" needle sheet
+  in
+  Alcotest.(check (list string))
+    "custom variant remains after dark and before arbitrary" classes
+    (List.map position classes |> List.sort compare |> List.map snd)
+
 (* A custom-variant expansion arrives through [extra], but it is not a declared
    utility joining the property family. Treating it as one flattens every
    built-in mask-image suborder onto the first slot. *)
@@ -3061,6 +3108,8 @@ let tests =
       test_recursive_compound_variant_order;
     test_case "compound variant inner value order" `Slow
       test_compound_variant_inner_value_order;
+    test_case "theme custom variant shadows prefix slot" `Quick
+      test_theme_custom_variant_shadows_prefix_slot;
     test_case "compound variant highest component" `Slow
       test_compound_variant_highest_component;
     test_case "compound variant same multiset" `Slow


### PR DESCRIPTION
Resolve registered custom-variant names before the built-in prefix grammar when constructing sort keys.\n\nThe CLI registers routed entrypoint variant names in the sort theme, so a declaration such as not-dark stays in the custom slot instead of sorting as built-in negation. This tightens the whole-sheet utility move ceiling from 6 to 5.