### PR TITLE
test: check negative cases against Tailwind

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -1124,11 +1124,107 @@ let check_handler_roundtrip (module H : Handler) class_name =
   | Error (`Msg msg) ->
       Alcotest.fail ("of_class failed for '" ^ class_name ^ "': " ^ msg)
 
-(** Generic test for invalid inputs - expects parsing to fail *)
-let check_invalid_input (module H : Handler) input =
-  match H.of_class Tw.Scheme.default input with
+(* Why a class must not parse. Each constructor is a claim about Tailwind as
+   well as about tw, and [check_negative_premises] holds every one of them to
+   the pinned CLI: a negative test whose premise is wrong -- Tailwind does emit
+   for the class -- passes forever otherwise. *)
+type rejection = Not_a_utility | Another_handler | Diverges of string
+
+let rejection_claim = function
+  | Not_a_utility -> "Tailwind emits nothing for it either"
+  | Another_handler -> "another tw handler owns it"
+  | Diverges why -> "Tailwind emits for it and tw does not: " ^ why
+
+(* The corpus [check_negative_premises] asks the CLI about, filled as the
+   negative tests run. One entry per class however many handlers refuse it. *)
+let negatives : (string, rejection) Hashtbl.t = Hashtbl.create 128
+
+let negative_corpus () =
+  Hashtbl.fold (fun cls why acc -> (cls, why) :: acc) negatives []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+(** Generic test for invalid inputs - expects parsing to fail. [why] says what
+    the rejection means, and is checked rather than taken on trust: the half
+    that needs no CLI here, the Tailwind half in [check_negative_premises]. *)
+let check_invalid_input ?(why = Not_a_utility) (module H : Handler) input =
+  (match H.of_class Tw.Scheme.default input with
   | Ok _ -> Alcotest.fail ("Expected error for: " ^ input)
-  | Error _ -> ()
+  | Error _ -> ());
+  (* Whether tw as a whole knows the class. Only [Another_handler] says it does,
+     and it is the one reason that does not make the class a tw gap. *)
+  let parses = Result.is_ok (Tw.of_string input) in
+  (match (why, parses) with
+  | Another_handler, false ->
+      Alcotest.failf
+        "%s: filed as owned by another handler, but Tw.of_string refuses it too"
+        input
+  | (Not_a_utility | Diverges _), true ->
+      Alcotest.failf "%s: Tw.of_string parses it, so \"%s\" is the wrong reason"
+        input (rejection_claim why)
+  | _ -> ());
+  Hashtbl.replace negatives input why
+
+(* The class names a sheet's rules select on. Read off the parsed selectors
+   rather than scanned for in the text: a non-ASCII or bracketed class is
+   escaped in the selector and spelled plainly in the class list, so a text scan
+   answers no for a class Tailwind did emit. *)
+let sheet_selectors css =
+  match Css.of_string css with
+  | Error e ->
+      Alcotest.failf "the tailwindcss CLI's own output does not parse: %s"
+        (Cascade.Error.to_string e)
+  | Ok { Css.stylesheet; _ } ->
+      Css.fold
+        (fun acc stmt ->
+          match Css.as_rule stmt with
+          | Some (selector, _, _) -> selector :: acc
+          | None -> acc)
+        [] stylesheet
+
+(** Ask the pinned CLI whether Tailwind agrees with every negative test that has
+    run. Nothing in [check_invalid_input] itself says Tailwind refuses the class
+    too, so a premise that is simply wrong passes on every run. One generation
+    covers the whole corpus: Tailwind's output for a set of classes is the union
+    of what it emits for each. *)
+let check_negative_premises () =
+  require_tailwind_cli ();
+  match negative_corpus () with
+  | [] ->
+      (* A filtered run that reached this before the tests that fill it. *)
+      Alcotest.skip ()
+  | corpus ->
+      (* Alcotest files a test's own stderr under [_build/_tests/], so the count
+         is reported at exit, where the summary line can be read beside it: a
+         corpus this test says nothing about is a corpus nobody sizes. *)
+      let size = List.length corpus in
+      at_exit (fun () ->
+          Fmt.epr "@.%d negative test classes held to Tailwind's answer.@." size);
+      let selectors =
+        sheet_selectors
+          (Tw_tools.Tailwind_gen.generate ~minify:true ~optimize:true
+             (List.map fst corpus))
+      in
+      let emits cls =
+        List.exists (Css.Selector.exists_class (String.equal cls)) selectors
+      in
+      let wrong =
+        List.filter_map
+          (fun (cls, why) ->
+            match (why, emits cls) with
+            | Not_a_utility, true ->
+                Fmt.kstr Option.some
+                  "%s: filed as not a utility, but Tailwind emits a rule for it"
+                  cls
+            | (Another_handler | Diverges _), false ->
+                Fmt.kstr Option.some
+                  "%s: filed as \"%s\", but Tailwind emits nothing" cls
+                  (rejection_claim why)
+            | _ -> None)
+          corpus
+      in
+      if wrong <> [] then
+        Alcotest.failf "%d of %d negative tests disagree with Tailwind:\n%s"
+          (List.length wrong) (List.length corpus) (String.concat "\n" wrong)
 
 let standard ~roundtrip ~invalid =
   Alcotest.
@@ -1144,9 +1240,9 @@ let check_parts (module H : Handler) parts =
 
 (** Helper that takes a list of parts, concatenates with "-", and checks that
     parsing fails *)
-let check_invalid_parts (module H : Handler) parts =
+let check_invalid_parts ?why (module H : Handler) parts =
   let class_name = String.concat "-" parts in
-  check_invalid_input (module H) class_name
+  check_invalid_input ?why (module H) class_name
 
 (** [check_typed_class cls value] checks that the typed constructor [value]
     pretty-prints to class name [cls] and that [cls] round-trips back through

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -343,9 +343,35 @@ val check_handler_roundtrip : (module Handler) -> string -> unit
     {!val-of_class} and converting back with {!val-to_class} round-trip
     correctly. *)
 
-val check_invalid_input : (module Handler) -> string -> unit
-(** [check_invalid_input h input] tests that parsing fails for invalid input as
-    expected. *)
+(** Why a class must not parse. Each constructor is a claim about Tailwind as
+    well as about tw, so that {!check_negative_premises} can hold it to the
+    pinned CLI. *)
+type rejection =
+  | Not_a_utility
+      (** Tailwind emits nothing for the class either, so refusing it is the
+          whole answer. *)
+  | Another_handler
+      (** A real utility a different tw handler owns: Tailwind emits for it and
+          so does {!Tw.of_string}, and only the handler under test says no. *)
+  | Diverges of string
+      (** Tailwind emits for the class and {!Tw.of_string} does not, with the
+          string saying why. Every one of these is a measured parity gap held
+          open here rather than a rejection that reads as intended. *)
+
+val check_invalid_input : ?why:rejection -> (module Handler) -> string -> unit
+(** [check_invalid_input ?why h input] tests that parsing fails for invalid
+    input as expected, and records [input] for {!check_negative_premises}. [why]
+    defaults to {!constructor-Not_a_utility}; the half of it that needs no CLI,
+    whether {!Tw.of_string} knows the class, is checked here. *)
+
+val check_negative_premises : unit -> unit
+(** [check_negative_premises ()] asks the pinned tailwindcss CLI whether every
+    negative test that has run so far had its premise right, in one generation
+    over the whole corpus. It skips without the CLI, and fails instead under
+    [TW_TAILWIND_TESTS=1], the way every other parity check here does.
+
+    It reads what the negative tests registered as they ran, so it belongs after
+    them: see [test/test.ml]. *)
 
 val standard :
   roundtrip:(unit -> unit) ->
@@ -357,9 +383,10 @@ val standard :
 val check_parts : (module Handler) -> string list -> unit
 (** [check_parts h parts] concatenates parts with "-" and tests roundtrip. *)
 
-val check_invalid_parts : (module Handler) -> string list -> unit
-(** [check_invalid_parts h parts] concatenates parts with "-" and tests that
-    parsing fails. *)
+val check_invalid_parts :
+  ?why:rejection -> (module Handler) -> string list -> unit
+(** [check_invalid_parts ?why h parts] concatenates parts with "-" and tests
+    that parsing fails, as {!check_invalid_input}. *)
 
 val check_typed_class : string -> Tw.t -> unit
 (** [check_typed_class cls value] checks that the typed constructor [value]

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,7 +29,6 @@ let () =
     (* Return test suites *)
     [
       Test_tw.suite;
-      Test_test_helpers.suite;
       Test_source_scan.suite;
       Test_svg.suite;
       Test_tables.suite;
@@ -94,4 +93,7 @@ let () =
       Test_text_shadow.suite;
       Test_touch.suite;
       Test_transitions.suite;
+      (* Last: its negative-premise case reads the corpus every suite above
+         fills as its negative tests run. *)
+      Test_test_helpers.suite;
     ]

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -20,8 +20,14 @@ let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide";
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-foo";
   (* A bracket with no number is not a length, so it is refused rather than read
-     as a bare identifier. *)
-  Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-x-[rem]"
+     as a bare identifier. Tailwind passes the bracket through unread and emits
+     border-inline-start-width: calc(rem * ...), which no browser accepts. *)
+  Test_helpers.check_invalid_input
+    ~why:
+      (Test_helpers.Diverges
+         "Tailwind passes the bracket through unread and emits calc(rem * ...)")
+    (module Tw.Divide.Handler)
+    "divide-x-[rem]"
 
 (* divide-x-[2em] and divide-y-[3vw] used to be refused: the width reader only
    knew px and rem, so an em or a vw stop fell through to "not a divide utility"

--- a/test/test_flex.ml
+++ b/test/test_flex.ml
@@ -61,8 +61,10 @@ let of_string_invalid () =
   in
 
   fail_display [ "flex"; "invalid" ];
-  fail_display [ "flex"; "col" ];
-  (* Now in flex_props *)
+  (* A real utility, read by Flex_layout rather than by this handler. *)
+  Test_helpers.check_invalid_parts ~why:Test_helpers.Another_handler
+    (module Tw.Flex.Handler)
+    [ "flex"; "col" ];
   fail_props [ "flex"; "invalid" ];
   fail_props [ "basis" ];
   fail_props [ "order" ];

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -133,17 +133,22 @@ let test_square_sizes () =
 
 let of_string_invalid () =
   (* Invalid sizing values *)
-  let test_invalid input =
+  let test_invalid ?why input =
     let class_name = String.concat "-" input in
-    check_invalid_input (module Tw.Sizing.Handler) class_name
+    check_invalid_input ?why (module Tw.Sizing.Handler) class_name
   in
 
   test_invalid [ "w" ];
   (* Missing value *)
   test_invalid [ "w"; "invalid" ];
-  (* Invalid value *)
-  test_invalid [ "w"; "1/0" ];
-  (* A zero denominator is not a percentage *)
+  (* A zero denominator is not a percentage, although Tailwind still emits the
+     uncomputable calculation. *)
+  test_invalid
+    ~why:
+      (Diverges
+         "Tailwind passes a zero denominator through as calc(1 / 0 * 100%), \
+          which no browser can compute; tw refuses the class instead")
+    [ "w"; "1/0" ];
   test_invalid [ "min" ];
   (* Missing dimension *)
   test_invalid [ "min"; "z"; "4" ];

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -312,6 +312,12 @@ let test_no_surplus_over_a_broad_class_set () =
   Test_helpers.check_no_dropped_declarations ~test_name diff;
   Test_helpers.check_no_surplus ~test_name diff
 
+(* Every negative test asserts tw refuses a class and nothing in the assertion
+   says Tailwind refuses it too, so a premise that is simply wrong passes on
+   every run. This is the one case that asks. It reads the corpus the negative
+   tests fill as they run, which is why [test/test.ml] lists this suite last. *)
+let test_negative_premises () = Test_helpers.check_negative_premises ()
+
 let tests =
   [
     Alcotest.test_case "class position: continuing selector" `Quick
@@ -358,6 +364,8 @@ let tests =
       test_respelling_settles_a_minifier_disagreement;
     Alcotest.test_case "no surplus over a broad class set" `Slow
       test_no_surplus_over_a_broad_class_set;
+    Alcotest.test_case "negative tests agree with Tailwind" `Quick
+      test_negative_premises;
   ]
 
 let suite = ("test_helpers", tests)

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -371,13 +371,17 @@ let test_scheme_from_declared_tokens_only () =
     scheme.Tw.Scheme.default_outline_width;
   Alcotest.(check bool)
     "the declared radius is read" true
-    (Tw.Scheme.radius scheme "full" = Some (Css.Px 9999.));
+    (Option.equal Css.Values.equal_length
+       (Tw.Scheme.radius scheme "full")
+       (Some (Css.Px 9999.)));
   Alcotest.(check bool)
     "an undeclared radius stays absent" false
     (Tw.Scheme.has_explicit_radius scheme "sm");
   Alcotest.(check bool)
     "the declared spacing step is read" true
-    (Tw.Scheme.spacing scheme 4 = Some (Css.Rem 1.));
+    (Option.equal Css.Values.equal_length
+       (Tw.Scheme.spacing scheme 4)
+       (Some (Css.Rem 1.)));
   Alcotest.(check bool)
     "an undeclared spacing step stays absent" false
     (Tw.Scheme.has_explicit_spacing scheme 8)


### PR DESCRIPTION
Negative expectations could pass when tw rejected a class that Tailwind accepts. These cases now require the pinned Tailwind oracle to agree.