### PR TITLE
color: emit arbitrary mix fallbacks

### DIFF
--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1237,42 +1237,48 @@ module Handler = struct
     | None -> [ d_stops ]
 
   (** Gradient with a simple color value + stops (no opacity) *)
-  let gradient_simple ~prefix ~set_var color_value extra_decls =
-    let d_var, _ = Var.binding set_var (Css.minify_color color_value) in
+  let gradient_simple ~theme ~prefix ~set_var color_value extra_decls =
+    let color_value = Color.resolve_bracket_css_color color_value in
     let d_stops, d_via_stops_opt = gradient_stops_decls prefix in
     let property_rules = gradient_all_property_rules () in
-    let declarations =
-      extra_decls @ [ d_var ] @ stops_as_decls d_stops d_via_stops_opt
-    in
-    style ~property_rules declarations
+    let stops = stops_as_decls d_stops d_via_stops_opt in
+    match Color.pre_color_mix_fallback theme color_value with
+    | None ->
+        let d_var, _ = Var.binding set_var (Css.minify_color color_value) in
+        style ~property_rules (extra_decls @ [ d_var ] @ stops)
+    | Some fallback ->
+        let fallback_decl, _ = Var.binding set_var fallback in
+        let enhanced_decl, _ = Var.binding set_var color_value in
+        let self decls = Css.rule ~selector:(Css.Selector.class_ "_") decls in
+        let supports =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ self [ enhanced_decl ] ]
+        in
+        style ~property_rules
+          ~rules:
+            (Some
+               [ self (extra_decls @ [ fallback_decl ]); supports; self stops ])
+          []
 
-  (* Gradient with opacity: fallback + @supports color-mix + stops *)
-  let gradient_with_opacity ~prefix ~set_var (fallback_color : Css.color)
-      (mix_color : Css.color) ?(extra_supports_decls = []) percent =
-    let d_fallback, _ = Var.binding set_var fallback_color in
-    let oklab_color =
-      Css.color_mix ~in_space:Oklab mix_color Css.Transparent ~percent1:percent
-    in
-    let d_oklab, _ = Var.binding set_var oklab_color in
-    let fallback_rule =
-      Css.rule ~selector:(Css.Selector.class_ "_") [ d_fallback ]
-    in
-    let supports_rule =
-      Css.supports ~condition:Color.color_mix_supports_condition
-        [
-          Css.rule ~selector:(Css.Selector.class_ "_")
-            (extra_supports_decls @ [ d_oklab ]);
-        ]
-    in
-    let d_stops, d_via_stops_opt = gradient_stops_decls prefix in
-    let property_rules = gradient_all_property_rules () in
-    let stops_rule =
-      Css.rule ~selector:(Css.Selector.class_ "_")
-        (stops_as_decls d_stops d_via_stops_opt)
-    in
-    style ~property_rules
-      ~rules:(Some [ fallback_rule; supports_rule; stops_rule ])
-      []
+  (* Gradient with opacity: either a static value, or a fallback followed by the
+     authored mix under [@supports], then the stop composition. *)
+  let gradient_with_opacity ~theme ~prefix ~set_var color opacity =
+    match Color.bracket_color_opacity ~theme color opacity with
+    | Color.Folded value -> gradient_simple ~theme ~prefix ~set_var value []
+    | Color.Guarded { fallback; mixed } ->
+        let d_fallback, _ = Var.binding set_var fallback in
+        let d_oklab, _ = Var.binding set_var mixed in
+        let self decls = Css.rule ~selector:(Css.Selector.class_ "_") decls in
+        let supports_rule =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ self [ d_oklab ] ]
+        in
+        let d_stops, d_via_stops_opt = gradient_stops_decls prefix in
+        let stops = stops_as_decls d_stops d_via_stops_opt in
+        let property_rules = gradient_all_property_rules () in
+        style ~property_rules
+          ~rules:(Some [ self [ d_fallback ]; supports_rule; self stops ])
+          []
 
   (** Convert gradient target to set_var and prefix *)
   let gradient_target_info = function
@@ -1376,16 +1382,15 @@ module Handler = struct
             (* Hex is known at compile time: compute oklab directly *)
             let alpha = Color.opacity_to_percent opacity /. 100.0 in
             let color = Color.hex_to_oklab_alpha h alpha in
-            gradient_simple ~prefix ~set_var color []
+            gradient_simple ~theme ~prefix ~set_var color []
         | Color_source.Plain (source, opacity) -> (
             (* A keyword or a bracket value: the colour is known without the
                scheme. *)
             let color = css_color_of_plain source in
             match opacity with
-            | None -> gradient_simple ~prefix ~set_var color []
+            | None -> gradient_simple ~theme ~prefix ~set_var color []
             | Some opacity ->
-                let percent = Color.opacity_to_percent opacity in
-                gradient_with_opacity ~prefix ~set_var color color percent))
+                gradient_with_opacity ~theme ~prefix ~set_var color opacity))
     | Gradient_stop_position (target, src) -> (
         let _prefix, _set_var, pos_var = gradient_target_info target in
         match src with
@@ -1493,14 +1498,10 @@ module Handler = struct
     | Bg_bracket_var_opacity (v, opacity) ->
         bg_bracket_color_var_opacity' v opacity
     | Bg_bracket_color (_, css_color) ->
-        let c =
-          match Color.css_color_to_hex css_color with
-          | Some h -> h
-          | None -> css_color
-        in
-        style [ Css.background_color c ]
+        Color.bracket_color_style ~theme ~property:Css.background_color
+          css_color
     | Bg_bracket_color_opacity (_, css_color, opacity) ->
-        Color.bracket_color_opacity_style ~property:Css.background_color
+        Color.bracket_color_opacity_style ~theme ~property:Css.background_color
           css_color opacity
     | Bg_current -> style [ Css.background_color Css.Current ]
     | Bg_current_opacity opacity -> Color.bg_current_with_opacity ~theme opacity

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2608,12 +2608,113 @@ module Handler = struct
      value is whatever the [\@theme] block bound it to, and that may be a colour
      space no hex can spell - so it takes the sRGB mix Tailwind writes instead.
      [value] is the colour already resolved against the theme. *)
-  let opacity_fallback ~percent c shade value =
-    match to_oklch_opt c shade with
-    | Some oklch ->
+  let opacity_fallback ?theme ~percent c shade value =
+    let overridden =
+      match palette_token c shade with
+      | Some token -> Scheme.theme_value theme token <> None
+      | None -> false
+    in
+    match (overridden, to_oklch_opt c shade) with
+    | false, Some oklch ->
         Css.hex (hex_with_alpha (rgb_to_hex (oklch_to_rgb oklch)) percent)
-    | None ->
+    | true, _ | false, None ->
         Css.color_mix ~in_space:Srgb value Css.Transparent ~percent1:percent
