### PR TITLE
cli: preserve runtime custom properties

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -102,10 +102,10 @@ let render_css ~(opts : gen_opts) stylesheet =
   in
   let stylesheet =
     if opts.optimize then
-      (* The generated sheet is a closed author stylesheet, so prune theme
-         tokens nothing references -- e.g. --spacing once p-0 folds to 0, which
-         Tailwind also drops. *)
-      Tw.Css.optimize ~prune_unused_custom_props:true stylesheet
+      (* Custom properties are an open runtime API: JavaScript, inline styles,
+         and separately loaded sheets can read declarations that have no local
+         var() reference. *)
+      Tw.Css.optimize stylesheet
     else stylesheet
   in
   Tw.Css.to_string ~minify:opts.minify stylesheet
@@ -432,9 +432,8 @@ let minify_flag =
 
 let optimize_flag =
   let doc =
-    "Optimize the generated CSS: merge and deduplicate rules, and drop theme \
-     tokens nothing references. Also passed to the Tailwind backend under \
-     --tailwind and --diff."
+    "Optimize the generated CSS by merging and deduplicating rules. Also \
+     passed to the Tailwind backend under --tailwind and --diff."
   in
   Arg.(value & flag & info [ "optimize" ] ~doc)
 

--- a/test/cli/options.t
+++ b/test/cli/options.t
@@ -4,6 +4,15 @@ not an implicit preference for one of them:
   $ tw -s flex --tailwind --diff 2>&1 | grep -c 'mutually exclusive'
   1
 
+Optimization must preserve public custom-property declarations. They are a
+runtime API even when no declaration in the generated sheet reads them:
+
+  $ cat > custom-property.html <<EOF
+  > <div class="[--anchor-gap:8px]"></div>
+  > EOF
+  $ tw --no-base --minify --optimize custom-property.html | grep -o -- '--anchor-gap:8px'
+  --anchor-gap:8px
+
 The Tailwind backend generates against the project's own entrypoint, so a
 [--tailwind] run over files reads the same [@theme] the native run does.
 A stub CLI stands in for the real one and echoes the entrypoint it was given:


### PR DESCRIPTION
Optimization could remove project custom properties that JavaScript, inline styles, or separately loaded CSS still reads. Keep those declarations as part of the open-world stylesheet contract.