### PR TITLE
rule: wrap bracketed has selectors in :is()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,8 @@
 
 ### Arbitrary values and validation
 
+- Bracketed `has`, `group-has` and `peer-has` variants retain Tailwind's
+  `:is(...)` wrapper for bare type and complex selectors.
 - An arbitrary length in a variant's class name is spelled as the author wrote
   it, so the selector matches the markup. `min-[0.5ch]:flex` emitted
   `.min-\[\.5ch\]\:flex`, a rule nothing on the page could match, for every

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1074,7 +1074,10 @@ let parse_px_value s =
    universal selector via {!Cascade.Nest.substitute}, the same substitution
    {!nest_selector} performs for anchored templates. *)
 let has_relative_selector s =
-  let sel = Css.Selector.read_relative (Cascade.Cursor.of_string s) in
+  let sel =
+    Css.Selector.read_relative
+      (Cascade.Cursor.of_string (Parse.decode_underscores s))
+  in
   Cascade.Nest.substitute ~parent:Css.Selector.universal sel
 
 (* Validate that a has-selector string can be parsed as a CSS selector. Rejects

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -460,10 +460,21 @@ let container_rule ?(inner_has_hover = false) query base_class selector props =
     accepts a bare leading combinator, e.g. [>div] or [~img]), with [&] (the
     utility's own element) resolved to the universal selector - the same
     substitution {!Modifiers.nest_selector} performs for [group-[...]] /
-    [peer-[...]] templates, via {!Cascade.Nest.substitute}. *)
+    [peer-[...]] templates, via {!Cascade.Nest.substitute}. The boolean records
+    whether that substitution happened, because Tailwind leaves the resulting
+    complex selector outside [:is()]. *)
 let has_relative_selector s =
-  let sel = Css.Selector.read_relative (Cascade.Cursor.of_string s) in
-  Cascade.Nest.substitute ~parent:Css.Selector.universal sel
+  let unresolved =
+    Css.Selector.read_relative
+      (Cascade.Cursor.of_string (Parse.decode_underscores s))
+  in
+  let has_nesting =
+    Css.Selector.any
+      (function Css.Selector.Nesting -> true | _ -> false)
+      unresolved
+  in
+  ( Cascade.Nest.substitute ~parent:Css.Selector.universal unresolved,
+    has_nesting )
 
 (* The selector a has-shorthand name stands for. [has-<state>] takes the same
    state names as the group/peer variants and matches what that state matches,
@@ -480,6 +491,19 @@ let resolve_has_shorthand = function
   | s when Style.is_data_attr_name s -> "[" ^ s ^ "]"
   | s -> ":" ^ s
 
+(* Tailwind puts a bracketed type, universal, selector-list, or complex selector
+   through [:is()] before it enters [:has()]. A class, ID, attribute or
+   pseudo-class stays simple, and a leading combinator stays relative. *)
+let wrap_has_bracket_selector ~has_nesting =
+  let open Css.Selector in
+  function
+  | sel when has_nesting -> sel
+  | List sels -> is_ sels
+  | ( Element _ | Universal _ | Combined _
+    | Compound ((Element _ | Universal _) :: _) ) as sel ->
+      is_ [ sel ]
+  | sel -> sel
+
 (* The [:has()] argument a has-variant matches, from the spelling the modifier
    stored: a state name resolves to its pseudo-class, anything else is already a
    selector. *)
@@ -487,10 +511,9 @@ let has_inner_selector raw =
   let str =
     if Style.is_has_shorthand raw then resolve_has_shorthand raw else raw
   in
-  match has_relative_selector str with
-  | Css.Selector.List sels when not (Style.is_has_shorthand raw) ->
-      Css.Selector.is_ sels
-  | sel -> sel
+  let sel, has_nesting = has_relative_selector str in
+  if Style.is_has_shorthand raw then sel
+  else wrap_has_bracket_selector ~has_nesting sel
 
 (* The relative selector a group/peer has-variant scopes to:
    [:where(.group):has(<inner>) *]. *)
@@ -518,12 +541,14 @@ let route_regular ~selector ~base_class ~modified_class ~modified ?has_hover
 let has_like_selector kind ?name ?shorthand ?(has_hover = false) ~selector
     selector_str base_class props =
   let open Css.Selector in
+  let parsed_selector, has_nesting = has_relative_selector selector_str in
+  (* A bracket value is one arbitrary selector and is wrapped when it is not
+     already relative. The [hocus] shorthand is genuinely two selectors and
+     stays a list. *)
   let parsed_selector =
-    match has_relative_selector selector_str with
-    (* A bracket list is one relative selector, so it goes in an [:is()]. The
-       [hocus] shorthand is genuinely two, and stays a list. *)
-    | List sels when shorthand = None -> is_ sels
-    | sel -> sel
+    match shorthand with
+    | None -> wrap_has_bracket_selector ~has_nesting parsed_selector
+    | Some _ -> parsed_selector
   in
   let has_part s =
     match shorthand with Some sh -> sh | None -> "[" ^ s ^ "]"

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -902,10 +902,10 @@ let test_has_data_and_not_composition () =
   has "not-peer-has-checked:opacity-0"
     ".not-peer-has-checked\\:opacity-0:not(:is(:where(.peer):has(:checked)~*))"
 
-(* A bracket [has-] argument is one relative selector, so a list inside it goes
-   in an [:is()]; a bare type selector keeps its brackets in the class name
-   rather than being read as a state name. And [group-not-] takes any variant as
-   its inner, not just the simple states. *)
+(* A bracket [has-] argument is one arbitrary relative selector, so Tailwind
+   wraps it in [:is()], including a bare type selector. The brackets stay in the
+   class name rather than being read as a state name. And [group-not-] takes any
+   variant as its inner, not just the simple states. *)
 let test_has_bracket_arguments () =
   let css cls =
     match Tw.of_string cls with
@@ -916,9 +916,15 @@ let test_has_bracket_arguments () =
     check bool cls true (Astring.String.is_infix ~affix (css cls))
   in
   has "has-[[data-a],[data-b]]:block" ":has(:is([data-a], [data-b]))";
-  has "has-[a]:block" ".has-\\[a\\]\\:block:has(a)";
+  has "has-[a]:block" ".has-\\[a\\]\\:block:has(:is(a))";
+  has "has-[:focus]:block" ".has-\\[\\:focus\\]\\:block:has(:focus)";
+  has "has-[.item]:block" ".has-\\[\\.item\\]\\:block:has(.item)";
+  has "has-[a_.item]:block" ".has-\\[a_\\.item\\]\\:block:has(:is(a .item))";
+  has "has-[&>img]:block" ".has-\\[\\&\\>img\\]\\:block:has(*>img)";
   has "group-has-[a]:block"
-    ".group-has-\\[a\\]\\:block:is(:where(.group):has(a) *)";
+    ".group-has-\\[a\\]\\:block:is(:where(.group):has(:is(a)) *)";
+  has "peer-has-[a]:block"
+    ".peer-has-\\[a\\]\\:block:is(:where(.peer):has(:is(a))~*)";
   has "group-not-has-[[data-hover],[data-focus]]:block"
     ":not(:has(:is([data-hover], [data-focus])))";
   (* the hocus shorthand really is two selectors and stays a list *)


### PR DESCRIPTION
Preserves Tailwind’s :is(...) shape for bracketed type, universal, list and non-nested complex has selectors, decodes encoded selector spaces, and leaves simple, relative and &-anchored forms unchanged.