### PR TITLE
examples: align the guide with runnable targets

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,62 +1,45 @@
 # Examples
 
-This folder contains runnable examples demonstrating different parts of the library.
+These runnable pages demonstrate `tw` and `tw.html`. Each example generates an
+`index.html` page and a stylesheet from the typed utility API; its Dune
+`runtest` alias compares that stylesheet with Tailwind CSS output.
 
-Build and test
-- Build all examples: `dune build`
-- Run CSS parity tests vs. the v4 CLI: `dune test`
-  - Each example generates `index.html` and its own CSS
-  - A `tailwind.css` is compiled with the CLI from `index.html`
-  - We compare our CSS to the CLI output using a structural diff
+## Inventory
 
-- `landing/` — Small landing page showcasing core utilities and layout.
-- `prose/` — Typography (prose) utilities with sizes, themes, and not-prose.
-- `colors/` — Color palette swatches and text-on-background examples.
-- `layout/` — Flexbox and Grid layouts with responsive examples.
-- `navigation/` — Responsive navigation bar.
-- `hero/` — Hero section with heading and CTAs.
-- `cards/` — Responsive cards grid.
-- `modifiers/` — Group, group-has, peer, peer-has, has, focus-within, focus-visible.
-- `dark_mode/` — Color scheme preferences via the `dark` modifier.
-- `accessibility/` — High contrast and reduced motion preferences.
-- `animations/` — Starting styles and transitions.
-Suggested improvements:
-- Split large demos into smaller, utility-focused examples (e.g., `examples/borders`, `examples/forms`).
-- Add parity checks comparing generated CSS with a reference output for each example.
+- `landing/` — Marketing page with gradients and a call to action.
+- `dashboard/` — Responsive analytics and administration layout.
+- `prose/` — Article typography, size variants, themes, and `not-prose`.
+- `forms/` — Form controls, input states, and validation.
+- `colors/` — Palette swatches, alpha variants, and contrasting text.
+- `layout/` — Flexbox and Grid layout patterns.
+- `modifiers/` — State, group, peer, `has`, and ARIA modifiers.
+- `animations/` — Keyframes, starting styles, and transitions.
+- `accessibility/` — Contrast, reduced-motion, and focus preferences.
 
-Build any example HTML/CSS:
+The manual page generated from `examples/index.ml` links to and embeds all nine
+examples.
 
-```bash
-# Landing
-dune build examples/landing:index.html examples/landing:landing.css && dune build examples/landing:tailwind.css
+## Build
 
-# Prose
-dune build examples/prose:index.html examples/prose:prose.css && dune build examples/prose:tailwind.css
+Build the manual and every example:
 
-# Colors
-dune build examples/colors:index.html examples/colors:colors.css && dune build examples/colors:tailwind.css
-
-# Layout
-dune build examples/layout:index.html examples/layout:layout.css && dune build examples/layout:tailwind.css
-
-# Navigation
-dune build examples/navigation:index.html examples/navigation:navigation.css && dune build examples/navigation:tailwind.css
-
-# Hero
-dune build examples/hero:index.html examples/hero:hero.css && dune build examples/hero:tailwind.css
-
-# Cards
-dune build examples/cards:index.html examples/cards:cards.css && dune build examples/cards:tailwind.css
-
-# Modifiers
-dune build examples/modifiers:index.html examples/modifiers:modifiers.css && dune build examples/modifiers:tailwind.css
-
-# Dark mode
-dune build examples/dark_mode:index.html examples/dark_mode:dark_mode.css && dune build examples/dark_mode:tailwind.css
-
-# Accessibility
-dune build examples/accessibility:index.html examples/accessibility:accessibility.css && dune build examples/accessibility:tailwind.css
-
-# Animations
-dune build examples/animations:index.html examples/animations:animations.css && dune build examples/animations:tailwind.css
+```sh
+opam exec -- dune build @examples/default
 ```
+
+Build one example's generated page and project stylesheet:
+
+```sh
+opam exec -- dune build \
+  _build/default/examples/landing/index.html \
+  _build/default/examples/landing/landing.css
+```
+
+Run its strict Tailwind parity check (replace `landing` with another inventory
+directory as needed):
+
+```sh
+TW_TAILWIND_TESTS=1 opam exec -- dune build @examples/landing/runtest
+```
+
+Run every example parity check with `@examples/runtest`.


### PR DESCRIPTION
The guide named removed examples and obsolete build targets, so its commands no longer reproduced the current example suite or Tailwind parity checks.