+
+  (* Resolve the colour tokens inside an arbitrary [color-mix()] through the
+     render's scheme. Tailwind emits that resolved mix in sRGB as the fallback,
+     then keeps the authored mix behind a [color-mix()] support query. When a
+     token is unavailable at compile time (including a token removed by the
+     project), the first operand is the legacy fallback instead. *)
+  let theme_var_color theme name =
+    match Option.bind (Scheme.token theme name) Css.parse_color with
+    | Some _ as color -> color
+    | None when Scheme.is_removed theme name -> None
+    | None ->
+        Option.map
+          (fun (c, shade) -> get_color_value ~theme c shade)
+          (theme_color_of_name name)
+
+  type mix_resolution = {
+    color : Css.color;
+    has_dynamic_color : bool;
+    unresolved : bool;
+  }
+
+  let static color = { color; has_dynamic_color = false; unresolved = false }
+
+  let fallback_space (space : Css.color_space option) =
+    match space with
+    | Some (Css.Lab | Css.Oklab | Css.Lch | Css.Oklch) -> Some Css.Srgb
+    | space -> space
+
+  let rec resolve_color_theme_vars theme seen (color : Css.color) =
+    match color with
+    | Css.Var v -> (
+        if List.mem v.name seen then
+          { color; has_dynamic_color = true; unresolved = true }
+        else
+          match theme_var_color theme v.name with
+          | None -> { color; has_dynamic_color = true; unresolved = true }
+          | Some value ->
+              let resolved =
+                resolve_color_theme_vars theme (v.name :: seen) value
+              in
+              { resolved with has_dynamic_color = true })
+    | Css.Current -> { color; has_dynamic_color = true; unresolved = true }
+    | Css.Mix { in_space; hue; color1; percent1; color2; percent2 } ->
+        let first = resolve_color_theme_vars theme seen color1 in
+        let second = resolve_color_theme_vars theme seen color2 in
+        let has_dynamic_color =
+          first.has_dynamic_color || second.has_dynamic_color
+        in
+        if not has_dynamic_color then static color
+        else if first.unresolved || second.unresolved then
+          (* A browser without [color-mix()] can still use the first operand.
+             Keep [unresolved] set so an enclosing mix follows the same rule. *)
+          { first with has_dynamic_color = true; unresolved = true }
+        else
+          {
+            color =
+              Css.Mix
+                {
+                  in_space = fallback_space in_space;
+                  hue;
+                  color1 = first.color;
+                  percent1;
+                  color2 = second.color;
+                  percent2;
+                };
+            has_dynamic_color = true;
+            unresolved = false;
+          }
+    | color -> static color
+
+  let pre_color_mix_fallback theme (color : Css.color) =
+    match color with
+    | Css.Mix _ ->
+        let resolved = resolve_color_theme_vars theme [] color in
+        if resolved.has_dynamic_color then Some resolved.color else None
+    | _ -> None
+
+  let bracket_colors_style ?merge_key ~theme ~properties css_color =
+    let declarations color =
+      List.map (fun property -> property color) properties
+    in
+    let color = resolve_bracket_css_color css_color in
+    match pre_color_mix_fallback theme color with
+    | None -> style ?merge_key (declarations color)
+    | Some fallback ->
+        let supports_block =
+          Css.supports ~condition:color_mix_supports_condition
+            [
+              Css.rule ~selector:(Css.Selector.class_ "_") (declarations color);
+            ]
+        in
+        style ?merge_key ~rules:(Some [ supports_block ])
+          (declarations fallback)
+
+  let bracket_color_style ?merge_key ~theme ~property css_color =
+    bracket_colors_style ?merge_key ~theme ~properties:[ property ] css_color
 
   (* The same colour set on several properties at once: a per-side border colour
      on the [x]/[y] axes needs two. *)
@@ -2697,9 +2798,10 @@ module Handler = struct
                fallback, so the fallback is the colour at full opacity. *)
             let fallback_decls =
               match opacity_var_name opacity with
-              | Some _ -> property_decls (Css.Var color_ref)
+              | Some _ -> property_decls color_value
               | None ->
-                  property_decls (opacity_fallback ~percent c shade color_value)
+                  property_decls
+                    (opacity_fallback ?theme ~percent c shade color_value)
             in
             let oklab_color =
               match opacity_var_name opacity with
@@ -2742,7 +2844,7 @@ module Handler = struct
   let border_with_opacity ?theme c shade opacity =
     color_with_opacity_style ?theme ~property:Css.border_color c shade opacity
 
-  let border_side_color_style side value =
+  let border_side_color_style theme side value =
     let sides = setters_of_side side in
     let apply c = style (List.map (fun set -> set c) sides) in
     match value with
@@ -2756,7 +2858,8 @@ module Handler = struct
             (decl :: List.map (fun set -> set (Var color_ref : Css.color)) sides)
     | Side_color.Named_opacity (color, shade, opacity) ->
         colors_with_opacity_style ~properties:sides color shade opacity
-    | Side_color.Bracket (_, css_color) -> apply css_color
+    | Side_color.Bracket (_, css_color) ->
+        bracket_colors_style ~theme ~properties:sides css_color
     | Side_color.Transparent -> apply (Css.hex "#0000")
     | Side_color.Current -> apply Css.Current
 
@@ -2823,38 +2926,48 @@ module Handler = struct
      opacity modifier applies to that value. Reading the bracket text back
      through the palette parser answered black for every colour the palette does
      not name. *)
-  let bracket_color_opacity css_color opacity =
+  let bracket_color_opacity ?(theme = Scheme.default) css_color opacity =
     match bracket_color_to_custom css_color with
     | Some c when opacity_var_name opacity = None ->
         Folded (custom_color_with_alpha c (opacity_to_percent opacity /. 100.0))
-    | _ ->
-        let fallback = resolve_bracket_css_color css_color in
-        Guarded { fallback; mixed = mix_alpha opacity fallback }
+    | _ -> (
+        let base = resolve_bracket_css_color css_color in
+        let mixed = mix_alpha opacity base in
+        match pre_color_mix_fallback theme mixed with
+        | Some fallback -> Guarded { fallback; mixed }
+        | None -> (
+            (* A fully static mix needs no progressive-enhancement pair: Cascade
+               can evaluate its inner mix and then the composed opacity. This is
+               especially important when [base] is itself a mix; using [base] as
+               the fallback would silently discard the slash opacity. *)
+            let normalized_base = Cascade.Values.normalize_color base in
+            let normalized =
+              mix_alpha opacity normalized_base
+              |> Cascade.Values.normalize_color
+            in
+            match normalized with
+            | Css.Mix _ -> Guarded { fallback = base; mixed }
+            | color -> Folded (Cascade.Values.nonkeyword_color color)))
 
-  let bracket_color_opacity_style ?merge_key ~property css_color opacity =
+  let bracket_color_opacity_style ?(theme = Scheme.default) ?merge_key ~property
+      css_color opacity =
     match bracket_color_to_custom css_color with
     | Some c -> color_with_opacity_style ~property ?merge_key c 500 opacity
     | None -> (
-        let base = resolve_bracket_css_color css_color in
-        match css_color with
-        | Css.Current | Css.Var _ ->
-            (* The browser resolves these at use time, so the alpha cannot be
-               folded in ahead of it the way a concrete colour's can - an
-               [oklch()] mix folds to a hex with its alpha, [currentcolor] has
-               nothing to fold. Tailwind writes the plain colour and puts the
-               mix behind the [color-mix()] guard; emitting the mix alone leaves
-               a browser without [color-mix()] no colour at all. *)
+        match bracket_color_opacity ~theme css_color opacity with
+        | Folded value -> style ?merge_key [ property value ]
+        | Guarded { fallback; mixed } ->
             let supports_block =
               Css.supports ~condition:color_mix_supports_condition
                 [
                   Css.rule ~selector:(Css.Selector.class_ "_")
-                    [ property (apply_alpha opacity base) ];
+                    [ property mixed ];
                 ]
             in
-            style ?merge_key ~rules:(Some [ supports_block ]) [ property base ]
-        | _ -> style ?merge_key [ property (apply_alpha opacity base) ])
+            style ?merge_key ~rules:(Some [ supports_block ])
+              [ property fallback ])
 
-  let outline_bracket_color_opacity_style inner css_color opacity =
+  let outline_bracket_color_opacity_style ~theme inner css_color opacity =
     let merge_key =
       if String.length inner > 0 && inner.[0] = '#' then
         (* Hex bracket colors: strip bracket+opacity for merging *)
@@ -2865,8 +2978,8 @@ module Handler = struct
            but Tailwind keeps them separate. *)
         "outline-[" ^ inner ^ "]" ^ opacity_suffix opacity
     in
-    bracket_color_opacity_style ~property:Css.outline_color ~merge_key css_color
-      opacity
+    bracket_color_opacity_style ~theme ~property:Css.outline_color ~merge_key
+      css_color opacity
 
   let outline_bracket_var_opacity_style v opacity =
     let bare_name = Parse.extract_var_name v in
@@ -2939,10 +3052,10 @@ module Handler = struct
         current_color_with_opacity ~property:Css.color opacity
     | Text_inherit -> text_inherit
     | Text_bracket_color (_orig, css_color) ->
-        let c = resolve_bracket_css_color css_color in
-        style ~merge_key:"text-" [ Css.color c ]
+        bracket_color_style ~theme ~merge_key:"text-" ~property:Css.color
+          css_color
     | Text_bracket_color_opacity (_orig, css_color, opacity) ->
-        bracket_color_opacity_style ~property:Css.color css_color opacity
+        bracket_color_opacity_style ~theme ~property:Css.color css_color opacity
     | Text_bracket_var v ->
         let bare_name = Parse.extract_var_name v in
         style ~merge_key:"text-" [ Css.color (Css.Var (Var.bracket bare_name)) ]
@@ -2981,7 +3094,8 @@ module Handler = struct
         in
         style ~merge_key:"text-" ~rules:(Some [ supports_block ])
           [ fallback_decl ]
