### PR TITLE
Retain routed custom variant ownership

### DIFF
--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -2166,13 +2166,20 @@ let routed_variant_defs defs derived =
         match template with Some body -> (name, body) :: acc | None -> acc)
       derived []
 
+(* A parsed routed statement keeps the candidate that produced its block.
+   Selector recovery remains the fallback for independently hoisted statements,
+   but cannot own a compound selector whose leading [:where(...)] hides the
+   candidate class from [first_class_of_statement]. *)
+let routed_owner owner stmt =
+  match owner with Some _ -> owner | None -> first_class_of_statement stmt
+
 let group_routed_rules ~own_order rules =
   let group = Hashtbl.create 8 in
   let order_of = Hashtbl.create 8 in
   let classless = ref [] in
   List.iter
-    (fun stmt ->
-      match first_class_of_statement stmt with
+    (fun (owner, stmt) ->
+      match routed_owner owner stmt with
       | None -> classless := stmt :: !classless
       | Some cls -> (
           let prev =
@@ -2221,7 +2228,8 @@ let routed_statements ~block_count ~own_order stmts =
      it: nested, the first would become [utilities.properties]. *)
   let hoisted, rules =
     List.partition
-      (fun stmt -> Css.as_layer stmt <> None || Css.as_property stmt <> None)
+      (fun (_, stmt) ->
+        Css.as_layer stmt <> None || Css.as_property stmt <> None)
       stmts
   in
   let group, order_of, classless = group_routed_rules ~own_order rules in
@@ -2238,7 +2246,7 @@ let routed_statements ~block_count ~own_order stmts =
   let unplaced =
     if classless = [] then [] else [ Css.layer ~name:[ "utilities" ] classless ]
   in
-  (block_count, ordered, unplaced @ dedup_statements hoisted)
+  (block_count, ordered, unplaced @ dedup_statements (List.map snd hoisted))
 
 (* Flattening is what turns the wrappers a variant builds around a [@utility]
    body into selectors: [.focus\:line-y { &:focus { ... } }] has to become
@@ -2268,8 +2276,18 @@ let parse_routed_block css =
         |> List.concat_map flattened_statement)
 
 let parse_routed_blocks ~own_order ~hoisted blocks =
-  let parsed = List.filter_map parse_routed_block blocks in
-  let hoisted = Option.value ~default:[] (parse_routed_block hoisted) in
+  let parsed =
+    List.filter_map
+      (fun (cls, block) ->
+        Option.map
+          (List.map (fun stmt -> (Some cls, stmt)))
+          (parse_routed_block block))
+      blocks
+  in
+  let hoisted =
+    Option.value ~default:[] (parse_routed_block hoisted)
+    |> List.map (fun stmt -> (None, stmt))
+  in
   List.concat parsed @ hoisted
   |> routed_statements ~block_count:(List.length parsed) ~own_order
 
@@ -2294,7 +2312,11 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
   let own_order = Hashtbl.create 8 in
   let blocks =
     List.filter_map
-      (routed_block ~theme ~defs ~udefs ~hoisted ~seen ~derived ~own_order)
+      (fun cls ->
+        Option.map
+          (fun block -> (cls, block))
+          (routed_block ~theme ~defs ~udefs ~hoisted ~seen ~derived ~own_order
+             cls))
       candidates
   in
   match blocks with
@@ -2308,4 +2330,4 @@ let custom_routed_utilities ~theme ~defs ~udefs candidates =
       let expand = apply_variants ~extra_defs ~udefs ~theme in
       parse_routed_blocks ~own_order
         ~hoisted:(expand (Buffer.contents hoisted))
-        (List.map expand blocks)
+        (List.map (fun (cls, block) -> (cls, expand block)) blocks)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 5, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 2, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -242,6 +242,40 @@ let test_declared_utility_keeps_its_nesting () =
         (Cascade.Css.to_string ~minify:true (Cascade.Css.v statements))
   | _ -> Alcotest.failf "expected one entry, got %d" (List.length entries)
 
+(* A compound ancestor variant puts [:where(...)] before the candidate class in
+   the expanded selector. The routed block still belongs to the candidate that
+   produced it; recovering ownership from the selector must not send all of its
+   custom-variant branches to an unplaced utilities layer at the end. *)
+let test_complex_custom_variant_keeps_candidate () =
+  let defs =
+    [
+      ( "dark",
+        "&:where(.dark,.dark \
+         *){@slot;}@media(prefers-color-scheme:dark){&:where(.system,.system \
+         *){@slot;}}" );
+    ]
+  in
+  let candidate = "dark:in-[figure]:outline-1" in
+  let count, entries, unplaced =
+    custom_routed_utilities ~theme:Tw.Scheme.default ~defs ~udefs:[]
+      [ candidate ]
+  in
+  check int "one candidate generated" 1 count;
+  check bool "no trailing unplaced utilities layer" false
+    (List.exists
+       (fun stmt ->
+         match Cascade.Css.layer_block_name stmt with
+         | Some name ->
+             Cascade.Css.Stylesheet.equal_layer_name name [ "utilities" ]
+         | None -> false)
+       unplaced);
+  match entries with
+  | [ (cls, _, statements) ] ->
+      check string "the originating candidate is retained" candidate cls;
+      check int "both custom branches stay in its block" 2
+        (List.length statements)
+  | _ -> Alcotest.failf "expected one entry, got %d" (List.length entries)
+
 (* {2 Functional utilities} *)
 
 (* The CSS each candidate gets from the declarations, as [class -> minified
@@ -392,6 +426,8 @@ let tests =
       test_apply_hoists_each_property_once;
     test_case "declared utility keeps its nesting" `Quick
       test_declared_utility_keeps_its_nesting;
+    test_case "complex custom variant keeps its candidate" `Quick
+      test_complex_custom_variant_keeps_candidate;
     test_case "functional value" `Quick test_functional_value;
     test_case "functional theme value" `Quick test_functional_theme_value;
     test_case "functional arbitrary value" `Quick


### PR DESCRIPTION
Keep each routed candidate name attached to the statements parsed from its expanded block.\n\nThis lets compound selectors beginning with :where(...) remain sortable instead of falling into a trailing unplaced utilities layer. It restores three multi-branch custom-variant rules and tightens the whole-sheet utility move ceiling from 5 to 2.