### PR TITLE
entrypoint: avoid duplicate color fallbacks

### DIFF
--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -2040,7 +2040,14 @@ let authored_color_mix_fallbacks ~theme stmts =
           match fallback_declaration declaration with
           | None -> loop (declaration :: pending) emitted rest
           | Some fallback ->
-              let base = Css.rule ~selector (List.rev (fallback :: pending)) in
+              let base_declarations =
+                match pending with
+                | previous :: _
+                  when Css.Declaration.equal_declaration previous fallback ->
+                    List.rev pending
+                | _ -> List.rev (fallback :: pending)
+              in
+              let base = Css.rule ~selector base_declarations in
               let enhanced = Css.rule ~selector [ declaration ] in
               let supports =
                 Css.supports ~condition:Tw.Color.color_mix_supports_condition
@@ -2053,12 +2060,19 @@ let authored_color_mix_fallbacks ~theme stmts =
   let rec lower_block stmts =
     List.concat_map
       (fun statement ->
-        let statement =
-          Css.Stylesheet.map_statement_children lower_block statement
-        in
-        match Css.as_rule statement with
-        | Some (selector, declarations, []) -> lower_rule selector declarations
-        | _ -> [ statement ])
+        match Css.as_supports statement with
+        | Some (condition, _)
+          when Css.Supports.equal condition
+                 Tw.Color.color_mix_supports_condition ->
+            [ statement ]
+        | _ -> (
+            let statement =
+              Css.Stylesheet.map_statement_children lower_block statement
+            in
+            match Css.as_rule statement with
+            | Some (selector, declarations, []) ->
+                lower_rule selector declarations
+            | _ -> [ statement ]))
       stmts
   in
   lower_block stmts

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -216,6 +216,14 @@ let test_authored_color_mix_fallbacks () =
         \  color: color-mix(in oklab, var(--color-brand) 25%, transparent);\n\
         \  em { color: color-mix(in oklab, var(--prose-color) 75%, \
          transparent); }\n\
+         }\n\
+         .existing {\n\
+        \  background-color: #fb2c3640;\n\
+        \  background-color: color-mix(in oklab, var(--color-brand) 25%, \
+         transparent);\n\
+         }\n\
+         .applied {\n\
+        \  @apply bg-gray-700/40;\n\
          }\n");
   let theme =
     Tw.Scheme.with_overrides Tw.Scheme.default
@@ -235,7 +243,12 @@ let test_authored_color_mix_fallbacks () =
      25%,transparent)}}.article \
      em{color:var(--prose-color)}@supports(color:color-mix(in \
      lab,red,red)){.article em{color:color-mix(in oklab,var(--prose-color) \
-     75%,transparent)}}"
+     75%,transparent)}}.existing{background-color:#fb2c3640}@supports(color:color-mix(in \
+     lab,red,red)){.existing{background-color:color-mix(in \
+     oklab,var(--color-brand) \
+     25%,transparent)}}.applied{background-color:#36415366}@supports(color:color-mix(in \
+     lab,red,red)){.applied{background-color:color-mix(in \
+     oklab,var(--color-gray-700) 40%,transparent)}}"
     (Cascade.Css.to_string ~minify:true out)
 
 (* Each utility an [@apply] pulls in hoists an [@property] block for every


### PR DESCRIPTION
A project fallback immediately before the same dynamic color-mix() was emitted twice. Reuse it while preserving the guarded enhanced value.