-    | Border_side_color (side, value) -> border_side_color_style side value
+    | Border_side_color (side, value) ->
+        border_side_color_style theme side value
     | Border (color, shade) -> border_color' color shade
     | Border_opacity (color, shade, opacity) ->
         border_with_opacity color shade opacity
@@ -2990,10 +3104,11 @@ module Handler = struct
     | Border_current_opacity opacity ->
         current_color_with_opacity ~property:Css.border_color opacity
     | Border_bracket_color (_orig, css_color) ->
-        let c = resolve_bracket_css_color css_color in
-        style ~merge_key:"border-" [ Css.border_color c ]
+        bracket_color_style ~theme ~merge_key:"border-"
+          ~property:Css.border_color css_color
     | Border_bracket_color_opacity (_orig, css_color, opacity) ->
-        bracket_color_opacity_style ~property:Css.border_color css_color opacity
+        bracket_color_opacity_style ~theme ~property:Css.border_color css_color
+          opacity
     | Accent (color, shade) -> accent' color shade
     | Accent_opacity (color, shade, opacity) ->
         accent_with_opacity color shade opacity
@@ -3003,10 +3118,11 @@ module Handler = struct
         current_color_with_opacity ~property:Css.accent_color opacity
     | Accent_inherit -> accent_inherit
     | Accent_bracket_color (_orig, css_color) ->
-        let c = resolve_bracket_css_color css_color in
-        style ~merge_key:"accent-" [ Css.accent_color c ]
+        bracket_color_style ~theme ~merge_key:"accent-"
+          ~property:Css.accent_color css_color
     | Accent_bracket_color_opacity (_orig, css_color, opacity) ->
-        bracket_color_opacity_style ~property:Css.accent_color css_color opacity
+        bracket_color_opacity_style ~theme ~property:Css.accent_color css_color
+          opacity
     | Caret (color, shade) -> caret' color shade
     | Caret_opacity (color, shade, opacity) ->
         caret_with_opacity color shade opacity
@@ -3016,10 +3132,11 @@ module Handler = struct
     | Caret_inherit -> caret_inherit
     | Caret_transparent -> caret_transparent
     | Caret_bracket_color (_orig, css_color) ->
-        let c = resolve_bracket_css_color css_color in
-        style ~merge_key:"caret-" [ Css.caret_color c ]
+        bracket_color_style ~theme ~merge_key:"caret-" ~property:Css.caret_color
+          css_color
     | Caret_bracket_color_opacity (_orig, css_color, opacity) ->
-        bracket_color_opacity_style ~property:Css.caret_color css_color opacity
+        bracket_color_opacity_style ~theme ~property:Css.caret_color css_color
+          opacity
     | Outline (color, shade) -> outline' color shade
     | Outline_opacity (color, shade, opacity) ->
         outline_with_opacity color shade opacity
@@ -3029,10 +3146,10 @@ module Handler = struct
     | Outline_inherit -> outline_inherit
     | Outline_transparent -> outline_transparent
     | Outline_bracket_color (_orig, css_color) ->
-        let c = resolve_bracket_css_color css_color in
-        style ~merge_key:"outline-" [ Css.outline_color c ]
+        bracket_color_style ~theme ~merge_key:"outline-"
+          ~property:Css.outline_color css_color
     | Outline_bracket_color_opacity (inner, css_color, opacity) ->
-        outline_bracket_color_opacity_style inner css_color opacity
+        outline_bracket_color_opacity_style ~theme inner css_color opacity
     | Outline_bracket_var v -> outline_bracket_var_style v
     | Outline_bracket_var_opacity (v, opacity) ->
         outline_bracket_var_opacity_style v opacity
@@ -3055,12 +3172,12 @@ module Handler = struct
           (current_color_with_opacity ~property:Css.color opacity)
     | Placeholder_inherit -> with_pseudo Css.Selector.Placeholder text_inherit
     | Placeholder_bracket_color (_orig, css_color) ->
-        let c = resolve_bracket_css_color css_color in
-        let s = style [ Css.color c ] in
-        with_pseudo Css.Selector.Placeholder s
+        with_pseudo Css.Selector.Placeholder
+          (bracket_color_style ~theme ~property:Css.color css_color)
     | Placeholder_bracket_color_opacity (_orig, css_color, opacity) ->
         with_pseudo Css.Selector.Placeholder
-          (bracket_color_opacity_style ~property:Css.color css_color opacity)
+          (bracket_color_opacity_style ~theme ~property:Css.color css_color
+             opacity)
 
   (* Suborder for the non-text color families: border first (0-9999), then the
      rest. text-color runs at priority 26 (see [priority]) with a fixed suborder
@@ -3366,6 +3483,9 @@ type bracket_opacity = Handler.bracket_opacity =
 
 let bracket_color_opacity = Handler.bracket_color_opacity
 let css_color_to_hex = Handler.css_color_to_hex
+let resolve_bracket_css_color = Handler.resolve_bracket_css_color
+let pre_color_mix_fallback = Handler.pre_color_mix_fallback
+let bracket_color_style = Handler.bracket_color_style
 let parse_bracket_color = Handler.parse_bracket_color
 
 type bracket_hint = Handler.bracket_hint =
@@ -3466,9 +3586,7 @@ let generic_color_with_opacity ?theme ~property c shade opacity =
           let base = to_css ?theme c shade in
           let fallback_color =
             if alpha_var then base
-            else
-              Css.color_mix ~in_space:Srgb base Css.Transparent
-                ~percent1:percent
+            else opacity_fallback ?theme ~percent c shade base
           in
           oklab_with_supports ?theme ~property
             ~fallback_decl:(property fallback_color) c shade opacity)
@@ -3515,7 +3633,7 @@ let divide_opacity_via_property ?theme ~selector c shade opacity =
   let fallback_color =
     if Handler.opacity_var_name opacity <> None then color_value
     else
-      Handler.opacity_fallback
+      Handler.opacity_fallback ?theme
         ~percent:(Handler.opacity_to_percent opacity)
         c shade color_value
   in
@@ -3536,10 +3654,10 @@ let bg_opacity_via_property ?theme c shade opacity =
      that is the colour at full opacity, as Tailwind emits. *)
   let fallback_decl =
     match Handler.opacity_var_name opacity with
-    | Some _ -> Css.background_color (Css.Var color_ref)
+    | Some _ -> Css.background_color color_value
     | None ->
         Css.background_color
