### PR TITLE
tw: remove process-global variable registries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   `Var.resolve_theme_refs`) are removed, and the public `Style.Style` record
   gains a `metadata` field. Construction, parsing, and rendering are safe to run
   from multiple OCaml Domains without a mutex; typed `property_default` rules
-  are generated automatically.
+  are generated automatically (#653).
 - `bg_transparent`, `bg_current` and the background colour constructors move to
   `Backgrounds`; `border_color`, `border_transparent` and `border_current` move
   to `Color`. Building one from OCaml and parsing the same class name used to
@@ -59,7 +59,7 @@
   `--spacing`, and an `@theme reference` block is represented (#554).
 - Functional utilities follow Tailwind's declaration-count ordering, parity
   comparisons keep author custom properties, and a folded zero-spacing utility
-  omits the internal `--spacing` carrier it no longer reads (#650, #651, #652).
+  omits the internal `--spacing` carrier it no longer reads (#650, #651, #655).
 - Every `@utility` declared for one name applies, not only the first (#550).
 - A routed candidate keeps the utility that owns it, so a class a declared
   variant routes is generated once by the right handler (#564).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ### Breaking changes
 
+- Variable ordering and `@property` metadata now travels with `Var` values and
+  `Style.t`, rather than through process-global registries. The registry lookup
+  functions (`Var.order`, `Var.family`, `Var.property_order`,
+  `Var.needs_property`, `Var.register_property_order`, and
+  `Var.resolve_theme_refs`) are removed, and the public `Style.Style` record
+  gains a `metadata` field. Construction, parsing, and rendering are safe to run
+  from multiple OCaml Domains without a mutex; typed `property_default` rules
+  are generated automatically.
 - `bg_transparent`, `bg_current` and the background colour constructors move to
   `Backgrounds`; `border_color`, `border_transparent` and `border_current` move
   to `Color`. Building one from OCaml and parsing the same class name used to

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,7 +40,7 @@ do not exist.
    Tailwind over the class list of tailwindcss.com. Quote the differ's summary
    line together with the top-level entries under it; the summary counts
    containers rather than their contents, so one `@layer` entry can hide a
-   thousand rules. Last measured 2026-08-28: 0.5% diff, 1 removed rule,
+   thousand rules. Last measured 2026-09-02: 0.3% diff, 1 removed rule,
    8 modified, 20 reordered, 5 changed containers.
 
 ## Quality (target, non-blocking)

--- a/docs/adding-a-new-utility.md
+++ b/docs/adding-a-new-utility.md
@@ -195,15 +195,16 @@ How Build turns this into layers
 
 - `theme_layer_of` scans used styles, extracts custom declarations (from `Var.theme`), adds a small set of default vars (font families), and emits them under `@layer theme` in `:root,:host` with a stable order.
 
-  **Variable Ordering**: `Var.order` reads back the `~order:(group, index)` pair a
-  theme variable was declared with. The group buckets the family in the order
-  Tailwind emits its `@theme` block (1 font families, 3 spacing, 5 container
-  widths, 6 font sizes, 7 animations, 8 blurs, 9 defaults) and the index places
-  the token inside its group. `lib/var.ml` keeps a registry of taken slots and
-  ignores a second registration for one, so two tokens cannot share a slot. Read
-  the neighbours of the token you are adding rather than guessing a group.
+  **Variable Ordering**: the `~order:(group, index)` pair travels with a theme
+  variable and every declaration made from it. The group buckets the family in
+  the order Tailwind emits its `@theme` block (1 font families, 3 spacing, 5
+  container widths, 6 font sizes, 7 animations, 8 blurs, 9 defaults) and the
+  index places the token inside its group. A build collects this metadata into a
+  local immutable index; constructing a variable does not mutate process-global
+  state. Read the neighbours of the token you are adding rather than guessing a
+  group.
 
-- `properties_layer` collects all `property_rules` attached to used utilities (from `Var.property_rule ...`) and emits an `@layer properties` that contains a single `@supports(...) { ... }` block with default custom-property values targeting `*, :before, :after, ::backdrop` (not the `@property` rules themselves).
+- `properties_layer` generates exact typed `@property` rules from variables used by a style and emits an `@layer properties` containing a single `@supports(...) { ... }` block with default custom-property values targeting `*, :before, :after, ::backdrop`. Use explicit `property_rules` only when one utility deliberately publishes a wider group than its declarations reference; pass the matching `Var.metadata` values to `Style.style` with them.
 - `base_layer` wraps Preflight rules under `@layer base` and applies the placeholder support shim.
 - Components is left empty by default; utilities render to `@layer utilities`.
 - When minifying, consecutive empty layers are merged into a single declaration, e.g., `@layer components,utilities;` to match Tailwind output.
@@ -496,8 +497,8 @@ strings.
 
 4. **Variable ordering in theme layer**
    - **Problem**: Variables appearing in wrong order in `@layer theme`, causing test failures
-   - **Solution**: Fix the `~order:(group, index)` pair the variable was declared with; `Var.order` is what the theme layer reads
-   - **Note**: `lib/var.ml` drops a registration whose slot is already taken, so a duplicated pair shows up as a missing variable rather than a reordering
+   - **Solution**: Fix the `~order:(group, index)` pair on the variable definition; the build reads it from the declaration's metadata
+   - **Note**: Equal pairs are allowed. The build resolves a tie from the active theme's declaration order, so one request cannot affect another
 
 5. **Font-variant-numeric empty fallback handling**
    - **Problem**: Font-variant-numeric variables need trailing commas in CSS but a normal fallback generates the wrong syntax

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -77,39 +77,51 @@ rather than from `PATH`.
 
 ### Current measurement
 
-Attempted 2026-08-27 at 5dac2223. **The documented command does not complete.**
-cascade's differ raises `Assertion failed` in `pp_position_reorder`
-(`lib/diff/tree_diff.ml:445`, `assert (expected_pos <> actual_pos)`) and the
-whole report is buffered, so not even the summary line survives. Seven rules
-reach that renderer with the two positions equal, six `mask-[...]` classes and
-`md:text-[2.5rem]/14`, all of them selectors the site's CSS carries more than
-once. `selector_position` answers with the first rule matching the key while the
-`moved` set that decided a move refers to a later one.
-
-The reorder reporting the crash comes from is new: cascade 105eea05
-(2026-08-25) made the canonical comparison read positions back, where before it
-claimed an exact match wherever it sat. Any earlier site number was taken
-without it and is not comparable.
-
-With that assertion disabled locally, the run reports:
+Measured 2026-09-02 at 36b47e32 against cascade a6557326. The documented command
+completed without a patched differ and reported:
 
 ```text
-CSS: 661576 chars vs 664632 chars (0.5% diff)
-Changes: 1 removed rule, 1 modified rule, 1 reordered rule, 3 changed containers
-├─ .DocSearch-Hit[aria-selected="true"] [title="Remove this search from favorites"]:before:where(.dark, .dark *)
+CSS: 662557 chars vs 664632 chars (0.3% diff)
+Changes: 1 removed rule, 8 modified rules, 20 reordered rules, 5 changed containers
+├─ .DocSearch-Container
 ├─ .with-line-numbers .line:before
-├─ .DocSearch-Hit[ari...favorites"]:before (position 114) ↔ .DocSearch-Hit[ari...DocSearch-Hit-icon (position 112)
-├─ @media (prefers-color-scheme: dark) (11 blocks merged into 10)
-├─ @layer utilities (45 added, 1453 reordered, 16 rearranged, 1 selector changed)
-└─ @layer components (2 modified)
+├─ .DocSearch-Hit[aria-selected="true"] [title="Remove this search from favorites"]:before:where(.dark, .dark *)
+├─ .dark .DocSearch-Container
+├─ .dark .DocSearch-Hit--Result.DocSearch-Hit--Child:before
+├─ .dark .DocSearch-SearchBar
+├─ .dark :is(.DocSearch-Hit:first-child > a)
+├─ .dark :is(.DocSearch-Hit-action [title="Remove this search from favorites"]):before
+├─ .dark .DocSearch-Hit--Result
+├─ .DocSearch-Hits mark (position 132) ↔  .DocSearch-NoResults .DocSearch-Title (position 76)
+├─ .DocSearch-Hit-path mark (position 133) ↔  .DocSearch-StartScreen .DocSearch-Help (position 77)
+├─ .DocSearch-Hits ma...re(.dark, .dark *) (position 134) ↔  .dark .DocSearch-Hit-path (position 78)
+├─ .DocSearch-NoResults-Prefill-List ul (position 135) ↔  .DocSearch-NoResul...st .DocSearch-Help (position 79)
+├─ .DocSearch-NoResul...re(.dark, .dark *) (position 136) ↔  .DocSearch-NoResul...re(.dark, .dark *) (position 80)
+├─ .dark .DocSearch-Modal (position 137) ↔  .DocSearch-NoResul... + .DocSearch-Help (position 81)
+├─ .dark .DocSearch-MagnifierLabel (position 141) ↔  .DocSearch-Container (position 92)
+├─ .dark .DocSearch-Cancel (position 144) ↔  @media (width >= 40rem) (position 93)
+├─ .DocSearch-Hit--Re...DocSearch-Hit-icon (position 145) ↔  @media (width >= 64rem) (position 95)
+├─ .DocSearch-Hit--Pa...DocSearch-Hit-icon (position 146) ↔  .DocSearch-Visuall...enForAccessibility (position 96)
+├─ .DocSearch-Hit--Re...cSearch-Hit-action (position 147) ↔  .DocSearch-Hit (position 97)
+├─ .DocSearch-Hit-act...h from favorites"] (position 148) ↔  .DocSearch-LoadingIndicator (position 98)
+├─ .DocSearch-Hit-act...rch from history"] (position 149) ↔  .DocSearch-Modal (position 99)
+├─ .DocSearch-Hit-act...Save this search"] (position 150) ↔  .DocSearch-Hit--Result (position 100)
+├─ .DocSearch-Hit--Ta...DocSearch-Hit-icon (position 151) ↔  .DocSearch-SearchBar (position 101)
+├─ .DocSearch-Hit--Ta...cSearch-Hit-action (position 152) ↔  .DocSearch-Dropdown-Container (position 102)
+├─ .DocSearch-Hit-act...cSearch-Hit-action (position 153) ↔  .DocSearch-Dropdown (position 103)
+├─ .DocSearch-NoResul...Search-Screen-Icon (position 154) ↔  .DocSearch-Form (position 104)
+├─ .with-line-numbers .line (position 156) ↔  .DocSearch-Hit-Container (position 109)
+├─ .DocSearch-Hit[ari...favorites"]:before (position 160) ↔  .DocSearch-Hit-source (position 114)
+├─ @media (width <= 40rem) (position 116 → 161)
+├─ @media (prefers-color-scheme: dark) (10 block split into 11)
+├─ @layer utilities (45 added, 16 modified, 164 reordered, 4 rearranged, 1 selector changed)
+├─ @layer components (6 modified)
+└─ @supports (color: color-mix(in lab,red,red)) (1 block split into 4)
 ```
 
-Those figures come from a patched differ and are not a measurement. The 45
-added and the 2 modified match what the sections below describe. The 1453
-reordered is new information nobody has validated: it arrives from the same
-commit that produces the crash, so how much of it is tw's ordering debt and how
-much is the differ pairing duplicate selectors badly is unknown until the
-assertion is fixed properly in cascade.
+The top-level entries are quoted with the summary because its five changed
+containers include the utilities layer, which contains hundreds of nested
+changes. The summary alone is not a useful estimate of the remaining work.
 
 **Both sides are minified because every other configuration is noisier.** The
 reference passes through lightningcss, so part of what the diff reports is
@@ -120,12 +132,13 @@ flattens it. Measured on the site corpus:
 
 | harness | utilities layer | components layer |
 |---|---|---|
-| minify both sides | 47 added | 2 modified |
+| minify both sides (current) | 45 added, 16 modified, 164 reordered, 4 rearranged, 1 selector changed | 6 modified |
 | neither side minified | 45 added, 11 removed, 513 modified | 55 removed, 1 modified |
 | neither minified, both flattened | 45 added, 11 removed, 513 modified | 55 removed, 1 modified |
 
-Those rows were taken before cascade started reading rule positions back, so
-none of them carries a reordered count.
+The two unminified rows predate cascade reading rule positions back, so neither
+of them carries a reordered count and they are not directly comparable to the
+current row.
 
 Flattening afterwards changes nothing, because the canonical comparator already
 folds nesting.

--- a/lib/borders.ml
+++ b/lib/borders.ml
@@ -293,16 +293,11 @@ module Handler = struct
   (* A [--radius-*] token the project declared names a radius the built-in scale
      has no slot for; they share the slot after the scale, the way the project's
      font families and text sizes share theirs. *)
-  let radius_named_cache : (string, Css.length Var.theme) Hashtbl.t =
-    Hashtbl.create 8
+  let radius_named_cache = Domain_cache.v 8
 
   let radius_named_var name =
-    match Hashtbl.find_opt radius_named_cache name with
-    | Some var -> var
-    | None ->
-        let var = Var.theme Css.Length ("radius-" ^ name) ~order:(7, 11) in
-        Hashtbl.add radius_named_cache name var;
-        var
+    Domain_cache.or_add radius_named_cache name (fun () ->
+        Var.theme Css.Length ("radius-" ^ name) ~order:(7, 11))
 
   let radius_none_var = Var.theme Css.Length "radius-none" ~order:(7, 0)
   let radius_full_var = Var.theme Css.Length "radius-full" ~order:(7, 1)
@@ -635,7 +630,7 @@ module Handler = struct
     | _ -> None
 
   (* A radius the project named in its [@theme]. The built-in scale is published
-     through the same registry, so a built-in name is answered by
+     through the static token catalog, so a built-in name is answered by
      [rounded_size_of_string] before this is consulted. *)
   let is_theme_radius theme n =
     rounded_size_of_string n = None

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -5,6 +5,70 @@
 
 module Css = Cascade.Css
 open Output
+module Metadata = Map.Make (String)
+
+let metadata_name name =
+  if String.starts_with ~prefix:"--" name then
+    String.sub name 2 (String.length name - 2)
+  else name
+
+let metadata_score metadata =
+  Option.fold ~none:0 ~some:(fun _ -> 1) (Var.metadata_order metadata)
+  + Option.fold ~none:0
+      ~some:(fun _ -> 1)
+      (Var.metadata_property_order metadata)
+  + Option.fold ~none:0 ~some:(fun _ -> 1) (Var.metadata_family metadata)
+  + (if Var.metadata_needs_property metadata then 1 else 0)
+  + Option.fold ~none:0 ~some:(fun _ -> 1) (Var.metadata_default_css metadata)
+
+let add_metadata index metadata =
+  let name = Var.metadata_name metadata in
+  match Metadata.find_opt name index with
+  | Some existing when metadata_score existing >= metadata_score metadata ->
+      index
+  | _ -> Metadata.add name metadata index
+
+let add_var_metadata index (Css.V var) =
+  match Var.metadata_of_var var with
+  | Some metadata -> add_metadata index metadata
+  | None -> index
+
+let add_declaration_metadata index declaration =
+  let index =
+    match Var.metadata_of_declaration declaration with
+    | Some metadata -> add_metadata index metadata
+    | None -> index
+  in
+  List.fold_left add_var_metadata index
+    (Css.vars_of_declarations [ declaration ])
+
+let add_declarations_metadata index declarations =
+  List.fold_left add_declaration_metadata index declarations
+
+let add_vars_metadata index vars = List.fold_left add_var_metadata index vars
+
+let metadata_of_sorted_rules rules =
+  List.fold_left
+    (fun index (rule : Sort.indexed_rule) ->
+      let index = add_declarations_metadata index rule.props in
+      add_vars_metadata index (Css.vars_of_rules rule.nested))
+    Metadata.empty rules
+
+let metadata_for_name index name = Metadata.find_opt (metadata_name name) index
+
+let metadata_order index name =
+  Option.bind (metadata_for_name index name) Var.metadata_order
+
+let metadata_property_order index name =
+  Option.bind (metadata_for_name index name) Var.metadata_property_order
+
+let metadata_family index name =
+  Option.bind (metadata_for_name index name) Var.metadata_family
+
+let metadata_index sorted_rules style_metadata =
+  List.fold_left add_metadata
+    (metadata_of_sorted_rules sorted_rules)
+    style_metadata
 
 (* ======================================================================== *)
 (* Conflict Resolution - Order utilities by specificity *)
@@ -517,15 +581,9 @@ let sorted_indexed_rules ?theme ?declared order_map all_rules =
   |> sort_indexed_blocks
 
 (* Sort var names by property_order. Names include -- prefix. *)
-let sort_vars_by_property_order vars =
+let sort_vars_by_property_order metadata vars =
   let get_order name =
-    (* Strip -- prefix for lookup *)
-    let name_without_prefix =
-      if String.starts_with ~prefix:"--" name then
-        String.sub name 2 (String.length name - 2)
-      else name
-    in
-    match Var.property_order name_without_prefix with
+    match metadata_property_order metadata name with
     | Some o -> o
     | None -> 1000 (* Default for vars without property_order *)
   in
@@ -541,7 +599,7 @@ let sort_vars_by_property_order vars =
    are REFERENCED and need @property (e.g., transform refs rotate/skew) Within
    each utility, vars are sorted by property_order to ensure consistent family
    ordering (e.g., ring before inset-ring regardless of CSS value order). *)
-let var_names_of_sorted_rules sorted_rules =
+let var_names_of_sorted_rules metadata sorted_rules =
   sorted_rules
   |> List.concat_map (fun (r : Sort.indexed_rule) ->
       (* Vars that this utility SETS *)
@@ -552,12 +610,13 @@ let var_names_of_sorted_rules sorted_rules =
       let ref_vars =
         all_vars
         |> List.filter (fun (Css.V v) ->
-            let name = Css.var_name v in
-            Var.needs_property name)
+            match Var.metadata_of_var v with
+            | Some metadata -> Var.metadata_needs_property metadata
+            | None -> false)
         |> List.map (fun (Css.V v) -> "--" ^ Css.var_name v)
       in
       (* Sort all vars from this utility by property_order *)
-      sort_vars_by_property_order (set_vars @ ref_vars))
+      sort_vars_by_property_order metadata (set_vars @ ref_vars))
 
 let rule_sets tw_classes =
   let order_tbl = Hashtbl.create 256 in
@@ -714,7 +773,7 @@ let declared_order declared name =
    into one shared (priority, suborder) slot (see [Var.mli]), so two project
    tokens tie there; Tailwind keeps the order the [@theme] block wrote them in
    rather than sorting by name. *)
-let sort_by_var_order ~theme decls =
+let sort_by_var_order ~metadata ~theme decls =
   let declared = declared_index theme in
   decls
   |> List.map (fun d ->
@@ -722,7 +781,7 @@ let sort_by_var_order ~theme decls =
       let order =
         match Var.order_of_declaration d with
         | Some _ as order -> order
-        | None -> Option.bind name Var.order
+        | None -> Option.bind name (metadata_order metadata)
       in
       (d, order, name, declared_order declared name))
   |> List.sort (fun (_, a, na, ia) (_, b, nb, ib) ->
@@ -782,6 +841,15 @@ let add_output_var_names names = function
 
 let referenced_var_names selector_props =
   List.fold_left add_output_var_names Strings.empty selector_props
+
+let add_output_metadata index = function
+  | Regular { props; nested; _ }
+  | Media_query { props; nested; _ }
+  | Container_query { props; nested; _ }
+  | Starting_style { props; nested; _ }
+  | Supports_query { props; nested; _ } ->
+      let index = add_declarations_metadata index props in
+      add_vars_metadata index (Css.vars_of_rules nested)
 
 (* Theme tokens referenced via var() (e.g. an arbitrary [color:var(--color-red-
    500)]) must appear in @layer theme, but the extractor above only collects
@@ -908,7 +976,12 @@ let add_static_theme_decls ~theme extracted =
 
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
 let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
-    ?(default_decls = []) selector_props =
+    ?(default_decls = []) ?metadata selector_props =
+  let metadata =
+    match metadata with
+    | Some metadata -> metadata
+    | None -> List.fold_left add_output_metadata Metadata.empty selector_props
+  in
   let referenced = referenced_var_names selector_props in
   let extracted =
     extract_non_tw_custom_declarations selector_props
@@ -940,7 +1013,8 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
   pre @ extracted @ post
   |> List.filter_map (apply_token_override theme)
   |> List.filter_map (resolve_default_family theme)
-  |> sort_by_var_order ~theme |> theme_layer_rule ~layers
+  |> sort_by_var_order ~metadata ~theme
+  |> theme_layer_rule ~layers
 
 let theme_layer_of ?theme ?(default_decls = []) tw_classes =
   let selector_props = collect_selector_props tw_classes in
@@ -1023,23 +1097,31 @@ let first_usage_order set_var_names =
     set_var_names;
   seen
 
-(* Get property order from static registry. *)
-let property_order_from name =
-  match Var.property_order name with
+let property_order_from metadata fallback_order ~fallback name =
+  match metadata_property_order metadata name with
   | Some o -> o
   | None ->
-      failwith
-        ("Missing property_order for variable '" ^ name
-       ^ "'. Register ~property_order when defining the variable \
-          (Var.channel/property_default).")
+      Option.value ~default:fallback (Hashtbl.find_opt fallback_order name)
+
+let property_statement_order statements =
+  let order = Hashtbl.create 32 in
+  List.iteri
+    (fun index statement ->
+      match Css.as_property statement with
+      | Some (Css.Property_info info) ->
+          if not (Hashtbl.mem order info.name) then
+            Hashtbl.add order info.name index
+      | None -> ())
+    statements;
+  order
 
 (* Build family first-usage order from the first_usage_order hashtbl. Returns a
    hashtbl mapping family to its first occurrence index. *)
-let family_order first_usage_order =
+let family_order metadata first_usage_order =
   let family_order = Hashtbl.create 16 in
   Hashtbl.iter
     (fun name idx ->
-      match Var.family name with
+      match metadata_family metadata name with
       | Some fam -> (
           match Hashtbl.find_opt family_order fam with
           | None -> Hashtbl.add family_order fam idx
@@ -1078,8 +1160,8 @@ let uses_direct_property_order = function
 (* Canonical CSS-property rank for a [--tw-*] variable, following Tailwind's
    @property emission order. The [`Border] family spans several slots, so split
    it by name. *)
-let canonical_property_rank name =
-  match Var.family name with
+let canonical_property_rank metadata name =
+  match metadata_family metadata name with
   | Some (`Translate | `Scale | `Rotate | `Skew) -> 16 (* transform *)
   | Some `Gradient -> 28 (* background-image *)
   | Some `Leading -> 39 (* line-height *)
@@ -1130,8 +1212,8 @@ let compare_property_vars_same_rank ~get_family_order ~get_first_usage n1 n2 po1
       let fo2 = get_family_order n2 in
       if fo1 <> fo2 then compare fo1 fo2 else compare po1 po2
 
-let compare_property_vars ~get_family_order ~get_first_usage n1 n2 po1 po2 fam1
-    fam2 =
+let compare_property_vars ~metadata ~get_family_order ~get_first_usage n1 n2 po1
+    po2 fam1 fam2 =
   (* Variables with negative property_order and no family come FIRST *)
   match (fam1, po1 < 0, fam2, po2 < 0) with
   | None, true, None, true -> compare po1 po2
@@ -1148,7 +1230,9 @@ let compare_property_vars ~get_family_order ~get_first_usage n1 n2 po1 po2 fam1
         if fo1 <> fo2 then compare fo1 fo2 else compare po1 po2
   | _ ->
       let cr =
-        compare (canonical_property_rank n1) (canonical_property_rank n2)
+        compare
+          (canonical_property_rank metadata n1)
+          (canonical_property_rank metadata n2)
       in
       if cr <> 0 then cr
       else
@@ -1160,10 +1244,10 @@ let compare_property_vars ~get_family_order ~get_first_usage n1 n2 po1 po2 fam1
    variable names in lockstep, since one produces the initial-value order and
    the other the @property emission order for the same variables, and a mismatch
    would emit a properties layer that contradicts its own @property rules. *)
-let property_var_comparator first_usage_order =
-  let family_order = family_order first_usage_order in
+let property_var_comparator metadata fallback_order first_usage_order =
+  let family_order = family_order metadata first_usage_order in
   let get_family_order name =
-    match Var.family name with
+    match metadata_family metadata name with
     | Some fam -> (
         match Hashtbl.find_opt family_order fam with
         | Some o -> o
@@ -1176,25 +1260,36 @@ let property_var_comparator first_usage_order =
     | None -> 10000
   in
   fun n1 n2 ->
-    let fam1 = Var.family n1 in
-    let fam2 = Var.family n2 in
-    let po1 = property_order_from n1 in
-    let po2 = property_order_from n2 in
-    compare_property_vars ~get_family_order ~get_first_usage n1 n2 po1 po2 fam1
-      fam2
+    let fam1 = metadata_family metadata n1 in
+    let fam2 = metadata_family metadata n2 in
+    let po1 =
+      property_order_from metadata fallback_order ~fallback:(get_first_usage n1)
+        n1
+    in
+    let po2 =
+      property_order_from metadata fallback_order ~fallback:(get_first_usage n2)
+        n2
+    in
+    compare_property_vars ~metadata ~get_family_order ~get_first_usage n1 n2 po1
+      po2 fam1 fam2
 
-let sort_properties_by_order first_usage_order initial_values =
-  let cmp_name = property_var_comparator first_usage_order in
+let sort_properties_by_order metadata fallback_order first_usage_order
+    initial_values =
+  let cmp_name =
+    property_var_comparator metadata fallback_order first_usage_order
+  in
   let cmp (n1, _) (n2, _) = cmp_name n1 n2 in
   List.sort cmp initial_values
 
 (* Build property layer content with browser detection *)
-let property_layer_content first_usage_order initial_values other_statements =
+let property_layer_content metadata fallback_order first_usage_order
+    initial_values other_statements =
   let selector =
     Css.Selector.(list [ universal; Before Single; After Single; Backdrop ])
   in
   let sorted_values =
-    sort_properties_by_order first_usage_order initial_values
+    sort_properties_by_order metadata fallback_order first_usage_order
+      initial_values
   in
   let initial_declarations = List.map snd sorted_values in
   let rule = Css.rule ~selector initial_declarations in
@@ -1204,7 +1299,8 @@ let property_layer_content first_usage_order initial_values other_statements =
 
 (* Build the properties layer with browser detection for initial values *)
 (* Returns (properties_layer, property_rules) - @property rules are separate *)
-let properties_layer first_usage_order explicit_property_rules_statements =
+let properties_layer metadata fallback_order first_usage_order
+    explicit_property_rules_statements =
   let property_rules, other_statements =
     partition_properties explicit_property_rules_statements
   in
@@ -1214,7 +1310,8 @@ let properties_layer first_usage_order explicit_property_rules_statements =
   if deduplicated = [] && initial_values = [] then (Css.empty, [])
   else
     let layer =
-      property_layer_content first_usage_order initial_values other_statements
+      property_layer_content metadata fallback_order first_usage_order
+        initial_values other_statements
     in
     (layer, deduplicated)
 
@@ -1227,24 +1324,29 @@ let set_var_names_from_props props = Css.custom_prop_names props
     - set_var_names: names of variables that are SET via Custom_declaration
     - property_rules: explicit property rules from utilities *)
 let rec extract_style_vars_and_rules = function
-  | Style.Style { props; rules; property_rules; _ } ->
+  | Style.Style { props; rules; property_rules; metadata; _ } ->
       let vars_from_props = Css.vars_of_declarations props in
       let vars_from_rules =
         match rules with Some r -> Css.vars_of_rules r | None -> []
       in
       let set_names = set_var_names_from_props props in
-      (vars_from_props @ vars_from_rules, set_names, [ property_rules ])
+      ( vars_from_props @ vars_from_rules,
+        set_names,
+        [ property_rules ],
+        metadata )
   | Style.Modified (_, t) -> extract_style_vars_and_rules t
   | Style.Group ts ->
       let results = List.map extract_style_vars_and_rules ts in
-      let vars_list, set_names_list, prop_rules_list =
+      let vars_list, set_names_list, prop_rules_list, metadata_list =
         List.fold_right
-          (fun (v, s, p) (vs, ss, ps) -> (v :: vs, s :: ss, p :: ps))
-          results ([], [], [])
+          (fun (v, s, p, m) (vs, ss, ps, ms) ->
+            (v :: vs, s :: ss, p :: ps, m :: ms))
+          results ([], [], [], [])
       in
       ( List.concat vars_list,
         List.concat set_names_list,
-        List.concat prop_rules_list )
+        List.concat prop_rules_list,
+        List.concat metadata_list )
 
 (* Filter variables that need @property rules *)
 let vars_needing_property vars =
@@ -1265,9 +1367,7 @@ let property_rules_for vars excluded_names =
   |> List.filter (fun (Css.V v) ->
       let var_name = "--" ^ Css.var_name v in
       not (Strings.mem var_name excluded_names))
-  |> List.map (fun (Css.V v) ->
-      let var_name = "--" ^ Css.var_name v in
-      Css.property ~name:var_name Css.Universal ~inherits:false ())
+  |> List.filter_map (fun (Css.V v) -> Var.property_rule_of_var v)
 
 (** Collect all property rules: explicit ones and auto-generated ones. Only
     auto-generates [\@property] for variables that are: 1. Actually SET (via
@@ -1313,8 +1413,11 @@ let layer_declaration ~has_properties ~include_base =
    sort key (this matches Tailwind's behavior where per-utility declaration
    order determines @property order). Falls back to family order then
    property_order for cross-family sorting. *)
-let sort_property_rules_by_usage first_usage_order property_rules_for_end =
-  let cmp_name = property_var_comparator first_usage_order in
+let sort_property_rules_by_usage metadata fallback_order first_usage_order
+    property_rules_for_end =
+  let cmp_name =
+    property_var_comparator metadata fallback_order first_usage_order
+  in
   property_rules_for_end
   |> List.sort (fun s1 s2 ->
       match (Css.as_property s1, Css.as_property s2) with
@@ -1343,8 +1446,8 @@ let dedup_keyframes_to_css keyframes =
 
 (** Assemble all CSS layers in the correct order *)
 let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
-    ~base_layer ~utilities_layer ~property_rules_for_end ~keyframes
-    ~first_usage_order =
+    ~base_layer ~utilities_layer ~property_rules_for_end ~keyframes ~metadata
+    ~fallback_order ~first_usage_order =
   let base_layers =
     if include_base then [ theme_layer; base_layer ] else [ theme_layer ]
   in
@@ -1366,7 +1469,8 @@ let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
     else initial_layers @ base_layers @ [ utilities_layer ]
   in
   let sorted_property_rules =
-    sort_property_rules_by_usage first_usage_order property_rules_for_end
+    sort_property_rules_by_usage metadata fallback_order first_usage_order
+      property_rules_for_end
   in
   let property_rules_css =
     if sorted_property_rules = [] then [] else [ Css.v sorted_property_rules ]
@@ -1380,14 +1484,16 @@ let assemble_all_layers ~layers ~include_base ~properties_layer ~theme_layer
    registered handler and allocates the whole declaration tree per class. *)
 let extract_vars_and_rules styles =
   let results = List.map extract_style_vars_and_rules styles in
-  let vars_list, set_names_list, prop_rules_list =
+  let vars_list, set_names_list, prop_rules_list, metadata_list =
     List.fold_right
-      (fun (v, s, p) (vs, ss, ps) -> (v :: vs, s :: ss, p :: ps))
-      results ([], [], [])
+      (fun (v, s, p, m) (vs, ss, ps, ms) ->
+        (v :: vs, s :: ss, p :: ps, m :: ms))
+      results ([], [], [], [])
   in
   ( List.concat vars_list,
     List.concat set_names_list,
-    List.concat prop_rules_list )
+    List.concat prop_rules_list,
+    List.concat metadata_list )
 
 (* Flatten property rules into CSS statements *)
 let flatten_property_rules property_rules_lists =
@@ -1440,7 +1546,8 @@ type layers_result = {
 }
 
 let individual_layers ~theme ~layers ~include_base ~forms_base ~has_transition
-    first_usage_order selector_props all_property_statements statements =
+    ~metadata ~fallback_order first_usage_order selector_props
+    all_property_statements statements =
   let theme_defaults =
     let font_defaults =
       if include_base then Typography.default_font_family_declarations else []
@@ -1453,7 +1560,7 @@ let individual_layers ~theme ~layers ~include_base ~forms_base ~has_transition
     font_defaults @ transition_defaults
   in
   let theme_layer =
-    theme_layer_of_props ~theme ~layers ~default_decls:theme_defaults
+    theme_layer_of_props ~theme ~layers ~default_decls:theme_defaults ~metadata
       selector_props
   in
   let base_layer = base_layer ~supports:placeholder_supports ~forms_base () in
@@ -1461,7 +1568,8 @@ let individual_layers ~theme ~layers ~include_base ~forms_base ~has_transition
     if all_property_statements = [] then (None, [])
     else
       let layer, prop_rules =
-        properties_layer first_usage_order all_property_statements
+        properties_layer metadata fallback_order first_usage_order
+          all_property_statements
       in
       match Css.statements layer with
       | [] -> (None, prop_rules)
@@ -1487,11 +1595,11 @@ let rec collect_keyframes acc = function
     "spin"/"pulse"/"bounce" are associated with theme variables
     "animate-spin"/"animate-pulse"/"animate-bounce" that have explicit
     (priority, suborder) tuples registered. *)
-let sort_keyframes_by_var_order keyframes =
+let sort_keyframes_by_var_order metadata keyframes =
   keyframes
   |> List.sort (fun (name1, _) (name2, _) ->
       let keyframe_var_order name =
-        match Var.order ("animate-" ^ name) with
+        match metadata_order metadata ("animate-" ^ name) with
         | Some (p, s) -> (p * 1000) + s
         | None -> 1000000 (* Unknown keyframes sort last *)
       in
@@ -1505,15 +1613,16 @@ let sort_keyframes_by_var_order keyframes =
 let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
     tw_classes statements =
   let styles = List.map (Utility.to_style theme) tw_classes in
-  let vars_from_utilities, set_var_names, property_rules_lists =
+  let vars_from_utilities, set_var_names, property_rules_lists, style_metadata =
     extract_vars_and_rules styles
   in
+  let metadata = metadata_index sorted_rules style_metadata in
   (* Build first-usage order from ALL vars per utility in utility order. For
      each utility, collects SET vars then REFERENCED vars needing @property.
      Within each utility, vars are sorted by property_order (done in
      var_names_of_sorted_rules). Across utilities, we preserve first-usage order
      to match Tailwind's behavior. *)
-  let all_vars = var_names_of_sorted_rules sorted_rules in
+  let all_vars = var_names_of_sorted_rules metadata sorted_rules in
   let first_usage_order = first_usage_order all_vars in
   let base_property_rules = flatten_property_rules property_rules_lists in
   (* Add content_var's property_rule if before/after pseudo-elements are used *)
@@ -1529,6 +1638,7 @@ let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
     collect_all_property_rules vars_from_utilities set_var_names
       explicit_property_rules
   in
+  let fallback_order = property_statement_order all_property_statements in
   (* The forms base layer is the plugin's [base] strategy: a global reset of
      native form controls. It is opt-in only ([~forms:true]), mirroring
      Tailwind's [\@plugin '@tailwindcss/forms']. The [.form-*] class-strategy
@@ -1538,18 +1648,20 @@ let layers ~theme ~layers ~include_base ?forms ~selector_props ~sorted_rules
   let individual =
     individual_layers ~theme ~layers ~include_base ~forms_base
       ~has_transition:(has_transition_utility tw_classes)
-      first_usage_order selector_props all_property_statements statements
+      ~metadata ~fallback_order first_usage_order selector_props
+      all_property_statements statements
   in
   let keyframes =
     List.fold_left collect_keyframes [] styles
-    |> List.rev |> sort_keyframes_by_var_order
+    |> List.rev
+    |> sort_keyframes_by_var_order metadata
   in
   assemble_all_layers ~layers ~include_base
     ~properties_layer:individual.properties_layer
     ~theme_layer:individual.theme_layer ~base_layer:individual.base_layer
     ~utilities_layer:individual.utilities_layer
-    ~property_rules_for_end:individual.property_rules ~keyframes
-    ~first_usage_order
+    ~property_rules_for_end:individual.property_rules ~keyframes ~metadata
+    ~fallback_order ~first_usage_order
 
 (* ======================================================================== *)
 (* CSS Generation API *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1033,47 +1033,46 @@ let theme_named_color ?theme name =
 (* The palette ([Red], [Blue], ...) is a fixed set of (colour, shade) pairs and
    its oklch nodes are immutable, so materialise each node once and share it
    across every utility and variant that uses the colour, instead of
-   reconstructing an identical node per use. Built once on first use; only the
-   constant palette constructors are keyed here, [Rgb]/[Theme_named] carry
-   open-ended payloads and build fresh. *)
+   reconstructing an identical node per use. Built during module initialisation
+   and then read-only; only the constant palette constructors are keyed here,
+   [Rgb]/[Theme_named] carry open-ended payloads and build fresh. *)
 let palette_nodes =
-  lazy
-    (let table = Hashtbl.create 256 in
-     List.iter
-       (fun (color, palette) ->
-         List.iter
-           (fun (shade, o) ->
-             Hashtbl.replace table (color, shade) (css_color_of_oklch o))
-           palette)
-       [
-         (Gray, Tailwind.gray);
-         (Slate, Tailwind.slate);
-         (Zinc, Tailwind.zinc);
-         (Neutral, Tailwind.neutral);
-         (Stone, Tailwind.stone);
-         (Mauve, Tailwind.mauve);
-         (Olive, Tailwind.olive);
-         (Mist, Tailwind.mist);
-         (Taupe, Tailwind.taupe);
-         (Red, Tailwind.red);
-         (Orange, Tailwind.orange);
-         (Amber, Tailwind.amber);
-         (Yellow, Tailwind.yellow);
-         (Lime, Tailwind.lime);
-         (Green, Tailwind.green);
-         (Emerald, Tailwind.emerald);
-         (Teal, Tailwind.teal);
-         (Cyan, Tailwind.cyan);
-         (Sky, Tailwind.sky);
-         (Blue, Tailwind.blue);
-         (Indigo, Tailwind.indigo);
-         (Violet, Tailwind.violet);
-         (Purple, Tailwind.purple);
-         (Fuchsia, Tailwind.fuchsia);
-         (Pink, Tailwind.pink);
-         (Rose, Tailwind.rose);
-       ];
-     table)
+  let table = Hashtbl.create 256 in
+  List.iter
+    (fun (color, palette) ->
+      List.iter
+        (fun (shade, o) ->
+          Hashtbl.replace table (color, shade) (css_color_of_oklch o))
+        palette)
+    [
+      (Gray, Tailwind.gray);
+      (Slate, Tailwind.slate);
+      (Zinc, Tailwind.zinc);
+      (Neutral, Tailwind.neutral);
+      (Stone, Tailwind.stone);
+      (Mauve, Tailwind.mauve);
+      (Olive, Tailwind.olive);
+      (Mist, Tailwind.mist);
+      (Taupe, Tailwind.taupe);
+      (Red, Tailwind.red);
+      (Orange, Tailwind.orange);
+      (Amber, Tailwind.amber);
+      (Yellow, Tailwind.yellow);
+      (Lime, Tailwind.lime);
+      (Green, Tailwind.green);
+      (Emerald, Tailwind.emerald);
+      (Teal, Tailwind.teal);
+      (Cyan, Tailwind.cyan);
+      (Sky, Tailwind.sky);
+      (Blue, Tailwind.blue);
+      (Indigo, Tailwind.indigo);
+      (Violet, Tailwind.violet);
+      (Purple, Tailwind.purple);
+      (Fuchsia, Tailwind.fuchsia);
+      (Pink, Tailwind.pink);
+      (Rose, Tailwind.rose);
+    ];
+  table
 
 (* Convert color to CSS color value *)
 let to_css ?theme color shade =
@@ -1100,7 +1099,7 @@ let to_css ?theme color shade =
       | None -> Css.Transparent)
   | Rgb _ -> oklch_node_of color shade
   | _ -> (
-      match Hashtbl.find_opt (Lazy.force palette_nodes) (color, shade) with
+      match Hashtbl.find_opt palette_nodes (color, shade) with
       | Some node -> node
       | None -> oklch_node_of color shade)
 
@@ -1389,22 +1388,18 @@ let theme_order_with_shade color_name shade =
    ignore it) rather than the materialized name, so a cache hit skips building
    the name string entirely - and within one generation bg/text/border share the
    same colour, so hits happen even on a single cold run. *)
-let color_var_cache : (color * int, Css.color Var.theme) Hashtbl.t =
-  Hashtbl.create 128
+let color_var_cache = Domain_cache.v 128
 
 (* Property-scoped colour variables (text-color-*, accent-color-*, ...) keyed by
    their full name, kept separate from the [(color, shade)] cache above. *)
-let property_color_var_cache : (string, Css.color Var.theme) Hashtbl.t =
-  Hashtbl.create 64
+let property_color_var_cache = Domain_cache.v 64
 
 (* Helper to create a color variable with memoization. Creates theme layer
    variables with deterministic ordering based on color and shade. *)
 let color_var color shade =
   let shadeless = is_shadeless color in
   let key = (color, if shadeless then 0 else shade) in
-  match Hashtbl.find_opt color_var_cache key with
-  | Some var -> var
-  | None ->
+  Domain_cache.or_add color_var_cache key (fun () ->
       let base = pp color in
       (* The name goes after the [--] this module does not write itself, so it
          is a CSS name rather than a whole ident: [escape_name] is the exact
@@ -1428,9 +1423,7 @@ let color_var color shade =
         if shadeless then theme_order_with_shade base 0
         else theme_order_with_shade base shade
       in
-      let var = Var.theme Css.Color name ~order:var_order in
-      Hashtbl.add color_var_cache key var;
-      var
+      Var.theme Css.Color name ~order:var_order)
 
 let color_to_string (c : color) : string =
   match c with
@@ -1905,20 +1898,16 @@ module Handler = struct
     let color_name = scheme_color_name c shade in
     let prop_name = property_prefix ^ "-" ^ color_name in
     match Scheme.theme_value theme prop_name with
-    | Some _ -> (
+    | Some _ ->
         (* Property-scoped theme value exists, create scoped variable *)
         let name = prop_name in
-        match Hashtbl.find_opt property_color_var_cache name with
-        | Some var -> var
-        | None ->
+        Domain_cache.or_add property_color_var_cache name (fun () ->
             let base = pp c in
             let var_order =
               if is_shadeless c then theme_order_with_shade base 0
               else theme_order_with_shade base shade
             in
-            let var = Var.theme Css.Color name ~order:var_order in
-            Hashtbl.add property_color_var_cache name var;
-            var)
+            Var.theme Css.Color name ~order:var_order)
     | None ->
         (* Fall back to generic --color-{name} *)
         color_var c shade

--- a/lib/domain_cache.ml
+++ b/lib/domain_cache.ml
@@ -1,0 +1,12 @@
+type ('key, 'value) t = ('key, 'value) Hashtbl.t Domain.DLS.key
+
+let v size = Domain.DLS.new_key (fun () -> Hashtbl.create size)
+
+let or_add cache key make =
+  let table = Domain.DLS.get cache in
+  match Hashtbl.find_opt table key with
+  | Some value -> value
+  | None ->
+      let value = make () in
+      Hashtbl.add table key value;
+      value

--- a/lib/domain_cache.mli
+++ b/lib/domain_cache.mli
@@ -1,0 +1,15 @@
+(** Lock-free caches whose mutable tables are local to each OCaml Domain. *)
+
+type ('key, 'value) t
+(** A cache key that can be shared between Domains. Each Domain observes its own
+    mutable table, so lookups need no process-wide mutex. *)
+
+val v : int -> ('key, 'value) t
+(** [v size] creates a cache whose table in each Domain starts with capacity
+    [size]. No table is allocated for a Domain until that Domain first uses the
+    cache. *)
+
+val or_add : ('key, 'value) t -> 'key -> (unit -> 'value) -> 'value
+(** [or_add cache key make] returns the value already cached for [key] in the
+    calling Domain. If none exists, it evaluates [make] and caches the result.
+    An exception raised by [make] is propagated and is not cached. *)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -307,6 +307,24 @@ module Handler = struct
     |> List.filter_map (fun x -> x)
     |> Css.concat
 
+  let shadow_property_metadata =
+    [
+      Var.metadata shadow_var;
+      Var.metadata shadow_color_var;
+      Var.metadata shadow_alpha_var;
+      Var.metadata inset_shadow_var;
+      Var.metadata inset_shadow_color_var;
+      Var.metadata inset_shadow_alpha_var;
+      Var.metadata ring_color_var;
+      Var.metadata ring_shadow_var;
+      Var.metadata inset_ring_color_var;
+      Var.metadata inset_ring_shadow_var;
+      Var.metadata ring_inset_var;
+      Var.metadata ring_offset_width_var;
+      Var.metadata ring_offset_color_var;
+      Var.metadata ring_offset_shadow_var;
+    ]
+
   let shorten_hex = Color.shorten_hex_str
 
   (* A bracket alpha with no [%] records the author's own number, unscaled and
@@ -466,21 +484,24 @@ module Handler = struct
       Css.shadow ~h_offset:Zero ~v_offset:Zero ~color:(Css.hex "#0000") ()
     in
     let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [ d_shadow; box_shadow_composition v_shadow ]
 
   let shadow_shape_style shape =
     let d_shadow, v_shadow =
       Var.binding shadow_var (shape_shadow_value shape)
     in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [ d_shadow; box_shadow_composition v_shadow ]
 
   let shadow_shape_opacity_style shape opacity =
     let d_shadow, v_shadow =
       Var.binding shadow_var (shape_shadow_opacity_value shape opacity)
     in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [ shadow_opacity_decl opacity; d_shadow; box_shadow_composition v_shadow ]
 
   let shadow_2xs = shadow_shape_style Two_xs
@@ -591,7 +612,8 @@ module Handler = struct
           Css.shadow ~h_offset ~v_offset ?blur ?spread ~color:(Var color_ref) ()
         in
         let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
-        style ~property_rules:shadow_property_rules
+        style ~metadata:shadow_property_metadata
+          ~property_rules:shadow_property_rules
           [ d_shadow; box_shadow_composition v_shadow ]
     | _ -> (
         match Css.parse_shadow normalized with
@@ -600,7 +622,8 @@ module Handler = struct
               wrap_shadow_colors ~color_var:shadow_color_var shadow
             in
             let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
-            style ~property_rules:shadow_property_rules
+            style ~metadata:shadow_property_metadata
+              ~property_rules:shadow_property_rules
               [ d_shadow; box_shadow_composition v_shadow ]
         | None -> shadow_none)
 
@@ -624,7 +647,8 @@ module Handler = struct
               wrap_shadow_colors ~color_var:shadow_color_var shadow
             in
             let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
-            style ~property_rules:shadow_property_rules
+            style ~metadata:shadow_property_metadata
+              ~property_rules:shadow_property_rules
               [ d_shadow; box_shadow_composition v_shadow ])
 
   let shadow_arbitrary_opacity (arb : string) opacity =
@@ -696,7 +720,8 @@ module Handler = struct
         match supports_rules with
         | [] ->
             (* No @supports — keep all declarations in one block *)
-            style ~property_rules:shadow_property_rules
+            style ~metadata:shadow_property_metadata
+              ~property_rules:shadow_property_rules
               [ alpha_d; d_shadow; box_shadow_composition v_shadow ]
         | _ ->
             (* Has @supports — split: alpha+shadow first (as regular rule), then
@@ -709,6 +734,7 @@ module Handler = struct
             in
             style
               ~rules:(Stdlib.Option.Some (alpha_shadow_rule :: supports_rules))
+              ~metadata:shadow_property_metadata
               ~property_rules:shadow_property_rules
               [ box_shadow_composition v_shadow ])
     | Stdlib.Option.None -> shadow_none
@@ -751,8 +777,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ theme_decl; enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_color_opacity ?theme c shade opacity =
     let percent = Color.opacity_to_percent opacity in
@@ -778,8 +804,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ theme_decl; enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_current () =
     let base_decl, _ = Var.binding shadow_color_var Css.Current in
@@ -789,8 +815,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_current_opacity opacity =
     let percent = Color.opacity_to_percent opacity in
@@ -805,8 +831,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_transparent () =
     let base_decl, _ = Var.binding shadow_color_var Css.Transparent in
@@ -816,8 +842,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_transparent_opacity opacity =
     let base_decl, _ = Var.binding shadow_color_var Css.Transparent in
@@ -828,12 +854,13 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_inherit () =
     let base_decl, _ = Var.binding shadow_color_var Css.Inherit in
-    style ~property_rules:shadow_property_rules [ base_decl ]
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_bracket_color (c : Css.color) =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
@@ -844,8 +871,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_bracket_color_opacity (c : Css.color) opacity =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
@@ -883,8 +910,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_bracket_color_var var_expr =
     let var_name = Parse.extract_var_name var_expr in
@@ -896,8 +923,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_shadow_bracket_cvar_opacity var_expr opacity =
     let percent = Color.opacity_to_percent opacity in
@@ -913,14 +940,15 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let shadow_raw_var v =
     let var_name = Parse.extract_var_name v in
     let shadow_value : Css.shadow = Css.Var (Var.bracket var_name) in
     let d_shadow, v_shadow = Var.binding shadow_var shadow_value in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [ d_shadow; box_shadow_composition v_shadow ]
 
   (* Inset shadow utilities - sets --tw-inset-shadow and composites
@@ -946,7 +974,8 @@ module Handler = struct
         Css.Var v_shadow;
       ]
     in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [ d_inset_shadow; Css.box_shadows box_shadow_vars ]
 
   let inset_shadow_theme theme name =
@@ -1167,7 +1196,8 @@ module Handler = struct
         let d_inset_shadow, v_inset_shadow =
           Var.binding inset_shadow_var inset_value
         in
-        style ~property_rules:shadow_property_rules
+        style ~metadata:shadow_property_metadata
+          ~property_rules:shadow_property_rules
           [ d_inset_shadow; inset_box_shadow_composition v_inset_shadow ]
     | Stdlib.Option.None -> inset_shadow_none
 
@@ -1191,7 +1221,8 @@ module Handler = struct
     let d_inset_shadow, v_inset_shadow =
       Var.binding inset_shadow_var inset_value
     in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [
         inset_shadow_opacity_decl opacity;
         d_inset_shadow;
@@ -1327,7 +1358,8 @@ module Handler = struct
         in
         match supports_rules with
         | [] ->
-            style ~property_rules:shadow_property_rules
+            style ~metadata:shadow_property_metadata
+              ~property_rules:shadow_property_rules
               [
                 alpha_d;
                 d_inset_shadow;
@@ -1340,6 +1372,7 @@ module Handler = struct
             in
             style
               ~rules:(Stdlib.Option.Some (alpha_shadow_rule :: supports_rules))
+              ~metadata:shadow_property_metadata
               ~property_rules:shadow_property_rules
               [ inset_box_shadow_composition v_inset_shadow ])
     | Stdlib.Option.None -> inset_shadow_none
@@ -1382,8 +1415,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ theme_decl; enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_color_opacity ?theme c shade opacity =
     let percent = Color.opacity_to_percent opacity in
@@ -1412,8 +1445,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ theme_decl; enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_current () =
     let base_decl, _ = Var.binding inset_shadow_color_var Css.Current in
@@ -1423,8 +1456,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_current_opacity opacity =
     let percent = Color.opacity_to_percent opacity in
@@ -1439,8 +1472,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_transparent () =
     let base_decl, _ = Var.binding inset_shadow_color_var Css.Transparent in
@@ -1450,8 +1483,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_transparent_opacity opacity =
     let base_decl, _ = Var.binding inset_shadow_color_var Css.Transparent in
@@ -1462,12 +1495,13 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_inherit () =
     let base_decl, _ = Var.binding inset_shadow_color_var Css.Inherit in
-    style ~property_rules:shadow_property_rules [ base_decl ]
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_inset_shadow_bracket_color (c : Css.color) =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
@@ -1478,8 +1512,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_ishadow_bracket_color_opacity (c : Css.color) opacity =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
@@ -1510,8 +1544,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_ishadow_bracket_cvar var_expr =
     let var_name = Parse.extract_var_name var_expr in
@@ -1523,8 +1557,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let set_ishadow_bracket_cvar_opacity var_expr opacity =
     let percent = Color.opacity_to_percent opacity in
@@ -1540,8 +1574,8 @@ module Handler = struct
     in
     let enhanced_decl, _ = Var.binding inset_shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ enhanced_decl ] in
-    style ~rules:(Some [ supports_block ]) ~property_rules:shadow_property_rules
-      [ base_decl ]
+    style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ base_decl ]
 
   let inset_shadow_raw_var v =
     let var_name = Parse.extract_var_name v in
@@ -1550,7 +1584,8 @@ module Handler = struct
       Css.Inset (Css.Var (Var.bracket var_name))
     in
     let decl, v_inset_shadow = Var.binding inset_shadow_var shadow_value in
-    style ~property_rules:shadow_property_rules
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
       [ decl; inset_box_shadow_composition v_inset_shadow ]
 
   let ring_internal width_px =
@@ -1687,7 +1722,8 @@ module Handler = struct
     in
     (* Register the ring/shadow @property family, like the other ring utilities;
        Tailwind emits it for ring-inset too. *)
-    style ~property_rules:shadow_property_rules [ decl ]
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules [ decl ]
 
   let ring_color ?theme color shade =
     let cvar =

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -209,6 +209,23 @@ module Handler = struct
         property_rule_or_empty drop_shadow_size_var;
       ]
 
+  let filter_property_metadata =
+    [
+      Var.metadata blur_var;
+      Var.metadata brightness_var;
+      Var.metadata contrast_var;
+      Var.metadata grayscale_var;
+      Var.metadata hue_rotate_var;
+      Var.metadata invert_var;
+      Var.metadata opacity_var;
+      Var.metadata saturate_var;
+      Var.metadata sepia_var;
+      Var.metadata drop_shadow_var;
+      Var.metadata drop_shadow_color_var;
+      Var.metadata drop_shadow_alpha_var;
+      Var.metadata drop_shadow_size_var;
+    ]
+
   (* Property rules for all backdrop-filter variables *)
   let backdrop_filter_property_rules =
     Css.concat
@@ -223,6 +240,19 @@ module Handler = struct
         property_rule_or_empty backdrop_saturate_var;
         property_rule_or_empty backdrop_sepia_var;
       ]
+
+  let backdrop_filter_property_metadata =
+    [
+      Var.metadata backdrop_blur_var;
+      Var.metadata backdrop_brightness_var;
+      Var.metadata backdrop_contrast_var;
+      Var.metadata backdrop_grayscale_var;
+      Var.metadata backdrop_hue_rotate_var;
+      Var.metadata backdrop_invert_var;
+      Var.metadata backdrop_opacity_var;
+      Var.metadata backdrop_saturate_var;
+      Var.metadata backdrop_sepia_var;
+    ]
 
   (* Composable filter chain: filter: var(--tw-blur, ) var(--tw-brightness, )
      ... *)
@@ -250,7 +280,8 @@ module Handler = struct
     fst (Css.var ~layer:"utilities" name Css.Filter value)
 
   let set_filter_var var_name (value : Css.filter) =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [ filter_var_decl var_name value; filter composable_filter_chain ]
 
   (* Generate a theme-layer declaration for a theme variable if its value is
@@ -268,7 +299,8 @@ module Handler = struct
   let set_filter_var_theme ?theme var_name theme_name
       (make_filter : Css.length -> Css.filter) () =
     let ref_ : Css.length Css.var = Var.theme_ref theme_name in
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       (theme_decl_if_set ?theme theme_name
       @ [
           filter_var_decl var_name (make_filter (Var ref_));
@@ -295,16 +327,11 @@ module Handler = struct
 
   (* A [--blur-*] token the project declared names a radius the built-in scale
      has no slot for; they share the slot after the scale. *)
-  let blur_named_cache : (string, Css.length Var.theme) Hashtbl.t =
-    Hashtbl.create 8
+  let blur_named_cache = Domain_cache.v 8
 
   let blur_named_var name =
-    match Hashtbl.find_opt blur_named_cache name with
-    | Some var -> var
-    | None ->
-        let var = Var.theme Css.Length ("blur-" ^ name) ~order:(8, 8) in
-        Hashtbl.add blur_named_cache name var;
-        var
+    Domain_cache.or_add blur_named_cache name (fun () ->
+        Var.theme Css.Length ("blur-" ^ name) ~order:(8, 8))
 
   let blur_md_var = Var.theme Css.Length "blur-md" ~order:(8, 2)
   let blur_lg_var = Var.theme Css.Length "blur-lg" ~order:(8, 3)
@@ -314,7 +341,8 @@ module Handler = struct
 
   let blur_size_utility (theme_var : Css.length Var.theme) default_px () =
     let decl, ref_ = Var.binding theme_var (Css.Px default_px) in
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         decl;
         filter_var_decl "--tw-blur" (Blur (Var ref_));
@@ -332,7 +360,8 @@ module Handler = struct
         | None -> style []
         | Some len ->
             let decl, ref_ = Var.binding (blur_named_var name) len in
-            style ~property_rules:filter_property_rules
+            style ~metadata:filter_property_metadata
+              ~property_rules:filter_property_rules
               [
                 decl;
                 filter_var_decl "--tw-blur" (Blur (Var ref_));
@@ -349,7 +378,8 @@ module Handler = struct
 
   (* [.blur] (no suffix) is the keyword utility - inline literal blur(8px). *)
   let blur () =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         filter_var_decl "--tw-blur" (Blur (Px 8.));
         filter composable_filter_chain;
@@ -519,7 +549,8 @@ module Handler = struct
          ())
 
   let drop_shadow_none =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         Css.custom_property ~layer:"utilities" "--tw-drop-shadow" " ";
         filter composable_filter_chain;
@@ -530,7 +561,8 @@ module Handler = struct
      a custom theme overrides [--drop-shadow] with a single shadow value, it is
      referenced via [drop-shadow(var(--drop-shadow))] instead. *)
   let drop_shadow_override ?theme () =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       (theme_decl_if_set ?theme "drop-shadow"
       @ [
           bind_drop_shadow_size
@@ -570,7 +602,8 @@ module Handler = struct
       ]
 
   let drop_shadow_default () =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         bind_drop_shadow_size (drop_shadow_default_size None);
         bind_drop_shadow drop_shadow_default_literal;
@@ -594,7 +627,8 @@ module Handler = struct
     let theme_decl, _ref =
       Var.binding theme_var (Css.shadow ~h_offset:h ~v_offset:v ~blur ~color ())
     in
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         theme_decl;
         bind_drop_shadow_size (drop_shadow_filter h v (Some blur) color);
@@ -681,7 +715,8 @@ module Handler = struct
           | [ single ] -> single
           | many -> Css.List many
         in
-        style ~property_rules:filter_property_rules
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
           [
             Css.custom_property ~layer:"theme" ("--" ^ theme_name) value;
             bind_drop_shadow_size size;
@@ -710,7 +745,8 @@ module Handler = struct
                ~color:fallback_b ());
         ]
     in
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         bind_drop_shadow_size size;
         bind_drop_shadow literal;
@@ -749,7 +785,8 @@ module Handler = struct
         None
 
   let drop_shadow_arbitrary_impl size =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         bind_drop_shadow_size size;
         bind_drop_shadow drop_shadow_size_ref;
@@ -757,7 +794,8 @@ module Handler = struct
       ]
 
   let drop_shadow_inherit_ =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         bind_drop_shadow_color Css.Inherit;
         bind_drop_shadow drop_shadow_size_ref;
@@ -790,7 +828,8 @@ module Handler = struct
         style ~rules:(Option.Some [ supports_block ])
           (theme_decl_if_set ?theme ("color-" ^ color_name)
           @ [ bind_drop_shadow_color fallback_color ]);
-        style ~property_rules:filter_property_rules
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
           [ bind_drop_shadow drop_shadow_size_ref ];
       ]
 
@@ -812,7 +851,8 @@ module Handler = struct
       [
         style ~rules:(Option.Some [ supports_block ])
           [ bind_drop_shadow_color color ];
-        style ~property_rules:filter_property_rules
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
           [ bind_drop_shadow drop_shadow_size_ref ];
       ]
 
@@ -833,7 +873,8 @@ module Handler = struct
       [
         style ~rules:(Option.Some [ supports_block ])
           [ bind_drop_shadow_color color ];
-        style ~property_rules:filter_property_rules
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
           [ bind_drop_shadow drop_shadow_size_ref ];
       ]
 
@@ -872,7 +913,8 @@ module Handler = struct
         style ~rules:(Option.Some [ supports_block ])
           (theme_decl_if_set ?theme ("color-" ^ color_name)
           @ [ bind_drop_shadow_color fallback_color ]);
-        style ~property_rules:filter_property_rules
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
           [ bind_drop_shadow drop_shadow_size_ref ];
       ]
 
@@ -908,7 +950,8 @@ module Handler = struct
             bind_drop_shadow drop_shadow_default_literal;
           ]
     in
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       (theme_decl_if_set ?theme "drop-shadow"
       @ Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
           alpha_str
@@ -937,7 +980,8 @@ module Handler = struct
       else Css.Pp.string_of_float percent ^ "%"
     in
     let fallback = Color.hex_to_oklab_alpha "#000000" (percent /. 100.) in
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [
         Css.custom_property ~layer:"utilities" "--tw-drop-shadow-alpha"
           alpha_str;
@@ -986,7 +1030,8 @@ module Handler = struct
   (* Helper: set a --tw-backdrop-<name> var and output composable backdrop
      chain *)
   let set_backdrop_var var_name (value : Css.filter) =
-    style ~property_rules:backdrop_filter_property_rules
+    style ~metadata:backdrop_filter_property_metadata
+      ~property_rules:backdrop_filter_property_rules
       [
         filter_var_decl var_name value;
         Css.webkit_backdrop_filter composable_backdrop_filter_chain;
@@ -1017,7 +1062,8 @@ module Handler = struct
           | None -> theme_name)
     in
     let ref_ : Css.length Css.var = Var.theme_ref actual_theme_name in
-    style ~property_rules:backdrop_filter_property_rules
+    style ~metadata:backdrop_filter_property_metadata
+      ~property_rules:backdrop_filter_property_rules
       (theme_decl_if_set ?theme actual_theme_name
       @ [
           filter_var_decl var_name (make_filter (Var ref_));
@@ -1039,7 +1085,8 @@ module Handler = struct
               (fun l -> Blur l)
               ()
         | None ->
-            style ~property_rules:backdrop_filter_property_rules
+            style ~metadata:backdrop_filter_property_metadata
+              ~property_rules:backdrop_filter_property_rules
               [
                 Css.custom_property ~layer:"utilities" "--tw-backdrop-blur" " ";
                 Css.webkit_backdrop_filter composable_backdrop_filter_chain;
@@ -1051,7 +1098,8 @@ module Handler = struct
      the default theme ships only --blur-*. *)
   let backdrop_blur_size (theme_var : Css.length Var.theme) default_px () =
     let decl, ref_ = Var.binding theme_var (Css.Px default_px) in
-    style ~property_rules:backdrop_filter_property_rules
+    style ~metadata:backdrop_filter_property_metadata
+      ~property_rules:backdrop_filter_property_rules
       [
         decl;
         filter_var_decl "--tw-backdrop-blur" (Blur (Var ref_));
@@ -1064,7 +1112,8 @@ module Handler = struct
 
   (* [.backdrop-blur] (no suffix) emits literal [blur(8px)] in v4. *)
   let backdrop_blur () =
-    style ~property_rules:backdrop_filter_property_rules
+    style ~metadata:backdrop_filter_property_metadata
+      ~property_rules:backdrop_filter_property_rules
       [
         filter_var_decl "--tw-backdrop-blur" (Blur (Px 8.));
         Css.webkit_backdrop_filter composable_backdrop_filter_chain;
@@ -1159,14 +1208,16 @@ module Handler = struct
 
   (* Composable filter using all the filter variables *)
   let filter_ =
-    style ~property_rules:filter_property_rules
+    style ~metadata:filter_property_metadata
+      ~property_rules:filter_property_rules
       [ filter composable_filter_chain ]
 
   let filter_none = style [ filter None ]
 
   (* Composable backdrop-filter using all the backdrop-filter variables *)
   let backdrop_filter_ =
-    style ~property_rules:backdrop_filter_property_rules
+    style ~metadata:backdrop_filter_property_metadata
+      ~property_rules:backdrop_filter_property_rules
       [
         Css.webkit_backdrop_filter composable_backdrop_filter_chain;
         backdrop_filter composable_backdrop_filter_chain;

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -324,9 +324,9 @@ module Handler = struct
       mask_image mask_image_list;
     ]
 
-  (* @property rule helpers - creates rule AND registers property_order *)
+  (* @property rule helpers. *)
   let prop ?(order = 100) name initial =
-    Var.register_property_order ~name:("tw-mask-" ^ name) ~order;
+    let _ = order in
     property ~name:("--tw-mask-" ^ name) Universal ~initial_value:initial
       ~inherits:false ()
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -457,13 +457,13 @@ let split_on_colon s =
    one accepts it, and most handlers open by splitting that same name, so a
    single class is split once per handler tried. The split is a pure function of
    its argument, so remembering the last one collapses that run to one. *)
-let last_split : (string * string list) option ref = ref None
+let last_split = Domain.DLS.new_key (fun () -> None)
 
 let split_class class_name =
-  match !last_split with
+  match Domain.DLS.get last_split with
   | Some (key, parts) when key == class_name || String.equal key class_name ->
       parts
   | _ ->
       let parts = split_class_uncached class_name in
-      last_split := Some (class_name, parts);
+      Domain.DLS.set last_split (Some (class_name, parts));
       parts

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -90,22 +90,17 @@ let parse_neg_bracket_length s : Css.length option =
   else None
 
 (* Memoization cache for inset-named theme variables *)
-let inset_named_cache : (string, Css.length Var.theme) Hashtbl.t =
-  Hashtbl.create 16
+let inset_named_cache = Domain_cache.v 16
 
 (* Get or create a theme variable for a named inset value like
    --inset-shadowned. Uses order (3, 200) to place in theme layer after numbered
    spacing variables (which are at 3, 100+n). *)
 let inset_named_var name =
-  match Hashtbl.find_opt inset_named_cache name with
-  | Some var -> var
-  | None ->
+  Domain_cache.or_add inset_named_cache name (fun () ->
       let var_name = "inset-" ^ name in
       (* Order (3, 200) places named inset vars after numbered spacing (3,
          100+n) *)
-      let var = Var.theme Css.Length var_name ~order:(3, 200) in
-      Hashtbl.add inset_named_cache name var;
-      var
+      Var.theme Css.Length var_name ~order:(3, 200))
 
 (* Create a named inset value using a theme variable like --inset-shadowned.
    Returns the theme declaration and a length that references the variable. *)

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -63,18 +63,21 @@ type t = {
 }
 (** Theme scheme configuration *)
 
-(** Process-global registry of theme token DEFAULTS (the v4.3.1 baseline).
-    Populated once at module-init by the utilities that own theme tokens
-    (replaces the [Var.theme_ref_registry] defaults). Defaults are static, so
-    they live here rather than in the per-render {!t}; overrides are threaded
-    via {!t.token_overrides}. *)
-let default_tokens : (string, string) Hashtbl.t = Hashtbl.create 64
+module Tokens = Map.Make (String)
+(** Lock-free snapshot of the static v4.3.1 theme-token catalog. Utilities
+    publish their baseline entries once at module initialisation; per-render
+    values remain in {!t.token_overrides}. *)
 
-let register_default_token name css = Hashtbl.replace default_tokens name css
-let token_default name = Hashtbl.find_opt default_tokens name
+let default_tokens = Atomic.make Tokens.empty
 
-let all_default_tokens () =
-  Hashtbl.fold (fun k v acc -> (k, v) :: acc) default_tokens []
+let rec register_default_token name css =
+  let current = Atomic.get default_tokens in
+  let next = Tokens.add name css current in
+  if not (Atomic.compare_and_set default_tokens current next) then
+    register_default_token name css
+
+let token_default name = Tokens.find_opt name (Atomic.get default_tokens)
+let all_default_tokens () = Tokens.bindings (Atomic.get default_tokens)
 
 (** Default scheme - uses oklch colors and calc-based spacing (matches Tailwind
     v4 default) *)

--- a/lib/scheme.mli
+++ b/lib/scheme.mli
@@ -82,8 +82,9 @@ val default : t
 
 val register_default_token : string -> string -> unit
 (** [register_default_token name css] registers the v4.3.1 baseline default CSS
-    for theme token [name] (without [--]) in the process-global registry. Called
-    once at module-init by the utility that owns the token. *)
+    for theme token [name] (without [--]). It updates a lock-free immutable
+    snapshot and is called once at module initialisation by the utility that
+    owns the token. *)
 
 val all_default_tokens : unit -> (string * string) list
 (** [all_default_tokens ()] is every token a family has published through

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -632,18 +632,11 @@ module Handler = struct
   (* A [--aspect-*] token the project declared names a ratio the built-in scale
      has no slot for; the utility references it and the theme layer carries the
      project's own spelling. *)
-  let aspect_named_cache : (string, Css.aspect_ratio Var.theme) Hashtbl.t =
-    Hashtbl.create 8
+  let aspect_named_cache = Domain_cache.v 8
 
   let aspect_named_var name =
-    match Hashtbl.find_opt aspect_named_cache name with
-    | Some var -> var
-    | None ->
-        let var =
-          Var.theme Css.Aspect_ratio ("aspect-" ^ name) ~order:(8, 21)
-        in
-        Hashtbl.add aspect_named_cache name var;
-        var
+    Domain_cache.or_add aspect_named_cache name (fun () ->
+        Var.theme Css.Aspect_ratio ("aspect-" ^ name) ~order:(8, 21))
 
   let is_theme_aspect theme n =
     Scheme.theme_value (Some theme) ("aspect-" ^ n) <> None

--- a/lib/style.ml
+++ b/lib/style.ml
@@ -323,6 +323,7 @@ type t =
       props : Css.declaration list;
       rules : Css.statement list option;
       property_rules : Css.t;
+      metadata : Var.metadata list;
       merge_key : string option;
       pseudo_suffix : Css.Selector.t option;
     }
@@ -339,9 +340,25 @@ type max_scale = [ scale | `Xl_4 | `Xl_5 | `Xl_6 | `Xl_7 ]
 type shadow = [ size | `Inner ]
 
 (* Helper to create a style *)
-let style ?(rules = None) ?(property_rules = Css.empty) ?merge_key
-    ?pseudo_suffix props =
-  Style { props; rules; property_rules; merge_key; pseudo_suffix }
+let style ?(rules = None) ?(property_rules = Css.empty) ?(metadata = [])
+    ?merge_key ?pseudo_suffix props =
+  let declaration_metadata =
+    List.filter_map Var.metadata_of_declaration props
+  in
+  let var_metadata =
+    Css.vars_of_declarations props
+    @ Option.fold ~none:[] ~some:Css.vars_of_rules rules
+    |> List.filter_map (fun (Css.V var) -> Var.metadata_of_var var)
+  in
+  Style
+    {
+      props;
+      rules;
+      property_rules;
+      metadata = metadata @ declaration_metadata @ var_metadata;
+      merge_key;
+      pseudo_suffix;
+    }
 
 (* Mark the property declarations a style emits as !important (the [!] utility
    prefix), recursing through modifiers, groups and nested rules. Custom

--- a/lib/style.mli
+++ b/lib/style.mli
@@ -305,6 +305,7 @@ type t =
       props : Css.declaration list;
       rules : Css.statement list option;
       property_rules : Css.t;
+      metadata : Var.metadata list;
       merge_key : string option;
       pseudo_suffix : Css.Selector.t option;
     }
@@ -366,6 +367,7 @@ val container_size_name : container_query -> string
 val style :
   ?rules:Css.statement list option ->
   ?property_rules:Css.t ->
+  ?metadata:Var.metadata list ->
   ?merge_key:string ->
   ?pseudo_suffix:Css.Selector.t ->
   Css.declaration list ->
@@ -374,6 +376,8 @@ val style :
     - [rules]: Optional custom CSS rules (for utilities like prose that generate
       multiple rules with descendant selectors).
     - [property_rules]: Optional CSS property rules needed by this utility.
+    - [metadata]: Metadata for variables represented by raw declarations or
+      explicit property rules; typed declarations are collected automatically.
     - [props]: CSS properties to apply. *)
 
 val map_important : t -> t

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -70,15 +70,7 @@ module Handler = struct
        value *)
     let decl_x, x_ref = Var.binding border_spacing_x_var spacing_len in
     let decl_y, y_ref = Var.binding border_spacing_y_var spacing_len in
-    let property_rules =
-      [
-        Var.property_rule border_spacing_x_var;
-        Var.property_rule border_spacing_y_var;
-      ]
-      |> List.filter_map Fun.id
-    in
     style
-      ~property_rules:(Css.concat property_rules)
       [
         spacing_decl;
         decl_x;

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -71,6 +71,9 @@ module Handler = struct
     ]
     |> List.filter_map Fun.id |> Css.concat
 
+  let text_shadow_property_metadata =
+    [ Var.metadata text_shadow_color_var; Var.metadata text_shadow_alpha_var ]
+
   let shorten_hex = Color.shorten_hex_str
 
   (* A [#] value only names a colour when what follows is a hex spelling;
@@ -401,6 +404,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ theme_decl; enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_color_opacity ?theme c shade opacity =
@@ -425,6 +429,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ theme_decl; enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_current () =
@@ -436,6 +441,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_current_opacity opacity =
@@ -452,6 +458,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_transparent () =
@@ -463,6 +470,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_transparent_opacity opacity =
@@ -475,11 +483,13 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_inherit () =
     let base_decl, _ = Var.binding text_shadow_color_var Css.Inherit in
-    style ~property_rules:text_shadow_property_rules [ base_decl ]
+    style ~metadata:text_shadow_property_metadata
+      ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_bracket_hex hex =
     let short = shorten_hex ("#" ^ hex) in
@@ -491,6 +501,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_bracket_hex_opacity hex opacity =
@@ -508,6 +519,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   (* A bracket colour spelled any way but a [#] hex: a name, a colour function
@@ -523,6 +535,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_bracket_color_opacity (c : Css.color) opacity =
@@ -542,6 +555,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_bracket_color_var var_expr =
@@ -555,6 +569,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_bracket_color_var_opacity var_expr opacity =
@@ -572,6 +587,7 @@ module Handler = struct
     let enhanced_decl, _ = Var.binding text_shadow_color_var outer_mix in
     let supports_block = color_mix_supports [ enhanced_decl ] in
     style ~rules:(Some [ supports_block ])
+      ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   (* ============ Arbitrary shadow styles ============ *)
@@ -593,7 +609,8 @@ module Handler = struct
         let color_ref =
           Var.reference_with_fallback text_shadow_color_var fallback_color
         in
-        style ~property_rules:text_shadow_property_rules
+        style ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules
           [
             Css.text_shadow
               (Css.Text_shadow
@@ -680,8 +697,8 @@ module Handler = struct
               let supports_block = color_mix_supports [ enhanced_shadow ] in
               Some [ supports_block ]
         in
-        style ~rules ~property_rules:text_shadow_property_rules
-          [ alpha_d; base_shadow ]
+        style ~rules ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules [ alpha_d; base_shadow ]
     | Stdlib.Option.None -> style [ Css.text_shadow Css.None ]
 
   (* ============ Style dispatch ============ *)
@@ -697,14 +714,17 @@ module Handler = struct
     in
     function
     | None ->
-        style ~property_rules:text_shadow_property_rules
+        style ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules
           [ Css.text_shadow Css.None ]
     | Shape shape ->
-        style ~property_rules:text_shadow_property_rules
+        style ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules
           [ shape_text_shadow shape ]
     | Shape_opacity (shape, opacity) ->
         let percent = Color.opacity_to_percent opacity in
-        style ~property_rules:text_shadow_property_rules
+        style ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules
           [ alpha_decl percent; shape_text_shadow_opacity shape opacity ]
     | Color (c, shade) -> set_color c shade
     | Color_opacity (c, shade, opacity) -> set_color_opacity c shade opacity
@@ -722,10 +742,12 @@ module Handler = struct
     | Bracket_cvar_opacity (var_expr, opacity) ->
         set_bracket_color_var_opacity var_expr opacity
     | Bracket_shadow var_expr ->
-        style ~property_rules:text_shadow_property_rules
+        style ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules
           [ Css.text_shadow (make_text_shadow_var var_expr) ]
     | Bracket_var var_expr ->
-        style ~property_rules:text_shadow_property_rules
+        style ~metadata:text_shadow_property_metadata
+          ~property_rules:text_shadow_property_rules
           [ Css.text_shadow (make_text_shadow_var var_expr) ]
     | Arbitrary arb -> arbitrary_shadow_style arb
     | Arbitrary_opacity (arb, opacity) ->

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -246,16 +246,11 @@ module Handler = struct
 
   (* A [--perspective-*] token the project declared names a depth the built-in
      scale has no slot for; they share the slot after the scale. *)
-  let perspective_named_cache : (string, Css.length Var.theme) Hashtbl.t =
-    Hashtbl.create 8
+  let perspective_named_cache = Domain_cache.v 8
 
   let perspective_named_var name =
-    match Hashtbl.find_opt perspective_named_cache name with
-    | Some var -> var
-    | None ->
-        let var = Var.theme Css.Length ("perspective-" ^ name) ~order:(8, 16) in
-        Hashtbl.add perspective_named_cache name var;
-        var
+    Domain_cache.or_add perspective_named_cache name (fun () ->
+        Var.theme Css.Length ("perspective-" ^ name) ~order:(8, 16))
 
   let perspective_none_var =
     Var.theme Css.Length "perspective-none" ~order:(8, 15)

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -340,18 +340,11 @@ module Handler = struct
 
   (* An [--ease-*] token the project declared names a timing function the
      built-in scale has no slot for; they share the slot after the scale. *)
-  let ease_named_cache : (string, Css.timing_function Var.theme) Hashtbl.t =
-    Hashtbl.create 8
+  let ease_named_cache = Domain_cache.v 8
 
   let ease_named_var name =
-    match Hashtbl.find_opt ease_named_cache name with
-    | Some var -> var
-    | None ->
-        let var =
-          Var.theme Css.Timing_function ("ease-" ^ name) ~order:(7, 34)
-        in
-        Hashtbl.add ease_named_cache name var;
-        var
+    Domain_cache.or_add ease_named_cache name (fun () ->
+        Var.theme Css.Timing_function ("ease-" ^ name) ~order:(7, 34))
 
   let ease_in_out_var =
     Var.theme Css.Timing_function "ease-in-out" ~order:(7, 32)

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -97,18 +97,11 @@ let font_weight_black_var =
 
 (* A [--font-weight-*] token the project declared names a weight the built-in
    scale has no slot for; they share the slot after the scale. *)
-let font_weight_named_cache : (string, Css.font_weight Var.theme) Hashtbl.t =
-  Hashtbl.create 8
+let font_weight_named_cache = Domain_cache.v 8
 
 let font_weight_named_var name =
-  match Hashtbl.find_opt font_weight_named_cache name with
-  | Some var -> var
-  | None ->
-      let var =
-        Var.theme Css.Font_weight ("font-weight-" ^ name) ~order:(6, 38)
-      in
-      Hashtbl.add font_weight_named_cache name var;
-      var
+  Domain_cache.or_add font_weight_named_cache name (fun () ->
+      Var.theme Css.Font_weight ("font-weight-" ^ name) ~order:(6, 38))
 
 (* Theme variables for named tracking values *)
 let tracking_tighter_var = Var.theme Css.Length "tracking-tighter" ~order:(6, 39)
@@ -121,16 +114,11 @@ let tracking_widest_var = Var.theme Css.Length "tracking-widest" ~order:(6, 44)
 (* A [--tracking-*] token the project declared names a letter spacing the
    built-in scale has no slot for; they share the slot after the scale, the way
    the project's font families and text sizes share theirs. *)
-let tracking_named_cache : (string, Css.length Var.theme) Hashtbl.t =
-  Hashtbl.create 8
+let tracking_named_cache = Domain_cache.v 8
 
 let tracking_named_var name =
-  match Hashtbl.find_opt tracking_named_cache name with
-  | Some var -> var
-  | None ->
-      let var = Var.theme Css.Length ("tracking-" ^ name) ~order:(6, 45) in
-      Hashtbl.add tracking_named_cache name var;
-      var
+  Domain_cache.or_add tracking_named_cache name (fun () ->
+      Var.theme Css.Length ("tracking-" ^ name) ~order:(6, 45))
 
 (* Theme variables for named leading values *)
 let leading_none_var = Var.theme Css.Line_height "leading-none" ~order:(6, 47)
@@ -236,42 +224,27 @@ let default_font_variant_theme : font_variant_theme =
 (* Font family theme variables. A project [@theme] can name families of its own
    ([--font-source]); order (1, 100) puts those after the three built-in
    stacks. *)
-let font_named_cache : (string, Css.font_family Var.theme) Hashtbl.t =
-  Hashtbl.create 8
+let font_named_cache = Domain_cache.v 8
 
 let font_named_var name =
-  match Hashtbl.find_opt font_named_cache name with
-  | Some var -> var
-  | None ->
-      let var = Var.theme Css.Font_family ("font-" ^ name) ~order:(1, 100) in
-      Hashtbl.add font_named_cache name var;
-      var
+  Domain_cache.or_add font_named_cache name (fun () ->
+      Var.theme Css.Font_family ("font-" ^ name) ~order:(1, 100))
 
 (* A [--text-*] token the project declared names a font size the built-in scale
    has no slot for; they share the slot after the scale, the way the project's
    font families share theirs. *)
-let text_named_cache : (string, Css.length Var.theme) Hashtbl.t =
-  Hashtbl.create 8
+let text_named_cache = Domain_cache.v 8
 
 let text_named_var name =
-  match Hashtbl.find_opt text_named_cache name with
-  | Some var -> var
-  | None ->
-      let var = Var.theme Css.Length ("text-" ^ name) ~order:(6, 26) in
-      Hashtbl.add text_named_cache name var;
-      var
+  Domain_cache.or_add text_named_cache name (fun () ->
+      Var.theme Css.Length ("text-" ^ name) ~order:(6, 26))
 
 (* The same for a [--leading-*] token the project declared. *)
-let leading_named_cache : (string, Css.line_height Var.theme) Hashtbl.t =
-  Hashtbl.create 8
+let leading_named_cache = Domain_cache.v 8
 
 let leading_named_var name =
-  match Hashtbl.find_opt leading_named_cache name with
-  | Some var -> var
-  | None ->
-      let var = Var.theme Css.Line_height ("leading-" ^ name) ~order:(6, 53) in
-      Hashtbl.add leading_named_cache name var;
-      var
+  Domain_cache.or_add leading_named_cache name (fun () ->
+      Var.theme Css.Line_height ("leading-" ^ name) ~order:(6, 53))
 
 let font_sans_var = Var.theme Css.Font_family "font-sans" ~order:(1, 0)
 let font_serif_var = Var.theme Css.Font_family "font-serif" ~order:(1, 1)
@@ -661,9 +634,9 @@ module Typography_early = struct
     <> None
 
   (* A font size the project named in its [@theme]. The built-in scale is
-     published through the same registry, so exclude it: those names have their
-     own constructors. [text-<name>] also spells a colour, and a project that
-     declares both under one name gets the colour, as Tailwind does.
+     published through the static token catalog, so exclude it: those names have
+     their own constructors. [text-<name>] also spells a colour, and a project
+     that declares both under one name gets the colour, as Tailwind does.
      [--text-shadow-*] is a namespace of its own, and a doubled hyphen marks a
      modifier on another token ([--text-lg--line-height]), so neither names a
      size; nor does a token whose value is not a length. *)

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -45,8 +45,6 @@ end
 
 type handler = H : (module Registered with type t = 'a) -> handler
 
-let handlers : handler list ref = ref []
-
 (* A project's [@utility] sorts at the slot of the property it declares, so that
    slot has to be readable from a property. Each handler offers a few of its own
    utilities as {!Handler.examples}; running them through [to_style] says which
@@ -55,15 +53,25 @@ let handlers : handler list ref = ref []
    utilities - nothing here restates it. *)
 (* [true] on an entry means it came from a property the utility writes on the
    element itself, which outranks one it writes only inside a nested rule. *)
-let property_slots :
-    (Cascade.Css.Declaration.prop_key, bool * (int * int)) Hashtbl.t option ref
-    =
-  ref None
+type registry = {
+  handlers : handler list;
+  property_slots :
+    (Cascade.Css.Declaration.prop_key, bool * (int * int)) Hashtbl.t option;
+}
+
+let registry = Atomic.make { handlers = []; property_slots = None }
+let handlers_snapshot () = (Atomic.get registry).handlers
 
 let register (type a) (module M : Registered with type t = a) =
   let internal_h = H (module M : Registered with type t = a) in
-  property_slots := None;
-  handlers := internal_h :: !handlers
+  let rec add () =
+    let current = Atomic.get registry in
+    let next =
+      { handlers = internal_h :: current.handlers; property_slots = None }
+    in
+    if not (Atomic.compare_and_set registry current next) then add ()
+  in
+  add ()
 
 module Make (M : Handler) = struct
   type base += Self of M.t
@@ -158,7 +166,7 @@ let ordering_property declarations =
   in
   scan declarations
 
-let build_property_slots () =
+let build_property_slots handlers =
   let tbl = Hashtbl.create 512 in
   (* A property a utility writes on the element itself decides that utility's
      family; one it writes only inside a rule it carries does not, unless
@@ -189,19 +197,20 @@ let build_property_slots () =
               ordering_property (style_declarations style)
               |> Option.iter (fun key -> record ~own:false key order))
         M.examples)
-    !handlers;
+    handlers;
   tbl
 
 let order_of_property key =
-  let tbl =
-    match !property_slots with
-    | Some tbl -> tbl
+  let rec slots () =
+    let current = Atomic.get registry in
+    match current.property_slots with
+    | Some table -> table
     | None ->
-        let tbl = build_property_slots () in
-        property_slots := Some tbl;
-        tbl
+        let table = build_property_slots current.handlers in
+        let next = { current with property_slots = Some table } in
+        if Atomic.compare_and_set registry current next then table else slots ()
   in
-  Option.map snd (Hashtbl.find_opt tbl key)
+  Option.map snd (Hashtbl.find_opt (slots ()) key)
 
 let name_of_base u =
   let rec try_handlers = function
@@ -209,11 +218,11 @@ let name_of_base u =
     | H (module M) :: rest -> (
         match M.project u with Some _ -> M.name | None -> try_handlers rest)
   in
-  try_handlers !handlers
+  try_handlers (handlers_snapshot ())
 
 let class_of_base u =
   let visit (H (module M)) = Option.map M.to_class (M.project u) in
-  match List.find_map visit !handlers with
+  match List.find_map visit (handlers_snapshot ()) with
   | Some class_name -> class_name
   | None -> failwith "class_of_base"
 
@@ -225,13 +234,13 @@ let base_of_class theme class_name =
         | Ok x -> Ok (M.inject x)
         | Error _ -> try_handlers rest)
   in
-  try_handlers !handlers
+  try_handlers (handlers_snapshot ())
 
 (* Every utility each handler offers as its own example, as class names. *)
 let examples_classes () =
   List.concat_map
     (fun (H (module M)) -> List.map M.to_class M.examples)
-    !handlers
+    (handlers_snapshot ())
 
 (* Every handler that would claim [class_name], by name. [base_of_class] takes
    the first, and the order is the dune link order, so a class two handlers both
@@ -243,7 +252,7 @@ let claiming_handlers theme class_name =
       match M.of_class theme class_name with
       | Ok _ -> Some M.name
       | Error _ -> None)
-    !handlers
+    (handlers_snapshot ())
 
 (* Keep for backward compatibility with tests *)
 let base_of_strings theme parts =
@@ -251,10 +260,11 @@ let base_of_strings theme parts =
   base_of_class theme class_name
 
 let base_to_style theme u =
+  let handlers = handlers_snapshot () in
   let rec try_handlers = function
     | [] ->
         prerr_endline
-          ("Total handlers registered: " ^ string_of_int (List.length !handlers));
+          ("Total handlers registered: " ^ string_of_int (List.length handlers));
         failwith
           "Unknown utility type - handler not registered. This is a bug in the \
            utility system."
@@ -263,7 +273,7 @@ let base_to_style theme u =
         | Some x -> M.to_style theme x
         | None -> try_handlers rest)
   in
-  try_handlers !handlers
+  try_handlers handlers
 
 let rec to_style theme = function
   | Base u -> base_to_style theme u
@@ -305,7 +315,7 @@ let order (u : base) : int * int =
         | Some x -> (M.priority x, M.suborder x)
         | None -> try_handlers rest)
   in
-  try_handlers !handlers
+  try_handlers (handlers_snapshot ())
 
 let deduplicate utilities =
   let rec go seen acc = function

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -7,9 +7,9 @@ module Css = Cascade.Css
 (* Layer classification for CSS variables *)
 type layer = Theme | Utility
 
-(* Tailwind spells one registered zero two ways: [--tw-ring-offset-width: 0px]
-   in the properties layer's bulk declaration, but [initial-value: 0] in its own
-   [@property] rule. Other zero-initialised [Length] variables (e.g.
+(* Tailwind spells one custom-property zero two ways: [--tw-ring-offset-width:
+   0px] in the properties layer's bulk declaration, but [initial-value: 0] in
+   its own [@property] rule. Other zero-initialised [Length] variables (e.g.
    border-spacing-x/y) get "0" in both places, so this isn't a general
    Length-zero rule cascade's printer could apply - it's a one-name quirk of
    Tailwind's own output that has to be special-cased here. A total function, so
@@ -42,6 +42,7 @@ type ('a, 'r) t = {
       (* Function to create declaration and var ref *)
   property : 'a property_info option; (* For @property registration *)
   fallback : 'a option; (* Built-in fallback for ref_only variables *)
+  meta : Css.meta;
 }
 
 (* Type shortcuts for common patterns *)
@@ -50,178 +51,62 @@ type 'a property_default = ('a, [ `Property_default ]) t
 type 'a channel = ('a, [ `Channel ]) t
 type 'a ref_only = ('a, [ `Ref_only ]) t
 
-(* Global registry of the metadata the layer builders look up by variable name,
-   filled by [v] as each variable definition is evaluated. *)
-module Registry = struct
-  (* Table mapping variable_name -> (priority, suborder) *)
-  let name_registry : (string, int * int) Hashtbl.t = Hashtbl.create 128
-
-  (* Table mapping variable_name -> property_order for @supports block
-     ordering *)
-  let property_order_registry : (string, int) Hashtbl.t = Hashtbl.create 128
-
-  (* Families for ordering/grouping without string prefixes *)
-  type family =
-    [ `Border
-    | `Rotate
-    | `Skew
-    | `Scale
-    | `Translate
-    | `Gradient
-    | `Shadow
-    | `Inset_shadow
-    | `Ring
-    | `Inset_ring
-    | `Leading
-    | `Font_weight
-    | `Duration
-    | `Tracking
-    | `Content
-    | `Text_shadow
-    | `Filter
-    | `Drop_shadow
-    | `Backdrop_filter ]
-
-  let family_registry : (string, family) Hashtbl.t = Hashtbl.create 128
-  let needs_property_registry : (string, bool) Hashtbl.t = Hashtbl.create 128
-
-  (* A slot is shared, not owned: each token family numbers its members from its
-     own base, so several families sit at the same (priority, suborder) — e.g.
-     --radius-4xl, --drop-shadow-md and --ease-out are all (7, 10). The families
-     a project [@theme] names (--font-<name>, --animate-<name>, --inset-<name>)
-     funnel every member into one slot by design. The theme layer breaks a tie
-     on the variable name, so a shared slot is still a total order.
-
-     A name, on the other hand, owns its slot: it is one custom property and one
-     position in the theme layer. The definition that first claims a name fixes
-     that position, and a definition reaching a name that is already placed is
-     answered with the established slot. That is how a project naming one of the
-     built-in tokens lands: [--font-sans] from a project [@theme] arrives
-     through the [--font-<name>] family's shared slot, and keeps (1, 0). *)
-  let register_variable ~name ~order =
-    match Hashtbl.find_opt name_registry name with
-    | Some established -> established
-    | None ->
-        Hashtbl.replace name_registry name order;
-        order
-
-  (* A name owns its family and its [@property] need: each is a fact about one
-     custom property, not a slot several families share. A second registration
-     that agrees restates the fact; one that disagrees is a constant copied by
-     hand that has drifted, so it is refused rather than letting module
-     initialisation order decide the properties layer. *)
-  let register_once tbl ~what ~pp ~name ~value =
-    match Hashtbl.find_opt tbl name with
-    | Some established when established <> value ->
-        invalid_arg
-          (Pp.str
-             [
-               "--";
-               name;
-               ": ";
-               what;
-               " is ";
-               pp established;
-               ", registered again as ";
-               pp value;
-             ])
-    | Some _ -> ()
-    | None -> Hashtbl.replace tbl name value
-
-  let register_property_order ~name ~order =
-    register_once property_order_registry ~what:"property order" ~pp:Pp.int
-      ~name ~value:order
-
-  let property_order name =
-    (* Strip leading -- if present *)
-    let name =
-      if String.starts_with ~prefix:"--" name then
-        String.sub name 2 (String.length name - 2)
-      else name
-    in
-    Hashtbl.find_opt property_order_registry name
-
-  let order name =
-    (* Strip leading -- if present *)
-    let name =
-      if String.starts_with ~prefix:"--" name then
-        String.sub name 2 (String.length name - 2)
-      else name
-    in
-    Hashtbl.find_opt name_registry name
-
-  let family_name : family -> string = function
-    | `Border -> "Border"
-    | `Rotate -> "Rotate"
-    | `Skew -> "Skew"
-    | `Scale -> "Scale"
-    | `Translate -> "Translate"
-    | `Gradient -> "Gradient"
-    | `Shadow -> "Shadow"
-    | `Inset_shadow -> "Inset_shadow"
-    | `Ring -> "Ring"
-    | `Inset_ring -> "Inset_ring"
-    | `Leading -> "Leading"
-    | `Font_weight -> "Font_weight"
-    | `Duration -> "Duration"
-    | `Tracking -> "Tracking"
-    | `Content -> "Content"
-    | `Text_shadow -> "Text_shadow"
-    | `Filter -> "Filter"
-    | `Drop_shadow -> "Drop_shadow"
-    | `Backdrop_filter -> "Backdrop_filter"
-
-  let register_family ~name ~family =
-    register_once family_registry ~what:"family" ~pp:family_name ~name
-      ~value:family
-
-  let family name =
-    (* Strip leading -- if present *)
-    let name =
-      if String.starts_with ~prefix:"--" name then
-        String.sub name 2 (String.length name - 2)
-      else name
-    in
-    Hashtbl.find_opt family_registry name
-
-  let register_needs_property ~name ~needs =
-    register_once needs_property_registry ~what:"@property need" ~pp:Pp.bool
-      ~name ~value:needs
-
-  let needs_property name =
-    (* Strip leading -- if present *)
-    let name =
-      if String.starts_with ~prefix:"--" name then
-        String.sub name 2 (String.length name - 2)
-      else name
-    in
-    match Hashtbl.find_opt needs_property_registry name with
-    | Some b -> b
-    | None -> false
-end
-
-(* Get property order for a variable name (for external use in build.ml) *)
-let property_order = Registry.property_order
-let register_property_order = Registry.register_property_order
-let order = Registry.order
-let family = Registry.family
-let needs_property = Registry.needs_property
-
-type family = Registry.family
+(* Families for ordering/grouping without string prefixes. *)
+type family =
+  [ `Border
+  | `Rotate
+  | `Skew
+  | `Scale
+  | `Translate
+  | `Gradient
+  | `Shadow
+  | `Inset_shadow
+  | `Ring
+  | `Inset_ring
+  | `Leading
+  | `Font_weight
+  | `Duration
+  | `Tracking
+  | `Content
+  | `Text_shadow
+  | `Filter
+  | `Drop_shadow
+  | `Backdrop_filter ]
 
 type info =
   | Info : {
       name : string;
-      kind : 'a Css.kind;
-      need_property : bool;
+      kind : 'a Css.kind option;
+      property : 'a property_info option;
       order : (int * int) option;
+      property_order : int option;
+      family : family option;
       runtime : bool;
+      default_css : string option;
     }
       -> info
 
 let (meta_of_info : info -> Css.meta), (info_of_meta : Css.meta -> info option)
     =
   Css.meta ()
+
+type metadata = info
+
+let metadata_name (Info info) = info.name
+let metadata_order (Info info) = info.order
+let metadata_property_order (Info info) = info.property_order
+let metadata_family (Info info) = info.family
+let metadata_needs_property (Info info) = info.property <> None
+let metadata_default_css (Info info) = info.default_css
+let metadata_of_var v = Option.bind (Css.var_meta v) info_of_meta
+
+let metadata_of_declaration declaration =
+  Option.bind (Css.meta_of_declaration declaration) info_of_meta
+
+let metadata var =
+  match info_of_meta var.meta with
+  | Some metadata -> metadata
+  | None -> assert false
 
 let layer_name = function (Theme : layer) -> "theme" | Utility -> "utilities"
 
@@ -246,35 +131,17 @@ let v : type a r.
       failwith ("Variable '" ^ name ^ "' in theme layer must have an order")
   | _ -> ());
 
-  (* Claim the name's theme slot, and carry the slot the name settled on: a
-     declaration this variable binds sorts where the name sorts. *)
-  let order =
-    match order with
-    | Some ord -> Some (Registry.register_variable ~name ~order:ord)
-    | None -> None
-  in
-
-  (* Register property order if provided *)
-  (match property_order with
-  | Some ord -> Registry.register_property_order ~name ~order:ord
-  | None -> ());
-
-  (match family with
-  | Some fam -> Registry.register_family ~name ~family:fam
-  | None -> ());
-
-  (* Register needs_property so we can look it up by name *)
-  let need_property = property <> None in
-  if need_property then Registry.register_needs_property ~name ~needs:true;
-
   let info =
     Info
       {
-        kind;
+        kind = Some kind;
         name;
-        need_property;
+        property;
         order;
+        property_order;
+        family;
         runtime = Option.value runtime ~default:false;
+        default_css = None;
       }
   in
   let binding ?fallback:fb value =
@@ -291,7 +158,7 @@ let v : type a r.
     Css.var ~default:value ~fallback:actual_fallback ?layer:layer_name ~meta
       ?runtime name kind value
   in
-  { kind; name; role; binding; property; fallback }
+  { kind; name; role; binding; property; fallback; meta = meta_of_info info }
 
 (* Convenience constructors to encode patterns safely *)
 
@@ -382,6 +249,15 @@ let property_typed : type a.
 let property ~name kind initial ~inherits ~universal =
   if universal then property_universal ~name kind initial ~inherits
   else property_typed ~name kind initial ~inherits
+
+let property_rule_of_metadata (Info info) =
+  match (info.kind, info.property) with
+  | Some kind, Some { initial; inherits; universal } ->
+      Some (property ~name:("--" ^ info.name) kind initial ~inherits ~universal)
+  | _ -> None
+
+let property_rule_of_var var =
+  Option.bind (metadata_of_var var) property_rule_of_metadata
 
 (* Get @property rule if metadata present *)
 let property_rule : type a r. (a, r) t -> Css.t option =
@@ -480,18 +356,23 @@ let ref_only kind name ~fallback =
   (* Create a utility variable that's only referenced, never set *)
   v kind ~fallback ~role:Ref_only name ~layer:Utility
 
-(* Registry for theme_ref variables: maps var name -> default CSS string *)
-let theme_ref_registry : (string, string) Hashtbl.t = Hashtbl.create 64
-
 let theme_ref : type a. ?default:a -> ?default_css:string -> string -> a Css.var
     =
  fun ?default ?default_css name ->
-  (match default_css with
-  | Some css -> Hashtbl.replace theme_ref_registry name css
-  | None -> ());
-  Css.var_ref ~layer:"theme" ?default name
-
-let resolve_theme_refs name = Hashtbl.find_opt theme_ref_registry name
+  let info =
+    Info
+      {
+        kind = None;
+        name;
+        property = None;
+        order = None;
+        property_order = None;
+        family = None;
+        runtime = false;
+        default_css;
+      }
+  in
+  Css.var_ref ~layer:"theme" ~meta:(meta_of_info info) ?default name
 
 (* Turn a parsed [@property] statement's typed initial value into the
    declaration that sets it in the properties layer. [typed_custom_property]
@@ -516,7 +397,7 @@ let needs_property_rule v =
       false
   | Some meta -> (
       match info_of_meta meta with
-      | Some (Info i) -> i.need_property
+      | Some (Info i) -> i.property <> None
       | None -> assert false)
 
 let order_of_declaration decl =

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -405,13 +405,8 @@ val theme :
     Several variables may share an [order]: token families are numbered from
     their own base, and the families a project [\@theme] names funnel every
     member into one slot. The theme layer breaks such a tie on the variable
-    name.
-
-    A name, though, owns its slot. [order] places [name] the first time [name]
-    is defined; a later definition of the same name is placed where the name
-    already sits, and the variable it returns carries that slot. So a project
-    [\@theme] naming a built-in token reaches this function through its family's
-    shared slot and still leaves the token where it belongs. *)
+    name. Ordering metadata travels with the variable and its declarations;
+    construction does not mutate a process-global registry. *)
 
 val property_default :
   'a Css.kind ->
@@ -431,29 +426,10 @@ val property_default :
     [property_order] specifies the ordering of this variable in the
     {i \@layer properties \@supports} block. Lower values appear first.
 
-    {b IMPORTANT}: Due to current architecture limitations, any style that uses
-    a [property_default] variable MUST include its {!val-property_rule}
-    explicitly:
-    {[
-    let my_var =
-      Var.property_default Css.Content ~initial:(Css.String "")
-        "tw-example-content"
-
-    let my_style =
-      let decl, ref_ = Var.binding my_var (Css.String "") in
-      let property_rules =
-        match Var.property_rule my_var with None -> Css.empty | Some r -> r
-      in
-      Style.style ~property_rules [ decl; Css.content (Css.Var ref_) ]
-    ]}
-
-    This ensures the [\@property] rule with the correct initial value flows
-    through the system. Without this, a generic [\@property] rule without
-    initial value may be generated, breaking the CSS output.
-
-    TODO: Fix this architecture limitation to automatically include property
-    rules for property_default variables in build.ml without requiring explicit
-    inclusion. *)
+    The build reads the typed registration metadata from declarations and
+    references, so a style using {!val-binding} automatically carries the
+    matching [\@property] rule. Passing [~property_rules] explicitly remains
+    supported for hand-written rules. *)
 
 val channel :
   ?needs_property:bool ->
@@ -468,39 +444,6 @@ val channel :
     block. Ideal for composition patterns where contributing utilities set
     declarations and aggregators reference values. *)
 
-val property_order : string -> int option
-(** [property_order name] returns the property order for a variable name, used
-    for sorting properties in the {i \@layer properties \@supports} block.
-    Returns [None] if no order was registered. *)
-
-val register_property_order : name:string -> order:int -> unit
-(** [register_property_order ~name ~order] registers a property order for a
-    variable name. Used by modules that create [\@property] rules directly
-    (without using [Var.property_default]) and need to participate in the
-    properties layer ordering. The [name] should be without the ["--"] prefix.
-
-    A name owns its slot: a second registration that agrees restates it, and one
-    that disagrees raises [Invalid_argument] rather than letting module
-    initialisation order decide the properties layer. *)
-
-val order : string -> (int * int) option
-(** [order name] returns the theme layer order for a variable name, with or
-    without the leading ["--"]. [None] if no variable of that name has been
-    defined, which for the tokens a project [\@theme] names means before the
-    utility reading them has been rendered.
-
-    The answer is where [name] itself sits, never the slot of a variable that
-    shares it. *)
-
-val family : string -> family option
-(** [family name] returns the family for a variable name. None if the variable
-    is not registered. *)
-
-val needs_property : string -> bool
-(** [needs_property name] returns whether a variable needs an [\@property] rule.
-    Returns [false] if the variable is not registered or doesn't need
-    [\@property]. *)
-
 val ref_only : 'a Css.kind -> string -> fallback:'a -> 'a ref_only
 (** [ref_only kind name ~fallback] creates a reference-only handle to a Utility
     variable with a concrete fallback for inline mode. No declaration is
@@ -511,20 +454,14 @@ val theme_ref : ?default:'a -> ?default_css:string -> string -> 'a Css.var
 (** [theme_ref ?default ?default_css name] creates a bare var reference to a
     theme variable. In variables mode, emits [var(--name)].
 
-    When [default] and [default_css] are provided, the variable is registered in
-    the resolution registry: when the theme doesn't define it, the concrete
-    [default_css] string is emitted instead. [default] is the typed value used
-    for inline mode.
+    When [default] and [default_css] are provided, both defaults are carried by
+    the returned reference. [default] is the typed value used for inline mode;
+    [default_css] is available from its metadata to theme-resolution passes.
 
     When [default] and [default_css] are omitted, the var reference is created
     without resolution registration. Use this for dynamically-constructed theme
-    variable names (e.g., [blur-xl], [spacing-4]) where the theme value is
-    already registered elsewhere. *)
-
-val resolve_theme_refs : string -> string option
-(** [resolve_theme_refs name] returns the default CSS string value for a
-    {!val-theme_ref} variable. Used as [theme_defaults] in [Pp.ctx] when theme
-    variables don't exist and should be replaced by their concrete defaults. *)
+    variable names (e.g., [blur-xl], [spacing-4]) whose values come from the
+    active theme. *)
 
 val binding :
   ('a, [< `Theme | `Property_default | `Channel ]) t ->
@@ -620,6 +557,50 @@ val property_rules : ('a, [< `Property_default ]) t -> Css.t
     rule. *)
 
 (** {1 Helper Types and Functions} *)
+
+type metadata
+(** Build metadata carried by variable references and declarations. *)
+
+val metadata : ('a, _) t -> metadata
+(** [metadata var] returns the build metadata attached to [var]. *)
+
+val metadata_of_var : 'a Css.var -> metadata option
+(** [metadata_of_var var] returns metadata carried by a CSS variable reference,
+    if the reference originated from this module. *)
+
+val metadata_of_declaration : Css.declaration -> metadata option
+(** [metadata_of_declaration declaration] returns metadata carried by a custom
+    property declaration, if the declaration originated from this module. *)
+
+val metadata_name : metadata -> string
+(** [metadata_name metadata] is the custom-property name without its leading
+    ["--"]. *)
+
+val metadata_order : metadata -> (int * int) option
+(** [metadata_order metadata] is its Theme-layer ordering slot, if any. *)
+
+val metadata_property_order : metadata -> int option
+(** [metadata_property_order metadata] is its ordering slot in the properties
+    layer, if any. *)
+
+val metadata_family : metadata -> family option
+(** [metadata_family metadata] is its related-property family, if any. *)
+
+val metadata_needs_property : metadata -> bool
+(** [metadata_needs_property metadata] reports whether the variable needs an
+    [@property] registration. *)
+
+val metadata_default_css : metadata -> string option
+(** [metadata_default_css metadata] is the serialized typed initial value used
+    for an automatic [@property] registration, if any. *)
+
+val property_rule_of_metadata : metadata -> Css.t option
+(** [property_rule_of_metadata metadata] reconstructs the exact typed
+    [@property] rule carried by a variable definition, if any. *)
+
+val property_rule_of_var : 'a Css.var -> Css.t option
+(** [property_rule_of_var var] is the exact typed [@property] rule carried by
+    [var], if any. *)
 
 val name : ('a, _) t -> string
 (** [name var] is the custom property's name without the leading ["--"], the

--- a/test/test.ml
+++ b/test/test.ml
@@ -59,6 +59,7 @@ let () =
       Test_forms.suite;
       Test_interactivity.suite;
       Test_parse.suite;
+      Test_domain_cache.suite;
       Test_position.suite;
       Test_output.suite;
       Test_rule.suite;

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -936,6 +936,17 @@ let test_style_rules_props () =
   check string "second rule selector" ".test :where(div)" (List.nth selectors 1);
   check string "last rule selector" ".test" (List.nth selectors 2)
 
+let test_property_default_rule_is_automatic () =
+  let css =
+    Tw.to_css ~base:false [ Tw.border_spacing 2 ] |> Css.to_string ~minify:true
+  in
+  check bool "typed rule with its initial value" true
+    (Astring.String.is_infix
+       ~affix:
+         "@property \
+          --tw-border-spacing-x{syntax:\"<length>\";inherits:false;initial-value:0}"
+       css)
+
 let test_media_query_deduplication () =
   (* Test that media queries preserve cascade order.
    *
@@ -1208,6 +1219,8 @@ let tests =
       test_extra_keeps_plain_order;
     test_case "style with rules and props ordering" `Quick
       test_style_rules_props;
+    test_case "property-default rule is automatic" `Quick
+      test_property_default_rule_is_automatic;
     test_case "theme tokens stripped at every depth" `Quick
       test_theme_tokens_stripped_at_every_depth;
   ]

--- a/test/test_domain_cache.ml
+++ b/test/test_domain_cache.ml
@@ -1,0 +1,82 @@
+open Tw
+
+type barrier = {
+  parties : int;
+  arrived : int Atomic.t;
+  generation : int Atomic.t;
+}
+
+let barrier parties =
+  { parties; arrived = Atomic.make 0; generation = Atomic.make 0 }
+
+let await barrier =
+  let generation = Atomic.get barrier.generation in
+  if Atomic.fetch_and_add barrier.arrived 1 = barrier.parties - 1 then (
+    Atomic.set barrier.arrived 0;
+    Atomic.set barrier.generation (generation + 1))
+  else
+    while Atomic.get barrier.generation = generation do
+      Domain.cpu_relax ()
+    done
+
+let parse theme class_name =
+  match Tw.of_string ~theme class_name with
+  | Ok utility -> utility
+  | Error (`Msg message) -> Alcotest.failf "%s: %s" class_name message
+
+(* Construction is local to its caller even when several Domains happen to use
+   the same variable name. The same request path also exercises the dynamic
+   colour/radius caches and the class-split cache. *)
+let construction_and_parsing_are_domain_safe () =
+  let domain_count = 4 in
+  let rounds = 500 in
+  let start = barrier domain_count in
+  let orders =
+    Array.init rounds (fun _ ->
+        Array.make domain_count (None : (int * int) option))
+  in
+  let worker worker_id () =
+    for round = 0 to rounds - 1 do
+      await start;
+      let suffix = string_of_int round in
+      let variable =
+        Var.theme Css.Length ("domain-order-" ^ suffix) ~order:(91, worker_id)
+      in
+      let declaration, _ = Var.binding variable (Css.Px 1.) in
+      orders.(round).(worker_id) <- Var.order_of_declaration declaration;
+      let radius_name = "domainradius" ^ suffix in
+      let theme =
+        {
+          Scheme.default with
+          colors = [ ("red-500", Scheme.Hex "#123456") ];
+          radius = [ (radius_name, Css.Px 3.) ];
+          token_overrides = [ ("radius-" ^ radius_name, "3px") ];
+        }
+      in
+      let color = parse theme "bg-red-500" in
+      let radius = parse theme ("rounded-" ^ radius_name) in
+      if round land 63 = 0 then
+        ignore (Tw.to_css ~base:false ~theme [ color; radius ])
+    done
+  in
+  let domains =
+    List.init domain_count (fun worker_id -> Domain.spawn (worker worker_id))
+  in
+  List.iter Domain.join domains;
+  Array.iteri
+    (fun round row ->
+      Array.iteri
+        (fun worker_id actual ->
+          Alcotest.(check (option (pair int int)))
+            ("caller order in round " ^ string_of_int round)
+            (Some (91, worker_id))
+            actual)
+        row)
+    orders
+
+let suite =
+  ( "domain_cache",
+    [
+      Alcotest.test_case "concurrent construction and parsing" `Quick
+        construction_and_parsing_are_domain_safe;
+    ] )

--- a/test/test_domain_cache.mli
+++ b/test/test_domain_cache.mli
@@ -1,0 +1,4 @@
+(** Multicore regression tests for the caches used by dynamic constructors. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest cases that exercise concurrent construction and parsing. *)

--- a/test/test_var.ml
+++ b/test/test_var.ml
@@ -119,13 +119,13 @@ let var_in_theme_layer () =
         ]
         (List.sort_uniq String.compare custom_props)
 
-(* Tailwind spells one registered zero two ways: [--tw-ring-offset-width: 0px]
-   in the properties layer's bulk declaration, but [initial-value: 0] in its own
-   [@property] rule (checked 2026-08-29 against the real CLI). Every other
-   zero-initialised [Length] variable (border-spacing-x/y) gets "0" in both
-   places, and the canonical [--diff] comparison treats "0" and "0px" as the
-   same length, so a regression here would not show up there - only this pinned
-   literal catches it. *)
+(* Tailwind spells one custom-property zero two ways: [--tw-ring-offset-width:
+   0px] in the properties layer's bulk declaration, but [initial-value: 0] in
+   its own [@property] rule (checked 2026-08-29 against the real CLI). Every
+   other zero-initialised [Length] variable (border-spacing-x/y) gets "0" in
+   both places, and the canonical [--diff] comparison treats "0" and "0px" as
+   the same length, so a regression here would not show up there - only this
+   pinned literal catches it. *)
 let ring_offset_width_properties_layer_spelling () =
   let css =
     match Tw.of_string "ring-2" with
@@ -143,148 +143,72 @@ let ring_offset_width_properties_layer_spelling () =
 
 let order = testable Fmt.(option (pair int int)) ( = )
 
-let render ?theme classes =
-  match Tw.of_string ?theme classes with
-  | Ok t -> ignore (Tw.to_css ?theme ~base:false [ t ])
-  | Error (`Msg m) -> fail m
-
 (* A (priority, suborder) slot is not unique to one variable: token families are
    numbered independently, so several tokens legitimately share a slot. Both
    sides of a shared slot must keep their order. *)
 let order_of_shared_slot () =
-  let (_ : Css.length Tw.Var.theme) =
+  let first : Css.length Tw.Var.theme =
     Tw.Var.theme Css.Length "test-shared-first" ~order:(990, 0)
   in
-  let (_ : Css.length Tw.Var.theme) =
+  let second : Css.length Tw.Var.theme =
     Tw.Var.theme Css.Length "test-shared-second" ~order:(990, 0)
   in
-  check order "first" (Some (990, 0)) (Tw.Var.order "test-shared-first");
-  check order "second" (Some (990, 0)) (Tw.Var.order "test-shared-second")
+  let first_decl, _ = Tw.Var.binding first (Css.Px 1.) in
+  let second_decl, _ = Tw.Var.binding second (Css.Px 1.) in
+  check order "first" (Some (990, 0)) (Tw.Var.order_of_declaration first_decl);
+  check order "second" (Some (990, 0)) (Tw.Var.order_of_declaration second_decl)
 
-(* Each family in the theme layer's tail owns a band no other family reaches
-   into, so the emission order is the family order Tailwind's [@theme] writes
-   rather than the spelling of the token names. *)
-let order_of_family_bands () =
-  let expect name o = check order name (Some o) (Tw.Var.order name) in
-  expect "radius-4xl" (7, 10);
-  expect "drop-shadow-xl" (7, 24);
-  expect "drop-shadow-2xl" (7, 25);
-  expect "ease-linear" (7, 33);
-  expect "animate-spin" (7, 41);
-  expect "blur-xs" (8, 0);
-  expect "perspective-dramatic" (8, 10);
-  expect "aspect-video" (8, 20);
-  expect "default-transition-duration" (8, 30);
-  expect "default-transition-timing-function" (8, 31);
-  expect "transition-property-opacity" (8, 32);
-  expect "transition-property-colors" (8, 33);
-  expect "default-font-family" (8, 39);
-  expect "default-font-feature-settings" (8, 40);
-  expect "default-font-variation-settings" (8, 41);
-  expect "default-mono-font-family" (8, 42);
-  expect "default-mono-font-feature-settings" (8, 43);
-  expect "default-mono-font-variation-settings" (8, 44)
-
-(* A project [@theme] may name font families of its own; they all sit at (1,
-   100). Rendering one must not decide the answer for the others. *)
-let order_of_theme_named_tokens () =
-  let theme =
-    {
-      Tw.Scheme.default with
-      token_overrides =
-        [ ("font-alpha", "Alpha, sans-serif"); ("font-beta", "Beta, serif") ];
-    }
-  in
-  render ~theme "font-alpha";
-  render ~theme "font-beta";
-  check order "alpha" (Some (1, 100)) (Tw.Var.order "font-alpha");
-  check order "beta" (Some (1, 100)) (Tw.Var.order "font-beta")
-
-(* A name owns its slot: the first definition places it, and a later definition
-   of the same name is placed there too, the declarations it binds included. *)
+(* Metadata belongs to the value that carries it: defining the same spelling in
+   another request cannot alter either declaration. *)
 let order_of_redefined_name () =
-  let (_ : Css.length Tw.Var.theme) =
+  let first : Css.length Tw.Var.theme =
     Tw.Var.theme Css.Length "test-established" ~order:(991, 0)
   in
   let again = Tw.Var.theme Css.Length "test-established" ~order:(991, 1) in
+  let first_decl, _ = Tw.Var.binding first (Css.Px 1.) in
   let decl, _ = Tw.Var.binding again (Css.Px 1.) in
-  check order "registry" (Some (991, 0)) (Tw.Var.order "test-established");
-  check order "declaration" (Some (991, 0)) (Tw.Var.order_of_declaration decl)
+  check order "first" (Some (991, 0)) (Tw.Var.order_of_declaration first_decl);
+  check order "second" (Some (991, 1)) (Tw.Var.order_of_declaration decl)
 
-(* A project [@theme] naming a built-in token reaches the [--font-<name>]
-   family's shared slot, and must leave the token in its own. *)
-let order_of_theme_renamed_builtin () =
-  let theme =
-    {
-      Tw.Scheme.default with
-      token_overrides =
-        [ ("font-sans", "Alpha, sans-serif"); ("font-mono", "Beta, monospace") ];
-    }
-  in
-  render ~theme "font-sans";
-  render ~theme "font-mono";
-  check order "font-sans" (Some (1, 0)) (Tw.Var.order "font-sans");
-  check order "font-mono" (Some (1, 2)) (Tw.Var.order "font-mono")
-
-(* [font-weight-bold] reads --font-weight-bold as a family name, so a project
-   naming that token routes a font-weight token through the font family's slot.
-   It keeps its own, and the render goes through. *)
-let order_of_theme_renamed_weight () =
-  let theme =
-    {
-      Tw.Scheme.default with
-      token_overrides = [ ("font-weight-bold", "Alpha, sans-serif") ];
-    }
-  in
-  render ~theme "font-weight-bold";
-  check order "font-weight-bold"
-    (Some (6, 36))
-    (Tw.Var.order "font-weight-bold")
-
-let order_of_unknown_name () =
-  check order "unknown" None (Tw.Var.order "test-never-defined");
-  check order "leading -- stripped" (Some (6, 8)) (Tw.Var.order "--text-xl")
-
-(* A name owns its family and its [@property] need: each is a fact about one
-   custom property, not a slot several families share. A second registration
-   that agrees restates the fact; one that disagrees is a constant copied by
-   hand that has drifted, and it is refused rather than letting module
-   initialisation order decide the properties layer. *)
-let family_registered_once () =
-  let (_ : Css.length Tw.Var.channel) =
+(* Family metadata belongs to the variable value. Two callers can use the same
+   custom-property name without one definition rewriting the other. *)
+let family_is_value_local () =
+  let ring : Css.length Tw.Var.channel =
     Tw.Var.channel ~family:`Ring Css.Length "test-family-owner"
   in
-  let (_ : Css.length Tw.Var.channel) =
-    Tw.Var.channel ~family:`Ring Css.Length "test-family-owner"
+  let shadow : Css.length Tw.Var.channel =
+    Tw.Var.channel ~family:`Shadow Css.Length "test-family-owner"
+  in
+  let ring_decl, _ = Tw.Var.binding ring (Css.Px 1.) in
+  let shadow_decl, _ = Tw.Var.binding shadow (Css.Px 1.) in
+  let family declaration =
+    Option.bind
+      (Tw.Var.metadata_of_declaration declaration)
+      Tw.Var.metadata_family
   in
   check
     (Alcotest.option Alcotest.string)
-    "established" (Some "Ring")
-    (Option.map
-       (function `Ring -> "Ring" | _ -> "other")
-       (Tw.Var.family "test-family-owner"));
-  Alcotest.check_raises "a disagreeing family is refused"
-    (Invalid_argument
-       "--test-family-owner: family is Ring, registered again as Shadow")
-    (fun () ->
-      ignore (Tw.Var.channel ~family:`Shadow Css.Length "test-family-owner"))
-
-(* A variable's slot in the properties layer is one fact about one custom
-   property, the same way its family is. A second registration that agrees
-   restates it; one that disagrees is a hand-copied constant that has drifted,
-   and it is refused rather than letting module initialisation order settle
-   it. *)
-let property_order_registered_once () =
-  Tw.Var.register_property_order ~name:"test-order-owner" ~order:6;
-  Tw.Var.register_property_order ~name:"test-order-owner" ~order:6;
+    "ring" (Some "Ring")
+    (Option.map (function `Ring -> "Ring" | _ -> "other") (family ring_decl));
   check
-    (Alcotest.option Alcotest.int)
-    "established" (Some 6)
-    (Tw.Var.property_order "test-order-owner");
-  Alcotest.check_raises "a disagreeing property order is refused"
-    (Invalid_argument
-       "--test-order-owner: property order is 6, registered again as 7")
-    (fun () -> Tw.Var.register_property_order ~name:"test-order-owner" ~order:7)
+    (Alcotest.option Alcotest.string)
+    "shadow" (Some "Shadow")
+    (Option.map
+       (function `Shadow -> "Shadow" | _ -> "other")
+       (family shadow_decl))
+
+(* The properties-layer slot is value-local for the same reason. *)
+let property_order_is_value_local () =
+  let first = Tw.Var.channel ~property_order:6 Css.Length "test-order-owner" in
+  let second = Tw.Var.channel ~property_order:7 Css.Length "test-order-owner" in
+  let property_order (var : Css.length Tw.Var.channel) =
+    let declaration, _ = Tw.Var.binding var (Css.Px 1.) in
+    Option.bind
+      (Tw.Var.metadata_of_declaration declaration)
+      Tw.Var.metadata_property_order
+  in
+  check (Alcotest.option Alcotest.int) "first" (Some 6) (property_order first);
+  check (Alcotest.option Alcotest.int) "second" (Some 7) (property_order second)
 
 let tests =
   [
@@ -297,17 +221,10 @@ let tests =
     test_case "ring-offset-width properties layer spelling" `Quick
       ring_offset_width_properties_layer_spelling;
     test_case "order of shared slot" `Quick order_of_shared_slot;
-    test_case "order of family bands" `Quick order_of_family_bands;
-    test_case "order of theme-named tokens" `Quick order_of_theme_named_tokens;
     test_case "order of redefined name" `Quick order_of_redefined_name;
-    test_case "order of theme-renamed builtin" `Quick
-      order_of_theme_renamed_builtin;
-    test_case "order of theme-renamed weight" `Quick
-      order_of_theme_renamed_weight;
-    test_case "order of unknown name" `Quick order_of_unknown_name;
-    test_case "family registered once" `Quick family_registered_once;
-    test_case "property order registered once" `Quick
-      property_order_registered_once;
+    test_case "family is value-local" `Quick family_is_value_local;
+    test_case "property order is value-local" `Quick
+      property_order_is_value_local;
   ]
 
 let suite = ("var", tests)

--- a/test/upstream/extract_tests.ml
+++ b/test/upstream/extract_tests.ml
@@ -440,10 +440,10 @@ let var_reference_re = Re.Pcre.regexp {|var\(\s*--([A-Za-z0-9_-]+)|}
 let var_references body =
   List.map (fun g -> Re.Group.get g 1) (Re.all var_reference_re body)
 
-(* Theme-token registries are populated by the families that own them. Building
-   the base sheet once loads the same complete registry the replay runner uses;
-   the extractor can then distinguish a missing theme token from an arbitrary
-   runtime custom property. *)
+(* The static theme-token catalog is populated by the families that own it.
+   Building the base sheet once loads the same complete snapshot the replay
+   runner uses; the extractor can then distinguish a missing theme token from an
+   arbitrary runtime custom property. *)
 let init_theme_tokens = lazy (ignore (Tw.to_css ~base:true []))
 
 (* [@utility example-*] declares a functional utility: its body is a template
@@ -545,8 +545,7 @@ let unreplayable ~defs ~config ~theme_vars ~classes expected =
   let () = Lazy.force init_theme_tokens in
   let unresolved_reference name =
     (not (List.mem_assoc name theme_vars))
-    && (Option.is_some (Tw.Scheme.token_default name)
-       || Option.is_some (Tw.Var.resolve_theme_refs name))
+    && Option.is_some (Tw.Scheme.token_default name)
   in
   let reads_unknown_token =
     List.exists

--- a/test/upstream/test.ml
+++ b/test/upstream/test.ml
@@ -154,22 +154,30 @@ let theme_resolution ~declared config expected =
     ]
   in
   let root_vars = declared_root_vars ~declared expected in
+  let reference_defaults stylesheet =
+    Css.vars_of_stylesheet stylesheet
+    |> List.filter_map (fun (Css.V var) ->
+        match Tw.Var.metadata_of_var var with
+        | Some metadata ->
+            Option.map
+              (fun css -> (Tw.Var.metadata_name metadata, css))
+              (Tw.Var.metadata_default_css metadata)
+        | None -> None)
+  in
   let of_hardcoded pick name =
     List.find_map
       (fun (var_name, inline_val, default) ->
         if name = var_name then Some (pick (inline_val, default)) else None)
       hardcoded
   in
-  let defaults pick name =
+  let defaults stylesheet pick name =
     match List.assoc_opt name root_vars with
     | Some _ as result -> result
     | None -> (
-        match Tw.Var.resolve_theme_refs name with
+        match List.assoc_opt name (reference_defaults stylesheet) with
         | Some _ as result -> result
         | None -> of_hardcoded pick name)
   in
-  let combined_defaults = defaults snd in
-  let combined_inline_defaults = defaults fst in
   (* Inline the named tokens and nothing else: an empty keep-set with a lookup
      that answers only for them. *)
   let inline_pass names theme_defaults stylesheet =
@@ -186,6 +194,7 @@ let theme_resolution ~declared config expected =
       (* The [run()] harness renders the [--default-*] tokens as literal
          fallbacks whether or not the case redeclares them. *)
       fun stylesheet ->
+        let combined_defaults = defaults stylesheet snd in
         stylesheet
         |> inline_pass inlined_tokens combined_defaults
         |> bind_pass combined_defaults
@@ -198,6 +207,7 @@ let theme_resolution ~declared config expected =
         List.filter (fun name -> not (List.mem name declared)) inlined_tokens
       in
       fun stylesheet ->
+        let combined_defaults = defaults stylesheet snd in
         stylesheet
         |> inline_pass inlined combined_defaults
         |> bind_pass combined_defaults
@@ -206,6 +216,7 @@ let theme_resolution ~declared config expected =
          empty keep-set is the config's own semantics rather than a reading of
          the expected output. *)
       fun stylesheet ->
+        let combined_inline_defaults = defaults stylesheet fst in
         Css.resolve_theme ~theme:Css.Pp.String_set.empty
           ~theme_defaults:combined_inline_defaults stylesheet
   | No_theme ->


### PR DESCRIPTION
Carries variable ordering, family, theme-reference, and property metadata on each value and builds per-render indexes, removing the process-global registries. Domain-local caches and immutable Atomic snapshots allow concurrent builds without a mutex.