### PR TITLE
test/upstream: retain routed layer source order

### DIFF
--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -153,6 +153,10 @@ type test_case = {
       (** The layer the test's CSS template puts [@tailwind utilities] in, when
           it puts it in one at all. Tailwind emits the generated utilities
           inside that layer and everything else beside it. *)
+  layer_before_theme : bool;
+      (** Whether that layer appeared before a later [@theme] block. Source
+          order decides whether Tailwind writes the generated layer before or
+          after the theme declarations beside it. *)
 }
 
 (* Parse [matchVariant('name', (value) => `template`, { values: {...} })] calls
@@ -758,6 +762,7 @@ let parse_file filename =
      what it holds: an [@layer] wrapping the author's own rules names nothing
      for the generator. *)
   let current_layer_wrap = ref None in
+  let current_layer_before_theme = ref false in
   let in_layer = ref None in
   let layer_open_re = Re.Pcre.regexp {|@layer\s+([A-Za-z0-9_-]+)\s*\{|} in
   let tailwind_utilities_re = Re.Pcre.regexp {|@tailwind\s+utilities|} in
@@ -810,6 +815,7 @@ let parse_file filename =
           theme_modes = List.rev !current_theme_modes;
           utility_defs = [];
           layer_wrap = !current_layer_wrap;
+          layer_before_theme = !current_layer_before_theme;
         }
         :: !block_tests;
     current_classes := [];
@@ -855,6 +861,7 @@ let parse_file filename =
     current_theme_modes := [];
     current_utility_defs := [];
     current_layer_wrap := None;
+    current_layer_before_theme := false;
     in_theme := None;
     in_utility := None;
     in_layer := None;
@@ -910,6 +917,18 @@ let parse_file filename =
           else if Re.execp theme_re line then (
             saw_keep_theme := true;
             current_config := Theme);
