### PR TITLE
parse: read complete variable references

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -80,13 +80,15 @@ let int_bounded ~name ~min ~max s =
 let is_valid_theme_name s = s <> "" && not (String.contains s '/')
 let ( >|= ) r f = Result.map f r
 
-(** Extract the bare variable name from a "var(--name)" string. Returns "name"
-    for "var(--name)", or the original string if not a var() reference. *)
 let extract_var_name s =
-  let len = String.length s in
-  if len > 6 && String.sub s 0 6 = "var(--" && s.[len - 1] = ')' then
-    String.trim (String.sub s 6 (len - 7))
-  else s
+  if not (String.starts_with ~prefix:"var(" s) then s
+  else
+    try
+      let cursor = Cascade.Cursor.of_string s in
+      match Cascade.Css.Variables.read_reference cursor with
+      | name, None -> name
+      | name, Some fallback -> name ^ ", " ^ fallback
+    with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> s
 
 (* One bracket, not two: the closing bracket has to be the last character. A
    suffix carrying a second bracket - one bracket with a bracket modifier, or

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -46,9 +46,9 @@ val ( >|= ) : ('a, 'e) result -> ('a -> 'b) -> ('b, 'e) result
     [Error e] unchanged. *)
 
 val extract_var_name : string -> string
-(** [extract_var_name s] extracts the bare variable name from ["var(--name)"],
-    returning ["name"]. If [s] is not a var() reference, returns [s] unchanged.
-*)
+(** [extract_var_name s] parses one complete [var()] reference and returns its
+    name without the [--] prefix, retaining an optional fallback after a comma.
+    If [s] is not exactly one valid reference, it returns [s] unchanged. *)
 
 val is_bracket_value : string -> bool
 (** [is_bracket_value s] returns [true] if [s] is one bracket-wrapped value. The

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -555,10 +555,27 @@ let bracket ?fallback name =
           read_whole ("--" ^ name) Css.Variables.read_reference_body_as_string
         else None
   in
+  (* [Parse.extract_var_name] leaves malformed references alone. Arbitrary
+     values historically also use [var(--...)] as a wrapper around a raw
+     custom-property name, where a loose closer belongs to that name. Retain
+     that interpretation only after the CSS reference reader has rejected the
+     whole string. *)
+  let raw_name =
+    let prefix = "var(--" in
+    let len = String.length name in
+    let prefix_len = String.length prefix in
+    if
+      parsed_reference = None
+      && String.starts_with ~prefix name
+      && len > prefix_len
+      && name.[len - 1] = ')'
+    then String.trim (String.sub name prefix_len (len - prefix_len - 1))
+    else name
+  in
   match parsed_reference with
   | Some (name, Some fallback) ->
       Css.var_ref ~runtime:true
         ~fallback:(Css.Values.syntax_fallback fallback)
         name
   | Some (name, None) -> Css.var_ref ~runtime:true name
-  | None -> Css.var_ref ?fallback name
+  | None -> Css.var_ref ?fallback raw_name

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -107,6 +107,19 @@ let test_parse_is_independent_of_history () =
   round_trips built;
   unknown "grid-cols-"
 
+(* A [var()] is one CSS component, not a prefix and suffix to slice away. A
+   loose closer after the function is outside the reference and must keep the
+   input untouched; a balanced nested fallback belongs to the reference body. *)
+let test_extract_var_name_reads_one_reference () =
+  let check expected input =
+    Alcotest.(check string) input expected (Tw.Parse.extract_var_name input)
+  in
+  check "x" "var(--x)";
+  check "x, calc(var(--y) + 1px)" "var(--x, calc(var(--y) + 1px))";
+  check "var(--x))" "var(--x))";
+  check "var(--x)garbage" "var(--x)garbage";
+  check "not-a-reference" "not-a-reference"
+
 (* The utilities that swallowed a second bracket refuse the class instead of
    raising out of [to_css]. Tailwind emits nothing for any of them. *)
 let test_double_bracket_class_rejected () =
@@ -207,6 +220,8 @@ let tests =
         test_redundant_zero_spellings_are_rejected;
       test_case "parsing is independent of parse history" `Quick
         test_parse_is_independent_of_history;
+      test_case "var name reads one complete reference" `Quick
+        test_extract_var_name_reads_one_reference;
       test_case "bracket value leaving the declaration is rejected" `Quick
         test_bracket_value_leaving_the_declaration_is_rejected;
       test_case "--spacing() shorthand ignored inside quotes" `Quick


### PR DESCRIPTION
Nested or fallback-bearing `var()` references could be truncated by string slicing and lose their fallback. The shared CSS reader now consumes one complete reference.