### PR TITLE
build: preserve declared utility order

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -360,26 +360,27 @@ let rule_to_triple order_map = function
         ~nested ~base_class ~merge_key
 
 (* Add index to each triple for stable sorting *)
-(* What [indexed_rule_to_statement] will emit, counted: the theme declarations
-   the utilities layer drops are not part of the rule Tailwind orders. A
-   declared utility's rules arrive as finished CSS and carry none. *)
-let rec declaration_count props nested =
-  List.length (filter_utility_properties props)
+(* What [indexed_rule_to_statement] will emit, counted. For a built-in, theme
+   declarations the utilities layer drops are not part of the rule Tailwind
+   orders. A declared utility is finished author CSS, so all its declarations
+   count, including custom properties without tw's internal layer annotation. *)
+let rec declaration_count ~filter props nested =
+  List.length (if filter then filter_utility_properties props else props)
   + List.fold_left
       (fun acc stmt ->
         acc
         +
         match Css.as_rule stmt with
-        | Some (_, decls, inner) -> declaration_count decls inner
+        | Some (_, decls, inner) -> declaration_count ~filter decls inner
         | None -> (
             match Css.as_declarations stmt with
-            | Some decls -> declaration_count decls []
+            | Some decls -> declaration_count ~filter decls []
             | None -> (
                 match Css.as_media stmt with
-                | Some (_, inner) -> declaration_count [] inner
+                | Some (_, inner) -> declaration_count ~filter [] inner
                 | None -> (
                     match Css.as_supports stmt with
-                    | Some (_, inner) -> declaration_count [] inner
+                    | Some (_, inner) -> declaration_count ~filter [] inner
                     | None -> 0))))
       0 nested
 
@@ -390,6 +391,9 @@ let add_index ?theme ?(declared = fun _ -> false) triples =
       Buffer.clear buf;
       Css.Selector.to_buffer buf sel;
       let selector_str = Buffer.contents buf in
+      let is_declared =
+        match base_class with Some c -> declared c | None -> false
+      in
       let media_key, nested_media_key = Sort.media_sort_keys typ nested in
       let responsive_media_key = Sort.responsive_media_key typ nested in
       let variant_order = Rule.compute_variant_order ~selector_str base_class in
@@ -401,9 +405,9 @@ let add_index ?theme ?(declared = fun _ -> false) triples =
          selector_kind = Sort.classify_selector sel;
          has_modifier_colon = Css.Selector.contains_modifier_colon sel;
          props;
-         declared =
-           (match base_class with Some c -> declared c | None -> false);
-         declaration_count = declaration_count props nested;
+         declared = is_declared;
+         declaration_count =
+           declaration_count ~filter:(not is_declared) props nested;
          order;
          nested;
          base_class;

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -2208,12 +2208,33 @@ let routed_slot ~own_order ~order_of cls =
       Stdlib.Option.value ~default:(max_int, max_int)
         (Hashtbl.find_opt order_of cls)
 
-let compare_routed_entries ~own_order ~order_of (c1, _) (c2, _) =
+(* Tailwind counts every declaration in a utility's AST, including ones in
+   nested rules and at-rules. [Css.fold] follows every kind of nested block, so
+   this does not need a brittle list of the block at-rules cascade knows. *)
+let routed_declaration_count stmts =
+  Css.fold
+    (fun count stmt ->
+      match Css.as_rule stmt with
+      | Some (_, declarations, _) -> count + List.length declarations
+      | None -> (
+          match Css.as_declarations stmt with
+          | Some declarations -> count + List.length declarations
+          | None -> count))
+    0 (Css.v stmts)
+
+let compare_routed_entries ~own_order ~order_of (c1, stmts1) (c2, stmts2) =
   let p1, s1 = routed_slot ~own_order ~order_of c1 in
   let p2, s2 = routed_slot ~own_order ~order_of c2 in
   let priority = Int.compare p1 p2 in
   let suborder = if priority <> 0 then priority else Int.compare s1 s2 in
-  if suborder <> 0 then suborder else String.compare c1 c2
+  if suborder <> 0 then suborder
+  else
+    let count =
+      Int.compare
+        (routed_declaration_count stmts2)
+        (routed_declaration_count stmts1)
+    in
+    if count <> 0 then count else String.compare c1 c2
 
 (* Within one declared utility, the rules it writes outright come before the
    ones a variant wrapped in an at-rule, the order the generator gives a

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -312,6 +312,30 @@ let test_functional_value () =
     ]
     [ "example-1"; "example-76"; "example-foo"; "example"; "example-2.5" ]
 
+(* For utilities in the same property slot, Tailwind sorts the one with more
+   declarations first. The modifier contributes the second declaration here, so
+   lexical candidate order is deliberately the wrong answer. *)
+let test_functional_property_count_order () =
+  let udefs =
+    [
+      ( "example-*",
+        " --resolved-value: --value([length]); --resolved-modifier: \
+         --modifier([length]) " );
+    ]
+  in
+  let _, entries, _ =
+    custom_routed_utilities ~theme:Tw.Scheme.default ~defs:[] ~udefs
+      [ "example-[12px]"; "example-[12px]/[16px]" ]
+  in
+  let css =
+    Tw.to_css ~theme:Tw.Scheme.default ~base:false ~layers:false ~extra:entries
+      []
+    |> Cascade.Css.to_string ~minify:true
+  in
+  check string "more declarations sort first"
+    ".example-\\[12px\\]\\/\\[16px\\]{--resolved-value:12px;--resolved-modifier:16px}.example-\\[12px\\]{--resolved-value:12px}"
+    css
+
 (* Curly blocks are declaration boundaries rather than opaque values: a nested
    rule may itself contain a functional declaration that needs resolving. *)
 let test_functional_nested_rule () =
@@ -445,6 +469,8 @@ let tests =
     test_case "complex custom variant keeps its candidate" `Quick
       test_complex_custom_variant_keeps_candidate;
     test_case "functional value" `Quick test_functional_value;
+    test_case "functional property count order" `Quick
+      test_functional_property_count_order;
     test_case "functional nested rule" `Quick test_functional_nested_rule;
     test_case "functional theme value" `Quick test_functional_theme_value;
     test_case "functional arbitrary value" `Quick


### PR DESCRIPTION
Counts emitted author declarations when ordering utilities that share a property slot, including custom properties and nested blocks. This preserves Tailwind's modifier-dependent order.