### PR TITLE
test/upstream: reject unplaced fixture lines

### DIFF
--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -225,8 +225,11 @@ let upstream_positive_cases basename =
   | None -> Alcotest.failf "%s not found. Run extract_tests.exe first." basename
   | Some p ->
       Upstream_fixture.read p
-      |> List.filter (fun (c : Upstream_fixture.case) ->
-          c.expected <> "" && c.classes <> [])
+      |> List.filter_map (fun (c : Upstream_fixture.case) ->
+          match c.expected with
+          | Some expected when expected <> "" && c.classes <> [] ->
+              Some (c, expected)
+          | Some _ | None -> None)
 
 (* Build the per-test scheme from the @theme tokens in the expected CSS, so
    of_string validates custom tokens against the threaded theme. *)
@@ -300,11 +303,9 @@ let check_upstream_positive_fixture_parse filename () =
   let cases = upstream_positive_cases filename in
   let rejected =
     cases
-    |> List.concat_map (fun (c : Upstream_fixture.case) ->
-        let theme =
-          upstream_scheme c.config c.theme_vars c.variants c.expected
-        in
-        let selectors = emitted_selectors c.expected in
+    |> List.concat_map (fun ((c : Upstream_fixture.case), expected) ->
+        let theme = upstream_scheme c.config c.theme_vars c.variants expected in
+        let selectors = emitted_selectors expected in
         c.classes
         |> List.filter (class_is_emitted selectors)
         (* A class the case's own [@utility] declares is CSS the case brought

--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -1,7 +1,7 @@
 (library
  (name upstream_fixture)
  (modules upstream_fixture)
- (libraries re))
+ (libraries fmt re))
 
 (executable
  (name extract_tests)

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -470,7 +470,7 @@ let stat_rejected = ref 0
 let stat_routed = ref 0
 let stat_expected_empty_cases = ref 0
 
-let run_test_case test () =
+let run_test_case test expected () =
   if test.classes = [] then ()
   else
     let base_scheme = scheme_of_theme_vars test.theme_vars in
@@ -556,9 +556,9 @@ let run_test_case test () =
       let inline = tokens_in_mode "inline" in
       let reference = tokens_in_mode "reference" in
       Tw.Scheme.with_overrides ~inline ~reference scheme
-        (theme_overrides_of ~declared test.config test.expected @ theme_vars)
+        (theme_overrides_of ~declared test.config expected @ theme_vars)
     in
-    let resolve_theme = theme_resolution ~declared test.config test.expected in
+    let resolve_theme = theme_resolution ~declared test.config expected in
     (* A class the case's own [@utility] declares means nothing to
        [Tw.of_string]: the declaration is CSS, and it reaches the sheet the way
        a project entrypoint's does, through [Entrypoint]. The rest of the case
@@ -588,7 +588,7 @@ let run_test_case test () =
     stat_parsed := !stat_parsed + List.length utilities;
     stat_rejected := !stat_rejected + List.length rejected;
     stat_routed := !stat_routed + routed_count;
-    if test.expected = "" then incr stat_expected_empty_cases;
+    if expected = "" then incr stat_expected_empty_cases;
     let our_stylesheet =
       if utilities = [] && routed_extra = [] && routed_stmts = [] then None
       else
@@ -612,7 +612,6 @@ let run_test_case test () =
           stylesheet |> resolve_theme |> Css.to_string ~minify:true
           |> String.trim
     in
-    let expected = test.expected in
     let expected_css = canonical_stylesheet_css expected in
     if our_css = "" && expected = "" then ()
     else
@@ -720,6 +719,11 @@ let test_color_tolerance () =
     "color-mix(in oklab, var(--x) 50%, transparent)"
     (color_mix_to_oklab "color-mix(in oklab, var(--x) 50%, transparent)")
 
+(* The reader's own grammar. Both fixtures are machine-written, so a line the
+   grammar has no place for means [extract_tests.ml] and [upstream_fixture.ml]
+   have drifted apart, or the fixture was edited by hand. The reader raises on
+   one instead of resuming its scan, which would drop the block the line sits in
+   and leave the case count as the only trace. *)
 let write_reader_regression_fixture name contents =
   let dir = "tmp" in
   if not (Sys.file_exists dir) then Sys.mkdir dir 0o755;
@@ -759,6 +763,89 @@ let test_reader_rejects_a_stray_line () =
       Alcotest.failf "read %d cases instead of rejecting the stray line"
         (List.length cases)
 
+let banner =
+  "#! 1 block extracted from variants.test.ts by extract_tests.exe -- do not \
+   edit\n"
+
+let read_result path =
+  match read path with
+  | cases -> Ok cases
+  | exception Malformed msg -> Error msg
+
+let check_rejected name contents =
+  let path =
+    write_reader_regression_fixture (name ^ ".txt") (banner ^ contents)
+  in
+  match read_result path with
+  | Error _ -> ()
+  | Ok cases ->
+      Alcotest.failf "%s: read %d cases instead of raising" name
+        (List.length cases)
+
+let test_reader_reads_a_block () =
+  let path =
+    write_reader_regression_fixture "reader_good.txt"
+      (banner
+     ^ "# a case\n@config run\nflex\n---\n.flex { display: flex }\n<<<>>>\n")
+  in
+  match read_result path with
+  | Error msg -> Alcotest.failf "a well-formed block was rejected: %s" msg
+  | Ok [ case ] ->
+      Alcotest.(check (list string)) "classes" [ "flex" ] case.classes;
+      Alcotest.(check (option string))
+        "expected CSS" (Some ".flex { display: flex }") case.expected
+  | Ok cases -> Alcotest.failf "one block read as %d cases" (List.length cases)
+
+(* Upstream tests that assert the compile throws are written without a [---]
+   section. They are a shape the extractor produces, so the reader keeps them
+   and says so rather than dropping them the way it drops nothing else. *)
+let test_reader_keeps_a_block_asserting_an_error () =
+  let path =
+    write_reader_regression_fixture "reader_throws.txt"
+      (banner ^ "# a case that throws\n@config run\nfoo bar\n<<<>>>\n")
+  in
+  match read_result path with
+  | Error msg -> Alcotest.failf "a block with no --- was rejected: %s" msg
+  | Ok [ case ] ->
+      Alcotest.(check (option string)) "no expected CSS" None case.expected
+  | Ok cases -> Alcotest.failf "one block read as %d cases" (List.length cases)
+
+let test_reader_rejects_a_stray_line_with_message () =
+  check_rejected "reader_stray"
+    "# a case\n@config run\nflex\nstray\n---\n.flex { display: flex }\n<<<>>>\n"
+
+let test_reader_rejects_an_unknown_config () =
+  check_rejected "reader_config"
+    "# a case\n@config bogus\nflex\n---\n.flex { display: flex }\n<<<>>>\n"
+
+let test_reader_rejects_a_headerless_block () =
+  check_rejected "reader_headerless"
+    "@config run\nflex\n---\n.flex { display: flex }\n<<<>>>\n"
+
+let test_reader_rejects_an_unclosed_block () =
+  check_rejected "reader_unclosed"
+    "# a case\n\
+     @config run\n\
+     flex\n\
+     ---\n\
+     .flex { display: flex }\n\
+     <<<>>>\n\
+     # added by hand\n\
+     @config run\n\
+     block\n\
+     ---\n\
+     .block { display: block }\n"
+
+let test_reader_rejects_a_directive_with_no_value () =
+  check_rejected "reader_directive"
+    "# a case\n\
+     @config run\n\
+     @theme-var spacing\n\
+     flex\n\
+     ---\n\
+     .flex { display: flex }\n\
+     <<<>>>\n"
+
 let print_parity_report () =
   Fmt.epr "@.=== upstream parity report ===@.";
   Fmt.epr "classes: %d total, %d parsed, %d routed, %d rejected@."
@@ -784,6 +871,10 @@ let print_parity_report () =
 let utilities_floor = 620
 let variants_floor = 150
 
+(* A block the extractor writes without a [---] section is an upstream test that
+   asserts the compile throws: it carries no CSS to replay. Those are the only
+   blocks that do not become a test, and the count is printed so every block of
+   the fixture is accounted for either way. *)
 let load basename floor =
   match path basename with
   | None ->
@@ -791,12 +882,26 @@ let load basename floor =
       exit 1
   | Some p ->
       let cases = read p in
-      let n = List.length cases in
+      (* [read] returns one case per block or raises, so a mismatch here is the
+         reader having grown a skip that says nothing. *)
+      let found = blocks p in
+      if List.length cases <> found then (
+        Fmt.epr "%s holds %d blocks but read as %d cases.@." p found
+          (List.length cases);
+        exit 1);
+      let replayable =
+        List.filter_map
+          (fun c -> Option.map (fun expected -> (c, expected)) c.expected)
+          cases
+      in
+      let n = List.length replayable in
+      Fmt.epr "%s: %d blocks, %d replayed, %d asserting a compile error@." p
+        found n (found - n);
       if n < floor then (
         Fmt.epr "%s yielded %d test cases, fewer than the floor of %d.@." p n
           floor;
         exit 1);
-      cases
+      replayable
 
 (* The floors count what a fixture holds, not where it came from: a block added
    to a generated fixture by hand raises the count and passes them, then
@@ -837,7 +942,10 @@ let () =
   at_exit print_parity_report;
 
   let alcotest_cases tests =
-    List.map (fun tc -> test_case tc.name `Quick (run_test_case tc)) tests
+    List.map
+      (fun (tc, expected) ->
+        test_case tc.name `Quick (run_test_case tc expected))
+      tests
   in
   let tolerance_cases =
     [
@@ -861,11 +969,29 @@ let () =
         test_reader_rejects_a_stray_line;
     ]
   in
+  let reader_cases =
+    [
+      test_case "a well-formed block reads" `Quick test_reader_reads_a_block;
+      test_case "a block with no --- keeps its place" `Quick
+        test_reader_keeps_a_block_asserting_an_error;
+      test_case "a stray line raises" `Quick
+        test_reader_rejects_a_stray_line_with_message;
+      test_case "an unknown @config raises" `Quick
+        test_reader_rejects_an_unknown_config;
+      test_case "a block with no header raises" `Quick
+        test_reader_rejects_a_headerless_block;
+      test_case "a block with no <<<>>> raises" `Quick
+        test_reader_rejects_an_unclosed_block;
+      test_case "a directive with no value raises" `Quick
+        test_reader_rejects_a_directive_with_no_value;
+    ]
+  in
   let suites =
     [
       ("utilities", alcotest_cases utility_tests);
       ("tolerance", tolerance_cases);
       ("reader regression", reader_regression_cases);
+      ("reader", reader_cases);
       ("variants", alcotest_cases variant_tests);
     ]
   in

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -720,6 +720,45 @@ let test_color_tolerance () =
     "color-mix(in oklab, var(--x) 50%, transparent)"
     (color_mix_to_oklab "color-mix(in oklab, var(--x) 50%, transparent)")
 
+let write_reader_regression_fixture name contents =
+  let dir = "tmp" in
+  if not (Sys.file_exists dir) then Sys.mkdir dir 0o755;
+  let path = Filename.concat dir name in
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc;
+  path
+
+let reader_regression_banner =
+  "#! 1 block extracted from variants.test.ts by extract_tests.exe -- do not \
+   edit\n"
+
+let test_reader_keeps_a_compile_error_block () =
+  let path =
+    write_reader_regression_fixture "reader_compile_error.txt"
+      (reader_regression_banner
+     ^ "# a case that throws\n@config run\nfoo bar\n<<<>>>\n")
+  in
+  Alcotest.(check int) "one case" 1 (List.length (read path))
+
+let test_reader_rejects_a_stray_line () =
+  let path =
+    write_reader_regression_fixture "reader_stray.txt"
+      (reader_regression_banner
+     ^ "# a case\n\
+        @config run\n\
+        flex\n\
+        stray\n\
+        ---\n\
+        .flex { display: flex }\n\
+        <<<>>>\n")
+  in
+  match read path with
+  | exception _ -> ()
+  | cases ->
+      Alcotest.failf "read %d cases instead of rejecting the stray line"
+        (List.length cases)
+
 let print_parity_report () =
   Fmt.epr "@.=== upstream parity report ===@.";
   Fmt.epr "classes: %d total, %d parsed, %d routed, %d rejected@."
@@ -814,10 +853,19 @@ let () =
         test_dropped_declarations_are_reported;
     ]
   in
+  let reader_regression_cases =
+    [
+      test_case "a compile-error block keeps its place" `Quick
+        test_reader_keeps_a_compile_error_block;
+      test_case "a stray fixture line is rejected" `Quick
+        test_reader_rejects_a_stray_line;
+    ]
+  in
   let suites =
     [
       ("utilities", alcotest_cases utility_tests);
       ("tolerance", tolerance_cases);
+      ("reader regression", reader_regression_cases);
       ("variants", alcotest_cases variant_tests);
     ]
   in

--- a/test/upstream/upstream_fixture.ml
+++ b/test/upstream/upstream_fixture.ml
@@ -29,6 +29,10 @@ type config =
   | No_theme
   | Run
 
+exception Malformed of string
+
+let fail_malformed fmt = Fmt.kstr (fun msg -> raise (Malformed msg)) fmt
+
 let config_of_string = function
   | "theme" -> Theme
   | "theme-inline" -> Theme_inline
@@ -36,14 +40,17 @@ let config_of_string = function
   | "theme-inline-reference" -> Theme_inline_reference
   | "none" -> No_theme
   | "run" -> Run
-  | _ -> No_theme
+  | name -> fail_malformed "unknown @config name %S" name
 
 type case = {
   source : string;  (** Fixture the case was read from. *)
   name : string;
   config : config;
   classes : string list;
-  expected : string;
+  expected : string option;
+      (** The [---] section, or [None] for a block the extractor wrote without
+          one: an upstream test that asserts the compile throws has no CSS to
+          replay. *)
   variants : string list;  (** [matchVariant] directive lines for this test. *)
   theme_vars : (string * string) list;
       (** [@theme] token overrides (name, value) captured from the test's CSS
@@ -96,173 +103,165 @@ let lines_of filename =
     close_in ic;
     String.split_on_char '\n' content
 
-let read filename =
-  match lines_of filename with
-  | [] -> []
-  | lines ->
-      let tests = ref [] in
-      let current_variants = ref [] in
-      let current_theme_vars = ref [] in
-      let current_theme_modes = ref [] in
-      let current_utility_defs = ref [] in
-      let current_layer_wrap = ref None in
-      let parse_config_line line =
-        let line = String.trim line in
-        if String.length line > 8 && String.sub line 0 8 = "@config " then
-          Some (config_of_string (String.sub line 8 (String.length line - 8)))
-        else None
-      in
-      (* A directive line is "<keyword> <name> <rest>"; the name runs to the
-         first space and the rest is kept as written. *)
-      let named_pair keyword line =
-        let n = String.length keyword in
-        if String.length line < n || String.sub line 0 n <> keyword then None
-        else
-          let tail = String.sub line n (String.length line - n) in
-          Option.map
-            (fun i ->
-              ( String.sub tail 0 i,
-                String.sub tail (i + 1) (String.length tail - i - 1) ))
-            (String.index_opt tail ' ')
-      in
-      let rec parse lines =
-        match lines with
-        | [] -> ()
-        | line :: rest ->
-            let line = String.trim line in
-            if String.length line > 2 && line.[0] = '#' && line.[1] = ' ' then (
-              let name = String.sub line 2 (String.length line - 2) in
-              current_variants := [];
-              current_theme_vars := [];
-              current_theme_modes := [];
-              current_utility_defs := [];
-              current_layer_wrap := None;
-              parse_config name No_theme rest)
-            else parse rest
-      and parse_config name default_config lines =
-        match lines with
-        | [] -> ()
-        | line :: rest -> (
-            match parse_config_line line with
-            | Some config -> parse_variants name config rest
-            | None -> parse_variants name default_config (line :: rest))
-      and parse_variants name config lines =
-        match lines with
-        | [] -> ()
-        | line :: rest -> (
-            let tl = String.trim line in
-            if String.length tl >= 9 && String.sub tl 0 9 = "@variant " then (
-              current_variants :=
-                String.sub tl 9 (String.length tl - 9) :: !current_variants;
-              parse_variants name config rest)
-            else
-              match named_pair "@theme-var " tl with
-              | Some pair ->
-                  current_theme_vars := pair :: !current_theme_vars;
-                  parse_variants name config rest
-              | None -> (
-                  match named_pair "@theme-mode " tl with
-                  | Some (n, modes) ->
-                      current_theme_modes :=
-                        (n, String.split_on_char ' ' modes)
-                        :: !current_theme_modes;
-                      parse_variants name config rest
-                  | None -> (
-                      match named_pair "@utility-def " tl with
-                      | Some pair ->
-                          current_utility_defs := pair :: !current_utility_defs;
-                          parse_variants name config rest
-                      | None ->
-                          if
-                            String.length tl >= 12
-                            && String.sub tl 0 12 = "@layer-wrap "
-                          then (
-                            current_layer_wrap :=
-                              Some (String.sub tl 12 (String.length tl - 12));
-                            parse_variants name config rest)
-                          else parse_classes name config (line :: rest))))
-      and parse_classes name config lines =
-        match lines with
-        | [] -> ()
-        | line :: rest ->
-            let line = String.trim line in
-            if line = "<<<>>>" then parse rest
-            else if line = "---" then
-              (* No classes line before ---, skip *)
-              parse_expected name config [] (Buffer.create 256) rest
-            else if String.length line > 2 && line.[0] = '#' && line.[1] = ' '
-            then (
-              (* New test without classes *)
-              let new_name = String.sub line 2 (String.length line - 2) in
-              current_variants := [];
-              current_theme_vars := [];
-              current_theme_modes := [];
-              current_utility_defs := [];
-              current_layer_wrap := None;
-              parse_config new_name No_theme rest)
-            else
-              let classes = split_classes line in
-              parse_after_classes name config classes rest
-      and parse_after_classes name config classes lines =
-        match lines with
-        | [] -> ()
-        | line :: rest ->
-            let line = String.trim line in
-            if line = "---" then
-              parse_expected name config classes (Buffer.create 256) rest
-            else if line = "<<<>>>" then
-              (* No expected CSS, skip this test *)
-              parse rest
-            else parse rest
-      and parse_expected name config classes buf lines =
-        match lines with
-        | [] ->
-            let expected = Buffer.contents buf |> String.trim in
-            if classes <> [] then
-              tests :=
-                {
-                  source = filename;
-                  name;
-                  config;
-                  classes;
-                  expected;
-                  variants = List.rev !current_variants;
-                  theme_vars = List.rev !current_theme_vars;
-                  theme_modes = List.rev !current_theme_modes;
-                  utility_defs = List.rev !current_utility_defs;
-                  layer_wrap = !current_layer_wrap;
-                }
-                :: !tests
-        | line :: rest ->
-            if String.trim line = "<<<>>>" then (
-              let expected = Buffer.contents buf |> String.trim in
-              if classes <> [] then
-                tests :=
-                  {
-                    source = filename;
-                    name;
-                    config;
-                    classes;
-                    expected;
-                    variants = List.rev !current_variants;
-                    theme_vars = List.rev !current_theme_vars;
-                    theme_modes = List.rev !current_theme_modes;
-                    utility_defs = List.rev !current_utility_defs;
-                    layer_wrap = !current_layer_wrap;
-                  }
-                  :: !tests;
-              parse rest)
-            else (
-              if Buffer.length buf > 0 then Buffer.add_char buf '\n';
-              Buffer.add_string buf line;
-              parse_expected name config classes buf rest)
-      in
-      parse lines;
-      List.rev !tests
+(* A line the reader cannot place: the fixtures are machine-written, so a line
+   outside the grammar means the extractor and the reader have drifted apart, or
+   the fixture was edited by hand. Either way it is a bug in this repository and
+   not an input to tolerate -- a reader that resumes its scan on such a line
+   drops the surrounding block with the case count as its only trace. *)
+let malformed filename line text expectation =
+  fail_malformed
+    "%s:%d: expected %s, read %S. The upstream fixtures are generated: \
+     regenerate with extract_tests.exe rather than editing them."
+    filename line expectation text
 
-(* A fixture is found beside the executable under the dune sandbox, and under
-   [upstream/] or [test/upstream/] when the test runs from a parent
-   directory. *)
+let after_prefix prefix s =
+  if String.starts_with ~prefix s then
+    let n = String.length prefix in
+    Some (String.sub s n (String.length s - n))
+  else None
+
+let split_first_space s =
+  Option.map
+    (fun i ->
+      (String.sub s 0 i, String.sub s (i + 1) (String.length s - i - 1)))
+    (String.index_opt s ' ')
+
+(* A directive line is "<keyword> <name> <rest>"; the name runs to the first
+   space and the rest is kept as written. A keyword carrying neither is
+   malformed rather than a class list that happens to start with an [@]. *)
+let named_pair filename line keyword arg =
+  match split_first_space arg with
+  | Some pair -> pair
+  | None -> malformed filename line arg (keyword ^ "<name> <value>")
+
+(* One block, in the shape [extract_tests.ml] writes it: a [# <name>] header, an
+   [@config] line, the repeatable directives, the class list, then [---] and the
+   expected CSS. An upstream test that asserts the compile throws is written
+   with no [---] and nothing after the class list.
+
+   The expected CSS is free-form and runs to the block's end, so it is the one
+   region a stray line can hide in; everything above it is checked. *)
+let parse_block filename block =
+  let header_line, name, body =
+    match block with
+    | [] -> fail_malformed "%s: an empty block (two <<<>>> in a row)" filename
+    | (n, header) :: rest -> (
+        let header = String.trim header in
+        match after_prefix "# " header with
+        | Some name -> (n, name, rest)
+        | None -> malformed filename n header "a block header (# <name>)")
+  in
+  let config = ref No_theme in
+  let variants = ref [] in
+  let theme_vars = ref [] in
+  let theme_modes = ref [] in
+  let utility_defs = ref [] in
+  let layer_wrap = ref None in
+  let read_config n arg =
+    match config_of_string arg with
+    | c -> config := c
+    | exception Malformed _ ->
+        malformed filename n arg
+          "one of @config theme, theme-inline, theme-reference, \
+           theme-inline-reference, none, run"
+  in
+  let handlers =
+    [
+      ("@config ", read_config);
+      ("@variant ", fun _ arg -> variants := arg :: !variants);
+      ( "@theme-var ",
+        fun n arg ->
+          theme_vars := named_pair filename n "@theme-var " arg :: !theme_vars
+      );
+      ( "@theme-mode ",
+        fun n arg ->
+          let token, modes = named_pair filename n "@theme-mode " arg in
+          theme_modes := (token, String.split_on_char ' ' modes) :: !theme_modes
+      );
+      ( "@utility-def ",
+        fun n arg ->
+          utility_defs :=
+            named_pair filename n "@utility-def " arg :: !utility_defs );
+      ("@layer-wrap ", fun _ arg -> layer_wrap := Some arg);
+    ]
+  in
+  let rec directives lines =
+    match lines with
+    | [] -> []
+    | (n, line) :: rest -> (
+        let line = String.trim line in
+        let hit =
+          List.find_map
+            (fun (prefix, handle) ->
+              Option.map (fun arg -> (handle, arg)) (after_prefix prefix line))
+            handlers
+        in
+        match hit with
+        | Some (handle, arg) ->
+            handle n arg;
+            directives rest
+        | None -> lines)
+  in
+  match directives body with
+  | [] ->
+      malformed filename header_line ("# " ^ name)
+        "a class list after the block header"
+  | (n, classes_line) :: after ->
+      let classes_line = String.trim classes_line in
+      if classes_line = "---" then
+        malformed filename n classes_line "a class list before ---";
+      let expected =
+        match after with
+        | [] -> None
+        | (n, separator) :: css ->
+            let separator = String.trim separator in
+            if separator <> "---" then
+              malformed filename n separator "--- or the end of the block";
+            Some (String.trim (String.concat "\n" (List.map snd css)))
+      in
+      {
+        source = filename;
+        name;
+        config = !config;
+        classes = split_classes classes_line;
+        expected;
+        variants = List.rev !variants;
+        theme_vars = List.rev !theme_vars;
+        theme_modes = List.rev !theme_modes;
+        utility_defs = List.rev !utility_defs;
+        layer_wrap = !layer_wrap;
+      }
+
+let read filename =
+  let numbered = List.mapi (fun i line -> (i + 1, line)) (lines_of filename) in
+  (* The [#!] banner is provenance rather than a block, and the extractor writes
+     it first or not at all. *)
+  let numbered =
+    match numbered with
+    | (_, first) :: rest
+      when String.starts_with ~prefix:"#!" (String.trim first) ->
+        rest
+    | lines -> lines
+  in
+  let rec split current blocks lines =
+    match lines with
+    | [] ->
+        (* The extractor closes every block, so what follows the last separator
+           is the file's trailing newline and nothing else. *)
+        List.iter
+          (fun (n, line) ->
+            if String.trim line <> "" then
+              malformed filename n line "a block closed by <<<>>>")
+          (List.rev current);
+        List.rev blocks
+    | (n, line) :: rest when String.trim line = "<<<>>>" -> (
+        match List.rev current with
+        | [] -> malformed filename n line "a block before <<<>>>"
+        | block -> split [] (block :: blocks) rest)
+    | entry :: rest -> split (entry :: current) blocks rest
+  in
+  List.map (parse_block filename) (split [] [] numbered)
+
 (* Blocks are counted on the separator the reader splits on, so the count is the
    reader's own notion of a block rather than a second one beside it. *)
 let blocks filename =

--- a/test/upstream/upstream_fixture.mli
+++ b/test/upstream/upstream_fixture.mli
@@ -18,12 +18,21 @@
 
     A generated fixture opens with a [#!] provenance banner naming the number of
     blocks the extractor wrote; {!blocks} and {!declared_blocks} read the two
-    counts so a caller can hold one against the other.
+    counts so a caller can hold one against the other. {!read} returns exactly
+    one case per block or raises {!Malformed}: it never skips a block it cannot
+    read.
 
     Both the fixture replay in [test/upstream/test.ml] and the parse-parity gate
     in [test/test_tw.ml] read the same corpus, so they read it here: two readers
     drifting apart is two different corpora behind one set of fixtures. See
     [extract_tests.ml] for how the fixtures are generated. *)
+
+exception Malformed of string
+(** Raised by {!read} on a line the fixture grammar has no place for, and by
+    {!config_of_string} on an unknown [@config] name. Both fixtures are
+    machine-written, so such a line means [extract_tests.ml] and this reader
+    have drifted apart, or the fixture was edited by hand. The message names the
+    file, the line and what was expected there. *)
 
 type config =
   | Theme  (** [@theme { ... }] *)
@@ -34,16 +43,19 @@ type config =
   | Run  (** the [run()] helper rather than [compileCss()] *)
 
 val config_of_string : string -> config
-(** [config_of_string s] reads an [@config] line's argument. An unknown name
-    reads as {!constructor-No_theme}, the shape a fixture without a theme has.
-*)
+(** [config_of_string s] reads an [@config] line's argument.
+
+    @raise Malformed on a name the extractor cannot have written. *)
 
 type case = {
   source : string;  (** Fixture the case was read from. *)
   name : string;
   config : config;
   classes : string list;
-  expected : string;
+  expected : string option;
+      (** The [---] section, or [None] for a block the extractor wrote without
+          one: an upstream test that asserts the compile throws has no CSS to
+          replay. *)
   variants : string list;  (** [matchVariant] directive lines for this test. *)
   theme_vars : (string * string) list;
       (** [@theme] token overrides (name, value) captured from the test's CSS
@@ -69,8 +81,13 @@ val split_classes : string -> string list
     such as [data-[foo_=_bar]:flex] whole. *)
 
 val read : string -> case list
-(** [read path] reads every block of the fixture at [path]. A file that does not
-    exist reads as no cases, which the caller's floor turns into a failure. *)
+(** [read path] reads every block of the fixture at [path], one case per block,
+    so [List.length (read path)] is {!blocks}. A file that does not exist reads
+    as no cases, which the caller's floor turns into a failure.
+
+    @raise Malformed
+      on any line the grammar above has no place for, rather than skipping the
+      block it sits in. *)
 
 val blocks : string -> int
 (** [blocks path] is the number of blocks in the fixture at [path], counted on


### PR DESCRIPTION
The fixture reader could silently skip malformed or newly shaped test blocks, making parity coverage look complete. Every nonblank line must now belong to a parsed fixture block.