### PR TITLE
lint: drop redundant constructor prefixes

### DIFF
--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -44,36 +44,35 @@ module Handler = struct
     | Arbitrary_size of string
 
   type radial_at_position =
-    | At_keyword of string (* keywords like "bottom", "top left" *)
-    | At_arbitrary of
+    | Keyword of string (* keywords like "bottom", "top left" *)
+    | Bracket of
         string (* arbitrary values like "25%" - stored without brackets *)
 
   type mask_angle =
-    | Angle_int of
-        int (* mask-linear-45 → calc(1deg * 45); mask-linear-1 → 1deg *)
-    | Angle_arb of string
+    | Int of int (* mask-linear-45 → calc(1deg * 45); mask-linear-1 → 1deg *)
+    | Arb of string
       (* mask-linear-[3rad] → 171.887deg, read and converted at style time *)
-    | Angle_arb_neg of string
+    | Arb_neg of string
   (* -mask-linear-[3rad] → calc(171.887deg * -1) *)
 
   type var_ref_kind = Plain_var | Length_var
 
   type t =
-    | Mask_position of direction * position_end * value
-    | Mask_var_ref of direction * position_end * var_ref_kind * string
+    | Position of direction * position_end * value
+    | Var_ref of direction * position_end * var_ref_kind * string
       (* (--var) or (length:--var) → sets position to var(--var) *)
-    | Mask_color_ref of direction * position_end * string
+    | Color_ref of direction * position_end * string
       (* (color:--var) → sets color to var(--var) *)
-    | Mask_stop_color of direction * position_end * Color.color * int
+    | Stop_color of direction * position_end * Color.color * int
       (* a palette entry as the stop colour *)
-    | Mask_stop_keyword of direction * position_end * Css.color * string
+    | Stop_keyword of direction * position_end * Css.color * string
       (* transparent / current as the stop colour *)
-    | Mask_linear_angle of mask_angle
-    | Mask_conic_angle of mask_angle
-    | Mask_radial (* just mask-radial with no position *)
-    | Mask_radial_at of radial_at_position (* mask-radial-at-* *)
-    | Mask_radial_shape of radial_shape (* mask-circle, mask-ellipse *)
-    | Mask_radial_size of radial_size (* mask-radial-closest-corner etc. *)
+    | Linear_angle of mask_angle
+    | Conic_angle of mask_angle
+    | Radial (* just mask-radial with no position *)
+    | Radial_at of radial_at_position (* mask-radial-at-* *)
+    | Radial_shape of radial_shape (* mask-circle, mask-ellipse *)
+    | Radial_size of radial_size (* mask-radial-closest-corner etc. *)
 
   type Utility.base += Self of t
 
@@ -578,7 +577,7 @@ module Handler = struct
      sheet as the author spelled it. *)
   let build_radial_at_style pos =
     match pos with
-    | At_arbitrary s -> (
+    | Bracket s -> (
         match radial_at_position s with
         | Some p -> style [ set radial_position_var p ]
         | None ->
@@ -588,7 +587,7 @@ module Handler = struct
                   (Var.css_name radial_position_var)
                   s;
               ])
