### PR TITLE
Interleave element variant permutations by utility order

### DIFF
--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -1214,13 +1214,16 @@ let compare_both_bracket_prefixes p1 p2 =
 
 (** Compare variant prefixes for bracket ordering. Named variants (has-checked)
     sort before bracket variants (has-[:checked]) within the same variant group.
-*)
+    Element-variant permutations with identical component keys tie here so their
+    utilities can interleave in [compare_variant_tail]. *)
 let compare_bracket_prefixes p1_prefix p2_prefix =
   let has_bracket p = String.length p > 0 && String.contains p '[' in
+  let has_element_variant p = String.contains p '*' in
   let b1 = has_bracket p1_prefix and b2 = has_bracket p2_prefix in
   if b1 && not b2 then 1
   else if b2 && not b1 then -1
   else if b1 && b2 then compare_both_bracket_prefixes p1_prefix p2_prefix
+  else if has_element_variant p1_prefix && has_element_variant p2_prefix then 0
   else String.compare p1_prefix p2_prefix
 
 (* Compare rules when both have variant_order > 0 *)

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -32,7 +32,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 1, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 0, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2467,6 +2467,19 @@ let test_repeated_child_variant_utility_order () =
   Test_helpers.check_class_order
     ~test_name:"repeated child variant follows utility order" classes
 
+let test_element_variant_permutations_interleave () =
+  (* Permuting [first] and the direct-child variant changes the selector, but
+     not the variant multiset. Tailwind keeps both padding candidates together
+     before moving on to the later inset-ring utility. *)
+  Test_helpers.check_class_order
+    ~test_name:"element variant permutations follow utility order"
+    [
+      "*:first:pt-0";
+      "first:*:pt-0";
+      "*:*:first:inset-ring";
+      "*:*:first:inset-ring-black/5";
+    ]
+
 let test_named_anchor_inner_order () =
   (* Naming a group or peer changes the marker class, not the state the variant
      wraps. The name must not make focus or checked fall into the zero/unknown
@@ -3139,6 +3152,8 @@ let tests =
       test_variant_arbitrary_numeric_order;
     test_case "repeated child variant follows utility order" `Slow
       test_repeated_child_variant_utility_order;
+    test_case "element variant permutations follow utility order" `Slow
+      test_element_variant_permutations_interleave;
     test_case "named anchor keeps inner state" `Slow
       test_named_anchor_inner_order;
     test_case "stacked data variant slot" `Slow test_stacked_data_variant_slot;


### PR DESCRIPTION
Let element-variant prefix permutations with identical component keys fall through to utility ordering. This pins the boundary and reduces whole-sheet utility-order moves from one to zero.