-          (Handler.opacity_fallback
+          (Handler.opacity_fallback ?theme
              ~percent:(Handler.opacity_to_percent opacity)
              c shade color_value)
   in

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -383,8 +383,9 @@ val apply_alpha :
 (** [apply_alpha ?in_space opacity color] applies the modifier while preserving
     the identity that every alpha of [transparent] is still [transparent]. *)
 
-val opacity_fallback : percent:float -> color -> int -> Css.color -> Css.color
-(** [opacity_fallback ~percent c shade value] is what a browser without
+val opacity_fallback :
+  ?theme:Scheme.t -> percent:float -> color -> int -> Css.color -> Css.color
+(** [opacity_fallback ?theme ~percent c shade value] is what a browser without
     [color-mix()] reads for [c] at [percent] opacity. A palette colour folds the
     alpha into a plain hex; a project token, whose [value] the theme supplies
     and which may name a colour space no hex can spell, takes an sRGB mix
@@ -546,6 +547,7 @@ val shorten_hex_str : string -> string
 (** [shorten_hex_str hex] shortens a hex color string if possible. *)
 
 val bracket_color_opacity_style :
+  ?theme:Scheme.t ->
   ?merge_key:string ->
   property:(Css.color -> Css.declaration) ->
   Css.color ->
@@ -564,7 +566,8 @@ type bracket_opacity =
       (** the colour itself, for a browser with no [color-mix()], and the mix
           that goes behind an [@supports] guard *)
 
-val bracket_color_opacity : Css.color -> opacity_modifier -> bracket_opacity
+val bracket_color_opacity :
+  ?theme:Scheme.t -> Css.color -> opacity_modifier -> bracket_opacity
 (** [bracket_color_opacity c opacity] is what [opacity] makes of the bracket
     colour [c]. It answers values rather than declarations because the
     properties they land on differ by family: a decoration colour writes a
@@ -594,6 +597,26 @@ val css_color_to_hex : Css.color -> Css.color option
 (** [css_color_to_hex c] converts a typed CSS color (Rgb, Rgba, Hsl) to a hex
     color for Tailwind parity. Returns [None] for color types that cannot be
     easily converted (oklch, oklab, etc.). *)
+
+val resolve_bracket_css_color : Css.color -> Css.color
+(** [resolve_bracket_css_color c] returns the compact emission form of an
+    arbitrary colour, folding static RGB/HSL spellings to hex when possible. *)
+
+val pre_color_mix_fallback : Scheme.t -> Css.color -> Css.color option
+(** [pre_color_mix_fallback theme c] is Tailwind's legacy value for an arbitrary
+    [color-mix()] containing dynamic colour operands. Theme variables are
+    resolved into an sRGB mix. If an operand cannot be resolved at compile time,
+    the first colour operand is used. [None] means no guard is needed. *)
+
+val bracket_color_style :
+  ?merge_key:string ->
+  theme:Scheme.t ->
+  property:(Css.color -> Css.declaration) ->
+  Css.color ->
+  Style.t
+(** [bracket_color_style ~theme ~property c] emits [c], preceded by its
+    pre-[color-mix()] fallback and followed by a guarded enhancement when the
+    arbitrary colour needs progressive enhancement. *)
 
 val round_n : int -> float -> float
 (** [round_n n f] rounds [f] to [n] decimal places. *)

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -198,24 +198,26 @@ module Handler = struct
     let rule = Css.rule ~selector [ Css.border_color Css.Inherit ] in
     style ~rules:(Some [ rule ]) []
 
-  let divide_bracket_color_style class_name inner c =
-    let color =
-      if String.length inner > 0 && inner.[0] = '#' then
-        let shortened = Color.shorten_hex_str inner in
-        Css.hex ("#" ^ shortened)
-      else match Color.css_color_to_hex c with Some h -> h | None -> c
-    in
+  let divide_bracket_color_style ~theme class_name c =
+    let color = Color.resolve_bracket_css_color c in
     let selector = divide_children_selector class_name in
-    let rule = Css.rule ~selector [ Css.border_color color ] in
-    style ~rules:(Some [ rule ]) []
+    let rule color = Css.rule ~selector [ Css.border_color color ] in
+    match Color.pre_color_mix_fallback theme color with
+    | None -> style ~rules:(Some [ rule color ]) []
+    | Some fallback ->
+        let supports =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [ rule color ]
+        in
+        style ~rules:(Some [ rule fallback; supports ]) []
 
   (* An opacity modifier applies to the colour the bracket was parsed into. The
      modifier read the bracket text back through the CSS colour parser and
      answered black whenever that failed, and it hung the [@supports] rule on
      the bare class rather than on the children the utility borders. *)
-  let divide_bracket_color_opacity_style class_name c opacity =
+  let divide_bracket_color_opacity_style ~theme class_name c opacity =
     let selector = divide_children_selector class_name in
-    match Color.bracket_color_opacity c opacity with
+    match Color.bracket_color_opacity ~theme c opacity with
     | Color.Folded value ->
         let rule = Css.rule ~selector [ Css.border_color value ] in
         style ~rules:(Some [ rule ]) []
@@ -337,10 +339,10 @@ module Handler = struct
     | Inherit -> divide_inherit_style ()
     | Bracket_color (inner, c) ->
         let class_name = to_class (Bracket_color (inner, c)) in
-        divide_bracket_color_style class_name inner c
+        divide_bracket_color_style ~theme class_name c
     | Bracket_color_opacity (inner, c, opacity) ->
         let class_name = to_class (Bracket_color_opacity (inner, c, opacity)) in
-        divide_bracket_color_opacity_style class_name c opacity
+        divide_bracket_color_opacity_style ~theme class_name c opacity
     | Line_style bs -> divide_style_style bs
 
   (* Tailwind's order across the family, read off its own output: divide-x,

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -347,6 +347,40 @@ module Handler = struct
     Css.supports ~condition:Color.color_mix_supports_condition
       [ Css.rule ~selector:(Css.Selector.class_ "_") decls ]
 
+  (* A bracket colour may need two assignments: the value a browser without
+     [color-mix()] can use, and the authored value under [@supports]. *)
+  let bracket_color_pair theme c =
+    let enhanced = Color.resolve_bracket_css_color c in
+    match Color.pre_color_mix_fallback theme enhanced with
+    | Stdlib.Option.None -> (enhanced, Stdlib.Option.None)
+    | Stdlib.Option.Some fallback -> (fallback, Stdlib.Option.Some enhanced)
+
+  let bracket_color_var_style ~theme var c =
+    let fallback, enhanced = bracket_color_pair theme c in
+    let fallback_decl, _ = Var.binding var fallback in
+    match enhanced with
+    | Stdlib.Option.None -> style [ fallback_decl ]
+    | Stdlib.Option.Some color ->
+        let enhanced_decl, _ = Var.binding var color in
+        let supports_block = color_mix_supports [ enhanced_decl ] in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+
+  let bracket_color_var_opacity_style ~theme var c opacity =
+    match Color.bracket_color_opacity ~theme c opacity with
+    | Color.Folded value -> style [ fst (Var.binding var value) ]
+    | Color.Guarded { fallback; mixed } ->
+        let fallback_decl, _ = Var.binding var fallback in
+        let enhanced_decl, _ = Var.binding var mixed in
+        let supports_block = color_mix_supports [ enhanced_decl ] in
+        style ~rules:(Some [ supports_block ]) [ fallback_decl ]
+
+  let bracket_opacity_pair theme c opacity =
+    let color = Color.resolve_bracket_css_color c in
+    let enhanced = Color.mix_alpha ~in_space:Oklab opacity color in
+    Option.map
+      (fun fallback -> (fallback, enhanced))
+      (Color.pre_color_mix_fallback theme enhanced)
+
   let relative_color_supports =
     Css.Supports.property "color" "lab(from red l a b)"
 
@@ -861,9 +895,10 @@ module Handler = struct
     style ~metadata:shadow_property_metadata
       ~property_rules:shadow_property_rules [ base_decl ]
 
-  let set_shadow_bracket_color (c : Css.color) =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let base_decl, _ = Var.binding shadow_color_var c in
+  let set_shadow_bracket_color ~theme (c : Css.color) =
+    let fallback, enhanced = bracket_color_pair theme c in
+    let base_decl, _ = Var.binding shadow_color_var fallback in
+    let c = Option.value ~default:fallback enhanced in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab ~var_name:"tw-shadow-alpha" c
         Css.Transparent
@@ -873,7 +908,7 @@ module Handler = struct
     style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
       ~property_rules:shadow_property_rules [ base_decl ]
 
-  let set_shadow_bracket_color_opacity (c : Css.color) opacity =
+  let set_shadow_bracket_color_opacity ~theme (c : Css.color) opacity =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
@@ -882,25 +917,28 @@ module Handler = struct
        guards, so the two are built separately. Folding the fallback through
        oklab as well made it depend on a colour-space round trip. *)
     let base_value, with_alpha =
-      match c with
-      (* A modifier reading a custom property has no percentage for an alpha
-         byte to carry, so the hex stays whole and the property mixes into the
-         guarded value instead. *)
-      | (Hex _ | Authored_hex _)
-        when Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) ->
-          (c, Color.mix_alpha ~in_space:Oklab opacity c)
-      | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-          let hex = "#" ^ rgba_hex_string r g b a in
-          ( Css.hex (Color.hex_with_alpha hex percent),
-            Color.hex_to_oklab_alpha hex alpha )
-      (* A colour with no sRGB hex has nothing to carry the alpha byte, so the
-         modifier stays a mix: sRGB for the plain fallback, oklab for the
-         guarded value. *)
-      | _ ->
-          let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
-          if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
-            (c, guarded)
-          else (Color.mix_alpha ~in_space:Srgb opacity c, guarded)
+      match bracket_opacity_pair theme c opacity with
+      | Some pair -> pair
+      | None -> (
+          match c with
+          (* A modifier reading a custom property has no percentage for an alpha
+             byte to carry, so the hex stays whole and the property mixes into
+             the guarded value instead. *)
+          | (Hex _ | Authored_hex _)
+            when Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) ->
+              (c, Color.mix_alpha ~in_space:Oklab opacity c)
+          | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
+              let hex = "#" ^ rgba_hex_string r g b a in
+              ( Css.hex (Color.hex_with_alpha hex percent),
+                Color.hex_to_oklab_alpha hex alpha )
+          (* A colour with no sRGB hex has nothing to carry the alpha byte, so
+             the modifier stays a mix: sRGB for the plain fallback, oklab for
+             the guarded value. *)
+          | _ ->
+              let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
+              if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
+                (c, guarded)
+              else (Color.mix_alpha ~in_space:Srgb opacity c, guarded))
     in
     let base_decl, _ = Var.binding shadow_color_var base_value in
     let enhanced_color =
@@ -1500,9 +1538,10 @@ module Handler = struct
     style ~metadata:shadow_property_metadata
       ~property_rules:shadow_property_rules [ base_decl ]
 
-  let set_inset_shadow_bracket_color (c : Css.color) =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let base_decl, _ = Var.binding inset_shadow_color_var c in
+  let set_inset_shadow_bracket_color ~theme (c : Css.color) =
+    let fallback, enhanced = bracket_color_pair theme c in
+    let base_decl, _ = Var.binding inset_shadow_color_var fallback in
+    let c = Option.value ~default:fallback enhanced in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab
         ~var_name:"tw-inset-shadow-alpha" c Css.Transparent
@@ -1512,7 +1551,7 @@ module Handler = struct
     style ~rules:(Some [ supports_block ]) ~metadata:shadow_property_metadata
       ~property_rules:shadow_property_rules [ base_decl ]
 
-  let set_ishadow_bracket_color_opacity (c : Css.color) opacity =
+  let set_ishadow_bracket_color_opacity ~theme (c : Css.color) opacity =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
     let percent = Color.opacity_to_percent opacity in
     let alpha = percent /. 100.0 in
@@ -1520,19 +1559,22 @@ module Handler = struct
        byte, the oklab spelling is kept for the guarded [color-mix], and a
        colour with no hex keeps its alpha as a mix in each space. *)
     let base_value, with_alpha =
-      match c with
-      | (Hex _ | Authored_hex _)
-        when Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) ->
-          (c, Color.mix_alpha ~in_space:Oklab opacity c)
-      | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-          let hex = "#" ^ rgba_hex_string r g b a in
-          ( Css.hex (Color.hex_with_alpha hex percent),
-            Color.hex_to_oklab_alpha hex alpha )
-      | _ ->
-          let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
-          if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
-            (c, guarded)
-          else (Color.mix_alpha ~in_space:Srgb opacity c, guarded)
+      match bracket_opacity_pair theme c opacity with
+      | Some pair -> pair
+      | None -> (
+          match c with
+          | (Hex _ | Authored_hex _)
+            when Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) ->
+              (c, Color.mix_alpha ~in_space:Oklab opacity c)
+          | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
+              let hex = "#" ^ rgba_hex_string r g b a in
+              ( Css.hex (Color.hex_with_alpha hex percent),
+                Color.hex_to_oklab_alpha hex alpha )
+          | _ ->
+              let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
+              if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then
+                (c, guarded)
+              else (Color.mix_alpha ~in_space:Srgb opacity c, guarded))
     in
     let base_decl, _ = Var.binding inset_shadow_color_var base_value in
     let enhanced_color =
