### PR TITLE
utility: make handler construction total

### DIFF
--- a/lib/accessibility.ml
+++ b/lib/accessibility.ml
@@ -16,7 +16,6 @@ open Style
 
 module Handler = struct
   type t = Auto | No_adjust
-  type Utility.base += Self of t
 
   let name = "accessibility"
   let priority _ = 36
@@ -42,8 +41,8 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let forced_color_adjust_auto = utility Auto
 let forced_color_adjust_none = utility No_adjust

--- a/lib/alignment.ml
+++ b/lib/alignment.ml
@@ -114,8 +114,6 @@ module Handler = struct
     | Place_self_center_safe
     | Place_self_end_safe
 
-  type Utility.base += Self of t
-
   let name = "alignment"
 
   (* Same priority as gap (15), differentiated by suborder: - Container
@@ -454,11 +452,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register alignment handler with Utility system *)
-let () = Utility.register (module Handler)
 
 (** Public API *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 (** {1 Justify Content Utilities} *)
 let justify_start = utility Justify_start

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -30,8 +30,6 @@ module Handler = struct
     | Bracket of string * Css.animation
     | Named of string
 
-  type Utility.base += Self of t
-
   let name = "animations"
 
   (* Match Tailwind ordering: animations after transforms, before cursor *)
@@ -363,9 +361,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let animate_none = utility No_animation
 let animate_spin = utility Spin
 let animate_ping = utility Ping

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -59,8 +59,6 @@ module Handler = struct
   (* Plain [property:value] (no /opacity), parsed by cascade into a typed,
      var-tracking declaration. *)
 
-  type Utility.base += Self of t
-
   let name = "arbitrary"
 
   (* Tailwind sorts an arbitrary property by the property it declares, not by
@@ -391,4 +389,4 @@ module Handler = struct
   let examples = []
 end
 
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -210,8 +210,6 @@ module Handler = struct
     (* bg-size-[...] bracket notation *)
     | Bg_size_bracket of string
 
-  type Utility.base += Self of t
-
   let to_class (t : t) =
     match t with
     | Bg (color, shade) ->
@@ -1938,9 +1936,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let bg ?opacity ?(shade = 500) color =
   Color.check_shade ~utility:"bg" color shade;

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -125,8 +125,6 @@ module Handler = struct
     | Neg_outline_offset of int
     | Neg_outline_offset_var of string (* -outline-offset-[var(--value)] *)
 
-  type Utility.base += Self of t
-
   let name = "borders"
 
   (* border-width/color/radius sort at priority 19. outline-* (canonical rank
@@ -1008,9 +1006,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 (** Separate handler for outline style utilities that need to come after outline
     colors (priority 23) AND after ring/shadow effects (priority 25). These are:
@@ -1020,7 +1018,6 @@ module Outline_style_handler = struct
   open Style
 
   type t = Dashed | Dotted | Double | None_ | Solid
-  type Utility.base += Self of t
 
   let name = "outline_style"
   let priority _ = 37
@@ -1072,8 +1069,9 @@ module Outline_style_handler = struct
   let examples = [ Solid ]
 end
 
-let () = Utility.register (module Outline_style_handler)
-let outline_style_utility x = Utility.base (Outline_style_handler.Self x)
+module Outline_style_utility = Utility.Make (Outline_style_handler)
+
+let outline_style_utility = Outline_style_utility.v
 
 (** {1 Border Width Utilities} *)
 

--- a/lib/box_sizing.ml
+++ b/lib/box_sizing.ml
@@ -7,7 +7,6 @@ module Handler = struct
   open Css
 
   type t = Border | Content
-  type Utility.base += Self of t
 
   let name = "box_sizing"
 
@@ -32,8 +31,8 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let box_border = utility Border
 let box_content = utility Content

--- a/lib/clipping.ml
+++ b/lib/clipping.ml
@@ -7,7 +7,6 @@ module Handler = struct
   open Css
 
   type t = Clip_polygon of (float * float) list
-  type Utility.base += Self of t
 
   let name = "clipping"
   let priority _ = 28
@@ -59,7 +58,7 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let clip_polygon points = utility (Clip_polygon points)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1800,7 +1800,6 @@ module Handler = struct
     | Placeholder_bracket_color_opacity of string * Css.color * opacity_modifier
 
   (** Extensible variant for color utilities *)
-  type Utility.base += Self of t
 
   (** Resolve the optionally-threaded theme, defaulting to the base scheme. *)
   let resolve_scheme = function Some s -> s | None -> Scheme.default
@@ -3358,8 +3357,8 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register color handler with Utility system *)
-let () = Utility.register (module Handler)
 
 (** Re-export helper functions from Handler for use by other modules *)
 let scheme_color_name = Handler.scheme_color_name
@@ -3728,7 +3727,7 @@ let bg_current_with_opacity ?theme opacity =
   Style.style ~rules:(Some [ supports_block ]) [ fallback_decl ]
 
 (** Public API *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let text ?opacity ?(shade = 500) color =
   check_shade ~utility:"text" color shade;

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -29,8 +29,6 @@ module Handler = struct
     | Columns_arbitrary_len of string (* columns-[16rem] *)
     | Columns_bracket_var of string
 
-  type Utility.base += Self of t
-
   let name = "columns"
   let priority _ = 12
 
@@ -167,9 +165,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let columns_auto = utility Columns_auto
 let columns n = utility (Columns_count n)
 let columns_3xs = utility Columns_3xs

--- a/lib/contain.ml
+++ b/lib/contain.ml
@@ -17,8 +17,6 @@ module Handler = struct
     | Inline_size
     | Arbitrary of string
 
-  type Utility.base += Self of t
-
   let name = "contain"
   let priority _ = 34
 
@@ -153,19 +151,20 @@ module Handler = struct
           else Error (`Msg "Invalid contain arbitrary value")
         else Error (`Msg "Not a contain utility")
 
-  let utility t = Utility.base (Self t)
   let examples = [ Strict ]
 end
 
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)
+
+let utility = Utility_factory.v
 
 (* Convenience functions *)
-let contain_none = Handler.utility None
-let contain_strict = Handler.utility Strict
-let contain_content = Handler.utility Content
-let contain_size = Handler.utility Size
-let contain_layout = Handler.utility Layout
-let contain_paint = Handler.utility Paint
-let contain_style = Handler.utility Contain_style
-let contain_inline_size = Handler.utility Inline_size
-let contain_arbitrary s = Handler.utility (Arbitrary s)
+let contain_none = utility Handler.None
+let contain_strict = utility Handler.Strict
+let contain_content = utility Handler.Content
+let contain_size = utility Handler.Size
+let contain_layout = utility Handler.Layout
+let contain_paint = utility Handler.Paint
+let contain_style = utility Handler.Contain_style
+let contain_inline_size = utility Handler.Inline_size
+let contain_arbitrary s = utility (Handler.Arbitrary s)

--- a/lib/containers.ml
+++ b/lib/containers.ml
@@ -14,8 +14,6 @@ module Handler = struct
     | Container_size (* @container-size - sets container-type: size *)
     | Container_named of string (* @container/name *)
 
-  type Utility.base += Self of t
-
   let name = "containers"
 
   (* Tailwind's utility order opens with the container utilities; the layout
@@ -132,9 +130,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 (** Container Query Modifiers *)
 let container_sm styles =

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -52,7 +52,6 @@ module Handler = struct
     | Zoom_out
 
   type t = Keyword of keyword | Bracket_var of string | Theme of string
-  type Utility.base += Self of t
 
   let name = "cursor"
   let priority _ = 11
@@ -221,11 +220,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register the cursor utility handlers *)
-let () = Utility.register (module Handler)
 
 (** Public API returning Utility.t *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let cursor_alias = utility (Keyword Alias)
 let cursor_all_scroll = utility (Keyword All_scroll)

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -28,8 +28,6 @@ module Handler = struct
     | Bracket_color_opacity of string * Css.color * Color.opacity_modifier
     | Line_style of Css.border_style
 
-  type Utility.base += Self of t
-
   let name = "divide"
 
   (* The divide properties follow gap and precede self-alignment. The unranked
@@ -476,9 +474,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let divide_x_reverse = utility X_reverse
 let divide_y_reverse = utility Y_reverse
 

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -201,8 +201,6 @@ module Handler = struct
     | Bg_blend_color
     | Bg_blend_luminosity
 
-  type Utility.base += Self of t
-
   let name = "effects"
   let priority = function Ring_inset -> 40 | _ -> 27
 
@@ -3262,9 +3260,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let order u = Some (Utility.order u)
 let mix_blend_luminosity = utility Mix_blend_luminosity
 let shadow_none = utility Shadow_none

--- a/lib/field_sizing.ml
+++ b/lib/field_sizing.ml
@@ -7,7 +7,6 @@ module Handler = struct
   open Css
 
   type t = Content | Fixed
-  type Utility.base += Self of t
 
   let name = "field_sizing"
   let priority _ = 5
@@ -32,8 +31,8 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let field_sizing_content = utility Content
 let field_sizing_fixed = utility Fixed

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -94,8 +94,6 @@ module Handler = struct
     | Backdrop_hue_rotate_arbitrary of string * Css.angle
     | Neg_backdrop_hue_rotate_arbitrary of string * Css.angle
 
-  type Utility.base += Self of t
-
   let name = "filters"
   let priority _ = 30
 
@@ -1660,12 +1658,11 @@ module Handler = struct
 end
 
 open Handler
-
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)
 
 (** {1 Public API - Utility Values} *)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let blur_none = utility Blur_none
 let blur_xs = utility Blur_xs
 let blur_sm = utility Blur_sm

--- a/lib/flex.ml
+++ b/lib/flex.ml
@@ -10,7 +10,6 @@ module Handler = struct
   open Css
 
   type t = Flex | Inline_flex
-  type Utility.base += Self of t
 
   (** Priority for flex display utilities. Display utilities all share priority
       4 and are ordered alphabetically by suborder. *)
@@ -43,10 +42,10 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let flex = utility Flex
 let inline_flex = utility Inline_flex
 

--- a/lib/flex_layout.ml
+++ b/lib/flex_layout.ml
@@ -22,8 +22,6 @@ module Handler = struct
     | Wrap
     | Wrap_reverse
 
-  type Utility.base += Self of t
-
   let name = "flex_layout"
   let priority _ = 16
 
@@ -66,10 +64,10 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let flex_row = utility Row
 let flex_row_reverse = utility Row_reverse
 let flex_col = utility Col

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -53,8 +53,6 @@ module Handler = struct
     | Order_last
     | Order_none
 
-  type Utility.base += Self of t
-
   let name = "flex_props"
 
   (* flex/grow/shrink/basis are the flexbox family (priority 7 - after sizing,
@@ -447,10 +445,10 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let flex_1 = utility Flex_1
 let flex_auto = utility Flex_auto
 let flex_initial = utility Flex_initial

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -116,7 +116,6 @@ module Handler = struct
   open Style
 
   type t = Input | Checkbox | Radio
-  type Utility.base += Self of t
 
   let name = "forms"
   let priority _ = 3
@@ -373,7 +372,6 @@ module Select = struct
   open Style
 
   type t = Select | Textarea | Multiselect
-  type Utility.base += Self of t
 
   let name = "forms_select"
   let priority _ = 8 (* After sizing (6), flex_props (7) *)
@@ -532,16 +530,16 @@ module Select = struct
 end
 
 (* Register both handlers *)
-let () = Utility.register (module Handler)
-let () = Utility.register (module Select)
+module Utility_factory = Utility.Make (Handler)
+module Select_utility = Utility.Make (Select)
 
 (* Public API *)
-let form_input = Utility.base (Handler.Self Handler.Input)
-let form_checkbox = Utility.base (Handler.Self Handler.Checkbox)
-let form_radio = Utility.base (Handler.Self Handler.Radio)
-let form_select = Utility.base (Select.Self Select.Select)
-let form_textarea = Utility.base (Select.Self Select.Textarea)
-let form_multiselect = Utility.base (Select.Self Select.Multiselect)
+let form_input = Utility_factory.v Handler.Input
+let form_checkbox = Utility_factory.v Handler.Checkbox
+let form_radio = Utility_factory.v Handler.Radio
+let form_select = Select_utility.v Select.Select
+let form_textarea = Select_utility.v Select.Textarea
+let form_multiselect = Select_utility.v Select.Multiselect
 
 (* ======================================================================== Base
    layer stylesheet - rules that apply to native HTML form elements when the

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -21,8 +21,6 @@ module Handler = struct
     | Space_x_reverse
     | Space_y_reverse
 
-  type Utility.base += Self of t
-
   let name = "gap"
   let priority _ = 17
 
@@ -509,11 +507,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
 (** Public API *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 (** Helpers to create Utility.t from Gap/Space *)
 let gap_util axis value = utility (Gap { axis; value })

--- a/lib/grid.ml
+++ b/lib/grid.ml
@@ -10,7 +10,6 @@ module Handler = struct
   open Css
 
   type t = Grid | Inline_grid
-  type Utility.base += Self of t
 
   (** Priority for grid display utilities. Display utilities all share priority
       4 and are ordered alphabetically by suborder. *)
@@ -43,9 +42,9 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let grid = utility Grid
 let inline_grid = utility Inline_grid

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -92,8 +92,6 @@ module Handler = struct
     | Row_end_arbitrary of string * Css.grid_line
     | Row_end_named of string (* row-end-custom *)
 
-  type Utility.base += Self of t
-
   let name = "grid_item"
 
   (** Priority 1 - before margin (priority 2) *)
@@ -524,10 +522,10 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let col n = utility (Col n)
 let col_auto = utility Col_auto
 let col_span n = utility (Col_span n)

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -61,8 +61,6 @@ module Handler = struct
     | Auto_rows_spacing of float  (** [auto-rows-<n>]: spacing-scaled track. *)
     | Auto_rows_arbitrary of string * Css.grid_template
 
-  type Utility.base += Self of t
-
   let name = "grid_template"
 
   (* Before flex_props (16) and alignment/gap (17) *)
@@ -518,9 +516,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let grid_cols n = utility (Grid_cols n)
 let grid_cols_none = utility Grid_cols_none
 let grid_cols_subgrid = utility Grid_cols_subgrid

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -61,8 +61,6 @@ module Handler = struct
     | Scheme_only_dark
     | Scheme_only_light
 
-  type Utility.base += Self of t
-
   let name = "interactivity"
 
   (* Interaction controls from resize through appearance share priority 11 so
@@ -381,9 +379,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let select_none = utility Select_none
 let select_text = utility Select_text
 let select_all = utility Select_all

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -8,7 +8,6 @@ module Screen_reader_handler = struct
   open Css
 
   type t = Sr_only | Not_sr_only
-  type Utility.base += Self of t
 
   let name = "screen_reader"
   let priority _ = 0
@@ -211,8 +210,6 @@ module Handler = struct
     | Break_inside_avoid
     | Break_inside_avoid_column
     | Break_inside_avoid_page
-
-  type Utility.base += Self of t
 
   let name = "layout"
 
@@ -763,16 +760,13 @@ module Handler = struct
 end
 
 open Handler
-
-(** Register both handlers with Utility system *)
-let () = Utility.register (module Screen_reader_handler)
-
-let () = Utility.register (module Handler)
+module Screen_reader_utility = Utility.Make (Screen_reader_handler)
+module Utility_factory = Utility.Make (Handler)
 
 (** {1 Public API - Utility Values} *)
 
 (* Layout utilities *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let block = utility Block
 let contents = utility Contents
 let flow_root = utility Flow_root
@@ -828,7 +822,7 @@ let float_start = utility Float_start
 let float_end = utility Float_end
 
 (* Screen reader utilities *)
-let sr_utility x = Utility.base (Screen_reader_handler.Self x)
+let sr_utility = Screen_reader_utility.v
 let sr_only = sr_utility Screen_reader_handler.Sr_only
 let not_sr_only = sr_utility Screen_reader_handler.Not_sr_only
 

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -25,7 +25,6 @@ module Handler = struct
   (** Local margin utility type *)
 
   (** Extensible variant for margin utilities *)
-  type Utility.base += Self of t
 
   let name = "margin"
   let priority _ = 2
@@ -327,9 +326,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility axis value = Utility.base (Self { axis; value })
+let utility axis value = Utility_factory.v { axis; value }
 
 let v d n =
   let s = Handler.Spacing (Spacing.int n :> Style.spacing) in

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -74,8 +74,6 @@ module Handler = struct
     | Radial_shape of radial_shape (* mask-circle, mask-ellipse *)
     | Radial_size of radial_size (* mask-radial-closest-corner etc. *)
 
-  type Utility.base += Self of t
-
   let name = "mask_gradient"
 
   (* Tailwind emits the mask-gradient utilities after the backgrounds and before
@@ -1196,9 +1194,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 (* Convenience functions for creating mask gradient utilities *)
 let mask_t_from value = utility (Position (Top, From, value))

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -75,8 +75,6 @@ module Handler = struct
     | Size_bracket of string
     | Size_bracket_var of string
 
-  type Utility.base += Self of t
-
   let name = "masks"
 
   (* After the backgrounds and the mask-gradient utilities, before fill and
@@ -612,9 +610,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let mask_none = utility No_mask
 let mask_add = utility Add
 let mask_exclude = utility Exclude

--- a/lib/overflow.ml
+++ b/lib/overflow.ml
@@ -27,8 +27,6 @@ module Handler = struct
     | Y_visible
     | Y_scroll
 
-  type Utility.base += Self of t
-
   let name = "overflow"
 
   (* Overflow comes after alignment (17) in Tailwind's utility ordering. *)
@@ -99,12 +97,11 @@ module Handler = struct
 end
 
 open Handler
-
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)
 
 (** {1 Public API} *)
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let overflow_auto = utility Auto
 let overflow_hidden = utility Hidden
 let overflow_clip = utility Clip

--- a/lib/overflow_wrap.ml
+++ b/lib/overflow_wrap.ml
@@ -12,7 +12,6 @@ module Handler = struct
   open Css
 
   type t = Normal | Break_word | Anywhere
-  type Utility.base += Self of t
 
   let name = "overflow_wrap"
 
@@ -54,9 +53,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let wrap_normal = utility Normal
 let wrap_break_word = utility Break_word
 let wrap_anywhere = utility Anywhere

--- a/lib/overscroll.ml
+++ b/lib/overscroll.ml
@@ -27,8 +27,6 @@ module Handler = struct
     | Y_contain
     | Y_none
 
-  type Utility.base += Self of t
-
   let name = "overscroll"
 
   (* Same priority as overflow (18) - these are related utilities *)
@@ -79,9 +77,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let overscroll_auto = utility Auto
 let overscroll_contain = utility Contain
 let overscroll_none = utility None_

--- a/lib/padding.ml
+++ b/lib/padding.ml
@@ -16,8 +16,6 @@ module Handler = struct
     value : padding_value;
   }
 
-  type Utility.base += Self of t
-
   let name = "padding"
   let priority _ = 23
 
@@ -189,9 +187,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility axis value = Utility.base (Self { axis; value })
+let utility axis value = Utility_factory.v { axis; value }
 let p n = utility `All (Handler.Standard (Spacing.int n))
 let px n = utility `X (Handler.Standard (Spacing.int n))
 let py n = utility `Y (Handler.Standard (Spacing.int n))

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -319,7 +319,6 @@ module Handler = struct
     | End_3_4
 
   (** Extensible variant for position utilities *)
-  type Utility.base += Self of t
 
   let name = "position"
 
@@ -1016,11 +1015,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
 (** Public API combinators *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let static = utility Position_static
 let relative = utility Position_relative

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -2034,7 +2034,6 @@ module Handler = struct
     | Not_prose
 
   (** Extensible variant for prose utilities *)
-  type Utility.base += Self of t
 
   (** Priority for prose size utilities *)
   let name = "prose"
@@ -2094,7 +2093,6 @@ module Color_Handler = struct
   (** The prose colour variants, as {!prose_style} names them. *)
 
   (** Extensible variant for prose color utilities *)
-  type Utility.base += Self of t
 
   (** Priority for prose color utilities *)
   let name = "prose-color"
@@ -2141,15 +2139,15 @@ module Color_Handler = struct
   let examples = []
 end
 
+module Utility_factory = Utility.Make (Handler)
 (** Register both handlers with Utility system *)
-let () = Utility.register (module Handler)
 
-let () = Utility.register (module Color_Handler)
+module Color_utility = Utility.Make (Color_Handler)
 
 (** Public API *)
-let utility x = Utility.base (Handler.Self x)
+let utility = Utility_factory.v
 
-let color_utility x = Utility.base (Color_Handler.Self x)
+let color_utility = Color_utility.v
 let prose = utility Handler.Prose
 let prose_sm = utility Handler.Prose_sm
 let prose_lg = utility Handler.Prose_lg

--- a/lib/scroll.ml
+++ b/lib/scroll.ml
@@ -35,8 +35,6 @@ module Handler = struct
     value : scroll_value;
   }
 
-  type Utility.base += Self of t
-
   let name = "scroll"
 
   (* Scroll margin and padding follow the snap controls in the shared
@@ -288,11 +286,10 @@ module Handler = struct
 end
 
 open Handler
-
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)
 
 let utility kind negative axis value =
-  Utility.base (Self { kind; negative; axis; value })
+  Utility_factory.v { kind; negative; axis; value }
 
 (* Scroll margin utilities *)
 let scroll_m' n = utility Margin (n < 0.0) All (Spacing (Float.abs n))

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -32,8 +32,6 @@ module Handler = struct
     | Thumb of color_spec
     | Track of color_spec
 
-  type Utility.base += Self of t
-
   let name = "scrollbar"
 
   (* Scrollbar properties follow scroll padding and precede list style. *)
@@ -236,4 +234,4 @@ module Handler = struct
   let examples = [ Width_auto; Gutter_auto; Thumb Current; Track Current ]
 end
 
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -52,8 +52,6 @@ module Handler = struct
     | Aspect_bracket_num of string (* aspect-[1.333] single number *)
     | Aspect_theme of string (* ratio named by a project [--aspect-*] token *)
 
-  type Utility.base += Self of t
-
   let name = "sizing"
 
   (* Tailwind spacing order helper: matches canonical spacing scale order. n is
@@ -909,11 +907,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register the sizing utility handlers *)
-let () = Utility.register (module Handler)
 
 (** Public API returning Utility.t *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let () = () (* Ensure utility is defined before usage below *)
 
@@ -1039,7 +1037,9 @@ let aspect_ratio w h = utility (Aspect_ratio (float_of_int w, float_of_int h))
 
 (* Order exposure for this module *)
 let order (u : Utility.base) =
-  match u with Self x -> Some (priority x, suborder x) | _ -> None
+  if String.equal (Utility.name_of_base u) Handler.name then
+    Some (Utility.order u)
+  else None
 
 (* Export container theme variables for use by other modules (e.g., Columns) *)
 let container_binding = Handler.container_binding

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -50,8 +50,6 @@ module Handler = struct
     | Stroke_width_typed_var of
         string (* full inner: "length:var(--my-width)" *)
 
-  type Utility.base += Self of t
-
   let name = "svg"
   let priority _ = 22
 
@@ -428,8 +426,7 @@ module Handler = struct
   let examples = [ Fill_none; Stroke_none; Stroke_0 ]
 end
 
-let () = Utility.register (module Handler)
-
+module Utility_factory = Utility.Make (Handler)
 open Handler
 
 let color_util name property color ?(shade = 500) () =
@@ -444,7 +441,7 @@ let color_util name property color ?(shade = 500) () =
   let def, css_var = Css.var var_name Css.Color typed_color in
   Style.style [ def; property (Css.Color (Css.Var css_var) : Css.svg_paint) ]
 
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let fill = color_util "fill" Css.fill
 let stroke = color_util "stroke" Css.stroke
 let fill_none = utility Fill_none

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -6,7 +6,6 @@ module Handler = struct
   open Style
 
   type t = Tab of int | Tab_arbitrary of string * Css.tab_size
-  type Utility.base += Self of t
 
   let name = "tab"
   let priority _ = 26
@@ -51,7 +50,7 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let tab n = utility (Tab n)

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -39,7 +39,6 @@ module Handler = struct
     | Caption_bottom
 
   (** Extensible variant for table utilities *)
-  type Utility.base += Self of t
 
   (** Priority for table utilities - comes before layout utilities *)
   let name = "tables"
@@ -269,11 +268,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register handler with Utility system *)
-let () = Utility.register (module Handler)
 
 (** Public API *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let border_collapse = utility Border_collapse
 let border_separate = utility Border_separate

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -41,8 +41,6 @@ module Handler = struct
     | Arbitrary of string
     | Arbitrary_opacity of string * Color.opacity_modifier
 
-  type Utility.base += Self of t
-
   let name = "text_shadow"
 
   (* An opacity-bearing shadow writes the alpha channel before text-shadow, so
@@ -943,9 +941,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let text_shadow_none = utility None
 let text_shadow_2xs = utility (Shape S_2xs)
 let text_shadow_xs = utility (Shape S_xs)

--- a/lib/touch.ml
+++ b/lib/touch.ml
@@ -26,8 +26,6 @@ module Handler = struct
     | Pan_y
     | Pinch_zoom
 
-  type Utility.base += Self of t
-
   let name = "touch"
 
   (* Touch-action follows cursor and opens the shared interaction band. *)
@@ -119,9 +117,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let touch_auto = utility Auto
 let touch_none = utility No_action
 let touch_manipulation = utility Manipulation

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -145,8 +145,6 @@ module Handler = struct
     | Origin_bottom_right
     | Origin_arbitrary of string * Css.transform_origin
 
-  type Utility.base += Self of t
-
   (** Priority for transform utilities *)
   let name = "transforms"
 
@@ -2010,11 +2008,11 @@ end
 
 open Handler
 
+module Utility_factory = Utility.Make (Handler)
 (** Register the transform utility handlers *)
-let () = Utility.register (module Handler)
 
 (** Public API returning Utility.t *)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 
 let rotate n = utility (Rotate n)
 let translate_x n = utility (Translate_x n)

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -42,8 +42,6 @@ module Handler = struct
     | Ease_arbitrary of string * Css.timing_function
     | Ease_theme of string (* timing function from an --ease-* token *)
 
-  type Utility.base += Self of t
-
   let name = "transitions"
 
   let priority = function
@@ -679,9 +677,9 @@ module Handler = struct
 end
 
 open Handler
+module Utility_factory = Utility.Make (Handler)
 
-let () = Utility.register (module Handler)
-let utility x = Utility.base (Self x)
+let utility = Utility_factory.v
 let transition_none = utility Transition_none
 let transition = utility Transition
 let transition_all = utility Transition_all

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -463,8 +463,6 @@ module Typography_early = struct
     | Named of string (* /snug → var(--leading-snug) *)
     | Bracket of string * Css.line_height (* /[4px] → 4px *)
 
-  type Utility.base += Self of t
-
   let name = "typography_early"
 
   (* Most early-typography families (text-align, font, leading) sort at priority
@@ -1758,8 +1756,6 @@ module Typography_late = struct
     | Content_raw of string * Css.content
       (* unquoted arbitrary: content-[attr(before)]; raw class text + value *)
     | Content_named of string (* content-<token> defined in the @theme *)
-
-  type Utility.base += Self of t
 
   let name = "typography_late"
 
@@ -3385,14 +3381,13 @@ module Typography_late = struct
     ]
 end
 
-(* Register both handlers *)
-let () = Utility.register (module Typography_early)
-let () = Utility.register (module Typography_late)
+module Early_utility = Utility.Make (Typography_early)
+module Late_utility = Utility.Make (Typography_late)
 
 (* Public API - using appropriate handler for each utility *)
 
 (* Early typography utilities - priority 22 *)
-let utility_early x = Utility.base (Typography_early.Self x)
+let utility_early = Early_utility.v
 let text_xs = utility_early Typography_early.Text_xs
 let text_sm = utility_early Typography_early.Text_sm
 let text_base = utility_early Typography_early.Text_base
@@ -3436,7 +3431,7 @@ let leading n = utility_early (Typography_early.Leading n)
 let leading' n = utility_early (Typography_early.Leading_step n)
 
 (* Late typography utilities - priority 24 *)
-let utility_late x = Utility.base (Typography_late.Self x)
+let utility_late = Late_utility.v
 
 let decoration_color ?(shade = 500) color =
   Color.check_shade ~utility:"decoration_color" color shade;

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -26,7 +26,6 @@ end
 
 module type Handler = sig
   type t
-  type base += Self of t
 
   val name : string
   val to_style : Scheme.t -> t -> Style.t
@@ -37,7 +36,14 @@ module type Handler = sig
   val examples : t list
 end
 
-type handler = H : (module Handler with type t = 'a) -> handler
+module type Registered = sig
+  include Handler
+
+  val inject : t -> base
+  val project : base -> t option
+end
+
+type handler = H : (module Registered with type t = 'a) -> handler
 
 let handlers : handler list ref = ref []
 
@@ -54,10 +60,24 @@ let property_slots :
     =
   ref None
 
-let register (type a) (module M : Handler with type t = a) =
-  let internal_h = H (module M : Handler with type t = a) in
+let register (type a) (module M : Registered with type t = a) =
+  let internal_h = H (module M : Registered with type t = a) in
   property_slots := None;
   handlers := internal_h :: !handlers
+
+module Make (M : Handler) = struct
+  type base += Self of M.t
+
+  module Registered = struct
+    include M
+
+    let inject value = Self value
+    let project = function Self value -> Some value | _ -> None
+  end
+
+  let () = register (module Registered)
+  let v value = Base (Self value)
+end
 
 (* The declarations a style writes on the element itself: a pseudo-element
    suffix or a rule of its own moves them off it. *)
@@ -187,14 +207,12 @@ let name_of_base u =
   let rec try_handlers = function
     | [] -> failwith "name_of_base"
     | H (module M) :: rest -> (
-        match u with M.Self _ -> M.name | _ -> try_handlers rest)
+        match M.project u with Some _ -> M.name | None -> try_handlers rest)
   in
   try_handlers !handlers
 
 let class_of_base u =
-  let visit (H (module M)) =
-    match u with M.Self x -> Some (M.to_class x) | _ -> None
-  in
+  let visit (H (module M)) = Option.map M.to_class (M.project u) in
   match List.find_map visit !handlers with
   | Some class_name -> class_name
   | None -> failwith "class_of_base"
@@ -204,7 +222,7 @@ let base_of_class theme class_name =
     | [] -> Error (`Msg "Unknown utility")
     | H (module M) :: rest -> (
         match M.of_class theme class_name with
-        | Ok x -> Ok (M.Self x)
+        | Ok x -> Ok (M.inject x)
         | Error _ -> try_handlers rest)
   in
   try_handlers !handlers
@@ -241,7 +259,9 @@ let base_to_style theme u =
           "Unknown utility type - handler not registered. This is a bug in the \
            utility system."
     | H (module M) :: rest -> (
-        match u with M.Self x -> M.to_style theme x | _ -> try_handlers rest)
+        match M.project u with
+        | Some x -> M.to_style theme x
+        | None -> try_handlers rest)
   in
   try_handlers !handlers
 
@@ -281,9 +301,9 @@ let order (u : base) : int * int =
           "Unknown utility type - handler not registered. This is a bug in the \
            utility system."
     | H (module M) :: rest -> (
-        match u with
-        | M.Self x -> (M.priority x, M.suborder x)
-        | _ -> try_handlers rest)
+        match M.project u with
+        | Some x -> (M.priority x, M.suborder x)
+        | None -> try_handlers rest)
   in
   try_handlers !handlers
 

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -14,7 +14,6 @@
 
       module Handler = struct
         type t = Block
-        type Utility.base += Self of t
 
         let name = "example"
         let priority _ = 4
@@ -35,8 +34,9 @@
         let examples = [ Block ]
       end
 
-      let () = Utility.register (module Handler)
-      let utility x = Utility.base (Handler.Self x)
+      module Utility_factory = Utility.Make (Handler)
+
+      let utility = Utility_factory.v
       let example_block = utility Handler.Block
     end
     ]}
@@ -60,8 +60,9 @@
     - 100+: Modifiers and special utilities
     - 800+: Component-level utilities (forms, etc.) *)
 
-type base = ..
-(** Base utility type without modifiers - extensible variant *)
+type base
+(** Base utility type without modifiers. Values are created only by a
+    {!Make}-registered handler, so dispatch over one is total. *)
 
 (** Unified utility type with modifiers support *)
 type t =
@@ -112,8 +113,6 @@ module type Handler = sig
   type t
   (** The utility type *)
 
-  type base += Self of t  (** Extension of the base utility type *)
-
   val name : string
   (** Name of this utility handler. *)
 
@@ -144,8 +143,11 @@ module type Handler = sig
       lets a project's [@utility] declaring it sort in the right place. *)
 end
 
-val register : (module Handler with type t = 'a) -> unit
-(** [register h] registers a utility handler module. *)
+module Make (H : Handler) : sig
+  val v : H.t -> t
+  (** Applying [Make] registers [H] at module initialization. [v value] packages
+      [value] as a utility handled by [H]. *)
+end
 
 val order_of_property : Cascade.Css.Declaration.prop_key -> (int * int) option
 (** [order_of_property k] is the [(priority, suborder)] of the utility family

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -10,8 +10,6 @@ module Handler = struct
     | Bare_var of string
     | Arbitrary of string * Css.zoom
 
-  type Utility.base += Self of t
-
   let name = "zoom"
 
   (* Tailwind emits [zoom-*] between the transforms and the animations. It
@@ -74,4 +72,4 @@ module Handler = struct
   let examples = [ Percent 100. ]
 end
 
-let () = Utility.register (module Handler)
+module Utility_factory = Utility.Make (Handler)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -904,7 +904,6 @@ let test_style_rules_props () =
   (* Create a test utility that wraps the style and provides the class name *)
   let module TestHandler = struct
     type t = Test
-    type Tw.Utility.base += Self of t
 
     let name = "test"
     let priority _ = 0
@@ -914,8 +913,8 @@ let test_style_rules_props () =
     let of_class _ _ = Error (`Msg "test utility")
     let examples = []
   end in
-  let () = Tw.Utility.register (module TestHandler) in
-  let test_utility = Tw.Utility.base (TestHandler.Self TestHandler.Test) in
+  let module TestUtility = Tw.Utility.Make (TestHandler) in
+  let test_utility = TestUtility.v TestHandler.Test in
   let extracted = Tw.Rule.outputs test_utility in
 
   (* Should generate rules in order: custom rules first, then base props *)


### PR DESCRIPTION
Public extensible constructors allowed utility values with no registered handler, leaving dispatch partial. `Utility.Make` now owns registration and construction together.