### PR TITLE
test/upstream: normalize static number math

### DIFF
--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -500,9 +500,6 @@ let variant_prefixes cls =
   | None -> []
   | Some i -> String.split_on_char ':' (String.sub cls 0 i)
 
-(* The math functions whose result Tailwind's minifier writes out. *)
-let math_functions = [ "calc("; "min("; "max("; "clamp("; "round(" ]
-
 (* Why the runner cannot reproduce a block that declares its own [@utility], or
    [None] when it can. Each reason is a gap to close, not a property of the
    corpus: the check goes when the gap does.
@@ -530,15 +527,10 @@ let math_functions = [ "calc("; "min("; "max("; "clamp("; "round(" ]
    theme. A dead declaration, or an arbitrary runtime custom property, is not a
    missing theme dependency.
 
-   An [@theme inline] token stands for its value at every use site, and
-   Tailwind's minifier folds a math function there to a number of its own
-   spelling ([calc(1 / 0.75)] comes out as [1.33333]). tw inlines the value as
-   written, and cascade prints a math function rather than working it out.
-
    [run()] compiles against an empty theme, so a named breakpoint variant the
    template never declares resolves to nothing upstream; tw's [Scheme.t] has no
    way to say "no breakpoints" (an empty list means the built-in ones). *)
-let unreplayable ~defs ~config ~theme_vars ~theme_modes ~classes expected =
+let unreplayable ~defs ~config ~theme_vars ~classes expected =
   let routed =
     List.filter
       (Tw_tools.Entrypoint.is_custom_routed ~defs:[] ~udefs:defs)
@@ -577,19 +569,6 @@ let unreplayable ~defs ~config ~theme_vars ~theme_modes ~classes expected =
           (variant_prefixes cls))
       classes
   in
-  let inlined_math =
-    List.exists
-      (fun (name, modes) ->
-        List.mem "inline" modes
-        &&
-        match List.assoc_opt name theme_vars with
-        | None -> false
-        | Some value ->
-            List.exists
-              (fun fn -> Astring.String.is_infix ~affix:fn value)
-              math_functions)
-      theme_modes
-  in
   let merged_with_builtin =
     (not applies)
     && List.exists
@@ -624,10 +603,6 @@ let unreplayable ~defs ~config ~theme_vars ~theme_modes ~classes expected =
     Some
       "a declared utility reads a theme token the fixture does not carry, so \
        tw cannot render it against the case's own theme"
-  else if inlined_math then
-    Some
-      "an inline theme token whose value is a math function Tailwind's \
-       minifier works out and cascade prints as written"
   else if undeclared_breakpoint then
     Some "a breakpoint variant the case's own theme does not declare"
   else None
@@ -836,7 +811,7 @@ let parse_file filename =
         List.find_map
           (fun t ->
             unreplayable ~defs ~config:t.config ~theme_vars:t.theme_vars
-              ~theme_modes:t.theme_modes ~classes:t.classes
+              ~classes:t.classes
               (Option.value ~default:"" t.expected))
           (List.rev !block_tests)
     in

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -43,12 +43,10 @@ open Cascade_diff
 open Alcotest
 open Upstream_fixture
 
