### PR TITLE
ci: follow cascade main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,10 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      # dune-project asks for cascade 1.2.0 and that release does not exist
-      # yet. Pin the tested development revision: following main made an
-      # unchanged PR start compiling against breaking API changes.
-      - name: Pin the tested cascade revision
-        run: opam pin add --no-action -y cascade.1.2.0 git+https://github.com/samoht/cascade.git#e829b2d629fe210a23415a218f1814d2abc0c1ad
+      # cascade 1.2.0 is not released yet. Follow main rather than freezing CI
+      # to one development commit, so upstream API changes are caught here.
+      - name: Pin cascade main
+        run: opam pin add --no-action -y cascade.1.2.0 git+https://github.com/samoht/cascade.git#main
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,8 +66,9 @@
   `@container-size` all resolve (#146, #151, #152, #154, #155, #156, #159, #180,
   #207, #216, #564).
 - Position and translate read a spacing step in either sign and a fraction of
-  any shape, so `-left-6/5`, `-top-2.5` and `translate-2` work alongside the
-  numeric steps (#160, #166, #172, #186, #210).
+  any shape, and a negated arbitrary inset accepts a parenthesised calc body,
+  so `-left-6/5`, `-top-2.5`, `-left-[(var(--a)+var(--b))]` and `translate-2`
+  work alongside the numeric steps (#160, #166, #172, #186, #210, #646).
 - Transforms, backgrounds, grids and typography take the keywords Tailwind
   documents: `translate-none`, `rotate-none`, `scale-none`, `perspective-near`,
   `duration-initial`, `ease-initial`, `via-none`, `grow-3`, `indent-px` and a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -254,8 +254,9 @@
 
 ### Parity and packaging
 
-- Require cascade 1.2.0, replacing the temporary pin to cascade's main branch,
-  so opam can resolve a supported pairing (#297, #302, #305).
+- Require cascade 1.2.0 for the released package pairing. While it remains
+  unreleased, CI pins cascade's main branch so builds and tests follow upstream
+  rather than an exact development revision (#297, #302, #305, #646).
 - Parity is measured over whole sheets and in a real browser. The ordering gate
   compares every statement in both sheets rather than the handful a test names,
   the upstream suite takes its expected values from committed fixtures rather

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,9 +404,9 @@ and the fields it keys on.
 1. **STOP** all other work immediately
 2. **FIX** the differ in `cascade/lib/diff/css_compare.ml` (with `tree_diff.ml` and
    `string_diff.ml` alongside it), add a case to `cascade/test/test_css_compare.ml`,
-   and land it in cascade. CI here pins cascade to its `main`, so the fix arrives
-   with the next run; bump the version bound in `dune-project` and `tw.opam` if it
-   needs a release
+   and land it in cascade. CI pins cascade to its `main` branch, so the fix
+   arrives with the next run; bump the version bound in `dune-project` and
+   `tw.opam` if it needs a release
 3. **VERIFY** it correctly detects the differences it was missing
 4. **THEN** resume your original task
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,5 +59,6 @@ do not exist.
 11. **Changelog + version.** A `CHANGES.md` entry for the version, every `#N`
     resolving to a merged PR, and the tag on the current `main` lineage.
 12. **Cascade bound.** `dune-project` and `tw.opam` name a cascade version CI
-    can resolve. CI pins cascade to its `main`; a local build compiles it from
-    source, so green locally is not green on CI.
+    can resolve. CI pins cascade's `main` branch; a local build compiles the
+    sibling checkout from source, so confirm both are on the same revision
+    before reading a difference as a tw regression.

--- a/docs/adding-a-new-utility.md
+++ b/docs/adding-a-new-utility.md
@@ -177,14 +177,14 @@ let font_weight_var = Var.channel Css.Font_weight "tw-font-weight"
 
 (* Every utility sets and uses it *)
 let font_bold =
-  let decl, var_ref = Var.binding font_weight_var (Weight 700) in
+  let decl, var_ref = Var.binding font_weight_var (Weight 700.) in
   Style.style [
     decl;
     font_weight (Var var_ref)
   ]
 
 let font_thin =
-  let decl, var_ref = Var.binding font_weight_var (Weight 100) in
+  let decl, var_ref = Var.binding font_weight_var (Weight 100.) in
   Style.style [
     decl;
     font_weight (Var var_ref)

--- a/dune
+++ b/dune
@@ -1,3 +1,8 @@
+; CLAUDE.md tells contributors to keep debug artefacts in tmp/, and dune builds
+; every directory it finds, so a stale scratch file there fails the whole build.
+
+(dirs :standard \ tmp)
+
 (env
  (dev
   ; -58 (no-cmx-file): a flambda missed-inlining hint that fires on

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -68,13 +68,25 @@ let parse_neg_bracket_length s : Css.length option =
     match Css.parse_length inner with
     | Some l -> Some (negate_length l)
     | None -> (
-        match
-          Cascade.Cursor.try_parse_full_err
-            (Css.Values.read_calc_expr Css.Values.read_length)
-            (Cascade.Cursor.of_string inner)
-        with
-        | Ok c -> Some (Css.Calc (Css.Calc.mul c (Css.Calc.float (-1.))))
-        | Error _ -> None)
+        if
+          String.length inner < 2
+          || inner.[0] <> '('
+          || inner.[String.length inner - 1] <> ')'
+        then None
+        else
+          (* The bracket form is a calc body without the [calc] function. Wrap
+             it before normalising so [+] and [-] are recognised as math
+             operators inside the parenthesised group. *)
+          let calc =
+            Parse.normalize_css_math_operators ("calc(" ^ inner ^ ")")
+          in
+          match
+            Cascade.Cursor.try_parse_full_err
+              (Css.Values.read_calc Css.Values.read_length)
+              (Cascade.Cursor.of_string calc)
+          with
+          | Ok c -> Some (Css.Calc (Css.Calc.mul c (Css.Calc.float (-1.))))
+          | Error _ -> None)
   else None
 
 (* Memoization cache for inset-named theme variables *)

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -387,47 +387,47 @@ let heading_rules base =
         Css.margin_top Zero;
         Css.margin_bottom (Em 0.888889);
         Css.font_size (Em 2.25);
-        Css.font_weight (Weight 800);
+        Css.font_weight (Weight 800.);
         Css.line_height (Num 1.11111);
       ];
     Css.rule
       ~selector:(where base (h1 ++ strong))
-      [ Css.color Css.Inherit; Css.font_weight (Css.Weight 900) ];
+      [ Css.color Css.Inherit; Css.font_weight (Css.Weight 900.) ];
     Css.rule ~selector:(where base h2)
       [
         Css.color (Css.Var prose_headings_v);
         Css.margin_top (Em 2.0);
         Css.margin_bottom (Em 1.0);
         Css.font_size (Em 1.5);
-        Css.font_weight (Weight 700);
+        Css.font_weight (Weight 700.);
         Css.line_height (Num 1.33333);
       ];
     Css.rule
       ~selector:(where base (h2 ++ strong))
-      [ Css.color Css.Inherit; Css.font_weight (Css.Weight 800) ];
+      [ Css.color Css.Inherit; Css.font_weight (Css.Weight 800.) ];
     Css.rule ~selector:(where base h3)
       [
         Css.color (Css.Var prose_headings_v);
         Css.margin_top (Em 1.6);
         Css.margin_bottom (Em 0.6);
         Css.font_size (Em 1.25);
-        Css.font_weight (Weight 600);
+        Css.font_weight (Weight 600.);
         Css.line_height (Num 1.6);
       ];
     Css.rule
       ~selector:(where base (h3 ++ strong))
-      [ Css.color Inherit; Css.font_weight (Weight 700) ];
+      [ Css.color Inherit; Css.font_weight (Weight 700.) ];
     Css.rule ~selector:(where base h4)
       [
         Css.color (Css.Var prose_headings_v);
         Css.margin_top (Em 1.5);
         Css.margin_bottom (Em 0.5);
-        Css.font_weight (Weight 600);
+        Css.font_weight (Weight 600.);
         Css.line_height (Num 1.5);
       ];
     Css.rule
       ~selector:(where base (h4 ++ strong))
-      [ Css.color Inherit; Css.font_weight (Weight 700) ];
+      [ Css.color Inherit; Css.font_weight (Weight 700.) ];
   ]
 
 (* Horizontal rule styles are defined inline in base_prose_rules *)
@@ -478,7 +478,7 @@ let kbd_rules base =
         Css.padding_inline_start (Em 0.375);
         font_family Inherit;
         Css.font_size (Em 0.875);
-        Css.font_weight (Weight 500);
+        Css.font_weight (Weight 500.);
       ];
   ]
 
@@ -497,7 +497,7 @@ let pre_code_rules base =
         Css.margin_bottom (Em 1.71429);
         Css.padding_inline_start (Em 1.14286);
         Css.font_size (Em 0.875);
-        Css.font_weight (Weight 400);
+        Css.font_weight (Weight 400.);
         Css.line_height (Num 1.71429);
         overflow_x Auto;
       ];
@@ -530,7 +530,7 @@ let code_rules base =
       [
         Css.color (Css.Var prose_code_v);
         Css.font_size (Em 0.875);
-        Css.font_weight (Weight 600);
+        Css.font_weight (Weight 600.);
       ];
     (* Code pseudo-elements come AFTER code rule to match Tailwind *)
     Css.rule
@@ -586,7 +586,7 @@ let table_rules base =
         Css.padding_inline_end (Em 0.571429);
         Css.padding_bottom (Em 0.571429);
         Css.padding_inline_start (Em 0.571429);
-        Css.font_weight (Weight 600);
+        Css.font_weight (Weight 600.);
       ];
     Css.rule ~selector:(where base tbody_tr)
       [
@@ -794,7 +794,7 @@ let link_and_strong_rules base =
     Css.rule ~selector:(where base a)
       [
         color (Css.Var prose_links_v);
-        Css.font_weight (Weight 500);
+        Css.font_weight (Weight 500.);
         text_decoration
           (Shorthand
              {
@@ -806,7 +806,7 @@ let link_and_strong_rules base =
       ];
     (* Strong *)
     Css.rule ~selector:(where base strong)
-      [ Css.color (Css.Var prose_bold_v); Css.font_weight (Weight 600) ];
+      [ Css.color (Css.Var prose_bold_v); Css.font_weight (Weight 600.) ];
     (* Strong inherit rules - group multiple selectors *)
     Css.rule
       ~selector:
@@ -860,7 +860,7 @@ let list_marker_rules base =
              where base (Css.Selector.combine ol Css.Selector.Child li);
              Css.Selector.Marker;
            ])
-      [ Css.color (Css.Var prose_counters_v); Css.font_weight (Weight 400) ];
+      [ Css.color (Css.Var prose_counters_v); Css.font_weight (Weight 400.) ];
     Css.rule
       ~selector:
         (Css.Selector.compound
@@ -916,7 +916,7 @@ let blockquote_rules base =
         margin_bottom (Em 1.6);
         padding_inline_start (Em 1.0);
         font_style Italic;
-        Css.font_weight (Weight 500);
+        Css.font_weight (Weight 500.);
       ];
     (* Blockquote pseudo-elements come AFTER blockquote rule *)
     Css.rule
@@ -949,7 +949,7 @@ let structural_element_rules base =
       [
         color (Css.Var prose_headings_v);
         margin_top (Em 1.25);
-        Css.font_weight (Weight 600);
+        Css.font_weight (Weight 600.);
       ];
     (* Horizontal rules *)
     Css.rule ~selector:(where base hr)

--- a/lib/tools/cascade_provenance.ml
+++ b/lib/tools/cascade_provenance.ml
@@ -38,7 +38,7 @@ let contains haystack word =
 (* The [dune-project] depends line is [(cascade (and (>= X) (< Y)))]; grabbed
    verbatim rather than sexp-parsed since it is only ever displayed, never
    compared against. *)
-let cascade_pin root =
+let cascade_constraint root =
   let path = Filename.concat root "dune-project" in
   match open_in path with
   | exception Sys_error _ -> None
@@ -95,22 +95,24 @@ let report () =
             Fmt.kstr run_line "git -C %s describe --tags --exact-match"
               cascade_dir
           in
-          let pin =
-            match cascade_pin root with Some p -> p | None -> "(unreadable)"
+          let constraint_ =
+            match cascade_constraint root with
+            | Some p -> p
+            | None -> "(unreadable)"
           in
           let position = checkout_position cascade_dir in
           match exact_tag with
           | Some tag ->
               Fmt.pr
-                "cascade: local checkout %s (tag %s, %s); dune-project pins \
-                 %s@."
-                sha tag position pin
+                "cascade: local checkout %s (tag %s, %s); dune-project \
+                 requires %s@."
+                sha tag position constraint_
           | None ->
               Fmt.pr
                 "@.WARNING: cascade checkout %s (%s) is not sitting on a \
-                 release tag; dune-project pins %s, and CI resolves that \
-                 constraint through its own opam pin, not this checkout. The \
-                 cascade/ symlink is a live sibling checkout other sessions \
-                 move, so a test failing here may be failing against cascade \
-                 code that is not on cascade's main.@.@."
-                sha position pin))
+                 release tag; dune-project requires %s, and CI resolves that \
+                 constraint through an opam pin to cascade main, not this \
+                 checkout. The cascade/ symlink is a live sibling checkout \
+                 other sessions move, so a test failing here may be failing \
+                 against cascade code that is not on cascade's main.@.@."
+                sha position constraint_))

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -1068,21 +1068,21 @@ module Typography_early = struct
         font_weight (Css.Var weight_theme_ref);
       ]
 
