### PR TITLE
entrypoint: emit authored mix fallbacks

### DIFF
--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1997,6 +1997,72 @@ let collect_properties_at_end stmts =
   in
   List.filter_map Fun.id keep @ at_end @ keyframes
 
+(* Tailwind runs authored CSS through Lightning CSS, which writes a legacy value
+   before a dynamic [color-mix()] and keeps the authored value behind a feature
+   query. Utility output already carries that pair; this pass is only applied to
+   the parsed entrypoint before the generated sheet is spliced in.
+
+   [flatten_nesting] has made every element rule flat by the time this runs, so
+   splitting one declaration into a rule/query pair preserves its exact place
+   among the author's declarations. *)
+let authored_color_mix_fallbacks ~theme stmts =
+  let fallback_declaration declaration =
+    let value = Css.declaration_value ~minify:true declaration in
+    match Css.parse_color value with
+    | None -> None
+    | Some color -> (
+        match Tw.Color.pre_color_mix_fallback theme color with
+        | None -> None
+        | Some fallback ->
+            let fallback_value =
+              Css.color fallback |> Css.Declaration.normalize
+              |> Css.declaration_value ~minify:true
+            in
+            let layer = Css.Declaration.custom_declaration_layer declaration in
+            Css.Declaration.parse_declaration ?layer
+              (Css.declaration_name declaration)
+              fallback_value
+            |> Option.map (fun fallback ->
+                if Css.declaration_is_important declaration then
+                  Css.important fallback
+                else fallback))
+  in
+  let lower_rule selector declarations =
+    let rec loop pending emitted = function
+      | [] ->
+          let emitted =
+            match pending with
+            | [] -> emitted
+            | _ -> Css.rule ~selector (List.rev pending) :: emitted
+          in
+          List.rev emitted
+      | declaration :: rest -> (
+          match fallback_declaration declaration with
+          | None -> loop (declaration :: pending) emitted rest
+          | Some fallback ->
+              let base = Css.rule ~selector (List.rev (fallback :: pending)) in
+              let enhanced = Css.rule ~selector [ declaration ] in
+              let supports =
+                Css.supports ~condition:Tw.Color.color_mix_supports_condition
+                  [ enhanced ]
+              in
+              loop [] (supports :: base :: emitted) rest)
+    in
+    loop [] [] declarations
+  in
+  let rec lower_block stmts =
+    List.concat_map
+      (fun statement ->
+        let statement =
+          Css.Stylesheet.map_statement_children lower_block statement
+        in
+        match Css.as_rule statement with
+        | Some (selector, declarations, []) -> lower_rule selector declarations
+        | _ -> [ statement ])
+      stmts
+  in
+  lower_block stmts
+
 let splice_into_entrypoint ~theme ~path generated =
   match read_file path with
   | exception Sys_error _ -> generated
@@ -2028,6 +2094,7 @@ let splice_into_entrypoint ~theme ~path generated =
             Css.flatten_nesting (Css.inline_imports loader p.Css.stylesheet)
           in
           Css.statements inlined
+          |> authored_color_mix_fallbacks ~theme
           |> List.concat_map (fun stmt ->
               match stmt with
               | Cascade.Stylesheet.Import { url; _ } when is_tailwind_import url

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -195,6 +195,49 @@ let test_apply_merges_one_rule () =
     ".btn{margin:calc(var(--spacing)*4);padding:calc(var(--spacing)*4)}"
     (Cascade.Css.to_string ~minify:true out)
 
+(* Lightning CSS lowers a dynamic [color-mix()] in author CSS as progressive
+   enhancement. A palette token can be resolved to a legacy colour; a custom
+   property declared by the rule cannot, so its first colour operand is the
+   fallback. Custom-property values and ordinary colour properties follow the
+   same rule. *)
+let test_authored_color_mix_fallbacks () =
+  let path = "color-mix-entry.css" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        "@import \"tailwindcss\";\n\
+         @theme { --color-brand: oklch(63.7% 0.237 25.331); }\n\
+         .article {\n\
+        \  --prose-color: var(--color-brand);\n\
+        \  --marker-color: color-mix(in oklab, var(--color-brand) 25%, \
+         transparent);\n\
+        \  color: color-mix(in oklab, var(--color-brand) 25%, transparent);\n\
+        \  em { color: color-mix(in oklab, var(--prose-color) 75%, \
+         transparent); }\n\
+         }\n");
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-brand", "oklch(63.7% 0.237 25.331)") ]
+  in
+  let out =
+    Fun.protect
+      ~finally:(fun () -> Sys.remove path)
+      (fun () -> splice_into_entrypoint ~theme ~path (Cascade.Css.v []))
+  in
+  check string "fallback immediately precedes each guarded authored value"
+    ".article{--prose-color:var(--color-brand);--marker-color:#fb2c3640}@supports(color:color-mix(in \
+     lab,red,red)){.article{--marker-color:color-mix(in \
+     oklab,var(--color-brand) \
+     25%,transparent)}}.article{color:#fb2c3640}@supports(color:color-mix(in \
+     lab,red,red)){.article{color:color-mix(in oklab,var(--color-brand) \
+     25%,transparent)}}.article \
+     em{color:var(--prose-color)}@supports(color:color-mix(in \
+     lab,red,red)){.article em{color:color-mix(in oklab,var(--prose-color) \
+     75%,transparent)}}"
+    (Cascade.Css.to_string ~minify:true out)
+
 (* Each utility an [@apply] pulls in hoists an [@property] block for every
    variable it sets, and the two shadow utilities set the same ones. The hoisted
    blocks are deduplicated on statement identity, so the sheet declares each
@@ -462,6 +505,8 @@ let tests =
     test_case "directives dropped" `Quick test_drop_directives;
     test_case "theme keyframes hoisted" `Quick test_hoist_theme_keyframes;
     test_case "@apply merges into one rule" `Quick test_apply_merges_one_rule;
+    test_case "authored color-mix fallbacks" `Quick
+      test_authored_color_mix_fallbacks;
     test_case "@apply hoists each property once" `Quick
       test_apply_hoists_each_property_once;
     test_case "declared utility keeps its nesting" `Quick


### PR DESCRIPTION
Tailwind lowers dynamic `color-mix()` declarations in project CSS into a legacy fallback followed by the authored value under `@supports`. Resolve theme variables through the render-local scheme and keep rule-local variables as runtime fallbacks, including custom-property declarations and imported or nested author rules.