### PR TITLE
test/upstream: preserve reused CSS binding metadata

### DIFF
--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -797,7 +797,8 @@ let parse_file filename =
       !current_variant_names |> List.rev
       |> List.filter_map (fun n -> Hashtbl.find_opt variant_defs n)
     in
-    if classes <> [] then
+    let emitted = classes <> [] in
+    if emitted then
       block_tests :=
         {
           name;
@@ -813,8 +814,14 @@ let parse_file filename =
         :: !block_tests;
     current_classes := [];
     current_variant_names := [];
-    current_theme_vars := [];
-    current_theme_modes := [];
+    (* A call with no candidates produces no fixture case, so it has not
+       consumed metadata read from a let-bound CSS template. Tailwind tests
+       commonly compile that template once to show it emits nothing, then pass
+       the same binding to [run] with candidates. Keep its theme input for that
+       later call; a real emitted case consumes it as before. *)
+    if emitted then (
+      current_theme_vars := [];
+      current_theme_modes := []);
     in_theme := None;
     in_expect := None
   in
@@ -841,8 +848,14 @@ let parse_file filename =
           List.map (fun t -> { t with utility_defs = defs }) !block_tests
           @ !tests);
     block_tests := [];
+    (* Metadata an empty call left available for another use of the same CSS
+       binding belongs only to this [test(...)] block. Do not let the final
+       empty assertion in one test seed the first case in the next. *)
+    current_theme_vars := [];
+    current_theme_modes := [];
     current_utility_defs := [];
     current_layer_wrap := None;
+    in_theme := None;
     in_utility := None;
     in_layer := None;
     saw_custom_utility := false

--- a/test/upstream/test_blocks_expected.txt
+++ b/test/upstream/test_blocks_expected.txt
@@ -1,4 +1,4 @@
-#! 9 blocks extracted from test_blocks_input.ts by extract_tests.exe -- do not edit
+#! 10 blocks extracted from test_blocks_input.ts by extract_tests.exe -- do not edit
 # top level
 @config run
 top-level
@@ -55,6 +55,25 @@ sized-4
         width: 4;
       }
       
+<<<>>>
+# reuses a let-bound utility template
+@config run
+@theme-var example-foo 123px
+@utility-def foo value: var(--example-foo);
+@layer-wrap utilities
+foo
+---
+
+      @layer utilities {
+        .foo {
+          value: var(--example-foo);
+        }
+      }
+
+      :root, :host {
+        --example-foo: 123px;
+      }
+
 <<<>>>
 # indented twice
 @config run

--- a/test/upstream/test_blocks_input.ts
+++ b/test/upstream/test_blocks_input.ts
@@ -82,6 +82,42 @@ describe('outer', () => {
     `)
   })
 
+  test('reuses a let-bound utility template', async () => {
+    let input = css`
+      @layer utilities {
+        @tailwind utilities;
+      }
+
+      @theme {
+        --example-foo: 123px;
+      }
+
+      @utility foo {
+        value: var(--example-foo);
+      }
+    `
+
+    expect(await compileCss(input)).toMatchInlineSnapshot(`
+      "
+      @layer utilities;
+      "
+    `)
+
+    expect(await run(['foo'], input)).toMatchInlineSnapshot(`
+      "
+      @layer utilities {
+        .foo {
+          value: var(--example-foo);
+        }
+      }
+
+      :root, :host {
+        --example-foo: 123px;
+      }
+"
+    `)
+  })
+
   describe('inner', () => {
     test('indented twice', async () => {
       expect(await run(['indented-twice'])).toMatchInlineSnapshot(`


### PR DESCRIPTION
Reusing a CSS template binding lost the source metadata needed to extract all associated tests. The extractor now carries that metadata into every use.