-    | At_keyword s ->
+    | Keyword s ->
         style
           [
             custom_property ~layer:"utilities"
@@ -694,17 +693,16 @@ module Handler = struct
   let angle_position_decl var angle =
     let negated a : angle = Calc (Expr (Val a, Mul, Num (-1.0))) in
     match angle with
-    | Angle_int n when n >= -1 && n <= 1 -> set var (Deg (float_of_int n))
-    | Angle_int n ->
-        set var (Calc (Expr (Val (Deg 1.0), Mul, Num (float_of_int n))))
+    | Int n when n >= -1 && n <= 1 -> set var (Deg (float_of_int n))
+    | Int n -> set var (Calc (Expr (Val (Deg 1.0), Mul, Num (float_of_int n))))
     (* A bracket value that is not an angle still reaches the sheet, negation
        and all, because the variable takes any token stream and Tailwind writes
        the text through. On its own it is carried as the spec-invalid angle it
        is; negated it is spelled out, because a typed [calc] over an invalid
        operand loses the spaces around the operator that both tools write. *)
-    | Angle_arb s ->
+    | Arb s ->
         set var (Option.value (arbitrary_angle s) ~default:(invalid_angle s))
-    | Angle_arb_neg s -> (
+    | Arb_neg s -> (
         match arbitrary_angle s with
         | Some a -> set var (negated a)
         | None ->
@@ -836,34 +834,34 @@ module Handler = struct
       build_conic_style ~theme pos_end value
     in
     function
-    | Mask_position (Top, pos_end, value) ->
+    | Position (Top, pos_end, value) ->
         build_directional_style Top pos_end value
-    | Mask_position (Right, pos_end, value) ->
+    | Position (Right, pos_end, value) ->
         build_directional_style Right pos_end value
-    | Mask_position (Bottom, pos_end, value) ->
+    | Position (Bottom, pos_end, value) ->
         build_directional_style Bottom pos_end value
-    | Mask_position (Left, pos_end, value) ->
+    | Position (Left, pos_end, value) ->
         build_directional_style Left pos_end value
-    | Mask_position (X, pos_end, value) -> build_x_style pos_end value
-    | Mask_position (Y, pos_end, value) -> build_y_style pos_end value
-    | Mask_position (Linear, pos_end, value) -> build_linear_style pos_end value
-    | Mask_position (Radial, pos_end, value) -> build_radial_style pos_end value
-    | Mask_position (Conic, pos_end, value) -> build_conic_style pos_end value
-    | Mask_linear_angle angle -> build_linear_angle_style angle
-    | Mask_conic_angle angle -> build_conic_angle_style angle
-    | Mask_radial -> build_radial_base_style
-    | Mask_radial_at pos -> build_radial_at_style pos
-    | Mask_radial_shape shape -> build_radial_shape_style shape
-    | Mask_radial_size size -> build_radial_size_style size
-    | Mask_var_ref (dir, pos_end, _, var_name) ->
+    | Position (X, pos_end, value) -> build_x_style pos_end value
+    | Position (Y, pos_end, value) -> build_y_style pos_end value
+    | Position (Linear, pos_end, value) -> build_linear_style pos_end value
+    | Position (Radial, pos_end, value) -> build_radial_style pos_end value
+    | Position (Conic, pos_end, value) -> build_conic_style pos_end value
+    | Linear_angle angle -> build_linear_angle_style angle
+    | Conic_angle angle -> build_conic_angle_style angle
+    | Radial -> build_radial_base_style
+    | Radial_at pos -> build_radial_at_style pos
+    | Radial_shape shape -> build_radial_shape_style shape
+    | Radial_size size -> build_radial_size_style size
+    | Var_ref (dir, pos_end, _, var_name) ->
         build_var_ref_style dir pos_end var_name
-    | Mask_color_ref (dir, pos_end, var_name) ->
+    | Color_ref (dir, pos_end, var_name) ->
         build_color_ref_style dir pos_end var_name
-    | Mask_stop_color (dir, pos_end, c, shade) ->
+    | Stop_color (dir, pos_end, c, shade) ->
         build_stop_color_style ~theme dir pos_end c shade
-    | Mask_stop_keyword (dir, pos_end, Current, _) ->
+    | Stop_keyword (dir, pos_end, Current, _) ->
         build_current_color_style dir pos_end
-    | Mask_stop_keyword (dir, pos_end, value, _) ->
+    | Stop_keyword (dir, pos_end, value, _) ->
         build_color_value_style dir pos_end value
 
   (* Tailwind sorts a layer's rules by the properties they set, walking the
@@ -908,27 +906,26 @@ module Handler = struct
     property_suborder (block + stop) + sides + if var then 0 else 1
 
   let suborder = function
-    | Mask_stop_keyword (dir, pos_end, _, _)
-    | Mask_stop_color (dir, pos_end, _, _) ->
+    | Stop_keyword (dir, pos_end, _, _) | Stop_color (dir, pos_end, _, _) ->
         stop_suborder dir pos_end ~color:true ~var:false
-    | Mask_color_ref (dir, pos_end, _) ->
+    | Color_ref (dir, pos_end, _) ->
         stop_suborder dir pos_end ~color:true ~var:true
-    | Mask_var_ref (dir, pos_end, _, _) ->
+    | Var_ref (dir, pos_end, _, _) ->
         stop_suborder dir pos_end ~color:false ~var:true
-    | Mask_position (dir, pos_end, _) ->
+    | Position (dir, pos_end, _) ->
         stop_suborder dir pos_end ~color:false ~var:false
-    | Mask_linear_angle _ -> property_suborder 231
-    | Mask_radial -> property_suborder 236
-    | Mask_radial_size (Arbitrary_size _) -> property_suborder 238
-    | Mask_conic_angle _ -> property_suborder 245
+    | Linear_angle _ -> property_suborder 231
+    | Radial -> property_suborder 236
+    | Radial_size (Arbitrary_size _) -> property_suborder 238
+    | Conic_angle _ -> property_suborder 245
     (* mask-circle, the radial size keywords and mask-radial-at-* write a
        --tw-mask-radial-* variable and no mask-image, so each closes the slot of
        the variable it names: --tw-mask-radial-shape (237),
        --tw-mask-radial-size (238) and --tw-mask-radial-position (239). The
        class name orders the ones sharing a slot. *)
-    | Mask_radial_shape _ -> Utility.Property_order.last 237
-    | Mask_radial_size _ -> Utility.Property_order.last 238
-    | Mask_radial_at _ -> Utility.Property_order.last 239
+    | Radial_shape _ -> Utility.Property_order.last 237
+    | Radial_size _ -> Utility.Property_order.last 238
+    | Radial_at _ -> Utility.Property_order.last 239
 
   (* Check if a float is a valid Tailwind spacing multiplier: non-negative,
      either an integer or ending in .5 *)
@@ -983,19 +980,19 @@ module Handler = struct
   let parse_directional ~theme dir pos_end rest =
     let suffix = String.concat "-" rest in
     match parse_paren_var suffix with
-    | Some (`Color, var_name) -> Ok (Mask_color_ref (dir, pos_end, var_name))
+    | Some (`Color, var_name) -> Ok (Color_ref (dir, pos_end, var_name))
     | Some (`Length, var_name) ->
-        Ok (Mask_var_ref (dir, pos_end, Length_var, var_name))
+        Ok (Var_ref (dir, pos_end, Length_var, var_name))
     | Some (`Position, var_name) ->
-        Ok (Mask_var_ref (dir, pos_end, Plain_var, var_name))
+        Ok (Var_ref (dir, pos_end, Plain_var, var_name))
     | None -> (
         match parse_value suffix with
-        | Some value -> Ok (Mask_position (dir, pos_end, value))
+        | Some value -> Ok (Position (dir, pos_end, value))
         | None -> (
             (* A stop is either a position or a colour, and the two share the
                syntax slot, so a colour name is the last thing tried. *)
             let keyword k =
-              Some (Mask_stop_keyword (dir, pos_end, k, String.concat "-" rest))
+              Some (Stop_keyword (dir, pos_end, k, String.concat "-" rest))
             in
             let stop =
               match rest with
@@ -1003,8 +1000,7 @@ module Handler = struct
               | [ "current" ] -> keyword Css.current_color
               | _ -> (
                   match Color.shade_of_strings ~theme rest with
-                  | Ok (c, shade) ->
-                      Some (Mask_stop_color (dir, pos_end, c, shade))
+                  | Ok (c, shade) -> Some (Stop_color (dir, pos_end, c, shade))
                   | Error _ -> None)
             in
             match stop with
@@ -1057,22 +1053,22 @@ module Handler = struct
     | [ "mask"; "linear"; n ] -> (
         if Parse.is_bracket_value n then
           let inner = Parse.bracket_inner n in
-          Ok (Mask_linear_angle (Angle_arb inner))
+          Ok (Linear_angle (Arb inner))
         else
           match int_of_string_opt n with
-          | Some i -> Ok (Mask_linear_angle (Angle_int i))
+          | Some i -> Ok (Linear_angle (Int i))
           | None -> Error (`Msg "Invalid mask-linear angle value"))
     (* -mask-linear-N (negative angle), -mask-linear-[arb] *)
     | [ ""; "mask"; "linear"; n ] -> (
         if Parse.is_bracket_value n then
           let inner = Parse.bracket_inner n in
-          Ok (Mask_linear_angle (Angle_arb_neg inner))
+          Ok (Linear_angle (Arb_neg inner))
         else
           match int_of_string_opt n with
-          | Some i -> Ok (Mask_linear_angle (Angle_int (-i)))
+          | Some i -> Ok (Linear_angle (Int (-i)))
           | None -> Error (`Msg "Invalid negative mask-linear angle value"))
     (* mask-radial *)
-    | [ "mask"; "radial" ] -> Ok Mask_radial
+    | [ "mask"; "radial" ] -> Ok Radial
     (* mask-radial-at-* *)
     | "mask" :: "radial" :: "at" :: rest when rest <> [] ->
         let position = String.concat " " rest in
@@ -1081,7 +1077,7 @@ module Handler = struct
           let inner = Parse.bracket_inner position in
           if radial_at_position inner = None then
             Error (`Msg ("Invalid mask-radial-at position: " ^ position))
-          else Ok (Mask_radial_at (At_arbitrary inner))
+          else Ok (Radial_at (Bracket inner))
         else
           (* Validate keyword positions: top, bottom, left, right, center and
              combinations *)
@@ -1091,7 +1087,7 @@ module Handler = struct
                 List.mem w [ "top"; "bottom"; "left"; "right"; "center" ])
               rest
           in
-          if is_valid_keyword then Ok (Mask_radial_at (At_keyword position))
+          if is_valid_keyword then Ok (Radial_at (Keyword position))
           else Error (`Msg ("Invalid mask-radial-at position: " ^ position))
     (* mask-radial-from-*, mask-radial-to-* *)
     | "mask" :: "radial" :: "from" :: rest when rest <> [] ->
@@ -1107,32 +1103,30 @@ module Handler = struct
     | [ "mask"; "conic"; n ] -> (
         if Parse.is_bracket_value n then
           let inner = Parse.bracket_inner n in
-          Ok (Mask_conic_angle (Angle_arb inner))
+          Ok (Conic_angle (Arb inner))
         else
           match int_of_string_opt n with
-          | Some i -> Ok (Mask_conic_angle (Angle_int i))
+          | Some i -> Ok (Conic_angle (Int i))
           | None -> Error (`Msg "Invalid mask-conic angle value"))
     (* -mask-conic-N (negative angle), -mask-conic-[arb] *)
     | [ ""; "mask"; "conic"; n ] -> (
         if Parse.is_bracket_value n then
           let inner = Parse.bracket_inner n in
-          Ok (Mask_conic_angle (Angle_arb_neg inner))
+          Ok (Conic_angle (Arb_neg inner))
         else
           match int_of_string_opt n with
-          | Some i -> Ok (Mask_conic_angle (Angle_int (-i)))
+          | Some i -> Ok (Conic_angle (Int (-i)))
           | None -> Error (`Msg "Invalid negative mask-conic angle value"))
     (* mask-circle, mask-ellipse *)
-    | [ "mask"; "circle" ] -> Ok (Mask_radial_shape Circle)
-    | [ "mask"; "ellipse" ] -> Ok (Mask_radial_shape Ellipse)
+    | [ "mask"; "circle" ] -> Ok (Radial_shape Circle)
+    | [ "mask"; "ellipse" ] -> Ok (Radial_shape Ellipse)
     (* mask-radial size keywords *)
     | [ "mask"; "radial"; "closest"; "corner" ] ->
-        Ok (Mask_radial_size Closest_corner)
-    | [ "mask"; "radial"; "closest"; "side" ] ->
-        Ok (Mask_radial_size Closest_side)
+        Ok (Radial_size Closest_corner)
+    | [ "mask"; "radial"; "closest"; "side" ] -> Ok (Radial_size Closest_side)
     | [ "mask"; "radial"; "farthest"; "corner" ] ->
-        Ok (Mask_radial_size Farthest_corner)
-    | [ "mask"; "radial"; "farthest"; "side" ] ->
-        Ok (Mask_radial_size Farthest_side)
+        Ok (Radial_size Farthest_corner)
+    | [ "mask"; "radial"; "farthest"; "side" ] -> Ok (Radial_size Farthest_side)
     (* mask-radial-[size] - arbitrary size *)
     | [ "mask"; "radial"; arb ] when Parse.is_bracket_value arb ->
         let size_value = Parse.bracket_inner arb in
@@ -1142,7 +1136,7 @@ module Handler = struct
         in
         if not (Parse.is_declaration_value size_value) then
           Error (`Msg ("Invalid mask-radial size: " ^ size_value))
-        else Ok (Mask_radial_size (Arbitrary_size size_value))
+        else Ok (Radial_size (Arbitrary_size size_value))
     | _ -> Error (`Msg "Not a mask gradient utility")
 
   let format_value = function
@@ -1155,50 +1149,50 @@ module Handler = struct
     | Arbitrary v -> "[" ^ v ^ "]"
 
   let to_class = function
-    | Mask_position (dir, pos_end, value) ->
+    | Position (dir, pos_end, value) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end ^ "-"
         ^ format_value value
-    | Mask_var_ref (dir, pos_end, Plain_var, var_name) ->
+    | Var_ref (dir, pos_end, Plain_var, var_name) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end ^ "-("
         ^ var_name ^ ")"
-    | Mask_var_ref (dir, pos_end, Length_var, var_name) ->
+    | Var_ref (dir, pos_end, Length_var, var_name) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end
         ^ "-(length:" ^ var_name ^ ")"
-    | Mask_stop_keyword (dir, pos_end, _, name) ->
+    | Stop_keyword (dir, pos_end, _, name) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end ^ "-"
         ^ name
-    | Mask_stop_color (dir, pos_end, c, shade) ->
+    | Stop_color (dir, pos_end, c, shade) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end ^ "-"
         ^ Color.color_to_string c
         ^ if Color.is_shadeless c then "" else "-" ^ string_of_int shade
-    | Mask_color_ref (dir, pos_end, var_name) ->
+    | Color_ref (dir, pos_end, var_name) ->
         "mask-" ^ direction_short dir ^ "-" ^ position_end_name pos_end
         ^ "-(color:" ^ var_name ^ ")"
-    | Mask_linear_angle (Angle_int n) ->
+    | Linear_angle (Int n) ->
         if n < 0 then "-mask-linear-" ^ string_of_int (-n)
         else "mask-linear-" ^ string_of_int n
-    | Mask_linear_angle (Angle_arb s) -> "mask-linear-[" ^ s ^ "]"
-    | Mask_linear_angle (Angle_arb_neg s) -> "-mask-linear-[" ^ s ^ "]"
-    | Mask_conic_angle (Angle_int n) ->
+    | Linear_angle (Arb s) -> "mask-linear-[" ^ s ^ "]"
+    | Linear_angle (Arb_neg s) -> "-mask-linear-[" ^ s ^ "]"
+    | Conic_angle (Int n) ->
         if n < 0 then "-mask-conic-" ^ string_of_int (-n)
         else "mask-conic-" ^ string_of_int n
-    | Mask_conic_angle (Angle_arb s) -> "mask-conic-[" ^ s ^ "]"
-    | Mask_conic_angle (Angle_arb_neg s) -> "-mask-conic-[" ^ s ^ "]"
-    | Mask_radial -> "mask-radial"
-    | Mask_radial_at (At_keyword pos) ->
+    | Conic_angle (Arb s) -> "mask-conic-[" ^ s ^ "]"
+    | Conic_angle (Arb_neg s) -> "-mask-conic-[" ^ s ^ "]"
+    | Radial -> "mask-radial"
+    | Radial_at (Keyword pos) ->
         "mask-radial-at-" ^ String.concat "-" (String.split_on_char ' ' pos)
-    | Mask_radial_at (At_arbitrary pos) -> "mask-radial-at-[" ^ pos ^ "]"
-    | Mask_radial_shape Circle -> "mask-circle"
-    | Mask_radial_shape Ellipse -> "mask-ellipse"
-    | Mask_radial_size Closest_corner -> "mask-radial-closest-corner"
-    | Mask_radial_size Closest_side -> "mask-radial-closest-side"
-    | Mask_radial_size Farthest_corner -> "mask-radial-farthest-corner"
-    | Mask_radial_size Farthest_side -> "mask-radial-farthest-side"
-    | Mask_radial_size (Arbitrary_size s) ->
+    | Radial_at (Bracket pos) -> "mask-radial-at-[" ^ pos ^ "]"
+    | Radial_shape Circle -> "mask-circle"
+    | Radial_shape Ellipse -> "mask-ellipse"
+    | Radial_size Closest_corner -> "mask-radial-closest-corner"
+    | Radial_size Closest_side -> "mask-radial-closest-side"
+    | Radial_size Farthest_corner -> "mask-radial-farthest-corner"
+    | Radial_size Farthest_side -> "mask-radial-farthest-side"
+    | Radial_size (Arbitrary_size s) ->
         let escaped = String.map (fun c -> if c = ' ' then '_' else c) s in
         "mask-radial-[" ^ escaped ^ "]"
 
-  let examples = [ Mask_linear_angle (Angle_int 0) ]
+  let examples = [ Linear_angle (Int 0) ]
 end
 
 open Handler
@@ -1207,23 +1201,23 @@ let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
 
 (* Convenience functions for creating mask gradient utilities *)
-let mask_t_from value = utility (Mask_position (Top, From, value))
-let mask_t_to value = utility (Mask_position (Top, To, value))
-let mask_r_from value = utility (Mask_position (Right, From, value))
-let mask_r_to value = utility (Mask_position (Right, To, value))
-let mask_b_from value = utility (Mask_position (Bottom, From, value))
-let mask_b_to value = utility (Mask_position (Bottom, To, value))
-let mask_l_from value = utility (Mask_position (Left, From, value))
-let mask_l_to value = utility (Mask_position (Left, To, value))
-let mask_x_from value = utility (Mask_position (X, From, value))
-let mask_x_to value = utility (Mask_position (X, To, value))
-let mask_y_from value = utility (Mask_position (Y, From, value))
-let mask_y_to value = utility (Mask_position (Y, To, value))
-let mask_linear_from value = utility (Mask_position (Linear, From, value))
-let mask_linear_to value = utility (Mask_position (Linear, To, value))
-let mask_radial = utility Mask_radial
-let mask_radial_at pos = utility (Mask_radial_at pos)
-let mask_radial_from value = utility (Mask_position (Radial, From, value))
-let mask_radial_to value = utility (Mask_position (Radial, To, value))
-let mask_conic_from value = utility (Mask_position (Conic, From, value))
-let mask_conic_to value = utility (Mask_position (Conic, To, value))
+let mask_t_from value = utility (Position (Top, From, value))
+let mask_t_to value = utility (Position (Top, To, value))
+let mask_r_from value = utility (Position (Right, From, value))
+let mask_r_to value = utility (Position (Right, To, value))
+let mask_b_from value = utility (Position (Bottom, From, value))
+let mask_b_to value = utility (Position (Bottom, To, value))
+let mask_l_from value = utility (Position (Left, From, value))
+let mask_l_to value = utility (Position (Left, To, value))
+let mask_x_from value = utility (Position (X, From, value))
+let mask_x_to value = utility (Position (X, To, value))
+let mask_y_from value = utility (Position (Y, From, value))
+let mask_y_to value = utility (Position (Y, To, value))
+let mask_linear_from value = utility (Position (Linear, From, value))
+let mask_linear_to value = utility (Position (Linear, To, value))
+let mask_radial = utility Radial
+let mask_radial_at pos = utility (Radial_at pos)
+let mask_radial_from value = utility (Position (Radial, From, value))
+let mask_radial_to value = utility (Position (Radial, To, value))
+let mask_conic_from value = utility (Position (Conic, From, value))
+let mask_conic_to value = utility (Position (Conic, To, value))

--- a/lib/mask_gradient.mli
+++ b/lib/mask_gradient.mli
@@ -6,7 +6,7 @@ module Handler : sig
   include Utility.Handler
 
   type value = Spacing of float | Percent of float | Arbitrary of string
-  type radial_at_position = At_keyword of string | At_arbitrary of string
+  type radial_at_position = Keyword of string | Bracket of string
 end
 
 val mask_t_from : Handler.value -> t

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -20,27 +20,26 @@ module Handler = struct
     | No_color
 
   type t =
-    | Text_shadow_none
-    | Text_shadow_shape of shape
-    | Text_shadow_shape_opacity of shape * Color.opacity_modifier
-    | Text_shadow_color of Color.color * int
-    | Text_shadow_color_opacity of Color.color * int * Color.opacity_modifier
-    | Text_shadow_current
-    | Text_shadow_current_opacity of Color.opacity_modifier
-    | Text_shadow_inherit
-    | Text_shadow_transparent
-    | Text_shadow_transparent_opacity of Color.opacity_modifier
-    | Text_shadow_bracket_hex of string
-    | Text_shadow_bracket_hex_opacity of string * Color.opacity_modifier
-    | Text_shadow_bracket_color of string * Css.color
-    | Text_shadow_bracket_color_opacity of
-        string * Css.color * Color.opacity_modifier
-    | Text_shadow_bracket_color_var of string
-    | Text_shadow_bracket_cvar_opacity of string * Color.opacity_modifier
-    | Text_shadow_bracket_shadow of string
-    | Text_shadow_bracket_var of string
-    | Text_shadow_arbitrary of string
-    | Text_shadow_arbitrary_opacity of string * Color.opacity_modifier
+    | None
+    | Shape of shape
+    | Shape_opacity of shape * Color.opacity_modifier
+    | Color of Color.color * int
+    | Color_opacity of Color.color * int * Color.opacity_modifier
+    | Current
+    | Current_opacity of Color.opacity_modifier
+    | Inherit
+    | Transparent
+    | Transparent_opacity of Color.opacity_modifier
+    | Bracket_hex of string
+    | Bracket_hex_opacity of string * Color.opacity_modifier
+    | Bracket_color of string * Css.color
+    | Bracket_color_opacity of string * Css.color * Color.opacity_modifier
+    | Bracket_color_var of string
+    | Bracket_cvar_opacity of string * Color.opacity_modifier
+    | Bracket_shadow of string
+    | Bracket_var of string
+    | Arbitrary of string
+    | Arbitrary_opacity of string * Color.opacity_modifier
 
   type Utility.base += Self of t
 
@@ -51,7 +50,7 @@ module Handler = struct
      ordinary shape and colour utilities remain in the later text-shadow
      band. *)
   let priority = function
-    | Text_shadow_shape_opacity _ | Text_shadow_arbitrary_opacity _ -> 38
+    | Shape_opacity _ | Arbitrary_opacity _ -> 38
     | _ -> 41
 
   let text_shadow_color_var =
@@ -699,41 +698,39 @@ module Handler = struct
       shape_text_shadow_opacity ~theme shape opacity
     in
     function
-    | Text_shadow_none ->
+    | None ->
         style ~property_rules:text_shadow_property_rules
           [ Css.text_shadow Css.None ]
-    | Text_shadow_shape shape ->
+    | Shape shape ->
         style ~property_rules:text_shadow_property_rules
           [ shape_text_shadow shape ]
-    | Text_shadow_shape_opacity (shape, opacity) ->
+    | Shape_opacity (shape, opacity) ->
         let percent = Color.opacity_to_percent opacity in
         style ~property_rules:text_shadow_property_rules
           [ alpha_decl percent; shape_text_shadow_opacity shape opacity ]
-    | Text_shadow_color (c, shade) -> set_color c shade
-    | Text_shadow_color_opacity (c, shade, opacity) ->
-        set_color_opacity c shade opacity
-    | Text_shadow_current -> set_current ()
-    | Text_shadow_current_opacity opacity -> set_current_opacity opacity
-    | Text_shadow_inherit -> set_inherit ()
-    | Text_shadow_transparent -> set_transparent ()
-    | Text_shadow_transparent_opacity opacity -> set_transparent_opacity opacity
-    | Text_shadow_bracket_hex hex -> set_bracket_hex hex
-    | Text_shadow_bracket_hex_opacity (hex, opacity) ->
-        set_bracket_hex_opacity hex opacity
-    | Text_shadow_bracket_color (_orig, c) -> set_bracket_color c
-    | Text_shadow_bracket_color_opacity (_orig, c, opacity) ->
+    | Color (c, shade) -> set_color c shade
+    | Color_opacity (c, shade, opacity) -> set_color_opacity c shade opacity
+    | Current -> set_current ()
+    | Current_opacity opacity -> set_current_opacity opacity
+    | Inherit -> set_inherit ()
+    | Transparent -> set_transparent ()
+    | Transparent_opacity opacity -> set_transparent_opacity opacity
+    | Bracket_hex hex -> set_bracket_hex hex
+    | Bracket_hex_opacity (hex, opacity) -> set_bracket_hex_opacity hex opacity
+    | Bracket_color (_orig, c) -> set_bracket_color c
+    | Bracket_color_opacity (_orig, c, opacity) ->
         set_bracket_color_opacity c opacity
-    | Text_shadow_bracket_color_var var_expr -> set_bracket_color_var var_expr
-    | Text_shadow_bracket_cvar_opacity (var_expr, opacity) ->
+    | Bracket_color_var var_expr -> set_bracket_color_var var_expr
+    | Bracket_cvar_opacity (var_expr, opacity) ->
         set_bracket_color_var_opacity var_expr opacity
-    | Text_shadow_bracket_shadow var_expr ->
+    | Bracket_shadow var_expr ->
         style ~property_rules:text_shadow_property_rules
           [ Css.text_shadow (make_text_shadow_var var_expr) ]
-    | Text_shadow_bracket_var var_expr ->
+    | Bracket_var var_expr ->
         style ~property_rules:text_shadow_property_rules
           [ Css.text_shadow (make_text_shadow_var var_expr) ]
-    | Text_shadow_arbitrary arb -> arbitrary_shadow_style arb
-    | Text_shadow_arbitrary_opacity (arb, opacity) ->
+    | Arbitrary arb -> arbitrary_shadow_style arb
+    | Arbitrary_opacity (arb, opacity) ->
         arbitrary_shadow_opacity_style arb opacity
 
   (* ============ Parsing ============ *)
@@ -783,7 +780,7 @@ module Handler = struct
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
-    | [ "text"; "shadow"; "none" ] -> Ok Text_shadow_none
+    | [ "text"; "shadow"; "none" ] -> Ok None
     (* Bare `text-shadow` is not a utility in v4 (no `--text-shadow` token); the
        named scale is `text-shadow-{2xs,xs,sm,md,lg}`. *)
     | [ "text"; "shadow" ] -> err_not_utility
@@ -799,20 +796,20 @@ module Handler = struct
           | _ -> Stdlib.Option.None
         in
         match (shape_opt, opacity) with
-        | Some shape, Color.No_opacity -> Ok (Text_shadow_shape shape)
-        | Some shape, op -> Ok (Text_shadow_shape_opacity (shape, op))
+        | Some shape, Color.No_opacity -> Ok (Shape shape)
+        | Some shape, op -> Ok (Shape_opacity (shape, op))
         | Stdlib.Option.None, Color.No_opacity when base = "inherit" ->
-            Ok Text_shadow_inherit
+            Ok Inherit
         | Stdlib.Option.None, _ when base = "inherit" -> err_not_utility
         | Stdlib.Option.None, Color.No_opacity when base = "transparent" ->
-            Ok Text_shadow_transparent
+            Ok Transparent
         | Stdlib.Option.None, op when base = "transparent" ->
-            Ok (Text_shadow_transparent_opacity op)
+            Ok (Transparent_opacity op)
         | Stdlib.Option.None, _ when starts_with "current" base -> (
             match opacity with
-            | Color.No_opacity when base = "current" -> Ok Text_shadow_current
+            | Color.No_opacity when base = "current" -> Ok Current
             | Color.No_opacity -> err_not_utility
-            | op -> Ok (Text_shadow_current_opacity op))
+            | op -> Ok (Current_opacity op))
         | Stdlib.Option.None, _ when Parse.is_bracket_value base -> (
             let inner = Parse.bracket_inner base in
             if starts_with "color:" inner then
@@ -831,31 +828,28 @@ module Handler = struct
               match (as_colour, opacity) with
               (* [inner], not [payload]: the class name keeps the hint the
                  author wrote, so it reads back as the class they spelled. *)
-              | Some c, Color.No_opacity ->
-                  Ok (Text_shadow_bracket_color (inner, c))
-              | Some c, op ->
-                  Ok (Text_shadow_bracket_color_opacity (inner, c, op))
+              | Some c, Color.No_opacity -> Ok (Bracket_color (inner, c))
+              | Some c, op -> Ok (Bracket_color_opacity (inner, c, op))
               | Stdlib.Option.None, Color.No_opacity ->
-                  Ok (Text_shadow_bracket_color_var payload)
+                  Ok (Bracket_color_var payload)
               | Stdlib.Option.None, op ->
-                  Ok (Text_shadow_bracket_cvar_opacity (payload, op))
+                  Ok (Bracket_cvar_opacity (payload, op))
             else if starts_with "shadow:" inner then
               let var_part = String.sub inner 7 (String.length inner - 7) in
-              Ok (Text_shadow_bracket_shadow var_part)
+              Ok (Bracket_shadow var_part)
             else if Parse.is_var inner && not (is_shadow_value inner) then
-              Ok (Text_shadow_bracket_var inner)
+              Ok (Bracket_var inner)
             else if is_hex_value inner then
               let hex = String.sub inner 1 (String.length inner - 1) in
               match opacity with
-              | Color.No_opacity -> Ok (Text_shadow_bracket_hex hex)
-              | op -> Ok (Text_shadow_bracket_hex_opacity (hex, op))
+              | Color.No_opacity -> Ok (Bracket_hex hex)
+              | op -> Ok (Bracket_hex_opacity (hex, op))
             else
               match Color.parse_bracket_color inner with
               | Some c -> (
                   match opacity with
-                  | Color.No_opacity ->
-                      Ok (Text_shadow_bracket_color (inner, c))
-                  | op -> Ok (Text_shadow_bracket_color_opacity (inner, c, op)))
+                  | Color.No_opacity -> Ok (Bracket_color (inner, c))
+                  | op -> Ok (Bracket_color_opacity (inner, c, op)))
               | Stdlib.Option.None -> (
                   if parse_arbitrary_shadow inner = Stdlib.Option.None then
                     (* Not a shadow, so not a utility: it used to fall back to
@@ -863,28 +857,27 @@ module Handler = struct
                     err_not_utility
                   else
                     match opacity with
-                    | Color.No_opacity -> Ok (Text_shadow_arbitrary inner)
-                    | op -> Ok (Text_shadow_arbitrary_opacity (inner, op))))
+                    | Color.No_opacity -> Ok (Arbitrary inner)
+                    | op -> Ok (Arbitrary_opacity (inner, op))))
         (* Not a size: a shadeless colour, which the multi-segment colour cases
            below never see because it fits in this single segment. *)
         | Stdlib.Option.None, Color.No_opacity -> (
             match Color.shade_of_strings ~theme [ base ] with
-            | Ok (color, shade) -> Ok (Text_shadow_color (color, shade))
+            | Ok (color, shade) -> Ok (Color (color, shade))
             | Error e -> Error e)
         | Stdlib.Option.None, op -> (
             match Color.shade_of_strings ~theme [ base ] with
-            | Ok (color, shade) ->
-                Ok (Text_shadow_color_opacity (color, shade, op))
+            | Ok (color, shade) -> Ok (Color_opacity (color, shade, op))
             | Error e -> Error e))
     | "text" :: "shadow" :: color_parts when List.exists has_opacity color_parts
       -> (
         match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
-            Ok (Text_shadow_color_opacity (color, shade, opacity))
+            Ok (Color_opacity (color, shade, opacity))
         | Error e -> Error e)
     | "text" :: "shadow" :: color_parts -> (
         match Color.shade_of_strings ~theme color_parts with
-        | Ok (color, shade) -> Ok (Text_shadow_color (color, shade))
+        | Ok (color, shade) -> Ok (Color (color, shade))
         | Error e -> Error e)
     | _ -> err_not_utility
 
@@ -898,39 +891,37 @@ module Handler = struct
     | S_lg -> "lg"
 
   let to_class = function
-    | Text_shadow_none -> "text-shadow-none"
-    | Text_shadow_shape shape -> "text-shadow-" ^ shape_to_string shape
-    | Text_shadow_shape_opacity (shape, opacity) ->
+    | None -> "text-shadow-none"
+    | Shape shape -> "text-shadow-" ^ shape_to_string shape
+    | Shape_opacity (shape, opacity) ->
         "text-shadow-" ^ shape_to_string shape ^ "/" ^ Color.pp_opacity opacity
-    | Text_shadow_color (c, shade) ->
+    | Color (c, shade) ->
         "text-shadow-" ^ Color.color_to_string c
         ^ if Color.is_shadeless c then "" else "-" ^ string_of_int shade
-    | Text_shadow_color_opacity (c, shade, opacity) ->
+    | Color_opacity (c, shade, opacity) ->
         "text-shadow-" ^ Color.color_to_string c
         ^ (if Color.is_shadeless c then "" else "-" ^ string_of_int shade)
         ^ "/" ^ Color.pp_opacity opacity
-    | Text_shadow_current -> "text-shadow-current"
-    | Text_shadow_current_opacity opacity ->
+    | Current -> "text-shadow-current"
+    | Current_opacity opacity ->
         "text-shadow-current/" ^ Color.pp_opacity opacity
-    | Text_shadow_inherit -> "text-shadow-inherit"
-    | Text_shadow_transparent -> "text-shadow-transparent"
-    | Text_shadow_transparent_opacity opacity ->
+    | Inherit -> "text-shadow-inherit"
+    | Transparent -> "text-shadow-transparent"
+    | Transparent_opacity opacity ->
         "text-shadow-transparent/" ^ Color.pp_opacity opacity
-    | Text_shadow_bracket_hex hex -> "text-shadow-[#" ^ hex ^ "]"
-    | Text_shadow_bracket_hex_opacity (hex, opacity) ->
+    | Bracket_hex hex -> "text-shadow-[#" ^ hex ^ "]"
+    | Bracket_hex_opacity (hex, opacity) ->
         "text-shadow-[#" ^ hex ^ "]/" ^ Color.pp_opacity opacity
-    | Text_shadow_bracket_color (orig, _) -> "text-shadow-[" ^ orig ^ "]"
-    | Text_shadow_bracket_color_opacity (orig, _, opacity) ->
+    | Bracket_color (orig, _) -> "text-shadow-[" ^ orig ^ "]"
+    | Bracket_color_opacity (orig, _, opacity) ->
         "text-shadow-[" ^ orig ^ "]/" ^ Color.pp_opacity opacity
-    | Text_shadow_bracket_color_var var_expr ->
-        "text-shadow-[color:" ^ var_expr ^ "]"
-    | Text_shadow_bracket_cvar_opacity (var_expr, opacity) ->
+    | Bracket_color_var var_expr -> "text-shadow-[color:" ^ var_expr ^ "]"
+    | Bracket_cvar_opacity (var_expr, opacity) ->
         "text-shadow-[color:" ^ var_expr ^ "]/" ^ Color.pp_opacity opacity
-    | Text_shadow_bracket_shadow var_expr ->
-        "text-shadow-[shadow:" ^ var_expr ^ "]"
-    | Text_shadow_bracket_var var_expr -> "text-shadow-[" ^ var_expr ^ "]"
-    | Text_shadow_arbitrary arb -> "text-shadow-[" ^ arb ^ "]"
-    | Text_shadow_arbitrary_opacity (arb, opacity) ->
+    | Bracket_shadow var_expr -> "text-shadow-[shadow:" ^ var_expr ^ "]"
+    | Bracket_var var_expr -> "text-shadow-[" ^ var_expr ^ "]"
+    | Arbitrary arb -> "text-shadow-[" ^ arb ^ "]"
+    | Arbitrary_opacity (arb, opacity) ->
         "text-shadow-[" ^ arb ^ "]/" ^ Color.pp_opacity opacity
 
   (* ============ Suborder ============ *)
@@ -939,26 +930,26 @@ module Handler = struct
      other utilities. Within that group, relative color @supports (lab) come
      first, then color-mix @supports, then no-@supports. *)
   let suborder = function