-  let font_thin = font_weight_utility font_weight_thin_var (Weight 100)
+  let font_thin = font_weight_utility font_weight_thin_var (Weight 100.)
 
   let font_extralight =
-    font_weight_utility font_weight_extralight_var (Weight 200)
+    font_weight_utility font_weight_extralight_var (Weight 200.)
 
-  let font_light = font_weight_utility font_weight_light_var (Weight 300)
-  let font_normal = font_weight_utility font_weight_normal_var (Weight 400)
-  let font_medium = font_weight_utility font_weight_medium_var (Weight 500)
-  let font_semibold = font_weight_utility font_weight_semibold_var (Weight 600)
-  let font_bold () = font_weight_utility font_weight_bold_var (Weight 700)
+  let font_light = font_weight_utility font_weight_light_var (Weight 300.)
+  let font_normal = font_weight_utility font_weight_normal_var (Weight 400.)
+  let font_medium = font_weight_utility font_weight_medium_var (Weight 500.)
+  let font_semibold = font_weight_utility font_weight_semibold_var (Weight 600.)
+  let font_bold () = font_weight_utility font_weight_bold_var (Weight 700.)
 
   let font_extrabold =
-    font_weight_utility font_weight_extrabold_var (Weight 800)
+    font_weight_utility font_weight_extrabold_var (Weight 800.)
 