@@ -1893,24 +1935,11 @@ module Handler = struct
     let d_shadow, _ = Var.binding ring_offset_shadow_var shadow_value in
     style [ d_width; d_shadow ]
 
-  let ring_offset_bracket_color (c : Css.color) =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let d, _ = Var.binding ring_offset_color_var c in
-    style [ d ]
+  let ring_offset_bracket_color ~theme (c : Css.color) =
+    bracket_color_var_style ~theme ring_offset_color_var c
 
-  let ring_offset_bracket_color_opacity (c : Css.color) opacity =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let percent = Color.opacity_to_percent opacity in
-    let alpha = percent /. 100.0 in
-    let with_alpha =
-      match c with
-      | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-          let hex = "#" ^ rgba_hex_string r g b a in
-          Color.hex_to_oklab_alpha hex alpha
-      | _ -> c
-    in
-    let d, _ = Var.binding ring_offset_color_var with_alpha in
-    style [ d ]
+  let ring_offset_bracket_color_opacity ~theme (c : Css.color) opacity =
+    bracket_color_var_opacity_style ~theme ring_offset_color_var c opacity
 
   let ring_offset_bracket_color_var v =
     let bare_name = Parse.extract_var_name v in
@@ -2028,24 +2057,11 @@ module Handler = struct
     let d, _ = Var.binding inset_ring_color_var Css.Inherit in
     style [ d ]
 
-  let inset_ring_bracket_color (c : Css.color) =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let d, _ = Var.binding inset_ring_color_var c in
-    style [ d ]
+  let inset_ring_bracket_color ~theme (c : Css.color) =
+    bracket_color_var_style ~theme inset_ring_color_var c
 
-  let inset_ring_bracket_color_opacity (c : Css.color) opacity =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let percent = Color.opacity_to_percent opacity in
-    let alpha = percent /. 100.0 in
-    let with_alpha =
-      match c with
-      | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-          let hex = "#" ^ rgba_hex_string r g b a in
-          Color.hex_to_oklab_alpha hex alpha
-      | _ -> c
-    in
-    let d, _ = Var.binding inset_ring_color_var with_alpha in
-    style [ d ]
+  let inset_ring_bracket_color_opacity ~theme (c : Css.color) opacity =
+    bracket_color_var_opacity_style ~theme inset_ring_color_var c opacity
 
   let inset_ring_bracket_color_var v =
     let bare_name = Parse.extract_var_name v in
@@ -2130,24 +2146,11 @@ module Handler = struct
     in
     style ~rules:(Some [ supports_block ]) [ fallback ]
 
-  let ring_bracket_color (c : Css.color) =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let d, _ = Var.binding ring_color_var c in
-    style [ d ]
+  let ring_bracket_color ~theme (c : Css.color) =
+    bracket_color_var_style ~theme ring_color_var c
 
-  let ring_bracket_color_with_opacity (c : Css.color) opacity =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let percent = Color.opacity_to_percent opacity in
-    let alpha = percent /. 100.0 in
-    let with_alpha =
-      match c with
-      | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-          let hex = "#" ^ rgba_hex_string r g b a in
-          Color.hex_to_oklab_alpha hex alpha
-      | _ -> c
-    in
-    let d, _ = Var.binding ring_color_var with_alpha in
-    style [ d ]
+  let ring_bracket_color_with_opacity ~theme (c : Css.color) opacity =
+    bracket_color_var_opacity_style ~theme ring_color_var c opacity
 
   let ring_bracket_color_var v =
     let bare_name = Parse.extract_var_name v in
@@ -2233,6 +2236,16 @@ module Handler = struct
   let bg_blend_luminosity = style [ background_blend_mode Luminosity ]
 
   let to_style theme =
+    let set_shadow_bracket_color = set_shadow_bracket_color ~theme in
+    let set_inset_shadow_bracket_color =
+      set_inset_shadow_bracket_color ~theme
+    in
+    let set_shadow_bracket_color_opacity =
+      set_shadow_bracket_color_opacity ~theme
+    in
+    let set_ishadow_bracket_color_opacity =
+      set_ishadow_bracket_color_opacity ~theme
+    in
     let set_shadow_color c shade = set_shadow_color ~theme c shade in
     let set_shadow_color_opacity c shade opacity =
       set_shadow_color_opacity ~theme c shade opacity
@@ -2256,6 +2269,18 @@ module Handler = struct
     let ring_color color shade = ring_color ~theme color shade in
     let ring_offset_color color shade = ring_offset_color ~theme color shade in
     let inset_ring_color color shade = inset_ring_color ~theme color shade in
+    let ring_bracket_color = ring_bracket_color ~theme in
+    let ring_bracket_color_with_opacity =
+      ring_bracket_color_with_opacity ~theme
+    in
+    let ring_offset_bracket_color = ring_offset_bracket_color ~theme in
+    let ring_offset_bracket_color_opacity =
+      ring_offset_bracket_color_opacity ~theme
+    in
+    let inset_ring_bracket_color = inset_ring_bracket_color ~theme in
+    let inset_ring_bracket_color_opacity =
+      inset_ring_bracket_color_opacity ~theme
+    in
     function
     | Shadow_none -> shadow_none
     | Shadow_2xs -> shadow_2xs

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2260,7 +2260,27 @@ let handle_modified ?theme util_inner modifier base_style extract_fn =
   in
   let base_class_name = Utility.to_class inner_util in
   let base_rules = extract_fn base_class_name inner_util style in