-    | Text_shadow_arbitrary_opacity (arb, _) -> (
+    | Arbitrary_opacity (arb, _) -> (
         match parse_arbitrary_shadow arb with
         | Some (_, _, _, Var_ref _) -> 6 (* @supports lab *)
         | Some (_, _, _, No_color) -> 7 (* @supports color-mix *)
         | Some (_, _, _, (Hex _ | Css_color _)) -> 8 (* no @supports *)
         | Stdlib.Option.None -> 9)
-    | Text_shadow_shape_opacity _ -> 8 (* no @supports *)
+    | Shape_opacity _ -> 8 (* no @supports *)
     | _ -> 0
 
-  let examples = [ Text_shadow_shape S_sm; Text_shadow_current ]
+  let examples = [ Shape S_sm; Current ]
 end
 
 open Handler
 
 let () = Utility.register (module Handler)
 let utility x = Utility.base (Self x)
-let text_shadow_none = utility Text_shadow_none
-let text_shadow_2xs = utility (Text_shadow_shape S_2xs)
-let text_shadow_xs = utility (Text_shadow_shape S_xs)
-let text_shadow_sm = utility (Text_shadow_shape S_sm)
-let text_shadow_md = utility (Text_shadow_shape S_md)
-let text_shadow_lg = utility (Text_shadow_shape S_lg)
-let text_shadow_arbitrary arb = utility (Text_shadow_arbitrary arb)
+let text_shadow_none = utility None
+let text_shadow_2xs = utility (Shape S_2xs)
+let text_shadow_xs = utility (Shape S_xs)
+let text_shadow_sm = utility (Shape S_sm)
+let text_shadow_md = utility (Shape S_md)
+let text_shadow_lg = utility (Shape S_lg)
+let text_shadow_arbitrary arb = utility (Arbitrary arb)

--- a/merlint.toml
+++ b/merlint.toml
@@ -69,12 +69,3 @@ files = [
   "lib/touch.ml*",
 ]
 exclude = ["E330"]
-
-# Both files are being rewritten elsewhere: mask_gradient is mid typed port and
-# text_shadow is mid rename, so their prefixes come off with those changes.
-[[rules]]
-files = [
-  "lib/mask_gradient.ml*",
-  "lib/text_shadow.ml*",
-]
-exclude = ["E334"]


### PR DESCRIPTION
Merlint E334 exclusions hid redundant constructor qualification in mask and text-shadow handlers. The constructors now use local names and the exclusions are removed.