### PR TITLE
changes: rewrite the unreleased 1.1.0 entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,32 +1,57 @@
-## 1.1.0
+## 1.1.0 (unreleased)
+
+### Breaking changes
+
+- `bg_transparent`, `bg_current` and the background colour constructors move to
+  `Backgrounds`; `border_color`, `border_transparent` and `border_current` move
+  to `Color`. Building one from OCaml and parsing the same class name used to
+  reach different handlers with different sort slots (#518).
+- Every spacing utility takes an `int`, and a primed variant takes a float, so
+  the common call needs no conversion. A float call site becomes `p' 2.5`
+  (#492).
+- An unrecognised class no longer raises. `Tw.str` raised, `Tw_html` copied the
+  name in silently, and `Tw_dom.use_str` crashed the browser render. Unknown
+  names pass through everywhere now, never raise from a rendering path, and are
+  reportable instead: `Tw.of_classes` returns them alongside the utilities, and
+  `Tw_html.unknown_classes` and `Tw_dom.unknown_classes` expose the same list.
+  Code that caught the exception to find a typo reads that list. `Tw.of_string`
+  is unchanged, so the CLI still reports a deliberately typed class as an error
+  (#514).
 
 ### Tailwind CSS 4.3.3
 
-- Track Tailwind CSS 4.3.3, update the system font stack and preflight, write
-  powerless hues as `none`, add the mauve, mist, olive, and taupe palettes,
-  and regenerate the upstream parity corpus
-  (#128, #129, #130, #132, #147, #153).
+- Track Tailwind CSS 4.3.3. `font-sans` carries the 4.3.2 system stack,
+  preflight scopes `:-moz-focusring` to non-iframe elements, and an achromatic
+  colour writes its powerless hue as `none` (#128, #129, #130, #132, #147).
+- Add the mauve, mist, olive and taupe palettes (#153).
 
-### CLI and project stylesheets
+### Project stylesheets
 
-- Compile complete CSS entrypoints and imports; scan Markdown, MDX,
-  JavaScript, and TypeScript; and expand author-written `@variant`,
-  `@custom-variant`, `--spacing()`, `theme()`, `@apply`, and `@utility`
-  constructs (#136, #137, #138, #139, #140, #141, #143, #195, #206).
-- Carry the entrypoint theme, declared variants, routed utilities, keyframes,
-  layers, properties, static theme scales, and v3 theme paths through class
-  generation (#170, #179, #193, #194, #221, #226, #227, #228, #229, #230,
+- `tw` compiles a whole CSS entrypoint instead of reading only its `@theme`.
+  `@import`, `@apply`, `@utility`, `@variant`, `@custom-variant`, `--spacing()`
+  and `theme()` all expand in author CSS, down to a declared utility's own
+  `@apply` and `@variant` (#136, #138, #139, #140, #141, #143, #195, #206).
+- A project's own theme reaches class generation, so its variants, keyframes,
+  layers, static scales, custom breakpoints and v3 dotted `theme()` paths apply
+  to the utilities tw generates from the markup, and a routed utility survives a
+  selector that is not a bare class (#170, #179, #193, #221, #227, #229, #230,
   #315, #320).
-- Gate typography utilities on the plugin, ignore candidates that cannot
-  render, recognize source boundaries correctly, tokenize entrypoint rewrites,
-  and make recursive content scans safe
-  (#142, #144, #145, #208, #288, #318, #321).
+- Class scanning covers Markdown, MDX, JavaScript and TypeScript, and finds
+  where a candidate ends with cascade's tokeniser rather than by guessing. A
+  bracket before whitespace is not a candidate, a candidate stops at the end of
+  its line, and a recursive scan stays inside the source tree (#137, #145,
+  #208, #288, #318, #321, #564).
+- Prose utilities are emitted only when the typography plugin is enabled, and a
+  candidate that raises while rendering an arbitrary value is dropped rather
+  than aborting the run (#142, #144).
 - A functional `@utility name-*` resolves `--value()` and `--modifier()`, and
   `@apply` of one produces its declarations instead of nothing. A token a
   utility only reads through `var()` is now declared in the theme layer whatever
   its family, `--spacing(N)` is multiplied out where the project inlines
   `--spacing`, and an `@theme reference` block is represented (#554).
 - Every `@utility` declared for one name applies, not only the first (#550).
+- A routed candidate keeps the utility that owns it, so a class a declared
+  variant routes is generated once by the right handler (#564).
 - Reject conflicting CLI backends instead of silently selecting one (#317).
 - Keep Tailwind's own at-rules out of the generated CSS: `@theme`, `@source`,
   `@plugin`, `@config`, `@reference`, and `@tailwind` used to reach the
@@ -34,25 +59,36 @@
 
 ### Utility coverage
 
-- Complete container, viewport, fractional, and logical sizing; support the
-  full position and spacing scales, arbitrary fraction denominators, and
-  consistent basis, translate, and size generation
-  (#146, #151, #152, #154, #155, #156, #159, #160, #166, #172, #180, #186,
-  #207, #210, #216, #293).
-- Expand transform, background, grid, typography, transition, and general
-  keyword coverage, including `none`, perspective, text indent, aspect ratio,
-  content, theme-named fonts, and arbitrary grid tracks
-  (#134, #157, #164, #171, #174, #175, #178, #181, #183, #184, #212, #218,
+- Sizing accepts the whole scale. The container scale reaches the logical
+  families and `basis-*`, both viewport axes and the `px` step work on the width
+  and height families, and a fraction takes any denominator, including zero and
+  improper ones. `w-3/8`, `min-w-7/12`, `max-h-dvw`, `size-px`, `basis-7xl` and
+  `@container-size` all resolve (#146, #151, #152, #154, #155, #156, #159, #180,
+  #207, #216, #564).
+- Position and translate read a spacing step in either sign and a fraction of
+  any shape, so `-left-6/5`, `-top-2.5` and `translate-2` work alongside the
+  numeric steps (#160, #166, #172, #186, #210).
+- Transforms, backgrounds, grids and typography take the keywords Tailwind
+  documents: `translate-none`, `rotate-none`, `scale-none`, `perspective-near`,
+  `duration-initial`, `ease-initial`, `via-none`, `grow-3`, `indent-px` and a
+  negative `-indent-4`. A zero translate keeps its unit, `aspect-[1.333]` takes
+  a bare number, `grid-cols-[min(50%,20rem)]` takes a math function,
+  `bg-position-[center_2rem]` keeps both axes, `content-[attr(before)]` takes an
+  unquoted function, and a font family the project named in its `@theme`
+  resolves (#134, #157, #164, #171, #174, #175, #178, #181, #183, #184, #218,
   #223).
-- Add logical and axis border utilities, arbitrary integer border widths,
-  mask stops and images, mask gradients, and typed divide utilities
-  (#148, #161, #162, #163, #165, #182, #222, #239, #265, #296).
-
+- Borders and masks cover their logical and arbitrary forms: axis and
+  single-side widths and colours (`border-x-16`, `border-bs-red-500`), any
+  integer width or outline offset, a mask colour stop, a bracket mask image, and
+  a zero mask stop that keeps its unit (#148, #161, #162, #163, #165, #182,
+  #222, #265).
+- A named spacing token declares the variable it references. Padding and gap
+  emitted `var(--spacing-<name>)` with nothing declaring it (#261).
 - Accept a value the project named in its own `@theme` wherever Tailwind does:
   shadows, blur radii, timing functions, font weights, line heights, letter
   spacing, corner radii, font sizes, perspectives, aspect ratios and max-widths
   (#447, #450, #457, #458, #459, #460, #461, #462, #463, #464).
-- Honour a `@theme` that REMOVES a token. A namespace reset (`--color-*:
+- Honour a `@theme` that removes a token. A namespace reset (`--color-*:
   initial`) now reaches tw at all, `--spacing: initial` drops the multiplier,
   a removed breakpoint stops resolving its variant, and a removed palette
   entry no longer leaves a utility referencing a variable nothing declares
@@ -71,17 +107,24 @@
   compiled. The value was re-parsed inside a `calc()` the code wrapped around
   it, so the added `)` silently closed the author's stray one and
   `-left-[0)/*1]` became `left: calc(0 * -1)` (#548).
-- Parse arbitrary lengths, calculations, theme and spacing functions, grid
-  tracks, colours, list styles, and custom properties through the shared CSS
-  parsers while preserving their original meaning
-  (#168, #171, #174, #175, #176, #177, #178, #187, #188, #189, #190, #191,
-  #192, #205, #212, #217, #218, #236, #241, #257, #266, #277, #278, #287,
-  #325).
-- Report invalid palette shades and arbitrary values as unknown classes rather
-  than crashing or emitting dead selectors; reject trailing text, malformed
-  channels, unitless decoration colours, and non-canonical numeric spellings
-  (#127, #234, #237, #257, #282, #284, #285, #307, #309).
-
+- An arbitrary value reads through the same CSS parsers as the rest of the
+  sheet, so a length, a compact `calc()`, a `var()` with its fallback, a
+  `theme()` in dot notation, a `--spacing()` call, a grid track, a colour and a
+  list style mean the same thing wherever they appear: `ml-[50%]`,
+  `left-[calc(5%-2px)]`, `py-[calc(--spacing(2)+1px)]` and `list-[upper-roman]`
+  all resolve, and a bracket colour is read as CSS before the palette is
+  consulted (#168, #176, #177, #187, #188, #189, #190, #191, #192, #205, #212,
+  #217, #236, #241, #262, #277, #278, #325).
+- A bad arbitrary value no longer takes the run down. Six bracket spellings
+  raised past the result-typed `of_string`, and nine `to_style` sites answered
+  an empty style instead of an error, so a class could crash the renderer or
+  silently emit nothing (#257, #266, #287).
+- A class that cannot mean anything is refused at parse time instead of
+  compiling to a dead selector. An invalid palette shade, a value the property
+  cannot take, a bracket value that escapes its declaration, trailing text
+  after the value, a colour channel with no byte and a non-canonical number are
+  all rejected, and a unitless decoration colour declares nothing rather than
+  guessing (#127, #234, #237, #282, #284, #285, #307, #309, #532).
 - Read an arbitrary value through cascade's own grammar rather than a private
   unit table, so a length, angle, colour, shadow, ease, blur, tracking,
   line-height, stroke width, border-spacing or gradient stop takes every unit
@@ -90,19 +133,28 @@
 - Refuse an unreadable arbitrary value at parse time, with the reason, instead
   of accepting the class and emitting nothing usable: animations, order,
   z-index, grid lines, the `not-has` shorthand, data expressions, gradient
-  interpolation, and a bracket carrying two brackets (#405, #406, #407, #408,
-  #410, #421, #422, #496).
+  interpolation, a bracket carrying two brackets, and `not-[...]` content no
+  selector reader can read (#405, #406, #407, #408, #410, #421, #422, #496,
+  #532).
 - Spell an arbitrary value in the class name the way the author wrote it, so a
-  class the parser produced reads back (#412, #413, #415, #489, #490).
+  class the parser produced reads back. `basis-[...]`, `perspective-[...]` and
+  a `min-[...]` breakpoint keep the author's spelling, `underline-offset-[...]`
+  gets its own class rather than sharing one, and an `nth-*` argument keeps its
+  bracket (#412, #413, #415, #489, #490, #532, #564).
+- A `var()` reference is read to its end wherever it appears, including inside
+  a bracket value, so one carrying its own parentheses or a fallback is not
+  truncated (#564).
 
 ### Colours and effects
 
-- Apply alpha modifiers consistently to theme variables, borders, rings,
-  decorations, strokes, shadows, and drop shadows; support shadeless and
-  `light-dark()` colours and preserve both default drop-shadow layers
-  (#169, #185, #201, #202, #209, #214, #225, #231, #244, #254, #281, #308,
-  #322, #323).
-
+- An opacity modifier reaches every colour family. A ring, a per-side border, a
+  shadow, a drop shadow, a decoration and a stroke all take one, the alpha can
+  itself be a variable (`bg-cyan-400/(--my-alpha-value)`), and `transparent` and
+  `inherit` take one everywhere. Shadeless names such as `shadow-white` and
+  `stroke-white` work, `light-dark()` and an arbitrary shadow colour resolve,
+  and a drop shadow keeps both of its default layers under an opacity (#169,
+  #185, #201, #202, #209, #214, #225, #231, #244, #254, #281, #308, #322,
+  #323).
 - A bracket colour carrying an opacity modifier no longer renders black.
   `text-[rebeccapurple]/50` and its siblings kept the parsed colour rather than
   re-reading the bracket text through the palette, whose failure arm answered
@@ -119,39 +171,63 @@
 
 ### Variants and selectors
 
-- Compose arbitrary, compound, negated, group, peer, `has`, `in`, container,
-  and at-rule variants with the correct anchors and nesting; parse selector
-  content structurally and support custom-variant selector shorthand
-  (#135, #167, #173, #196, #197, #198, #199, #200, #203, #204, #211, #213,
-  #215, #219, #220, #224, #231, #232, #233, #235, #238, #280, #314).
-
+- Variants compose in the combinations Tailwind allows. `group-*` and `peer-*`
+  take any state and a name (`peer-checked/draft`), `has-*` takes any variant,
+  a bare data attribute or a bracket selector (`has-[a]`, `has-peer-checked`),
+  `not-*` composes over any variant, `in-*` scopes to an ancestor in a given
+  state (`in-focus`), a container query nests with the variants around it, and
+  an arbitrary variant works with no `&` anchor (`[code]:pr-4`). A hover gate
+  nests inside a wrapping media or container query, an inner selector survives
+  an at-rule variant such as `[@supports(display:grid)]:grid`, and a project's
+  `@custom-variant` selector shorthand is read (#167, #173, #196, #197, #198,
+  #199, #200, #203, #204, #211, #213, #215, #219, #224, #231, #232, #233, #235,
+  #238, #280, #314).
+- A variant no longer costs the rule inside it. A hover gate survives an
+  at-rule variant, a peer hover gate survives a selector variant, a variant
+  stays wrapped around a `@starting-style` rule, and a class a variant renames
+  keeps the default transition theme (#564).
 - `[attr~=value]` attribute selectors work in arbitrary variants. The gate
   rejected any bracket containing `~`, reading the whitespace-list operator as
   a sibling combinator (#509).
 - `supports-*` emits the test the author wrote, as a typed condition rather
-  than a string reparsed after assembly (#389, #484).
+  than a string reparsed after assembly, and a bare property expands to a
+  feature test instead of aborting the run (#135, #389, #484).
 - A container query is refused as a `not-*` inner, and a media inner is refused
   inside a group or peer negation, matching what Tailwind accepts (#488, #493).
 
 ### CSS ordering and structure
 
-- Match Tailwind's ordering for supports fallbacks, container variants,
-  logical sizing, line clamp, layout, drop shadows, divide, masks, outlines,
-  insets, basis fractions, theme tokens, and routed variants
-  (#242, #243, #249, #250, #251, #253, #261, #262, #263, #264, #267, #268,
-  #269, #291, #292, #310, #311, #312).
-- Group `@apply`, `@property`, `@starting-style`, and layer output correctly,
-  and interleave project utilities with the built-in property family they
-  implement (#194, #220, #226, #228, #255, #256, #271, #313, #316, #319,
-  #324).
-
+- Utilities land where Tailwind puts them across the sheet. A colour's
+  `@supports` rule stays with its fallback, container variants order by width,
+  the logical sizing families sort last, line-clamp sorts with box-sizing, and
+  isolation, float, clear, divide, masks, outline colours, the drop-shadow
+  sizes, inset start and end, the basis fractions and the theme namespaces each
+  follow Tailwind's order. An unvarianted utility comes before the `not-*`
+  group, and a variable whose slot was already taken is no longer dropped from
+  the sheet (#242, #243, #249, #250, #251, #253, #263, #264, #267, #268, #269,
+  #291, #292, #310, #311, #312).
+- Around forty more property families emit in Tailwind's band: fill and stroke
+  ahead of object-fit, aspect ratio before the dimensions, tab size inside
+  typography, field sizing after display, logical block margins before the
+  physical sides, ring widths in numeric order, and the transform, filter,
+  gradient, gap, delay and list-style families throughout (#564).
+- Stacked and compound variants sort by what they contain rather than by their
+  prefix text. A compound carries its inner value, a recursive compound follows
+  its whole path, an arbitrary variant orders by its selector, data variants
+  group by predicate, and repeated element variants collapse to one key (#564).
+- Blocks group the way Tailwind groups them. A run of `@starting-style`
+  utilities emits as one block, the utilities one `@apply` pulls in land in a
+  single rule, the `@property` an applied utility brings is hoisted and
+  deduplicated, a pseudo-element declares its content once, and a project's own
+  utilities interleave with the built-in family writing the same property
+  (#194, #220, #226, #228, #255, #256, #271, #313, #316, #319, #324).
 - A declared `@utility` sorts after the built-ins of its family, as Tailwind
   puts it, so on an element carrying both the declared one wins; and a
   multi-rule one keeps its nesting rather than being flattened and scattered
   (#516).
-- The variant cascade comes from one table instead of four copies on three
-  numeric scales. An unrecognised prefix used to return 0, which put the rule
-  in a different sort bucket entirely rather than merely out of order (#520).
+- The variant cascade comes from one table. An unrecognised prefix used to
+  return 0, which put the rule in a different sort bucket entirely rather than
+  merely out of order (#520).
 - The late typography colour block and the priority-7 theme tail emit in
   Tailwind's order; `divide-x-reverse`, container queries and column values
   sort where Tailwind puts them (#429, #443, #494, #523).
@@ -171,51 +247,21 @@
 - Add the typed `divide` constructors, from `divide_x` to `divide_style`: only
   the two reverse utilities were exposed, so the rest of the family was
   reachable from a class string but not from OCaml (#239, closes #5).
-- An unrecognised class has one behaviour everywhere. `Tw.str` raised,
-  `Tw_html` copied the name in silently, and `Tw_dom.use_str` crashed the
-  browser render. Unknown names now pass through everywhere, never raise from a
-  rendering path, and are reportable: `Tw.of_classes` returns them alongside
-  the utilities, and `Tw_html.unknown_classes` and `Tw_dom.unknown_classes`
-  expose the same list. `Tw.of_string` is unchanged, so the CLI still reports a
-  deliberately typed class as an error (#514).
-- **Breaking:** `bg_transparent`, `bg_current` and the background colour
-  constructors move to `Backgrounds`; `border_color`, `border_transparent` and
-  `border_current` move to `Color`. Building one from OCaml and parsing the
-  same class name used to reach different handlers with different sort slots
-  (#518).
-- Every spacing utility takes an `int`, with a primed variant for a float, so
-  the common call needs no conversion (#492).
 - `divide_x_length` accepts a line-width keyword. Tailwind renders
   `divide-x-[thin]`, and the parser already did, but the typed constructor
   raised on it (#522).
 
-### Documentation, compatibility, and release quality
+### Parity and packaging
 
-- Document how Tailwind parity is measured and update the contributor
-  documentation to match the current code layout (#240, #283).
-- Strengthen the fixture, ordering, browser-rendering, and suite-trust gates,
-  including structural and layer-order comparisons
-  (#158, #258, #259, #270, #286, #301).
-- Require Cascade 1.1.0 and its released comparison API, removing the moving
-  CI dependency (#297, #302).
-- The browser rendering comparison actually runs in CI. `npm ci` installs
-  Playwright but not the browser it drives, and the check skipped silently
-  without one, so eight suites reported no rendering difference because they
-  never looked. CI installs Chromium now, and a missing browser fails rather
-  than skips (#513).
-- The upstream parity suite no longer takes its expected values from Tailwind's
-  own output. Breaking four built-in defaults used to leave it passing every
-  case; the same breakage now fails it (#512).
-- The typography plugin's descendant rules are exercised against real markup
-  rather than bare divs, which is most of the largest plugin (#519).
-- A whole-sheet order gate measures where every utility lands, not only the
-  handful a test names. Every Tailwind oracle here runs the differ in canonical
-  mode, which normalises cascade-neutral rule order, so a family emitted in the
-  wrong band was invisible to all of them. The gate reads the statement sequence
-  out of both sheets over the site class list and pins the fewest statements
-  that have to move, which stands at 581 of 3885 unambiguous pairs and only
-  ratchets down. A missing or off-version Tailwind CLI skips it with a line
-  saying so, and `TW_TAILWIND_TESTS=1`, which CI sets, makes that a failure.
+- Require cascade 1.2.0, replacing the temporary pin to cascade's main branch,
+  so opam can resolve a supported pairing (#297, #302, #305).
+- Parity is measured over whole sheets and in a real browser. The ordering gate
+  compares every statement in both sheets rather than the handful a test names,
+  the upstream suite takes its expected values from committed fixtures rather
+  than from Tailwind's own output, the typography plugin is exercised against
+  real markup, and CI installs the browser the rendering comparison drives,
+  which it had been skipping silently (#158, #258, #259, #270, #286, #301,
+  #512, #513, #519).
 
 ## 1.0.0
 


### PR DESCRIPTION
Much of the 1.1.0 block indexed PR numbers by theme rather than saying what changed, and the breaking changes were unmarked and buried, so a reader upgrading could not tell what affected them. The cascade requirement was also recorded as 1.1.0 rather than the 1.2.0 the build has needed since #305.