-  List.concat_map (apply_modifier_to_rule ?theme modifier) base_rules
+  let expanded = List.map (apply_modifier_to_rule ?theme modifier) base_rules in
+  match modifier with
+  | Style.Pseudo_marker | Style.Pseudo_selection ->
+      (* These variants expand one source rule into several browser-safe
+         selectors. Keep each selector's declarations and nested fallback query
+         together: Tailwind writes [fallback; @supports] for one marker before
+         moving to the next, rather than all fallbacks followed by all
+         enhancements. *)
+      let rec interleave rows =
+        let heads, tails =
+          List.fold_right
+            (fun row (heads, tails) ->
+              match row with
+              | [] -> (heads, tails)
+              | head :: tail -> (head :: heads, tail :: tails))
+            rows ([], [])
+        in
+        match heads with [] -> [] | _ -> heads @ interleave tails
+      in
+      interleave expanded
+  | _ -> List.concat expanded
 
 (* Handle Group style by extracting each item *)
 let handle_group class_name util_inner styles extract_fn =

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -64,19 +64,6 @@ module Handler = struct
     | Thumb s -> "scrollbar-thumb-" ^ spec_class s
     | Track s -> "scrollbar-track-" ^ spec_class s
 
-  let hex_string_of (c : Css.color) : string =
-    let fmt r g b a =
-      let h2 = Pp.hex_byte in
-      "#" ^ h2 r ^ h2 g ^ h2 b ^ if a = 255 then "" else h2 a
-    in
-    match c with
-    | Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ } -> fmt r g b a
-    | _ -> (
-        match Color.css_color_to_hex c with
-        | Some (Css.Hex { r; g; b; a } | Css.Authored_hex { r; g; b; a; _ }) ->
-            fmt r g b a
-        | _ -> "#000000")
-
   (* Return (declarations placed on the rule, optional @supports rules) that set
      [set_var] to the resolved colour. *)
   let value_decls ?theme ~set_var spec :
@@ -137,19 +124,35 @@ module Handler = struct
             ]
         in
         ([ fallback ], [ supports ])
-    | Bracket (_, css_color, Color.No_opacity) ->
-        let folded =
-          match Color.css_color_to_hex css_color with
-          | Some h -> h
-          | None -> css_color
-        in
-        ([ fst (Var.binding set_var folded) ], [])
-    | Bracket (_, css_color, op) ->
-        let percent = Color.opacity_to_percent op in
-        let oklab =
-          Color.hex_to_oklab_alpha (hex_string_of css_color) (percent /. 100.)
-        in
-        ([ fst (Var.binding set_var oklab) ], [])
+    | Bracket (_, css_color, Color.No_opacity) -> (
+        let enhanced = Color.resolve_bracket_css_color css_color in
+        let scheme = Option.value ~default:Scheme.default theme in
+        match Color.pre_color_mix_fallback scheme enhanced with
+        | None -> ([ fst (Var.binding set_var enhanced) ], [])
+        | Some fallback ->
+            let fallback_decl, _ = Var.binding set_var fallback in
+            let enhanced_decl, _ = Var.binding set_var enhanced in
+            let supports =
+              Css.supports ~condition:Color.color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_") [ enhanced_decl ];
+                ]
+            in
+            ([ fallback_decl ], [ supports ]))
+    | Bracket (_, css_color, op) -> (
+        let scheme = Option.value ~default:Scheme.default theme in
+        match Color.bracket_color_opacity ~theme:scheme css_color op with
+        | Color.Guarded { fallback; mixed } ->
+            let fallback_decl, _ = Var.binding set_var fallback in
+            let enhanced_decl, _ = Var.binding set_var mixed in
+            let supports =
+              Css.supports ~condition:Color.color_mix_supports_condition
+                [
+                  Css.rule ~selector:(Css.Selector.class_ "_") [ enhanced_decl ];
+                ]
+            in
+            ([ fallback_decl ], [ supports ])
+        | Color.Folded value -> ([ fst (Var.binding set_var value) ], []))
 
   let compose ?theme ~set_var spec =
     let main_decls, supports_rules = value_decls ?theme ~set_var spec in

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -452,22 +452,34 @@ let compare_same_media_group (r1 : indexed_rule) (r2 : indexed_rule) cond1 cond2
           r1.selector_str r2.selector_str r1.order r2.order r1.index r2.index
 
 let compare_media_rules (r1 : indexed_rule) (r2 : indexed_rule) =
-  let nested_cmp = Bool.compare (r1.nested <> []) (r2.nested <> []) in
-  if nested_cmp <> 0 then nested_cmp
+  let same_utility =
+    match (r1.base_class, r2.base_class) with
+    | Some b1, Some b2 -> String.equal b1 b2
+    | _ -> false
+  in
+  if same_utility then
+    (* A progressive-enhancement pair under a media variant is emitted as two
+       media outputs for the same class: the fallback has declarations and the
+       enhancement carries a nested [@supports]. Preserve their source order,
+       just as the regular-vs-media comparator below does for one utility. *)
+    Int.compare r1.index r2.index
   else
-    let group1, sub1 = extract_media_sort_key r1.rule_type in
-    let group2, sub2 = extract_media_sort_key r2.rule_type in
-    let key_cmp = Int.compare group1 group2 in
-    if key_cmp <> 0 then key_cmp
+    let nested_cmp = Bool.compare (r1.nested <> []) (r2.nested <> []) in
+    if nested_cmp <> 0 then nested_cmp
     else
-      let cond1 = match r1.rule_type with `Media c -> Some c | _ -> None in
-      let cond2 = match r2.rule_type with `Media c -> Some c | _ -> None in
-      let cond_cmp =
-        compare_media_conditions group1 sub1 sub2 cond1 cond2 r1.media_key
-          r2.media_key
-      in
-      if cond_cmp <> 0 then cond_cmp
-      else compare_same_media_group r1 r2 cond1 cond2
+      let group1, sub1 = extract_media_sort_key r1.rule_type in
+      let group2, sub2 = extract_media_sort_key r2.rule_type in
+      let key_cmp = Int.compare group1 group2 in
+      if key_cmp <> 0 then key_cmp
+      else
+        let cond1 = match r1.rule_type with `Media c -> Some c | _ -> None in
+        let cond2 = match r2.rule_type with `Media c -> Some c | _ -> None in
+        let cond_cmp =
+          compare_media_conditions group1 sub1 sub2 cond1 cond2 r1.media_key
+            r2.media_key
+        in
+        if cond_cmp <> 0 then cond_cmp
+        else compare_same_media_group r1 r2 cond1 cond2
 
 (* ======================================================================== *)
 (* Regular vs Media Comparison *)
@@ -1275,58 +1287,65 @@ let compare_variant_tail r1 r2 =
               else Int.compare r1.index r2.index)
 
 let compare_variant_ordered r1 r2 =
