### PR TITLE
test/upstream: ignore redundant vendor prefixes

### DIFF
--- a/test/upstream/dune
+++ b/test/upstream/dune
@@ -6,7 +6,7 @@
 (executable
  (name extract_tests)
  (modules extract_tests)
- (libraries re fmt astring cascade tw_tools))
+ (libraries re fmt astring cascade tw tw_tools))
 
 (test
  (name test)

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -440,10 +440,11 @@ let var_reference_re = Re.Pcre.regexp {|var\(\s*--([A-Za-z0-9_-]+)|}
 let var_references body =
   List.map (fun g -> Re.Group.get g 1) (Re.all var_reference_re body)
 
-(* Tailwind runs its output through a minifier that adds vendor prefixes. A
-   declared utility's body reaches the sheet as written, so a snapshot spelling
-   a prefixed property no definition wrote is one tw cannot produce. *)
-let vendor_prefixes = [ "-webkit-"; "-moz-"; "-ms-" ]
+(* Theme-token registries are populated by the families that own them. Building
+   the base sheet once loads the same complete registry the replay runner uses;
+   the extractor can then distinguish a missing theme token from an arbitrary
+   runtime custom property. *)
+let init_theme_tokens = lazy (ignore (Tw.to_css ~base:true []))
 
 (* [@utility example-*] declares a functional utility: its body is a template
    whose [--value(...)] and [--modifier(...)] reads stand for the candidate's
@@ -523,14 +524,11 @@ let math_functions = [ "calc("; "min("; "max("; "clamp("; "round(" ]
    govern replays; every other class still goes through the built-in generator,
    which has no reference-token mode.
 
-   A [var(--name)] a definition reads is rendered against tw's own theme when
-   the fixture carries no value for it, which is either a token Tailwind never
-   emitted or a value it emitted from the case's theme. A case with no class for
-   the declarations to govern never reads it, so it is kept.
-
-   Tailwind's minifier vendor-prefixes what it emits. A declared utility's body
-   reaches tw's sheet as written, so a snapshot holding a prefixed property no
-   definition wrote is out of reach.
+   A [var(--name)] a definition reads and the snapshot retains is rendered
+   against tw's own theme when the fixture carries no value for it, which is
+   either a token Tailwind never emitted or a value it emitted from the case's
+   theme. A dead declaration, or an arbitrary runtime custom property, is not a
+   missing theme dependency.
 
    An [@theme inline] token stands for its value at every use site, and
    Tailwind's minifier folds a math function there to a number of its own
@@ -552,21 +550,21 @@ let unreplayable ~defs ~config ~theme_vars ~theme_modes ~classes expected =
         if is_functional def then None else unreadable_declaration (snd def))
       defs
   in
-  let unresolved_reference name = not (List.mem_assoc name theme_vars) in
+  let () = Lazy.force init_theme_tokens in
+  let unresolved_reference name =
+    (not (List.mem_assoc name theme_vars))
+    && (Option.is_some (Tw.Scheme.token_default name)
+       || Option.is_some (Tw.Var.resolve_theme_refs name))
+  in
   let reads_unknown_token =
     List.exists
-      (fun (_, body) -> List.exists unresolved_reference (var_references body))
+      (fun (_, body) ->
+        List.exists
+          (fun name ->
+            unresolved_reference name
+            && Astring.String.is_infix ~affix:("var(--" ^ name) expected)
+          (var_references body))
       defs
-  in
-  let prefixed_snapshot =
-    List.exists
-      (fun prefix ->
-        Astring.String.is_infix ~affix:prefix expected
-        && not
-             (List.exists
-                (fun (_, body) -> Astring.String.is_infix ~affix:prefix body)
-                defs))
-      vendor_prefixes
   in
   let applies = List.exists (fun (_, b) -> contains_apply b) defs in
   let undeclared_breakpoint =
@@ -622,8 +620,6 @@ let unreplayable ~defs ~config ~theme_vars ~theme_modes ~classes expected =
       "@theme reference and %d class(es) the declarations do not govern, which \
        tw has no reference-token mode for"
       (List.length classes - List.length routed)
-  else if prefixed_snapshot then
-    Some "Tailwind's minifier vendor-prefixed a declared utility's property"
   else if reads_unknown_token && routed <> [] then
     Some
       "a declared utility reads a theme token the fixture does not carry, so \

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -263,6 +263,58 @@ let drop_theme_keyframes stylesheet =
        (fun stmt -> Option.is_none (Css.as_keyframes stmt))
        (Css.statements stylesheet))
 
+(* Compatibility minifiers add prefixed declarations beside the declaration a
+   utility authored. For parity, that duplicate is semantically inert only when
+   the same declaration block holds an identical unprefixed property and value.
+   A lone prefix, or a prefix whose value maps to another keyword, stays in the
+   comparison. Parse warnings leave the input alone so this normalisation cannot
+   hide a declaration the CSS reader dropped. *)
+let vendor_prefixes = [ "-webkit-"; "-moz-"; "-ms-" ]
+
+let declaration_parts declaration =
+  let text = Css.Declaration.to_string ~minify:true declaration in
+  match String.index_opt text ':' with
+  | None -> None
+  | Some i ->
+      Some
+        ( String.sub text 0 i,
+          String.sub text (i + 1) (String.length text - i - 1) )
+
+let unprefixed_name name =
+  List.find_map
+    (fun prefix ->
+      if String.starts_with ~prefix name then
+        Some
+          (String.sub name (String.length prefix)
+             (String.length name - String.length prefix))
+      else None)
+    vendor_prefixes
+
+let drop_redundant_vendor_prefixes css =
+  match Css.of_string css with
+  | Ok { stylesheet; warnings = []; _ } ->
+      let stylesheet =
+        Css.Stylesheet.map_declarations
+          (fun declarations ->
+            List.filter
+              (fun declaration ->
+                match declaration_parts declaration with
+                | Some (name, value) -> (
+                    match unprefixed_name name with
+                    | None -> true
+                    | Some name ->
+                        not
+                          (List.exists
+                             (fun candidate ->
+                               declaration_parts candidate = Some (name, value))
+                             declarations))
+                | None -> true)
+              declarations)
+          stylesheet
+      in
+      Css.to_string ~minify:true stylesheet |> String.trim
+  | Ok _ | Error _ -> css
+
 (* [color-mix(in oklab, C p%, transparent)] denotes the concrete colour C at
    alpha p, which LightningCSS folds to an [oklab(...)] in the fixtures. tw
    keeps the colour itself (exact and shorter once cascade folds it to a hex),
@@ -629,9 +681,11 @@ let run_test_case test expected () =
       | None -> ""
       | Some stylesheet ->
           stylesheet |> resolve_theme |> Css.to_string ~minify:true
-          |> String.trim
+          |> String.trim |> drop_redundant_vendor_prefixes
     in
-    let expected_css = canonical_stylesheet_css expected in
+    let expected_css =
+      canonical_stylesheet_css expected |> drop_redundant_vendor_prefixes
+    in
     if our_css = "" && expected = "" then ()
     else
       let normalize_colors s =
@@ -696,6 +750,19 @@ let test_color_mix_percentage () =
     "color-mix(in oklab, red var(--opacity-half, .5), transparent)"
     "color-mix(in oklab, red var(--opacity-half, .5), transparent)";
   check "text outside color-mix untouched" "opacity: .5" "opacity: .5"
+
+let test_redundant_vendor_prefixes () =
+  let check msg expected input =
+    Alcotest.(check string) msg expected (drop_redundant_vendor_prefixes input)
+  in
+  check "identical prefixed declarations are redundant"
+    ".x{mask-image:var(--x)}"
+    ".x{-webkit-mask-image:var(--x);-webkit-mask-image:var(--x);mask-image:var(--x)}";
+  check "a mapped prefix remains observable"
+    ".x{-webkit-mask-composite:source-in;mask-composite:intersect}"
+    ".x{-webkit-mask-composite:source-in;mask-composite:intersect}";
+  check "a prefix with no unprefixed declaration remains observable"
+    ".x{-webkit-mask-image:var(--x)}" ".x{-webkit-mask-image:var(--x)}"
 
 (* Guards [truncate_color_precision]: it truncates (never rounds) the
    oklab-family axes to three decimals like Tailwind's snapshot serialiser, so
@@ -970,6 +1037,8 @@ let () =
     [
       test_case "oklab precision truncation" `Quick test_color_tolerance;
       test_case "color-mix percentage" `Quick test_color_mix_percentage;
+      test_case "redundant vendor prefixes" `Quick
+        test_redundant_vendor_prefixes;
       test_case "the theme echo is limited to declared tokens" `Quick
         test_echo_only_declared_tokens;
       test_case "the scheme is built from declared tokens only" `Quick

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -1,4 +1,4 @@
-#! 700 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
+#! 701 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
 # sr-only
 @config run
 sr-only
@@ -877,7 +877,7 @@ isolate isolation-auto
       .z-auto {
         z-index: auto;
       }
-      
+
 <<<>>>
 # z-index
 @config run
@@ -22665,7 +22665,7 @@ example-1 example-2
         .example-2 {
           --resolved-value: 2;
         }
-        
+
 <<<>>>
 # functional utilities must resolve at least one `--value(…)`
 @config run
@@ -23522,6 +23522,20 @@ example-foo
           background-color: var(--example-foo);
         }
         
+<<<>>>
+# declaration nodes are only replaced/removed once
+@config run
+@utility-def mask-r-* --mask-right: linear-gradient(to left, transparent, black --value(percentage)); --mask-right: linear-gradient( to left, transparent calc(var(--spacing) * --modifier(integer)), black calc(var(--spacing) * --value(integer)) ); mask-image: var(--mask-linear), var(--mask-radial), var(--mask-conic);
+mask-r-20%
+---
+
+        .mask-r-20\% {
+          --mask-right: linear-gradient(to left, transparent, black 20%);
+          -webkit-mask-image: var(--mask-linear), var(--mask-radial), var(--mask-conic);
+          -webkit-mask-image: var(--mask-linear), var(--mask-radial), var(--mask-conic);
+          mask-image: var(--mask-linear), var(--mask-radial), var(--mask-conic);
+        }
+
 <<<>>>
 # resolve value based on `@theme`
 @config run


### PR DESCRIPTION
Lightning CSS can remove a redundant vendor-prefixed mask declaration that Tailwind emits beside the standard form. Parity normalization now compares the surviving declaration.