### PR TITLE
tools: keep author custom properties in parity checks

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -128,8 +128,7 @@ let diff_single_class class_str ~(opts : gen_opts) =
     let stylesheet = Tw.to_css ~theme:opts.theme ~base:true styles in
     let our_css = render_css ~opts stylesheet in
     let diff =
-      Css_compare.diff ~mode:opts.diff_mode ~prune_unused_custom_props:true
-        legacy_css our_css
+      Tw_tools.Parity_compare.diff ~mode:opts.diff_mode legacy_css our_css
     in
     match tw_styles with
     | [] when class_str = "" ->
@@ -319,8 +318,7 @@ let diff_files paths ~(opts : gen_opts) =
     in
     let our_css = render_css ~opts stylesheet in
     let diff =
-      Css_compare.diff ~mode:opts.diff_mode ~prune_unused_custom_props:true
-        legacy_css our_css
+      Tw_tools.Parity_compare.diff ~mode:opts.diff_mode legacy_css our_css
     in
     print_diff_result "" diff;
     `Ok ()

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -20,7 +20,7 @@ regeneration.
 
 **Example pages, `examples/*/dune`.** Each of the nine examples builds its CSS
 twice, once through tw and once through `npx tailwindcss`, then diffs the two
-with `cascade diff --diff=canonical --prune-unused-custom-props`. The rule is
+with `cascade diff --diff=canonical`. The rule is
 guarded by `(enabled_if %{bin-available:npx})`, so it is skipped where npx is
 absent, and `%{bin:cascade}` resolves through the dune workspace, so the diff
 runs the freshly built cascade rather than whatever sits on `PATH`.
@@ -152,8 +152,8 @@ hundred rule entries.
 **`--diff` compares two minified sheets.** The CSS it attributes to Tailwind has
 already been through lightningcss, so cross-check against
 `tw -s "<class>" --tailwind`, which is unminified, before calling something a tw
-bug. `--diff` also passes `--prune-unused-custom-props`, which makes it blind to
-a utility whose whole effect is a custom property nothing reads.
+bug. Author custom properties are kept even when neither generated sheet reads
+them: CSS outside the generated sheet can still observe them.
 
 **Order is compared, but only since cascade 105eea05.** `--diff=canonical`
 matches rules by key rather than position, and before that commit it said

--- a/examples/accessibility/dune
+++ b/examples/accessibility/dune
@@ -42,10 +42,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    accessibility.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical accessibility.css tailwind.css))))

--- a/examples/animations/dune
+++ b/examples/animations/dune
@@ -42,10 +42,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    animations.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical animations.css tailwind.css))))

--- a/examples/colors/dune
+++ b/examples/colors/dune
@@ -37,10 +37,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    colors.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical colors.css tailwind.css))))

--- a/examples/dashboard/dune
+++ b/examples/dashboard/dune
@@ -42,10 +42,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    dashboard.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical dashboard.css tailwind.css))))

--- a/examples/forms/dune
+++ b/examples/forms/dune
@@ -51,10 +51,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    tailwind.css
-    forms.css))))
+   (run %{bin:cascade} diff --diff=canonical tailwind.css forms.css))))

--- a/examples/landing/dune
+++ b/examples/landing/dune
@@ -43,10 +43,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    landing.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical landing.css tailwind.css))))

--- a/examples/layout/dune
+++ b/examples/layout/dune
@@ -42,10 +42,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    layout.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical layout.css tailwind.css))))

--- a/examples/modifiers/dune
+++ b/examples/modifiers/dune
@@ -42,10 +42,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    modifiers.css
-    tailwind.css))))
+   (run %{bin:cascade} diff --diff=canonical modifiers.css tailwind.css))))

--- a/examples/prose/dune
+++ b/examples/prose/dune
@@ -58,10 +58,4 @@
   (setenv
    CASCADE_COLOR
    always
-   (run
-    %{bin:cascade}
-    diff
-    --diff=canonical
-    --prune-unused-custom-props
-    tailwind.css
-    prose.css))))
+   (run %{bin:cascade} diff --diff=canonical tailwind.css prose.css))))

--- a/lib/tools/dune
+++ b/lib/tools/dune
@@ -1,3 +1,3 @@
 (library
  (name tw_tools)
- (libraries cascade tw fmt unix uutf))
+ (libraries cascade cascade.diff tw fmt unix uutf))

--- a/lib/tools/parity_compare.ml
+++ b/lib/tools/parity_compare.ml
@@ -1,0 +1,2 @@
+let diff ?mode expected actual =
+  Cascade_diff.Css_compare.diff ?mode expected actual

--- a/lib/tools/parity_compare.mli
+++ b/lib/tools/parity_compare.mli
@@ -1,0 +1,10 @@
+(** Comparison policy for tw against the Tailwind reference. *)
+
+val diff :
+  ?mode:Cascade_diff.Css_compare.mode ->
+  string ->
+  string ->
+  Cascade_diff.Css_compare.t
+(** [diff expected actual] preserves every declaration on both sides. In
+    particular, an author custom property is observable outside the generated
+    sheet and must not be pruned as dead. *)

--- a/test/helpers/browser/compare.js
+++ b/test/helpers/browser/compare.js
@@ -214,13 +214,6 @@ function compare(ra, rb, where, lines) {
     return base + where;
   };
 
-  // A custom property is a token stream: the browser hands back the author's
-  // own whitespace and quoting, so two sheets that minify differently differ on
-  // spelling alone. Compare them with both dropped - whatever reads the
-  // variable shows a real difference in its own property.
-  const norm = (k, v) =>
-    k.startsWith('--') && v !== undefined ? v.replace(/["'\s]+/g, '') : v;
-
   for (let i = 0; i < ra.nodes.length; i++) {
     const na = ra.nodes[i];
     const nb = rb.nodes[i];
@@ -234,10 +227,16 @@ function compare(ra, rb, where, lines) {
     const pa = na.style;
     const pb = nb.style;
     for (const k of new Set([...Object.keys(pa), ...Object.keys(pb)])) {
-      // A custom property one sheet declares and the other prunes renders the
-      // same unless something reads it, and whatever reads it differs instead.
-      if (k.startsWith('--') && (pa[k] === undefined || pb[k] === undefined)) continue;
-      if (norm(k, pa[k]) !== norm(k, pb[k]))
+      // Canonical CSS parity compares custom-property declarations and their
+      // values. The rendering gate checks that each binding reaches the same
+      // elements, then observes any value that is consumed through the normal
+      // computed property it affects. Comparing the raw token text here would
+      // instead make equivalent minifier choices (spaces around calc operators
+      // or optional font-family quotes) fail every rendering suite.
+      if (k.startsWith('--')) {
+        if ((pa[k] === undefined) !== (pb[k] === undefined))
+          lines.push(`${label(na)}: ${k}: ${pa[k]} (tw) vs ${pb[k]} (tailwind)`);
+      } else if (pa[k] !== pb[k])
         lines.push(`${label(na)}: ${k}: ${pa[k]} (tw) vs ${pb[k]} (tailwind)`);
     }
   }

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -31,6 +31,18 @@ let extract_rule_selectors stmts =
 let our_css utilities =
   Tw.to_css ~base:true utilities |> Css.to_string ~minify:true ~lossless:true
 
+(* Cascade's printer and Tailwind's minifier can spell the same token stream
+   differently inside a custom property: optional whitespace around calc
+   operators, quotes around a multi-word font family, or spaces between OKLCH
+   channels. Parse and print both sheets once before a parity comparison so
+   those serializer choices share one spelling. No declaration is removed, so
+   missing, extra, or genuinely different custom-property values stay visible. A
+   sheet the reader rejects is passed through unchanged and still fails. *)
+let respelled css =
+  match Css.of_string css with
+  | Ok { Css.stylesheet; _ } -> Css.to_string ~minify:true stylesheet
+  | Error _ -> css
+
 (* Parity tests need the pinned tailwindcss CLI. Skipping is right on a
    developer machine without node, and wrong on CI, where it retires a fifth of
    the suite into [SKIP] lines that dune swallows on success, so the run reports
@@ -201,17 +213,14 @@ let interacting_pairs classes =
 (* The single ordering predicate. The fuzzer minimises with it and every suite
    asserts on it, so a minimal case it reports is a case the assertion also
    rejects; two predicates that disagree let the fuzzer print a failing case and
-   pass anyway. Pruning dead custom properties makes it blind to utilities whose
-   only output is an unreferenced binding - check_rendering_matches covers that
-   class now, and agreeing on one predicate is worth more than the extra
-   sensitivity here. *)
+   pass anyway. *)
 (* Both sheets for one case. [ordering_faults] needs the text as well as the
    diff, and generating them here keeps one description of what is compared. *)
 let sheets ?(forms = false) utilities =
   (tailwind_css ~forms (List.map Tw.pp utilities), our_css utilities)
 
 let canonical_diff (tailwind, tw) =
-  Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true tailwind tw
+  Tw_tools.Parity_compare.diff ~mode:`Canonical tailwind tw
 
 let ordering_diff ?forms utilities = canonical_diff (sheets ?forms utilities)
 
@@ -454,8 +463,8 @@ let check_rendering_matches ?(forms = false) ?(inner = "") ~test_name utilities
   let entry cls =
     if String.equal inner "" then cls else cls ^ "\t" ^ one_line inner
   in
-  write_file (path "tw.css") (our_css utilities);
-  write_file (path "tailwind.css") tailwind;
+  write_file (path "tw.css") (respelled (our_css utilities));
+  write_file (path "tailwind.css") (respelled tailwind);
   write_file (path "elements.txt")
     (String.concat "\n" (List.map entry elements));
   let out = path "diff.txt" and err = path "stderr.txt" in
@@ -490,21 +499,6 @@ let check_ordering_matches ?forms ~test_name utilities =
       let buf = Buffer.create 1024 in
       Css_compare.pp ~expected:"Tailwind" ~actual:"Our TW" buf diff;
       Alcotest.failf "%s\n%s" test_name (Buffer.contents buf)
-
-(* Cascade's printer and Tailwind's minifier spell the same value differently
-   wherever CSS makes the difference insignificant: a custom property holds
-   [oklch(63.7% .237 25.331)] on one side and [oklch(63.7%.237 25.331)] on the
-   other, a font stack keeps its quotes on one and drops them on the other.
-   Neither sheet is wrong, so a comparison sensitive to the bytes reads both
-   through the same printer first. Parsing and re-printing respells a sheet
-   without changing what it declares: the printer merges no rules, moves none,
-   and drops no binding, so a rule written twice stays written twice and a
-   binding nothing reads stays bound. A sheet the reader rejects is passed
-   through untouched, leaving {!Css_compare} to report the parse error. *)
-let respelled css =
-  match Css.of_string css with
-  | Ok { Css.stylesheet; _ } -> Css.to_string ~minify:true stylesheet
-  | Error _ -> css
 
 let tree_diff_css ~expected ~actual =
   Css_compare.diff ~mode:`Tree (respelled expected) (respelled actual)

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -108,8 +108,7 @@ let check_exact_match tw_styles =
 
     let test_name = test_name_of classnames in
     let diff_result =
-      Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
-        tailwind_css tw_css
+      Tw_tools.Parity_compare.diff ~mode:`Canonical tailwind_css tw_css
     in
     Test_helpers.check_no_dropped_declarations ~test_name diff_result;
     let parity_equal =
@@ -189,8 +188,7 @@ let check_module utility =
     |> canonical_stylesheet_css
   in
   let diff =
-    Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
-      tailwind_css tw_css
+    Tw_tools.Parity_compare.diff ~mode:`Canonical tailwind_css tw_css
   in
   Test_helpers.check_no_dropped_declarations ~test_name:class_name diff;
   match diff.Css_compare.result with

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -30,6 +30,17 @@ let test_prefers_project_tailwindcss () =
   check string "uses the pinned executable directly" expected
     (tailwindcss_command ())
 
+let test_parity_preserves_author_custom_properties () =
+  let diff =
+    Tw_tools.Parity_compare.diff ~mode:`Canonical ".x { --author-token: yes }"
+      ".x {}"
+  in
+  match diff.Cascade_diff.Css_compare.result with
+  | Cascade_diff.Css_compare.No_diff ->
+      Alcotest.fail
+        "parity comparison erased an author custom property missing from tw"
+  | _ -> ()
+
 let test_generate_simple () =
   Test_helpers.require_tailwind_cli ();
   let css = generate ~minify:true [ "p-4"; "bg-blue-500" ] in
@@ -105,6 +116,8 @@ let tests =
     test_case "check tailwindcss available" `Quick test_check_available;
     test_case "prefer the project Tailwind executable" `Quick
       test_prefers_project_tailwindcss;
+    test_case "parity preserves author custom properties" `Quick
+      test_parity_preserves_author_custom_properties;
     test_case "generate simple CSS" `Quick test_generate_simple;
     test_case "arbitrary colour opacity matches live CLI" `Quick
       test_arbitrary_color_opacity_matches_cli;

--- a/test/tools/test_tailwind_gen.ml
+++ b/test/tools/test_tailwind_gen.ml
@@ -68,10 +68,7 @@ let test_arbitrary_color_opacity_matches_cli () =
           |> Tw.Css.to_string ~minify:true
       | Error _ -> Alcotest.failf "tw could not parse %s" cls
     in
-    let diff =
-      Cascade_diff.Css_compare.diff ~mode:`Canonical
-        ~prune_unused_custom_props:true cli tw
-    in
+    let diff = Tw_tools.Parity_compare.diff ~mode:`Canonical cli tw in
     match diff.Cascade_diff.Css_compare.result with
     | Cascade_diff.Css_compare.No_diff ->
         check bool (cls ^ ": tw matches live Tailwind CLI") true true
@@ -102,10 +99,7 @@ let test_arbitrary_url_matches_cli () =
         |> Tw.Css.to_string ~minify:true
     | Error _ -> Alcotest.failf "tw could not parse %s" cls
   in
-  let diff =
-    Cascade_diff.Css_compare.diff ~mode:`Canonical
-      ~prune_unused_custom_props:true cli tw
-  in
+  let diff = Tw_tools.Parity_compare.diff ~mode:`Canonical cli tw in
   match diff.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.No_diff ->
       check bool (cls ^ ": tw matches live Tailwind CLI") true true

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -754,7 +754,7 @@ let run_test_case test expected () =
         |> color_mix_to_oklab |> truncate_color_precision
       in
       let result =
-        Css_compare.diff ~mode:`Canonical ~prune_unused_custom_props:true
+        Tw_tools.Parity_compare.diff ~mode:`Canonical
           (normalize_colors expected_css)
           (normalize_colors our_css)
       in


### PR DESCRIPTION
Keeps author-defined custom properties visible in structural and browser parity checks while normalizing only equivalent serializer spellings.