-  match (r1.rule_type, r2.rule_type) with
-  | `Supports _, `Supports _
-    when r1.variant_order = r2.variant_order
-         && is_modifier_supports r1.base_class
-         && is_modifier_supports r2.base_class ->
-      compare_supports_by_key r1 r2
-  | _ ->
-      let list_cmp =
-        compare_variant_order_lists r1.variant_orders r2.variant_orders
-      in
-      if list_cmp <> 0 then list_cmp
-      else
-        let p1_prefix, _, data_depth1 = r1.variant_key in
-        let p2_prefix, _, data_depth2 = r2.variant_key in
-        (* The descending variant-order lists tie (same variant multiset), so
-           hover:sm: and sm:hover: arrive here indistinguishable. The query a
-           rule writes on the outside decides between them, hover before sm and
-           sm before md; a nested breakpoint or hover, the prefix and the
-           utility's own priority order what is left. *)
-        let media_cmp =
-          match compare_container_values r1 r2 p1_prefix p2_prefix with
-          | Some c -> c
-          | None -> (
-              match (r1.media_key, r2.media_key) with
-              | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
-              | _ -> 0)
+  let same_utility =
+    match (r1.base_class, r2.base_class) with
+    | Some b1, Some b2 -> String.equal b1 b2
+    | _ -> false
+  in
+  if same_utility then Int.compare r1.index r2.index
+  else
+    match (r1.rule_type, r2.rule_type) with
+    | `Supports _, `Supports _
+      when r1.variant_order = r2.variant_order
+           && is_modifier_supports r1.base_class
+           && is_modifier_supports r2.base_class ->
+        compare_supports_by_key r1 r2
+    | _ ->
+        let list_cmp =
+          compare_variant_order_lists r1.variant_orders r2.variant_orders
         in
-        if media_cmp <> 0 then media_cmp
+        if list_cmp <> 0 then list_cmp
         else
-          let nested_cmp =
-            Int.compare
-              (nested_order r1.rule_type r1.nested)
-              (nested_order r2.rule_type r2.nested)
+          let p1_prefix, _, data_depth1 = r1.variant_key in
+          let p2_prefix, _, data_depth2 = r2.variant_key in
+          (* The descending variant-order lists tie (same variant multiset), so
+             hover:sm: and sm:hover: arrive here indistinguishable. The query a
+             rule writes on the outside decides between them, hover before sm
+             and sm before md; a nested breakpoint or hover, the prefix and the
+             utility's own priority order what is left. *)
+          let media_cmp =
+            match compare_container_values r1 r2 p1_prefix p2_prefix with
+            | Some c -> c
+            | None -> (
+                match (r1.media_key, r2.media_key) with
+                | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
+                | _ -> 0)
           in
-          if nested_cmp <> 0 then nested_cmp
+          if media_cmp <> 0 then media_cmp
           else
-            let nested_media_cmp = compare_nested_media r1 r2 in
-            if nested_media_cmp <> 0 then nested_media_cmp
+            let nested_cmp =
+              Int.compare
+                (nested_order r1.rule_type r1.nested)
+                (nested_order r2.rule_type r2.nested)
+            in
+            if nested_cmp <> 0 then nested_cmp
             else
-              (* Two container variants at the same width are already fully
-                 ordered: what remains is the utility's own priority, so the
-                 prefix must not step in and group @sm/main away from @sm. *)
-              let prefix_cmp =
-                match (r1.rule_type, r2.rule_type) with
-                | `Container _, `Container _ -> 0
-                | _ -> compare_bracket_prefixes p1_prefix p2_prefix
-              in
-              if prefix_cmp <> 0 then prefix_cmp
+              let nested_media_cmp = compare_nested_media r1 r2 in
+              if nested_media_cmp <> 0 then nested_media_cmp
               else
-                let data_depth_cmp = Int.compare data_depth1 data_depth2 in
-                if data_depth_cmp <> 0 then data_depth_cmp
-                else compare_variant_tail r1 r2
+                (* Two container variants at the same width are already fully
+                   ordered: what remains is the utility's own priority, so the
+                   prefix must not step in and group @sm/main away from @sm. *)
+                let prefix_cmp =
+                  match (r1.rule_type, r2.rule_type) with
+                  | `Container _, `Container _ -> 0
+                  | _ -> compare_bracket_prefixes p1_prefix p2_prefix
+                in
+                if prefix_cmp <> 0 then prefix_cmp
+                else
+                  let data_depth_cmp = Int.compare data_depth1 data_depth2 in
+                  if data_depth_cmp <> 0 then data_depth_cmp
+                  else compare_variant_tail r1 r2
 
 (* Compare two Supports rules *)
 let compare_supports_rules r1 r2 =

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -85,13 +85,10 @@ module Handler = struct
 
   (* Bracket color: fill/stroke with a typed Css.color, converting to hex when
      possible for minified output *)
-  let bracket_color_style ~property css_color =
-    let color =
-      match Color.css_color_to_hex css_color with
-      | Some hex_c -> hex_c
-      | None -> css_color
-    in
-    style [ property (Css.Color color : Css.svg_paint) ]
+  let bracket_color_style ~theme ~property css_color =
+    Color.bracket_color_style ~theme
+      ~property:(fun color -> property (Css.Color color : Css.svg_paint))
+      css_color
 
   (* Bracket var: fill/stroke "var(--my-color)" *)
   let bracket_var_style ~property ~merge_key v =
@@ -102,8 +99,8 @@ module Handler = struct
   (* Bracket colour with opacity. The paint the modifier applies to is the
      colour the bracket was parsed into: reading the bracket text back as a hex
      answered black for every colour with no hex spelling. *)
-  let bracket_color_opacity_style ~property css_color opacity =
-    Color.bracket_color_opacity_style
+  let bracket_color_opacity_style ~theme ~property css_color opacity =
+    Color.bracket_color_opacity_style ~theme
       ~property:(fun c -> property (Css.Color c : Css.svg_paint))
       css_color opacity
 
@@ -138,9 +135,9 @@ module Handler = struct
     | Fill_color_opacity (color, shade, opacity) ->
         Color.fill_with_opacity ~theme color shade opacity
     | Fill_bracket_color (_, css_color) ->
-        bracket_color_style ~property:Css.fill css_color
+        bracket_color_style ~theme ~property:Css.fill css_color
     | Fill_bracket_color_opacity (_, css_color, opacity) ->
-        bracket_color_opacity_style ~property:Css.fill css_color opacity
+        bracket_color_opacity_style ~theme ~property:Css.fill css_color opacity
     | Fill_bracket_var v | Fill_bracket_typed_var v ->
         bracket_var_style ~property:Css.fill ~merge_key:"fill-" v
     | Fill_bracket_var_opacity (v, opacity)
@@ -158,9 +155,10 @@ module Handler = struct
     | Stroke_color_opacity (color, shade, opacity) ->
         Color.stroke_with_opacity ~theme color shade opacity
     | Stroke_bracket_color (_, css_color) ->
-        bracket_color_style ~property:Css.stroke css_color
+        bracket_color_style ~theme ~property:Css.stroke css_color
     | Stroke_bracket_color_opacity (_, css_color, opacity) ->
-        bracket_color_opacity_style ~property:Css.stroke css_color opacity
+        bracket_color_opacity_style ~theme ~property:Css.stroke css_color
+          opacity
     | Stroke_bracket_var v | Stroke_bracket_typed_var v ->
         bracket_var_style ~property:Css.stroke ~merge_key:"stroke-" v
     | Stroke_bracket_var_opacity (v, opacity)

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -529,12 +529,17 @@ module Handler = struct
   (* A bracket colour spelled any way but a [#] hex: a name, a colour function
      or a relative colour. One with an sRGB hex takes it, so it reads the same
      as the hex arm above; one without stays as written. *)
-  let set_bracket_color (c : Css.color) =
-    let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
-    let base_decl, _ = Var.binding text_shadow_color_var c in
+  let set_bracket_color ~theme (c : Css.color) =
+    let enhanced = Color.resolve_bracket_css_color c in
+    let fallback =
+      match Color.pre_color_mix_fallback theme enhanced with
+      | Some fallback -> fallback
+      | None -> enhanced
+    in
+    let base_decl, _ = Var.binding text_shadow_color_var fallback in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab ~var_name:text_shadow_alpha_name
-        c Css.Transparent
+        enhanced Css.Transparent
     in
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
@@ -542,14 +547,17 @@ module Handler = struct
       ~metadata:text_shadow_property_metadata
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
-  let set_bracket_color_opacity (c : Css.color) opacity =
+  let set_bracket_color_opacity ~theme (c : Css.color) opacity =
     let c = match Color.css_color_to_hex c with Some h -> h | None -> c in
     let guarded = Color.mix_alpha ~in_space:Oklab opacity c in
     (* A modifier reading a custom property has no percentage a plain fallback
        can hold, so the fallback keeps the colour as written. *)
     let base_value =
-      if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then c
-      else Color.mix_alpha ~in_space:Srgb opacity c
+      match Color.pre_color_mix_fallback theme guarded with
+      | Some fallback -> fallback
+      | None ->
+          if Stdlib.Option.is_some (Color.opacity_var_bare_of opacity) then c
+          else Color.mix_alpha ~in_space:Srgb opacity c
     in
     let base_decl, _ = Var.binding text_shadow_color_var base_value in
     let enhanced_color =
@@ -708,6 +716,8 @@ module Handler = struct
   (* ============ Style dispatch ============ *)
 
   let to_style theme =
+    let set_bracket_color = set_bracket_color ~theme in
+    let set_bracket_color_opacity = set_bracket_color_opacity ~theme in
     let set_color c shade = set_color ~theme c shade in
     let set_color_opacity c shade opacity =
       set_color_opacity ~theme c shade opacity

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2624,21 +2624,30 @@ module Typography_late = struct
     in
     style ~rules:(Some [ supports_block ]) [ fallback_decl ]
 
-  let decoration_bracket_color_style inner c =
-    let color =
-      if String.length inner > 0 && inner.[0] = '#' then
-        let shortened = Color.shorten_hex_str inner in
-        Css.hex ("#" ^ shortened)
-      else match Color.css_color_to_hex c with Some h -> h | None -> c
-    in
-    style ~merge_key:"decoration-" [ text_decoration_color color ]
+  let decoration_bracket_color_style ~theme c =
+    let enhanced = Color.resolve_bracket_css_color c in
+    match Color.pre_color_mix_fallback theme enhanced with
+    | None -> style ~merge_key:"decoration-" [ text_decoration_color enhanced ]
+    | Some fallback ->
+        let supports_block =
+          Css.supports ~condition:Color.color_mix_supports_condition
+            [
+              Css.rule ~selector:(Css.Selector.class_ "_")
+                [
+                  webkit_text_decoration_color enhanced;
+                  text_decoration_color enhanced;
+                ];
+            ]
+        in
+        style ~merge_key:"decoration-" ~rules:(Some [ supports_block ])
+          [ text_decoration_color fallback ]
 
   (* An opacity modifier applies to the colour the bracket was parsed into. The
      modifier read the bracket text back as a hex and answered black whenever
      that failed, and it wrote the mix in place of the colour for every spelling
      that is not a [#] hex, where Tailwind folds the alpha in. *)
-  let decoration_bracket_color_with_opacity c opacity =
-    match Color.bracket_color_opacity c opacity with
+  let decoration_bracket_color_with_opacity ~theme c opacity =
+    match Color.bracket_color_opacity ~theme c opacity with
     | Color.Folded value ->
         style ~merge_key:"decoration-" [ text_decoration_color value ]
     | Color.Guarded { fallback; mixed } ->
@@ -3164,11 +3173,10 @@ module Typography_late = struct
     | Decoration_current_opacity opacity ->
         decoration_current_with_opacity opacity
     | Decoration_inherit -> decoration_inherit
-    | Decoration_bracket_color (inner, c) ->
-        decoration_bracket_color_style inner c
+    | Decoration_bracket_color (_, c) -> decoration_bracket_color_style ~theme c
     | Decoration_bracket_invalid_color _ -> style []
     | Decoration_bracket_color_opacity (_, c, opacity) ->
-        decoration_bracket_color_with_opacity c opacity
+        decoration_bracket_color_with_opacity ~theme c opacity
     | Decoration_bracket_var v -> decoration_bracket_var_style v
     | Decoration_bracket_var_opacity (v, opacity) ->
         decoration_bracket_var_with_opacity v opacity

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -349,8 +349,9 @@ let test_alpha_from_a_var () =
   has "fill-red-500/(--a)"
     "color-mix(in oklab,var(--color-red-500) var(--a),transparent)";
   has "bg-[#0088cc]/(--a)" "color-mix(in oklab,#08c var(--a),transparent)";
-  (* the fallback is the colour at full opacity, with no alpha folded in *)
-  has "bg-cyan-400/(--a)" "background-color:var(--color-cyan-400)";
+  (* Tailwind resolves the token into the full-opacity fallback and keeps the
+     variable reference for the guarded mix. *)
+  has "bg-cyan-400/(--a)" "background-color:oklch(78.9%.154 211.53)";
   (* both spellings round-trip *)
   Alcotest.(check string)
     "the shorthand round-trips" "bg-cyan-400/(--a)"
@@ -1013,6 +1014,27 @@ let test_out_of_gamut_oklch () =
     "blue-500 maps to the fallback Tailwind publishes" "#3080ff"
     (rgb_to_hex (oklch_to_rgb blue_500))
 
+let test_removed_mix_token_stays_runtime () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("color-red-500", "initial") ]
+  in
+  let class_name =
+    "bg-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]"
+  in
+  let css =
+    match Tw.of_string ~theme class_name with
+    | Ok utility ->
+        Tw.to_css ~theme ~base:false [ utility ]
+        |> Tw.Css.to_string ~minify:true
+    | Error (`Msg message) -> Alcotest.failf "%s: %s" class_name message
+  in
+  Alcotest.(check bool)
+    "removed theme token is the runtime fallback" true
+    (Astring.String.is_infix ~affix:"background-color:var(--color-red-500)" css);
+  Alcotest.(check bool)
+    "removed theme token is not resolved through the default palette" false
+    (Astring.String.is_infix ~affix:"oklch(63.7% .237 25.331)" css)
+
 let tests =
   [
     ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
@@ -1075,6 +1097,9 @@ let tests =
     ( "Opacity modifier rejects non-numeric",
       `Quick,
       test_opacity_modifier_rejects_non_numeric );
+    ( "Removed color-mix token stays runtime",
+      `Quick,
+      test_removed_mix_token_stays_runtime );
     ("Shorthand hex with alpha", `Quick, test_shorthand_hex_alpha);
     ("Out-of-gamut OKLCH", `Quick, test_out_of_gamut_oklch);
   ]

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -1328,6 +1328,77 @@ let grid_flex_math_tracks () =
       "grid-cols-[repeat(2,calc(1fr*2))]";
     ]
 
+(* Tailwind keeps an sRGB-compatible declaration before every oklab
+   [color-mix()] that depends on a palette token. Keep these on the real CLI
+   oracle: the fallback requires resolving palette [var()] tokens through the
+   active theme, and Lightning CSS then folds the transparent marker mixes to
+   hex. *)
+let pre_color_mix_fallbacks () =
+  let check_class class_name =
+    match of_string class_name with
+    | Ok utility -> check utility
+    | Error (`Msg message) -> Alcotest.failf "%s: %s" class_name message
+  in
+  List.iter check_class
+    [
+      "marker:text-[color-mix(in_oklab,var(--color-gray-700)_25%,transparent)]";
+      "dark:marker:text-[color-mix(in_oklab,var(--color-gray-300)_35%,transparent)]";
+      "border-[color-mix(in_oklab,var(--color-gray-950),white_90%)]";
+      "bg-cyan-400/(--my-alpha-value)";
+      "dark:fill-sky-300/50";
+      "bg-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "fill-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "stroke-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "decoration-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "divide-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "ring-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "inset-ring-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "ring-offset-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "from-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "via-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "to-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "scrollbar-thumb-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "scrollbar-track-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "shadow-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "inset-shadow-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "text-shadow-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]";
+      "bg-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "fill-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "stroke-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "decoration-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "divide-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "ring-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "inset-ring-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "ring-offset-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "from-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "via-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "to-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "scrollbar-thumb-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "scrollbar-track-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "shadow-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "inset-shadow-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "text-shadow-[color-mix(in_oklab,var(--color-red-500)_25%,transparent)]/50";
+      "bg-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "fill-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "stroke-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "decoration-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "divide-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "ring-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "inset-ring-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "ring-offset-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "from-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "via-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "to-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "scrollbar-thumb-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "scrollbar-track-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "shadow-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "inset-shadow-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "text-shadow-[color-mix(in_oklab,red_25%,transparent)]/50";
+      "bg-[color-mix(in_oklab,var(--runtime-color)_25%,transparent)]";
+      "bg-[color-mix(in_oklab,var(--runtime-color),white_20%)]";
+      "dark:border-[color-mix(in_oklab,var(--color-gray-950),white_20%)]";
+    ]
+
 (* A class name that is not a tw utility is not a fatal error anywhere in the
    library: [str] returns the utilities it did recognise, and [of_classes] hands
    the names it rejected back so a typo is reportable rather than invisible. *)
@@ -1391,6 +1462,7 @@ let core_tests =
     test_case "3d transforms" `Slow transforms_3d;
     test_case "grid columns reordering" `Slow grid_cols_reordering;
     test_case "grid flex math tracks" `Slow grid_flex_math_tracks;
+    test_case "pre-color-mix fallbacks" `Slow pre_color_mix_fallbacks;
     (* Stable ordering tests *)
     test_case "stable: base utils order" `Quick stable_order_basic;
     test_case "stable: responsive vs regular" `Quick stable_order_with_modifiers;


### PR DESCRIPTION
Tailwind's generated CSS preserves an sRGB value for browsers without `color-mix()`, while tw previously dropped those colors entirely. Theme operands are resolved through the render-local scheme; unknown or removed properties remain runtime fallbacks.