-(* Colour comparison is normalised the way Tailwind normalises its own
-   snapshots: [color_mix_to_oklab] then [truncate_color_precision] run on both
-   sides before the diff, so an [oklab] fixture and tw's exact colour describe
-   the same value. That is pure fixture skew, not a tw bug: Tailwind's snapshot
-   serialiser truncates oklab axes for cross-OS stability, and the fixtures fold
-   a concrete-colour opacity to [oklab] where tw keeps the shorter exact colour.
+(* Fixture comparison normalises semantic artifacts of Tailwind's serializer and
+   compatibility minifier on both sides before the diff: colour precision,
+   concrete colour-mix folds, redundant vendor prefixes, and a static math
+   function that reduces to one number. None of those is a generator choice.
    Nothing else is tolerated: the diff a case reports is the diff it fails on.
    (A [--font-sans] / [--tw-prose-*] custom-property allowance, a
    [--text-*--line-height] allowance, a mask-angle calc allowance, an [@property
@@ -313,6 +311,69 @@ let drop_redundant_vendor_prefixes css =
           stylesheet
       in
       Css.to_string ~minify:true stylesheet |> String.trim
+  | Ok _ | Error _ -> css
+
+(* LightningCSS evaluates a static dimensionless math function before writing a
+   snapshot. Cascade deliberately preserves authored math in several property
+   grammars, so canonical comparison evaluates only a function that parses in
+   full as a [<number>] and reduces to a concrete numeric leaf. A dimension, a
+   [var()] or an unknown function remains byte-for-byte visible. Concrete
+   results use the snapshot serializer's six-significant-figure budget. *)
+
+let rec concrete_number : Css.number -> float option = function
+  | Css.Num value -> Some value
+  | Css.Calc calc -> concrete_number_calc calc
+  | Css.Var _ | Css.Round _ | Css.Mod _ | Css.Rem _ | Css.Hypot _ | Css.Pow _
+  | Css.Sqrt _ | Css.Abs _ | Css.Sign _ | Css.Sin _ ->
+      None
+
+and concrete_number_calc : Css.number Css.calc -> float option = function
+  | Css.Num value -> Some value
+  | Css.Val number -> concrete_number number
+  | Css.Nested calc | Css.Parens calc -> concrete_number_calc calc
+  | Css.Expr (left, op, right) -> (
+      match (concrete_number_calc left, concrete_number_calc right) with
+      | Some left, Some right -> (
+          match op with
+          | Css.Add -> Some (left +. right)
+          | Css.Sub -> Some (left -. right)
+          | Css.Mul -> Some (left *. right)
+          | Css.Div when right <> 0. -> Some (left /. right)
+          | Css.Div -> None)
+      | None, _ | _, None -> None)
+  | Css.Var _ | Css.Math_const _ | Css.Sibling_index | Css.Sibling_count
+  | Css.Math_fn _ ->
+      None
+
+let fold_declaration_static_number_math declaration =
+  let authored = Css.Declaration.string_of_value ~minify:true declaration in
+  let cursor = Cascade.Cursor.of_string authored in
+  match
+    try Some (Css.Values.read_number cursor)
+    with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> None
+  with
+  | Some (Css.Num _) -> declaration
+  | Some _ when not (Cascade.Cursor.is_done cursor) -> declaration
+  | Some number -> (
+      match concrete_number (Css.Values.normalize_number number) with
+      | Some value when Float.is_finite value -> (
+          let value = Css.Pp.round_sig 6 value in
+          let value =
+            Css.Pp.to_string ~minify:true Css.Values.pp_number (Css.Num value)
+          in
+          try Css.Declaration.with_value declaration value
+          with Cascade.Cursor.Parse_error _ | Invalid_argument _ ->
+            declaration)
+      | Some _ | None -> declaration)
+  | None -> declaration
+
+let fold_static_number_math css =
+  match Css.of_string css with
+  | Ok { stylesheet; warnings = []; _ } ->
+      Css.Stylesheet.map_declarations
+        (List.map fold_declaration_static_number_math)
+        stylesheet
+      |> Css.to_string ~minify:true |> String.trim
   | Ok _ | Error _ -> css
 
 (* [color-mix(in oklab, C p%, transparent)] denotes the concrete colour C at
@@ -689,7 +750,8 @@ let run_test_case test expected () =
     if our_css = "" && expected = "" then ()
     else
       let normalize_colors s =
-        truncate_color_precision (color_mix_to_oklab (color_mix_percentage s))
+        s |> fold_static_number_math |> color_mix_percentage
+        |> color_mix_to_oklab |> truncate_color_precision
       in
       let result =
         Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
@@ -763,6 +825,24 @@ let test_redundant_vendor_prefixes () =
     ".x{-webkit-mask-composite:source-in;mask-composite:intersect}";
   check "a prefix with no unprefixed declaration remains observable"
     ".x{-webkit-mask-image:var(--x)}" ".x{-webkit-mask-image:var(--x)}"
+
+let test_static_number_math () =
+  let check msg expected input =
+    Alcotest.(check string) msg expected (fold_static_number_math input)
+  in
+  check "static division is evaluated" ".x{line-height:1.33333}"
+    ".x{line-height:calc(1 / 0.75)}";
+  check "the serializer's six significant figures are used"
+    ".x{opacity:.333333}" ".x{opacity:calc(1 / 3)}";
+  check "static addition is evaluated" ".x{opacity:3}" ".x{opacity:calc(1 + 2)}";
+  check "dimensional math is not a number" ".x{width:calc(1px + 2px)}"
+    ".x{width:calc(1px + 2px)}";
+  check "a variable remains observable" ".x{opacity:calc(var(--x)/2)}"
+    ".x{opacity:calc(var(--x) / 2)}";
+  check "another CSS function remains observable" ".x{color:rgb(1 2 3)}"
+    ".x{color:rgb(1 2 3)}";
+  check "a function in a string remains observable"
+    ".x{content:\"calc(1 / 3)\"}" ".x{content:\"calc(1 / 3)\"}"
 
 (* Guards [truncate_color_precision]: it truncates (never rounds) the
    oklab-family axes to three decimals like Tailwind's snapshot serialiser, so
@@ -1039,6 +1119,7 @@ let () =
       test_case "color-mix percentage" `Quick test_color_mix_percentage;
       test_case "redundant vendor prefixes" `Quick
         test_redundant_vendor_prefixes;
+      test_case "static number math" `Quick test_static_number_math;
       test_case "the theme echo is limited to declared tokens" `Quick
         test_echo_only_declared_tokens;
       test_case "the scheme is built from declared tokens only" `Quick

--- a/test/upstream/utilities.txt
+++ b/test/upstream/utilities.txt
@@ -1,4 +1,4 @@
-#! 701 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
+#! 702 blocks extracted from utilities.test.ts by extract_tests.exe -- do not edit
 # sr-only
 @config run
 sr-only
@@ -23591,6 +23591,22 @@ example-a
         --resolved-value: 8;
       }
       
+<<<>>>
+# sub namespaces can live in different @theme blocks (1)
+@config run
+@theme-var text-xs 0.75rem
+@theme-var text-xs--line-height calc(1 / 0.75)
+@theme-mode text-xs reference
+@theme-mode text-xs--line-height inline reference
+@utility-def example-* font-size: --value(--text); line-height: --value(--text-*--line-height);
+example-xs
+---
+
+      .example-xs {
+        font-size: var(--text-xs, .75rem);
+        line-height: 1.33333;
+      }
+
 <<<>>>
 # sub namespaces can live in different @theme blocks (2)
 @config run


### PR DESCRIPTION
Lightning CSS folds static numeric expressions that Tailwind leaves as math functions, producing fixture-only differences. Parity normalization now compares their evaluated number.