### PR TITLE
tw: expose typed constructors for supported utilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
 
 ### Utility coverage
 
+- Typed construction covers clear, background attachment/clip/origin/position,
+  repeat and size, outline width/colour, ring offsets, and background blend
+  modes (#649).
 - Sizing accepts the whole scale. The container scale reaches the logical
   families and `basis-*`, both viewport axes and the `px` step work on the width
   and height families, and a fraction takes any denominator, including zero and

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -9,7 +9,6 @@
     What's not:
     - Radial or conic gradients.
     - Multiple gradient stops beyond from/via/to.
-    - Background size, position, repeat utilities.
 
     Parsing contract (`of_string`):
     - Accepts ["bg"; "gradient"; "to"; direction], ["from"; color; shade],
@@ -1948,6 +1947,38 @@ let bg ?opacity ?(shade = 500) color =
 
 let bg_transparent = utility Bg_transparent
 let bg_current = utility Bg_current
+let bg_fixed = utility Bg_fixed
+let bg_local = utility Bg_local
+let bg_scroll = utility Bg_scroll
+let bg_clip_border = utility Bg_clip_border
+let bg_clip_padding = utility Bg_clip_padding
+let bg_clip_content = utility Bg_clip_content
+let bg_clip_text = utility Bg_clip_text
+let bg_origin_border = utility Bg_origin_border
+let bg_origin_padding = utility Bg_origin_padding
+let bg_origin_content = utility Bg_origin_content
+let bg_bottom = utility (Bg_position Position.Bottom)
+let bg_bottom_left = utility (Bg_position Position.Bottom_left)
+let bg_bottom_right = utility (Bg_position Position.Bottom_right)
+let bg_center = utility (Bg_position Position.Center)
+let bg_left = utility (Bg_position Position.Left)
+let bg_left_bottom = utility (Bg_position Position.Left_bottom)
+let bg_left_top = utility (Bg_position Position.Left_top)
+let bg_right = utility (Bg_position Position.Right)
+let bg_right_bottom = utility (Bg_position Position.Right_bottom)
+let bg_right_top = utility (Bg_position Position.Right_top)
+let bg_top = utility (Bg_position Position.Top)
+let bg_top_left = utility (Bg_position Position.Top_left)
+let bg_top_right = utility (Bg_position Position.Top_right)
+let bg_repeat = utility Bg_repeat
+let bg_no_repeat = utility Bg_no_repeat
+let bg_repeat_x = utility Bg_repeat_x
+let bg_repeat_y = utility Bg_repeat_y
+let bg_repeat_round = utility Bg_repeat_round
+let bg_repeat_space = utility Bg_repeat_space
+let bg_auto = utility Bg_auto
+let bg_cover = utility Bg_cover
+let bg_contain = utility Bg_contain
 let bg_gradient_to dir = utility (Bg_gradient_to dir)
 
 let from_color ?(shade = 500) color =

--- a/lib/backgrounds.mli
+++ b/lib/backgrounds.mli
@@ -28,6 +28,114 @@ val bg_transparent : t
 val bg_current : t
 (** [bg_current] uses [currentColor] for the background. *)
 
+(** {1 Background Attachment} *)
+
+val bg_fixed : t
+(** [bg_fixed] fixes the background relative to the viewport. *)
+
+val bg_local : t
+(** [bg_local] scrolls the background with the element's contents. *)
+
+val bg_scroll : t
+(** [bg_scroll] fixes the background relative to the element. *)
+
+(** {1 Background Clip} *)
+
+val bg_clip_border : t
+(** [bg_clip_border] clips the background to the border box. *)
+
+val bg_clip_padding : t
+(** [bg_clip_padding] clips the background to the padding box. *)
+
+val bg_clip_content : t
+(** [bg_clip_content] clips the background to the content box. *)
+
+val bg_clip_text : t
+(** [bg_clip_text] clips the background to the foreground text. *)
+
+(** {1 Background Origin} *)
+
+val bg_origin_border : t
+(** [bg_origin_border] positions the background from the border box. *)
+
+val bg_origin_padding : t
+(** [bg_origin_padding] positions the background from the padding box. *)
+
+val bg_origin_content : t
+(** [bg_origin_content] positions the background from the content box. *)
+
+(** {1 Background Position} *)
+
+val bg_bottom : t
+(** [bg_bottom] positions the background at the bottom. *)
+
+val bg_bottom_left : t
+(** [bg_bottom_left] positions the background at the bottom left. *)
+
+val bg_bottom_right : t
+(** [bg_bottom_right] positions the background at the bottom right. *)
+
+val bg_center : t
+(** [bg_center] centers the background. *)
+
+val bg_left : t
+(** [bg_left] positions the background at the left. *)
+
+val bg_left_bottom : t
+(** [bg_left_bottom] positions the background at the left bottom. *)
+
+val bg_left_top : t
+(** [bg_left_top] positions the background at the left top. *)
+
+val bg_right : t
+(** [bg_right] positions the background at the right. *)
+
+val bg_right_bottom : t
+(** [bg_right_bottom] positions the background at the right bottom. *)
+
+val bg_right_top : t
+(** [bg_right_top] positions the background at the right top. *)
+
+val bg_top : t
+(** [bg_top] positions the background at the top. *)
+
+val bg_top_left : t
+(** [bg_top_left] positions the background at the top left. *)
+
+val bg_top_right : t
+(** [bg_top_right] positions the background at the top right. *)
+
+(** {1 Background Repeat} *)
+
+val bg_repeat : t
+(** [bg_repeat] repeats the background on both axes. *)
+
+val bg_no_repeat : t
+(** [bg_no_repeat] prevents the background from repeating. *)
+
+val bg_repeat_x : t
+(** [bg_repeat_x] repeats the background horizontally. *)
+
+val bg_repeat_y : t
+(** [bg_repeat_y] repeats the background vertically. *)
+
+val bg_repeat_round : t
+(** [bg_repeat_round] repeats and scales the background to avoid clipping. *)
+
+val bg_repeat_space : t
+(** [bg_repeat_space] repeats the background with space between tiles. *)
+
+(** {1 Background Size} *)
+
+val bg_auto : t
+(** [bg_auto] uses the background image's intrinsic size. *)
+
+val bg_cover : t
+(** [bg_cover] scales the background to cover its container. *)
+
+val bg_contain : t
+(** [bg_contain] scales the background to fit inside its container. *)
+
 val bg_gradient_to : direction -> t
 (** [bg_gradient_to dir] sets gradient direction. Prefer this typed variant over
     the fixed functions when composing logic. *)

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -1321,6 +1321,12 @@ let rounded_es_full = utility (Rounded (Corner.End_start, Rsz_full))
 (** {1 Outline Utilities} *)
 
 let outline = utility Outline
+
+let outline_width n =
+  if n < 0 then invalid_arg "outline_width: width must be non-negative"
+  else if n = 0 then utility Outline_0
+  else utility (Outline_width n)
+
 let outline_none = outline_style_utility Outline_style_handler.None_
 let outline_offset_0 = utility (Outline_offset 0)
 let outline_offset_1 = utility (Outline_offset 1)

--- a/lib/borders.mli
+++ b/lib/borders.mli
@@ -601,6 +601,12 @@ val rounded_es_full : t
 val outline : t
 (** [outline] sets outline-style from var and outline-width to 1px. *)
 
+val outline_width : int -> t
+(** [outline_width n] sets outline width to [n] pixels. The zero value emits
+    [outline-0].
+
+    @raise Invalid_argument if [n] is negative. *)
+
 val outline_none : t
 (** [outline_none] removes the outline. *)
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -3747,6 +3747,16 @@ let text_inherit = utility Text_inherit
 let border_transparent = utility Border_transparent
 let border_current = utility Border_current
 
+let outline_color ?opacity ?(shade = 500) color =
+  check_shade ~utility:"outline_color" color shade;
+  match opacity with
+  | None -> utility (Outline (color, shade))
+  | Some pct -> utility (Outline_opacity (color, shade, opacity_of_int pct))
+
+let outline_transparent = utility Outline_transparent
+let outline_current = utility Outline_current
+let outline_inherit = utility Outline_inherit
+
 let accent ?opacity ?(shade = 500) color =
   check_shade ~utility:"accent" color shade;
   match opacity with

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -305,6 +305,19 @@ val border_transparent : t
 val border_current : t
 (** [border_current] uses [currentColor] for border color. *)
 
+val outline_color : ?opacity:int -> ?shade:int -> color -> t
+(** [outline_color color] sets the outline color. [shade] defaults to 500 and
+    [opacity] sets the alpha modifier (0-100). *)
+
+val outline_transparent : t
+(** [outline_transparent] makes the outline fully transparent. *)
+
+val outline_current : t
+(** [outline_current] uses [currentColor] for the outline. *)
+
+val outline_inherit : t
+(** [outline_inherit] inherits the outline color. *)
+
 val accent : ?opacity:int -> ?shade:int -> color -> t
 (** [accent color] sets the accent color for form controls. [shade] defaults to
     500. [opacity] sets the alpha modifier (0-100). *)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -3296,6 +3296,21 @@ let ring_color ?opacity ?(shade = 500) color =
   | Some pct ->
       utility (Ring_color_opacity (color, shade, Color.opacity_of_int pct))
 
+let ring_offset_width n =
+  if n < 0 then invalid_arg "ring_offset_width: width must be non-negative"
+  else utility (Ring_offset_width n)
+
+let ring_offset_color ?opacity ?(shade = 500) color =
+  Color.check_shade ~utility:"ring_offset_color" color shade;
+  match opacity with
+  | None -> utility (Ring_offset_color (color, shade))
+  | Some pct ->
+      utility
+        (Ring_offset_color_opacity (color, shade, Color.opacity_of_int pct))
+
+let ring_offset_transparent = utility Ring_offset_transparent
+let ring_offset_current = utility Ring_offset_current
+let ring_offset_inherit = utility Ring_offset_inherit
 let inset_ring = utility Inset_ring_default
 let opacity n = utility (Opacity n)
 let mix_blend_normal = utility Mix_blend_normal
@@ -3315,6 +3330,22 @@ let mix_blend_saturation = utility Mix_blend_saturation
 let mix_blend_color = utility Mix_blend_color
 let mix_blend_plus_darker = utility Mix_blend_plus_darker
 let mix_blend_plus_lighter = utility Mix_blend_plus_lighter
+let bg_blend_normal = utility Bg_blend_normal
+let bg_blend_multiply = utility Bg_blend_multiply
+let bg_blend_screen = utility Bg_blend_screen
+let bg_blend_overlay = utility Bg_blend_overlay
+let bg_blend_darken = utility Bg_blend_darken
+let bg_blend_lighten = utility Bg_blend_lighten
+let bg_blend_color_dodge = utility Bg_blend_color_dodge
+let bg_blend_color_burn = utility Bg_blend_color_burn
+let bg_blend_hard_light = utility Bg_blend_hard_light
+let bg_blend_soft_light = utility Bg_blend_soft_light
+let bg_blend_difference = utility Bg_blend_difference
+let bg_blend_exclusion = utility Bg_blend_exclusion
+let bg_blend_hue = utility Bg_blend_hue
+let bg_blend_saturation = utility Bg_blend_saturation
+let bg_blend_color = utility Bg_blend_color
+let bg_blend_luminosity = utility Bg_blend_luminosity
 
 (* Export ring/shadow variables for use by Forms *)
 let shadow_var = Handler.shadow_var

--- a/lib/effects.mli
+++ b/lib/effects.mli
@@ -102,6 +102,24 @@ val ring_color : ?opacity:int -> ?shade:int -> color -> t
 val ring_inset : t
 (** [ring_inset] applies an inset ring. *)
 
+val ring_offset_width : int -> t
+(** [ring_offset_width n] sets the ring offset width to [n] pixels.
+
+    @raise Invalid_argument if [n] is negative. *)
+
+val ring_offset_color : ?opacity:int -> ?shade:int -> color -> t
+(** [ring_offset_color color] sets the ring offset color. [shade] defaults to
+    500 and [opacity] sets the alpha modifier (0-100). *)
+
+val ring_offset_transparent : t
+(** [ring_offset_transparent] makes the ring offset transparent. *)
+
+val ring_offset_current : t
+(** [ring_offset_current] uses [currentColor] for the ring offset. *)
+
+val ring_offset_inherit : t
+(** [ring_offset_inherit] inherits the ring offset color. *)
+
 (** {1 Ring/Shadow Variables}
 
     These variables are used internally by ring and shadow utilities, and are
@@ -183,3 +201,53 @@ val mix_blend_plus_darker : t
 
 val mix_blend_plus_lighter : t
 (** [mix_blend_plus_lighter] sets mix-blend-mode to plus-lighter (Safari). *)
+
+(** {1 Background Blend Mode Utilities} *)
+
+val bg_blend_normal : t
+(** [bg_blend_normal] uses normal background blending. *)
+
+val bg_blend_multiply : t
+(** [bg_blend_multiply] uses multiply background blending. *)
+
+val bg_blend_screen : t
+(** [bg_blend_screen] uses screen background blending. *)
+
+val bg_blend_overlay : t
+(** [bg_blend_overlay] uses overlay background blending. *)
+
+val bg_blend_darken : t
+(** [bg_blend_darken] uses darken background blending. *)
+
+val bg_blend_lighten : t
+(** [bg_blend_lighten] uses lighten background blending. *)
+
+val bg_blend_color_dodge : t
+(** [bg_blend_color_dodge] uses color-dodge background blending. *)
+
+val bg_blend_color_burn : t
+(** [bg_blend_color_burn] uses color-burn background blending. *)
+
+val bg_blend_hard_light : t
+(** [bg_blend_hard_light] uses hard-light background blending. *)
+
+val bg_blend_soft_light : t
+(** [bg_blend_soft_light] uses soft-light background blending. *)
+
+val bg_blend_difference : t
+(** [bg_blend_difference] uses difference background blending. *)
+
+val bg_blend_exclusion : t
+(** [bg_blend_exclusion] uses exclusion background blending. *)
+
+val bg_blend_hue : t
+(** [bg_blend_hue] uses hue background blending. *)
+
+val bg_blend_saturation : t
+(** [bg_blend_saturation] uses saturation background blending. *)
+
+val bg_blend_color : t
+(** [bg_blend_color] uses color background blending. *)
+
+val bg_blend_luminosity : t
+(** [bg_blend_luminosity] uses luminosity background blending. *)

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -820,6 +820,12 @@ let float_right = utility Float_right
 let float_none = utility Float_none
 let float_start = utility Float_start
 let float_end = utility Float_end
+let clear_left = utility Clear_left
+let clear_right = utility Clear_right
+let clear_none = utility Clear_none
+let clear_both = utility Clear_both
+let clear_start = utility Clear_start
+let clear_end = utility Clear_end
 
 (* Screen reader utilities *)
 let sr_utility = Screen_reader_utility.v

--- a/lib/layout.mli
+++ b/lib/layout.mli
@@ -176,6 +176,26 @@ val float_start : t
 val float_end : t
 (** [float_end] sets float to inline-end. *)
 
+(** {1 Clear Utilities} *)
+
+val clear_left : t
+(** [clear_left] clears left floats. *)
+
+val clear_right : t
+(** [clear_right] clears right floats. *)
+
+val clear_none : t
+(** [clear_none] does not clear floats. *)
+
+val clear_both : t
+(** [clear_both] clears floats on both sides. *)
+
+val clear_start : t
+(** [clear_start] clears inline-start floats. *)
+
+val clear_end : t
+(** [clear_end] clears inline-end floats. *)
+
 val box_decoration_clone : t
 (** [box_decoration_clone] sets box-decoration-break to clone. *)
 

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -391,7 +391,23 @@ val float_end : t
 (** {2 Clear}
     @see <https://tailwindcss.com/docs/clear> Clear *)
 
-(** TODO: Implement clear utilities. *)
+val clear_left : t
+(** [clear_left] clears left floats. *)
+
+val clear_right : t
+(** [clear_right] clears right floats. *)
+
+val clear_none : t
+(** [clear_none] does not clear floats. *)
+
+val clear_both : t
+(** [clear_both] clears floats on both sides. *)
+
+val clear_start : t
+(** [clear_start] clears inline-start floats. *)
+
+val clear_end : t
+(** [clear_end] clears inline-end floats. *)
 
 (** {2 Isolation}
     @see <https://tailwindcss.com/docs/isolation> Isolation *)
@@ -1996,12 +2012,29 @@ val content : string -> t
     @see <https://tailwindcss.com/docs/background-attachment>
       Background Attachment *)
 
-(** TODO: Implement background-attachment utilities. *)
+val bg_fixed : t
+(** [bg_fixed] fixes the background relative to the viewport. *)
+
+val bg_local : t
+(** [bg_local] scrolls the background with the element's contents. *)
+
+val bg_scroll : t
+(** [bg_scroll] fixes the background relative to the element. *)
 
 (** {2 Background Clip}
     @see <https://tailwindcss.com/docs/background-clip> Background Clip *)
 
-(** TODO: Implement background-clip utilities. *)
+val bg_clip_border : t
+(** [bg_clip_border] clips the background to the border box. *)
+
+val bg_clip_padding : t
+(** [bg_clip_padding] clips the background to the padding box. *)
+
+val bg_clip_content : t
+(** [bg_clip_content] clips the background to the content box. *)
+
+val bg_clip_text : t
+(** [bg_clip_text] clips the background to the foreground text. *)
 
 (** {2 Background Color}
     @see <https://tailwindcss.com/docs/background-color> Background Color *)
@@ -2082,23 +2115,90 @@ val to_color : ?shade:int -> color -> t
 (** {2 Background Origin}
     @see <https://tailwindcss.com/docs/background-origin> Background Origin *)
 
-(** TODO: Implement background-origin utilities. *)
+val bg_origin_border : t
+(** [bg_origin_border] positions the background from the border box. *)
+
+val bg_origin_padding : t
+(** [bg_origin_padding] positions the background from the padding box. *)
+
+val bg_origin_content : t
+(** [bg_origin_content] positions the background from the content box. *)
 
 (** {2 Background Position}
     @see <https://tailwindcss.com/docs/background-position> Background Position
 *)
 
-(** TODO: Implement background-position utilities. *)
+val bg_bottom : t
+(** [bg_bottom] positions the background at the bottom. *)
+
+val bg_bottom_left : t
+(** [bg_bottom_left] positions the background at the bottom left. *)
+
+val bg_bottom_right : t
+(** [bg_bottom_right] positions the background at the bottom right. *)
+
+val bg_center : t
+(** [bg_center] centers the background. *)
+
+val bg_left : t
+(** [bg_left] positions the background at the left. *)
+
+val bg_left_bottom : t
+(** [bg_left_bottom] positions the background at the left bottom. *)
+
+val bg_left_top : t
+(** [bg_left_top] positions the background at the left top. *)
+
+val bg_right : t
+(** [bg_right] positions the background at the right. *)
+
+val bg_right_bottom : t
+(** [bg_right_bottom] positions the background at the right bottom. *)
+
+val bg_right_top : t
+(** [bg_right_top] positions the background at the right top. *)
+
+val bg_top : t
+(** [bg_top] positions the background at the top. *)
+
+val bg_top_left : t
+(** [bg_top_left] positions the background at the top left. *)
+
+val bg_top_right : t
+(** [bg_top_right] positions the background at the top right. *)
 
 (** {2 Background Repeat}
     @see <https://tailwindcss.com/docs/background-repeat> Background Repeat *)
 
-(** TODO: Implement background-repeat utilities. *)
+val bg_repeat : t
+(** [bg_repeat] repeats the background on both axes. *)
+
+val bg_no_repeat : t
+(** [bg_no_repeat] prevents the background from repeating. *)
+
+val bg_repeat_x : t
+(** [bg_repeat_x] repeats the background horizontally. *)
+
+val bg_repeat_y : t
+(** [bg_repeat_y] repeats the background vertically. *)
+
+val bg_repeat_round : t
+(** [bg_repeat_round] repeats and scales the background to avoid clipping. *)
+
+val bg_repeat_space : t
+(** [bg_repeat_space] repeats the background with space between tiles. *)
 
 (** {2 Background Size}
     @see <https://tailwindcss.com/docs/background-size> Background Size *)
 
-(** TODO: Implement background-size utilities. *)
+val bg_auto : t
+(** [bg_auto] uses the background image's intrinsic size. *)
+
+val bg_cover : t
+(** [bg_cover] scales the background to cover its container. *)
+
+val bg_contain : t
+(** [bg_contain] scales the background to fit inside its container. *)
 
 (** {1 Borders} *)
 
@@ -2187,12 +2287,27 @@ val border_double : t
 (** {2 Outline Width}
     @see <https://tailwindcss.com/docs/outline-width> Outline Width *)
 
-(** TODO: Implement outline-width utilities. *)
+val outline_width : int -> t
+(** [outline_width n] sets outline width to [n] pixels. The zero value emits
+    [outline-0].
+
+    @raise Invalid_argument if [n] is negative. *)
 
 (** {2 Outline Color}
     @see <https://tailwindcss.com/docs/outline-color> Outline Color *)
 
-(** TODO: Implement outline-color utilities. *)
+val outline_color : ?opacity:int -> ?shade:int -> color -> t
+(** [outline_color color] sets the outline color. [shade] defaults to 500 and
+    [opacity] sets the alpha modifier (0-100). *)
+
+val outline_transparent : t
+(** [outline_transparent] makes the outline fully transparent. *)
+
+val outline_current : t
+(** [outline_current] uses [currentColor] for the outline. *)
+
+val outline_inherit : t
+(** [outline_inherit] inherits the outline color. *)
 
 (** {2 Outline Style}
     @see <https://tailwindcss.com/docs/outline-style> Outline Style *)
@@ -2609,12 +2724,26 @@ val ring_color : ?opacity:int -> ?shade:int -> color -> t
 (** {2 Ring Offset Width}
     @see <https://tailwindcss.com/docs/ring-offset-width> Ring Offset Width *)
 
-(** TODO: Implement ring-offset-width utilities. *)
+val ring_offset_width : int -> t
+(** [ring_offset_width n] sets the ring offset width to [n] pixels.
+
+    @raise Invalid_argument if [n] is negative. *)
 
 (** {2 Ring Offset Color}
     @see <https://tailwindcss.com/docs/ring-offset-color> Ring Offset Color *)
 
-(** TODO: Implement ring-offset-color utilities. *)
+val ring_offset_color : ?opacity:int -> ?shade:int -> color -> t
+(** [ring_offset_color color] sets the ring offset color. [shade] defaults to
+    500 and [opacity] sets the alpha modifier (0-100). *)
+
+val ring_offset_transparent : t
+(** [ring_offset_transparent] makes the ring offset transparent. *)
+
+val ring_offset_current : t
+(** [ring_offset_current] uses [currentColor] for the ring offset. *)
+
+val ring_offset_inherit : t
+(** [ring_offset_inherit] inherits the ring offset color. *)
 
 (** {2 Text Shadow}
     @see <https://tailwindcss.com/docs/text-shadow> Text Shadow *)
@@ -2701,7 +2830,53 @@ val mix_blend_plus_lighter : t
     @see <https://tailwindcss.com/docs/background-blend-mode>
       Background Blend Mode *)
 
-(** TODO: Implement background-blend-mode utilities. *)
+val bg_blend_normal : t
+(** [bg_blend_normal] uses normal background blending. *)
+
+val bg_blend_multiply : t
+(** [bg_blend_multiply] uses multiply background blending. *)
+
+val bg_blend_screen : t
+(** [bg_blend_screen] uses screen background blending. *)
+
+val bg_blend_overlay : t
+(** [bg_blend_overlay] uses overlay background blending. *)
+
+val bg_blend_darken : t
+(** [bg_blend_darken] uses darken background blending. *)
+
+val bg_blend_lighten : t
+(** [bg_blend_lighten] uses lighten background blending. *)
+
+val bg_blend_color_dodge : t
+(** [bg_blend_color_dodge] uses color-dodge background blending. *)
+
+val bg_blend_color_burn : t
+(** [bg_blend_color_burn] uses color-burn background blending. *)
+
+val bg_blend_hard_light : t
+(** [bg_blend_hard_light] uses hard-light background blending. *)
+
+val bg_blend_soft_light : t
+(** [bg_blend_soft_light] uses soft-light background blending. *)
+
+val bg_blend_difference : t
+(** [bg_blend_difference] uses difference background blending. *)
+
+val bg_blend_exclusion : t
+(** [bg_blend_exclusion] uses exclusion background blending. *)
+
+val bg_blend_hue : t
+(** [bg_blend_hue] uses hue background blending. *)
+
+val bg_blend_saturation : t
+(** [bg_blend_saturation] uses saturation background blending. *)
+
+val bg_blend_color : t
+(** [bg_blend_color] uses color background blending. *)
+
+val bg_blend_luminosity : t
+(** [bg_blend_luminosity] uses luminosity background blending. *)
 
 (** {2 Mask Clip}
     @see <https://tailwindcss.com/docs/mask-clip> Mask Clip *)

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -176,6 +176,29 @@ let check_exact_match tw_styles =
 let check tw_style = check_exact_match [ tw_style ]
 let check_list tw_styles = check_exact_match tw_styles
 
+let check_module utility =
+  Test_helpers.require_tailwind_cli ();
+  let class_name = Utility.to_class utility in
+  let tw_css =
+    Build.to_css [ utility ]
+    |> Css.to_string ~minify:true ~lossless:true
+    |> canonical_stylesheet_css
+  in
+  let tailwind_css =
+    generate_tailwind_css ~minify:true ~optimize:true [ class_name ]
+    |> canonical_stylesheet_css
+  in
+  let diff =
+    Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+      tailwind_css tw_css
+  in
+  Test_helpers.check_no_dropped_declarations ~test_name:class_name diff;
+  match diff.Css_compare.result with
+  | Css_compare.No_diff -> ()
+  | _ ->
+      Alcotest.failf "%s differs from Tailwind:\n%s" class_name
+        (Test_helpers.describe_diff diff)
+
 (* ===== UPSTREAM PARSE PARITY ============================================= *)
 
 (* The case's own [@custom-variant]s, as the two scheme fields that carry them.
@@ -584,7 +607,6 @@ let content_variants () =
 
 let prose_basic () =
   check prose;
-  (* TODO: Implement prose size variants *)
   check prose_sm;
   check prose_lg;
   check prose_xl;
@@ -644,6 +666,83 @@ let ordering_complex_card () =
 (* These tests exercise features that may have incomplete typed API or known
    diffs against real Tailwind. They serve as regression targets: once the
    underlying implementation is fixed, the test should pass. *)
+
+let typed_utility_surface () =
+  check_module Layout.clear_left;
+  check_list
+    [ clear_left; clear_right; clear_none; clear_both; clear_start; clear_end ];
+  check_module Backgrounds.bg_fixed;
+  check_list [ bg_fixed; bg_local; bg_scroll ];
+  check_list [ bg_clip_border; bg_clip_padding; bg_clip_content; bg_clip_text ];
+  check_list [ bg_origin_border; bg_origin_padding; bg_origin_content ];
+  check_list
+    [
+      bg_bottom;
+      bg_bottom_left;
+      bg_bottom_right;
+      bg_center;
+      bg_left;
+      bg_left_bottom;
+      bg_left_top;
+      bg_right;
+      bg_right_bottom;
+      bg_right_top;
+      bg_top;
+      bg_top_left;
+      bg_top_right;
+    ];
+  check_list
+    [
+      bg_repeat;
+      bg_no_repeat;
+      bg_repeat_x;
+      bg_repeat_y;
+      bg_repeat_round;
+      bg_repeat_space;
+    ];
+  check_list [ bg_auto; bg_cover; bg_contain ];
+  check_module (Borders.outline_width 0);
+  check_list [ outline_width 0; outline_width 2 ];
+  check_module (Color.outline_color blue);
+  check_list
+    [
+      outline_color blue;
+      outline_color ~opacity:50 ~shade:600 red;
+      outline_transparent;
+      outline_current;
+      outline_inherit;
+    ];
+  check_module (Effects.ring_offset_width 0);
+  check_list [ ring_offset_width 0; ring_offset_width 2 ];
+  check_module (Effects.ring_offset_color blue);
+  check_list
+    [
+      ring_offset_color blue;
+      ring_offset_color ~opacity:50 ~shade:600 red;
+      ring_offset_transparent;
+      ring_offset_current;
+      ring_offset_inherit;
+    ];
+  check_module Effects.bg_blend_normal;
+  check_list
+    [
+      bg_blend_normal;
+      bg_blend_multiply;
+      bg_blend_screen;
+      bg_blend_overlay;
+      bg_blend_darken;
+      bg_blend_lighten;
+      bg_blend_color_dodge;
+      bg_blend_color_burn;
+      bg_blend_hard_light;
+      bg_blend_soft_light;
+      bg_blend_difference;
+      bg_blend_exclusion;
+      bg_blend_hue;
+      bg_blend_saturation;
+      bg_blend_color;
+      bg_blend_luminosity;
+    ]
 
 (* Helper: parse a Tailwind class string via of_string; fail the test if the
    class is not recognised by our parser (i.e. the feature is completely
@@ -869,45 +968,38 @@ let word_break_utilities () =
   check break_keep
 
 (* -- 6. Scroll margin and scroll padding ---------------------------------- *)
-(* scroll-margin and scroll-padding utilities exist in the parser (CLI works)
-   but have no typed API in tw.mli (marked as TODO).
-   Test via of_string. *)
 
 let scroll_margin () =
-  check (require_parse "scroll-m-4");
-  check (require_parse "scroll-mt-4");
-  check (require_parse "scroll-mr-2");
-  check (require_parse "scroll-mb-8");
-  check (require_parse "scroll-ml-4");
-  check (require_parse "scroll-mx-4");
-  check (require_parse "scroll-my-2")
+  check_module (Scroll.scroll_mt 4);
+  check (scroll_m 4);
+  check (scroll_mt 4);
+  check (scroll_mr 2);
+  check (scroll_mb 8);
+  check (scroll_ml 4);
+  check (scroll_mx 4);
+  check (scroll_my 2)
 
 let scroll_padding () =
-  check (require_parse "scroll-p-4");
-  check (require_parse "scroll-pt-4");
-  check (require_parse "scroll-pr-2");
-  check (require_parse "scroll-pb-8");
-  check (require_parse "scroll-pl-4");
-  check (require_parse "scroll-px-4");
-  check (require_parse "scroll-py-2")
+  check_module (Scroll.scroll_pt 4);
+  check (scroll_p 4);
+  check (scroll_pt 4);
+  check (scroll_pr 2);
+  check (scroll_pb 8);
+  check (scroll_pl 4);
+  check (scroll_px 4);
+  check (scroll_py 2)
 
-let scroll_margin_padding_combined () =
-  check_list [ require_parse "scroll-mt-4"; require_parse "scroll-px-2" ]
+let scroll_margin_padding_combined () = check_list [ scroll_mt 4; scroll_px 2 ]
 
 (* -- 7. Border spacing axis variants -------------------------------------- *)
-(* border-spacing-x and border-spacing-y have no typed API but the parser
-   supports them. The combined border-spacing has a typed API. *)
 
 let border_spacing_axis () =
-  check (require_parse "border-spacing-x-4");
-  check (require_parse "border-spacing-y-2");
-  check_list
-    [ require_parse "border-spacing-x-4"; require_parse "border-spacing-y-2" ]
+  check_module (Tables.border_spacing_x 4.);
+  check_module (Tables.border_spacing_y 2.)
 
 let border_spacing_combined () =
-  (* Typed API border_spacing combined with axis-specific *)
   check (border_spacing 4);
-  check_list [ border_spacing 4; require_parse "border-spacing-x-8" ]
+  check_module (Tables.border_spacing_x 8.)
 
 (* -- 8. Opacity modifiers (Tailwind v3 compat / v4 approach) -------------- *)
 (* In Tailwind v4, bg-opacity-* and text-opacity-* are removed in favor of
@@ -1296,6 +1388,7 @@ let core_tests =
     test_case "prose basic" `Slow prose_basic;
     test_case "prose with modifiers" `Slow prose_with_modifiers;
     test_case "prose ordering" `Quick prose_ordering;
+    test_case "typed utility surface" `Slow typed_utility_surface;
     (* Cross-handler ordering *)
     test_case "order: padding/margin" `Quick ordering_padding_margin;
     test_case "order: layout/sizing" `Quick ordering_layout_sizing;


### PR DESCRIPTION
Several supported utility families were available only through class-string parsing, leaving typed callers without equivalent constructors. Expose that surface and verify its generated CSS against Tailwind.