-  let font_black = font_weight_utility font_weight_black_var (Weight 900)
+  let font_black = font_weight_utility font_weight_black_var (Weight 900.)
 
   let font_serif =
     let serif_decl, serif_ref =
@@ -1114,7 +1114,12 @@ module Typography_early = struct
       Scheme.theme_value (Some theme) (token ^ "--font-feature-settings")
     with
     | None -> []
-    | Some v -> [ font_feature_settings (Css.Feature_list v) ]
+    | Some v -> (
+        (* The token holds the declaration's text, so cascade's own parser turns
+           it into the tag/value list the property carries. *)
+        match Css.parse_declaration "font-feature-settings" v with
+        | Some decl -> [ decl ]
+        | None -> [])
 
   let font_weight_theme theme name =
     match Scheme.theme_value (Some theme) ("font-weight-" ^ name) with
@@ -1123,7 +1128,9 @@ module Typography_early = struct
         match Parse.decimal_int raw with
         | None -> style []
         | Some n ->
-            font_weight_utility (font_weight_named_var name) (Css.Weight n))
+            font_weight_utility
+              (font_weight_named_var name)
+              (Css.Weight (float_of_int n)))
 
   let font_named ?fallback theme name =
     let token = "font-" ^ name in
@@ -1416,13 +1423,16 @@ module Typography_early = struct
     | Font_extrabold -> font_extrabold
     | Font_black -> font_black
     | Font_bracket_weight (_, n) ->