+
+          (* The generated utilities and the theme declarations remain beside
+             one another in source order. [current_layer_wrap] is set only after
+             its block closes, so seeing a later [@theme] records the one
+             ordering the replay cannot recover from the two statements
+             alone. *)
+          if
+            Option.is_some !current_layer_wrap
+            && (Re.execp theme_inline_ref_re line
+               || Re.execp theme_inline_re line
+               || Re.execp theme_ref_re line || Re.execp theme_re line)
+          then current_layer_before_theme := true;
 
           (* Capture [@theme] token declarations. Enter just after the opener's
              [{] and read on until the block's closing [}]. *)
@@ -1118,6 +1137,7 @@ let () =
         (fun (n, body) -> Fmt.pr "@utility-def %s %s@." n body)
         test.utility_defs;
       Option.iter (Fmt.pr "@layer-wrap %s@.") test.layer_wrap;
+      if test.layer_before_theme then Fmt.pr "@layer-before-theme true@.";
       Fmt.pr "%s@." (String.concat " " test.classes);
       (match test.expected with
       | Some css ->

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -221,7 +221,7 @@ let canonical_stylesheet_css css = String.trim css
    theme block, the [@property] rules, and whatever a declared utility hoists.
    tw wraps the whole sheet in its own layer scaffolding, so keep the layer the
    template named and flatten the rest. *)
-let keep_only_layer name stylesheet =
+let keep_only_layer ~before_theme name stylesheet =
   let rec go stmts =
     List.concat_map
       (fun stmt ->
@@ -234,7 +234,21 @@ let keep_only_layer name stylesheet =
           | None -> [ stmt ])
       stmts
   in
-  Css.v (go (Css.statements stylesheet))
+  let statements = go (Css.statements stylesheet) in
+  let statements =
+    if not before_theme then statements
+    else
+      let wrapped, rest =
+        List.partition
+          (fun stmt ->
+            match Css.as_layer stmt with
+            | Some (Some n, _) -> Css.Stylesheet.equal_layer_name n [ name ]
+            | Some (None, _) | None -> false)
+          statements
+      in
+      wrapped @ rest
+  in
+  Css.v statements
 
 (* Tailwind compiled the corpus from each case's own [@theme] block, with no
    default theme behind it, so the [@keyframes] that theme declares are in no
@@ -605,7 +619,8 @@ let run_test_case test expected () =
         let sheet =
           match test.layer_wrap with
           | None -> sheet
-          | Some name -> keep_only_layer name sheet
+          | Some name ->
+              keep_only_layer ~before_theme:test.layer_before_theme name sheet
         in
         Some (drop_theme_keyframes sheet)
     in

--- a/test/upstream/test_blocks_expected.txt
+++ b/test/upstream/test_blocks_expected.txt
@@ -61,6 +61,7 @@ sized-4
 @theme-var example-foo 123px
 @utility-def foo value: var(--example-foo);
 @layer-wrap utilities
+@layer-before-theme true
 foo
 ---
 

--- a/test/upstream/upstream_fixture.ml
+++ b/test/upstream/upstream_fixture.ml
@@ -11,6 +11,7 @@
     @theme-mode <name> <modifiers>        (optional, repeatable)
     @utility-def <name> <body>            (optional, repeatable)
     @layer-wrap <layer>                   (optional)
+    @layer-before-theme true              (optional)
     <space-separated class list>
     ---
     <expected CSS>
@@ -69,6 +70,9 @@ type case = {
       (** The layer the test's CSS template compiles [@tailwind utilities] into,
           when it names one. Tailwind puts the generated utilities in it and
           everything else beside it. *)
+  layer_before_theme : bool;
+      (** Whether the wrapped utilities precede a later [@theme] block in the
+          source template. *)
 }
 
 (** Split a class line by spaces, but don't split inside brackets. *)
@@ -157,6 +161,7 @@ let parse_block filename block =
   let theme_modes = ref [] in
   let utility_defs = ref [] in
   let layer_wrap = ref None in
+  let layer_before_theme = ref false in
   let read_config n arg =
     match config_of_string arg with
     | c -> config := c
@@ -183,6 +188,12 @@ let parse_block filename block =
           utility_defs :=
             named_pair filename n "@utility-def " arg :: !utility_defs );
       ("@layer-wrap ", fun _ arg -> layer_wrap := Some arg);
+      ( "@layer-before-theme ",
+        fun n arg ->
+          match arg with
+          | "true" -> layer_before_theme := true
+          | "false" -> layer_before_theme := false
+          | _ -> malformed filename n arg "true or false" );
     ]
   in
   let rec directives lines =
@@ -230,6 +241,7 @@ let parse_block filename block =
         theme_modes = List.rev !theme_modes;
         utility_defs = List.rev !utility_defs;
         layer_wrap = !layer_wrap;
+        layer_before_theme = !layer_before_theme;
       }
 
 let read filename =

--- a/test/upstream/upstream_fixture.mli
+++ b/test/upstream/upstream_fixture.mli
@@ -74,6 +74,9 @@ type case = {
       (** The layer the test's CSS template compiles [@tailwind utilities] into,
           when it names one. Tailwind puts the generated utilities in it and
           everything else beside it. *)
+  layer_before_theme : bool;
+      (** Whether the wrapped utilities precede a later [@theme] block in the
+          source template. *)
 }
 
 val split_classes : string -> string list

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -1,4 +1,4 @@
-#! 699 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
+#! 700 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
 # sr-only
 @config run
 sr-only
@@ -22498,6 +22498,26 @@ basis-sm max-w-sm min-w-sm w-sm
         flex-basis: var(--spacing-sm);
       }
       
+<<<>>>
+# custom static utility emit CSS variables if the utility is used
+@config run
+@theme-var example-foo 123px
+@utility-def foo value: var(--example-foo);
+@layer-wrap utilities
+@layer-before-theme true
+foo
+---
+
+      @layer utilities {
+        .foo {
+          value: var(--example-foo);
+        }
+      }
+
+      :root, :host {
+        --example-foo: 123px;
+      }
+
 <<<>>>
 # Multiple static utilities are merged
 @config run


### PR DESCRIPTION
A routed utility layer could move after a later theme block, changing the source order exercised by the fixture. Routed layer metadata now retains its original position.