### PR TITLE
build: omit unused runtime theme carriers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,9 @@
   utility only reads through `var()` is now declared in the theme layer whatever
   its family, `--spacing(N)` is multiplied out where the project inlines
   `--spacing`, and an `@theme reference` block is represented (#554).
+- Functional utilities follow Tailwind's declaration-count ordering, parity
+  comparisons keep author custom properties, and a folded zero-spacing utility
+  omits the internal `--spacing` carrier it no longer reads (#650, #651, #652).
 - Every `@utility` declared for one name applies, not only the first (#550).
 - A routed candidate keeps the utility that owns it, so a class a declared
   variant routes is generated once by the right handler (#564).

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -743,18 +743,45 @@ let theme_layer_rule ~layers = function
       if layers then Css.v [ Css.layer ~name:[ "theme" ] [ rule ] ]
       else Css.v [ rule ]
 
+(* Read every [var()] from a declaration's serialized value. The normal typed
+   walk is faster, but a nested calculation can hold another typed [calc()]
+   inside a [Val] node (space-x's reverse multiplier is one example), and that
+   node is intentionally opaque to the generic calc walker. Tokenising the value
+   directly supplies the exhaustive dependency view this build decision needs
+   without imposing custom-property declaration grammar on an arbitrary
+   property's otherwise-valid value. *)
+let add_declaration_var_names names declarations =
+  List.fold_left
+    (fun names declaration ->
+      let value = Css.declaration_value declaration in
+      Css.Variables.var_refs_in_value_string value
+      |> List.fold_left (fun names name -> Strings.add name names) names)
+    names declarations
+
+let rec add_statement_var_names names statements =
+  List.fold_left
+    (fun names statement ->
+      let names =
+        add_declaration_var_names names
+          (Css.Stylesheet.statement_declarations statement)
+      in
+      add_statement_var_names names
+        (Css.Stylesheet.statement_children statement))
+    names statements
+
 (* Every var() referenced anywhere in a utility's output (top-level props and
    nested @media/@supports). *)
-let var_names_of_output = function
-  | Regular { props; nested; _ } | Media_query { props; nested; _ } ->
-      (* [nested] can hold @media statements (compound variants like
-         hover:dark:) whose rules reference theme vars; recurse fully so those
-         references are collected and their theme tokens declared. *)
-      Css.vars_of_declarations props @ Css.vars_of_stylesheet (Css.v nested)
-  | Container_query { props; nested; _ } ->
-      Css.vars_of_declarations props @ Css.vars_of_stylesheet (Css.v nested)
-  | Starting_style { props; _ } | Supports_query { props; _ } ->
-      Css.vars_of_declarations props
+let add_output_var_names names = function
+  | Regular { props; nested; _ }
+  | Media_query { props; nested; _ }
+  | Container_query { props; nested; _ }
+  | Starting_style { props; nested; _ }
+  | Supports_query { props; nested; _ } ->
+      let names = add_declaration_var_names names props in
+      add_statement_var_names names nested
+
+let referenced_var_names selector_props =
+  List.fold_left add_output_var_names Strings.empty selector_props
 
 (* Theme tokens referenced via var() (e.g. an arbitrary [color:var(--color-red-
    500)]) must appear in @layer theme, but the extractor above only collects
@@ -766,10 +793,8 @@ let var_names_of_output = function
    [@theme reference] one is declared outside the sheet, so neither is emitted.
    [exclude] holds the already-emitted (set) token names. *)
 let referenced_theme_decls ~theme ~exclude selector_props =
-  selector_props
-  |> List.concat_map var_names_of_output
-  |> List.map Css.any_var_name
-  |> List.sort_uniq String.compare
+  referenced_var_names selector_props
+  |> Strings.to_list
   |> List.filter_map (fun full ->
       if
         String.length full <= 2
@@ -847,12 +872,48 @@ let derived_font_feature_decls ~theme ~have =
           Some (Css.custom_property ~layer:"theme" ("--" ^ name) v)
       | _ -> None)
 
+(* A runtime theme declaration attached to a utility is a dependency carrier,
+   not independent output. A zero-valued spacing utility, for example, has
+   already folded its value to [0px] and no longer reads [--spacing]. Non-
+   runtime theme declarations retain Tailwind's emission semantics even when the
+   utility folded their value. [theme(static)] is the explicit runtime
+   exception: it asks for the whole theme whether a utility reads each token or
+   not. *)
+let keep_extracted_theme_decl ~theme ~referenced decl =
+  theme.Scheme.static_theme
+  || (not (Var.is_runtime_declaration decl))
+  ||
+  match Css.custom_declaration_name decl with
+  | Some name -> Strings.mem name referenced
+  | None -> false
+
+(* [theme(static)] on the package import emits every theme variable, not only
+   the ones a utility used. The palette is by far the biggest part of it. *)
+let add_static_theme_decls ~theme extracted =
+  if not theme.Scheme.static_theme then extracted
+  else
+    let have = names_set_of extracted in
+    let registered =
+      Scheme.all_default_tokens ()
+      |> List.map (fun (name, css) ->
+          Css.custom_property ~layer:"theme" ("--" ^ name) css)
+    in
+    extracted
+    @ List.filter
+        (fun d ->
+          match Css.custom_declaration_name d with
+          | Some n -> not (Strings.mem n have)
+          | None -> true)
+        (Color.Handler.all_palette_declarations ~theme () @ registered)
+
 (* Internal helper to compute theme layer from pre-extracted outputs. *)
 let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
     ?(default_decls = []) selector_props =
+  let referenced = referenced_var_names selector_props in
   let extracted =
     extract_non_tw_custom_declarations selector_props
     |> List.filter_map (apply_token_override theme)
+    |> List.filter (keep_extracted_theme_decl ~theme ~referenced)
   in
   let extracted =
     extracted
@@ -862,25 +923,7 @@ let theme_layer_of_props ?(theme = Scheme.default) ?(layers = true)
   let extracted =
     extracted @ derived_font_feature_decls ~theme ~have:(names_set_of extracted)
   in
-  (* [theme(static)] on the package import emits every theme variable, not only
-     the ones a utility used. The palette is by far the biggest part of it. *)
-  let extracted =
-    if not theme.Scheme.static_theme then extracted
-    else
-      let have = names_set_of extracted in
-      let registered =
-        Scheme.all_default_tokens ()
-        |> List.map (fun (name, css) ->
-            Css.custom_property ~layer:"theme" ("--" ^ name) css)
-      in
-      extracted
-      @ List.filter
-          (fun d ->
-            match Css.custom_declaration_name d with
-            | Some n -> not (Strings.mem n have)
-            | None -> true)
-          (Color.Handler.all_palette_declarations ~theme () @ registered)
-  in
+  let extracted = add_static_theme_decls ~theme extracted in
   let pre_defaults, post_defaults = split_defaults default_decls in
 
   (* Filter defaults to remove duplicates of extracted vars *)

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -215,6 +215,7 @@ type info =
       kind : 'a Css.kind;
       need_property : bool;
       order : (int * int) option;
+      runtime : bool;
     }
       -> info
 
@@ -266,7 +267,16 @@ let v : type a r.
   let need_property = property <> None in
   if need_property then Registry.register_needs_property ~name ~needs:true;
 
-  let info = Info { kind; name; need_property; order } in
+  let info =
+    Info
+      {
+        kind;
+        name;
+        need_property;
+        order;
+        runtime = Option.value runtime ~default:false;
+      }
+  in
   let binding ?fallback:fb value =
     let meta = meta_of_info info in
     let layer_name = Some (layer_name layer) in
@@ -514,6 +524,12 @@ let order_of_declaration decl =
   | None -> None
   | Some meta -> (
       match info_of_meta meta with Some (Info t) -> t.order | None -> None)
+
+let is_runtime_declaration decl =
+  match Css.meta_of_declaration decl with
+  | None -> false
+  | Some meta -> (
+      match info_of_meta meta with Some (Info t) -> t.runtime | None -> false)
 
 let property_initial_declaration = declaration_of_property_info
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]

--- a/lib/var.mli
+++ b/lib/var.mli
@@ -639,6 +639,10 @@ val order_of_declaration : Css.declaration -> (int * int) option
 (** [order_of_declaration d] returns theme ordering information for a custom
     declaration. *)
 
+val is_runtime_declaration : Css.declaration -> bool
+(** [is_runtime_declaration d] is [true] when [d] belongs to a theme variable
+    created with [~runtime:true]. *)
+
 val property_initial_declaration : Css.property_info -> Css.declaration
 (** [property_initial_declaration info] is the declaration that sets a parsed
     [@property] statement's typed initial value in the properties layer's bulk

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -4,6 +4,7 @@ open Tw.Color
 open Tw.Backgrounds
 open Tw.Padding
 open Tw.Margin
+open Tw.Position
 open Tw.Modifiers
 open Test_helpers
 
@@ -974,21 +975,60 @@ let test_media_query_deduplication () =
   Alcotest.(check int)
     "preserves cascade with nested and top-level media" 2 count_768px
 
-(* p-0 folds to 0, so the unused --spacing token is pruned, matching
-   Tailwind. *)
+(* A zero spacing utility contains no [var(--spacing)] reference, so the build
+   must not put its internal carrier declaration in the theme layer. This is a
+   build invariant: the parity gate must not need a later generic custom-
+   property pruning pass to hide the unused token. *)
 let check_spacing_zero_prune () =
   let config = { Tw.Build.base = false; forms = None; layers = true } in
-  let css =
-    Tw.Build.to_css ~config [ p 0 ]
-    |> Css.optimize ~prune_unused_custom_props:true
-    |> Css.to_string ~minify:true
+  let css utility =
+    Tw.Build.to_css ~config [ utility ] |> Css.to_string ~minify:true
   in
+  let check_zero name property utility =
+    let css = css utility in
+    Alcotest.(check bool)
+      (name ^ " emits zero") true
+      (Astring.String.is_infix ~affix:(property ^ ":0") css);
+    Alcotest.(check bool)
+      (name ^ " omits unused --spacing")
+      false
+      (Astring.String.is_infix ~affix:"--spacing" css)
+  in
+  check_zero "p-0" "padding" (p 0);
+  check_zero "mb-0" "margin-bottom" (mb 0);
+  check_zero "top-0" "top" (top 0);
+  check_zero "inset-0" "inset" (inset 0)
+
+(* A runtime carrier is optional only after every use of it has folded away.
+   [space-x-2.5] nests the spacing calculation inside a second [calc()] for the
+   reverse-axis multiplier, so it exercises the full declaration-value walk
+   rather than the direct [padding:calc(var(--spacing)*n)] shape. *)
+let check_nested_spacing_keeps_runtime_carrier () =
+  let utility =
+    match Tw.of_string "space-x-2.5" with
+    | Ok utility -> utility
+    | Error (`Msg msg) -> Alcotest.fail msg
+  in
+  let css = Tw.to_css ~base:false [ utility ] |> Css.to_string ~minify:true in
   Alcotest.(check bool)
-    "p-0 is padding:0" true
-    (Astring.String.is_infix ~affix:"padding:0" css);
+    "utility still reads --spacing" true
+    (Astring.String.is_infix ~affix:"var(--spacing)" css);
   Alcotest.(check bool)
-    "p-0 drops unused --spacing" false
-    (Astring.String.is_infix ~affix:"--spacing" css)
+    "theme keeps referenced --spacing" true
+    (Astring.String.is_infix ~affix:"--spacing:" css)
+
+(* Dependency discovery inspects the value of every emitted declaration. An
+   arbitrary value can be valid for its real property while not being a valid
+   custom-property declaration value (a top-level unmatched closing delimiter is
+   one example), so that inspection must never reparse it through a synthetic
+   declaration. *)
+let check_dependency_scan_accepts_adversarial_value () =
+  let utility =
+    match Tw.of_string "mask-conic-[0)/*1]" with
+    | Ok utility -> utility
+    | Error (`Msg msg) -> Alcotest.fail msg
+  in
+  ignore (Tw.to_css ~base:false [ utility ])
 
 (* A utility that only REFERENCES a theme colour token via var() (here an
    arbitrary bg-[color:var(--color-red-500)]) must still emit that token in
@@ -1104,6 +1144,10 @@ let tests =
     test_case "referenced theme token emitted" `Quick
       test_referenced_theme_token;
     test_case "spacing-0 prunes --spacing" `Quick check_spacing_zero_prune;
+    test_case "nested spacing keeps --spacing" `Quick
+      check_nested_spacing_keeps_runtime_carrier;
+    test_case "dependency scan accepts adversarial value" `Quick
+      check_dependency_scan_accepts_adversarial_value;
     test_case "theme layer - empty" `Quick check_theme_layer_empty;
     test_case "theme layer - with color" `Quick check_theme_layer_with_color;
     test_case "Tw.Build.conflict_order delegates to Utility.order" `Quick

--- a/test/test_theme.ml
+++ b/test/test_theme.ml
@@ -122,7 +122,8 @@ let theme_family_block_order () =
   check (list string) "Tailwind family block order" expected actual
 
 (* Utilities across ten modules bind [--spacing] as they emit, each supplying
-   the value the theme layer declares. Each has to bind it to
+   the value the theme layer declares. A binding must survive exactly when the
+   finished utility still reads it, and every surviving binding must use
    [Theme.spacing_base]: a hand-written copy of the step leaves whichever
    utilities kept it declaring a stale [--spacing], and a sheet that mixes the
    two keeps only one of the declarations. *)
@@ -152,24 +153,31 @@ let one_spacing_declaration () =
       | Ok u -> u
       | Error (`Msg m) -> failf "%s: %s" cls m
     in
-    match Css.layer_block [ "theme" ] (Tw.to_css ~base:false [ style ]) with
+    let sheet = Tw.to_css ~base:false [ style ] in
+    let reads_spacing =
+      Astring.String.is_infix ~affix:"var(--spacing)"
+        (Css.to_string ~minify:true sheet)
+    in
+    match Css.layer_block [ "theme" ] sheet with
     | None -> failf "%s: expected @layer theme" cls
     | Some statements ->
-        Css.rules_of_statements statements
-        |> List.concat_map snd
-        |> List.filter_map (fun d ->
-            match Css.custom_declaration_name d with
-            | Some "--spacing" -> Some (cls, Css.declaration_value d)
-            | _ -> None)
+        let bindings =
+          Css.rules_of_statements statements
+          |> List.concat_map snd
+          |> List.filter_map (fun d ->
+              match Css.custom_declaration_name d with
+              | Some "--spacing" -> Some (cls, Css.declaration_value d)
+              | _ -> None)
+        in
+        check int (cls ^ " carrier count")
+          (if reads_spacing then 1 else 0)
+          (List.length bindings);
+        bindings
   in
   let base = Css.Pp.to_string Css.pp_length Tw.Theme.spacing_base in
   let found = List.concat_map declared classes in
-  check int "every class declares --spacing" (List.length classes)
-    (List.length found);
-  check
-    (list (pair string string))
-    "every binding declares the same step"
-    (List.map (fun cls -> (cls, base)) classes)
+  List.iter
+    (fun (cls, value) -> check string (cls ^ " carrier value") base value)
     found
 
 let tests =


### PR DESCRIPTION
Keeps build-time theme values available to generators while omitting unused runtime carrier variables from emitted CSS. Supersedes #652 after the stack was reordered.