-        let weight_util_decl, _ = Var.binding font_weight_var (Weight n) in
+        let weight_util_decl, _ =
+          Var.binding font_weight_var (Weight (float_of_int n))
+        in
         let property_rules =
           match Var.property_rule font_weight_var with
           | None -> Css.empty
           | Some rule -> rule
         in
-        style ~property_rules [ weight_util_decl; font_weight (Weight n) ]
+        style ~property_rules
+          [ weight_util_decl; font_weight (Weight (float_of_int n)) ]
     | Font_bracket_weight_var (_, var_str) ->
         let bare_name = Parse.extract_var_name var_str in
         let var_ref : Css.font_weight Css.var = Var.bracket bare_name in
@@ -1491,13 +1501,13 @@ module Typography_early = struct
         let bare_name = Parse.extract_var_name var_str in
         let var_ref : Css.font_family Css.var = Var.bracket bare_name in
         style [ font_family (Var var_ref) ]
-    | Font_features_quoted s ->
-        (* Normalize comma spacing: "c2sc","smcp" → "c2sc", "smcp" *)
-        let normalized =
-          String.split_on_char ',' (Parse.decode_underscores s)
-          |> List.map String.trim |> String.concat ", "
-        in
-        style [ font_feature_settings (Feature_list normalized) ]
+    | Font_features_quoted s -> (
+        match
+          Css.parse_declaration "font-feature-settings"
+            (Parse.decode_underscores s)
+        with
+        | Some decl -> style [ decl ]
+        | None -> style [])
     | Font_features_var var_str ->
         let bare_name = Parse.extract_var_name var_str in
         let var_ref : Css.font_feature_settings Css.var =

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -531,7 +531,8 @@ let rule_surplus where acc (rule : Tree_diff.rule_diff) =
       Fmt.str "%s%s (the whole rule)" where selector :: acc
   | Tree_diff.Content_changed { selector; added_properties; _ } ->
       List.fold_left
