### PR TITLE
effects, text-shadow: preserve palette color space

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -162,6 +162,8 @@
 
 ### Colours and effects
 
+- Palette box, inset-box and text shadows keep Tailwind's authored OKLCH value
+  as their unguarded fallback instead of converting it to sRGB hex.
 - An opacity modifier reaches every colour family. A ring, a per-side border, a
   shadow, a drop shadow, a decoration and a stroke all take one, the alpha can
   itself be a variable (`bg-cyan-400/(--my-alpha-value)`), and `transparent` and

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -760,17 +760,16 @@ module Handler = struct
                 Color.rgb_to_hex rgb))
 
   let set_shadow_color ?theme c shade =
-    let hex_value =
-      shadow_color_hex ?theme ~property_prefix:"box-shadow-color" c shade
+    let color_value =
+      Color.property_color_value ?theme ~property_prefix:"box-shadow-color" c
+        shade
     in
-    let base_decl, _ = Var.binding shadow_color_var (Css.hex hex_value) in
+    let base_decl, _ = Var.binding shadow_color_var color_value in
     let theme_color_var =
       Color.property_color_var ?theme ~property_prefix:"box-shadow-color" c
         shade
     in
-    let theme_decl, color_ref =
-      Var.binding theme_color_var (Css.hex hex_value)
-    in
+    let theme_decl, color_ref = Var.binding theme_color_var color_value in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab ~var_name:"tw-shadow-alpha"
         (Css.Var color_ref) Css.Transparent
@@ -1397,18 +1396,16 @@ module Handler = struct
                 Color.rgb_to_hex rgb))
 
   let set_inset_shadow_color ?theme c shade =
-    let hex_value =
-      inset_shadow_color_hex ?theme ~property_prefix:"inset-box-shadow-color" c
-        shade
+    let color_value =
+      Color.property_color_value ?theme
+        ~property_prefix:"inset-box-shadow-color" c shade
     in
-    let base_decl, _ = Var.binding inset_shadow_color_var (Css.hex hex_value) in
+    let base_decl, _ = Var.binding inset_shadow_color_var color_value in
     let theme_color_var =
       Color.property_color_var ?theme ~property_prefix:"inset-box-shadow-color"
         c shade
     in
-    let theme_decl, color_ref =
-      Var.binding theme_color_var (Css.hex hex_value)
-    in
+    let theme_decl, color_ref = Var.binding theme_color_var color_value in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab
         ~var_name:"tw-inset-shadow-alpha" (Css.Var color_ref) Css.Transparent

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -391,12 +391,16 @@ module Handler = struct
             Color.rgb_to_hex rgb)
 
   let set_color ?theme c shade =
-    let hex_value = color_hex ?theme c shade in
-    let base_decl, _ = Var.binding text_shadow_color_var (Css.hex hex_value) in
-    let theme_color_var = Color.color_var c shade in
-    let theme_decl, color_ref =
-      Var.binding theme_color_var (Css.hex hex_value)
+    let color_value =
+      Color.property_color_value ?theme ~property_prefix:"text-shadow-color" c
+        shade
     in
+    let base_decl, _ = Var.binding text_shadow_color_var color_value in
+    let theme_color_var =
+      Color.property_color_var ?theme ~property_prefix:"text-shadow-color" c
+        shade
+    in
+    let theme_decl, color_ref = Var.binding theme_color_var color_value in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab ~var_name:text_shadow_alpha_name
         (Css.Var color_ref) Css.Transparent

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -267,6 +267,22 @@ let test_shadeless_shadow_colors () =
   has "inset-shadow-white/20"
     ".inset-shadow-white\\/20{--tw-inset-shadow-color:#fff3}"
 
+(* A default palette token is already an OKLCH colour. Tailwind keeps that value
+   as the unguarded shadow-colour fallback; converting it to sRGB hex changes
+   wide-gamut colours before the [color-mix()] enhancement applies. *)
+let test_palette_shadow_colors_keep_oklch () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  in
+  has "shadow-indigo-500" "--tw-shadow-color:oklch(58.5%.233 277.117)";
+  has "inset-shadow-indigo-500"
+    "--tw-inset-shadow-color:oklch(58.5%.233 277.117)"
+
 (* shadow-inner is a shadow shape like the others: it sets --tw-shadow and
    composes, rather than writing box-shadow directly. *)
 let test_shadow_inner () =
@@ -571,6 +587,8 @@ let tests =
       test_shadow_bracket_alpha_tracking;
     test_case "undefined colour shade" `Quick test_undefined_shade;
     test_case "shadeless shadow colors" `Quick test_shadeless_shadow_colors;
+    test_case "palette shadow colors keep OKLCH" `Quick
+      test_palette_shadow_colors_keep_oklch;
     test_case "shadow-inner" `Quick test_shadow_inner;
     test_case "arbitrary shadow list" `Quick test_arbitrary_shadow_list;
     test_case "arbitrary shadow lengths" `Quick test_arbitrary_shadow_lengths;

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -156,10 +156,8 @@ let rendering_matches_tailwind () =
       "shadow-md";
       "shadow-lg";
       "shadow-none";
-      (* A palette colour would only re-report the known theme-token gap
-         (--color-indigo-500 as a hex where Tailwind keeps oklch), which [tw
-         --diff] already reports; the keyword colours conflict with the sizes
-         just as well. *)
+      (* The keyword colours conflict with the sizes just as well as palette
+         colours; palette fallback syntax has a focused regression below. *)
       "shadow-current";
       "shadow-transparent";
       "inset-shadow-sm";

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -45,6 +45,18 @@ let test_theme_override () =
     "text-shadow-2xs @theme override flows to #0000001a" true
     (Astring.String.is_infix ~affix:"#0000001a" css)
 
+(* Default palette colours stay in their authored OKLCH space, matching the
+   fallback Tailwind emits before its guarded [color-mix()] declaration. *)
+let test_palette_color_keeps_oklch () =
+  let css =
+    Tw.to_css ~base:false [ parse "text-shadow-sky-300" ]
+    |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check bool)
+    "text-shadow-sky-300 keeps its palette OKLCH value" true
+    (Astring.String.is_infix
+       ~affix:"--tw-text-shadow-color:oklch(82.8%.111 230.318)" css)
+
 (* An arbitrary text-shadow reads every CSS length, not the px/rem/em subset. A
    token that is not a length used to drop out of the list and shift its
    neighbours along, so [0 1ch 2px] became a two-length [0 2px]. *)
@@ -232,6 +244,8 @@ let tests =
       Alcotest.test_case "default scale (v4.3.1)" `Quick test_default_scale;
       Alcotest.test_case "@theme override threads through" `Quick
         test_theme_override;
+      Alcotest.test_case "palette color keeps OKLCH" `Quick
+        test_palette_color_keeps_oklch;
       Alcotest.test_case "arbitrary colour function" `Quick
         test_arbitrary_color_function;
       Alcotest.test_case "arbitrary colour opacity" `Quick


### PR DESCRIPTION
Keeps default palette values in OKLCH for box, inset-box, and text-shadow fallbacks while preserving scoped project colors and the guarded color-mix enhancement.