-        (fun acc prop -> Fmt.str "%s%s { %s }" where selector prop :: acc)
+        (fun acc (prop, value) ->
+          Fmt.str "%s%s { %s: %s }" where selector prop value :: acc)
         acc added_properties
   | _ -> acc
 

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -23,10 +23,9 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
 (* Measured 2026-08-30 over [classlist.txt], 4825 classes of tailwindcss.com,
    against cascade main at e829b2d6. Both keys and grouping come out of
    cascade's printer, so the number is only comparable against the cascade a run
-   was built with, and every run prints which one that was. CI resolves cascade
-   through opam from the range [dune-project] pins; a local [cascade/] symlink
-   sitting on someone's branch is the first thing to check when the count moves
-   for no reason in the sort code.
+   was built with, and every run prints which one that was. CI pins cascade main
+   through opam; a local [cascade/] symlink sitting on someone's branch is the
+   first thing to check when the count moves for no reason in the sort code.
 
    [pairs] is pinned as a floor as well: a sheet that lost most of its rules
    would otherwise have nothing left to be out of order, and the gate would read


### PR DESCRIPTION
Cascade 1.2.0 is unreleased, and an exact development pin let upstream API drift reach tw only after local code had diverged. Follow Cascade main in CI and keep tw compiling against its current structural APIs; commits 67e693c4 and 8dbd0531 also preserve negated parenthesised insets and keep the documented `tmp/` scratch directory out of Dune.