### PR TITLE
rule: preserve nested color-mix guards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,10 @@
   at-rule variant, a peer hover gate survives a selector variant, a variant
   stays wrapped around a `@starting-style` rule, and a class a variant renames
   keeps the default transition theme (#564).
+- An opacity colour keeps its progressive-enhancement `@supports` guard when
+  wrapped in a supports, container or starting-style variant. The modern
+  `color-mix()` declaration was previously left unguarded inside that wrapper
+  (#666).
 - `[attr~=value]` attribute selectors work in arbitrary variants. The gate
   rejected any bracket containing `~`, reading the whitespace-list operator as
   a sibling combinator (#509).

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2199,6 +2199,24 @@ and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
     media_query ~condition:outer ~selector:sel ~props:[] ?base_class:bc
       ~nested:(supports_stmt :: nested) ()
   in
+  let wrap_supports_in_at_rule = function
+    | Container_query ({ selector; props; nested; _ } as r) ->
+        let supports_stmt =
+          Css.supports ~condition [ Css.rule ~selector props ]
+        in
+        Container_query { r with props = []; nested = supports_stmt :: nested }
+    | Supports_query ({ selector; props; nested; _ } as r) ->
+        let supports_stmt =
+          Css.supports ~condition [ Css.rule ~selector props ]
+        in
+        Supports_query { r with props = []; nested = supports_stmt :: nested }
+    | Starting_style ({ selector; props; nested; _ } as r) ->
+        let supports_stmt =
+          Css.supports ~condition [ Css.rule ~selector props ]
+        in
+        Starting_style { r with props = []; nested = supports_stmt :: nested }
+    | other -> other
+  in
   apply_modifier_to_rule ?theme modifier inner
   |> List.map (function
     | Regular { selector; props; base_class; has_hover; _ } ->
@@ -2213,7 +2231,8 @@ and apply_modifier_to_supports_query ?theme modifier ~condition ~selector ~props
     | Media_query { condition = outer; selector; props; base_class; nested; _ }
       ->
         wrap_supports_in_media outer selector props base_class nested
-    | other -> other)
+    | (Container_query _ | Supports_query _ | Starting_style _) as outer ->
+        wrap_supports_in_at_rule outer)
 
 (* An outer variant on a [@starting-style] rule, the way the [@supports] case
    does it: run the modifier on the inner rule so all the selector and media

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -362,6 +362,35 @@ let test_opacity_supports_under_variant () =
   check bool "the @supports block follows the fallback" true
     (idx "#fb2c3680" < idx "@supports")
 
+(* A variant whose own effect is an at-rule wraps both halves of an opacity
+   colour. The modern half still needs its inner color-mix feature query; losing
+   it makes the nested output differ from Tailwind and leaves the enhancement at
+   the wrong structural depth. *)
+let test_opacity_supports_inside_at_rule_variant () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let nested cls wrapper =
+    check bool cls true
+      (Astring.String.is_infix
+         ~affix:(wrapper ^ "{@supports(color:color-mix(in lab,red,red)){")
+         (css cls))
+  in
+  nested "supports-backdrop-filter:bg-black/25"
+    "@supports(backdrop-filter:var(--tw))";
+  nested "@sm:bg-black/25" "@container(width>=24rem)";
+  let starting = css "starting:bg-black/25" in
+  let position affix = Astring.String.find_sub ~sub:affix starting in
+  check bool "starting:bg-black/25" true
+    (match
+       ( position "@starting-style{",
+         position "@supports(color:color-mix(in lab,red,red)){" )
+     with
+    | Some outer, Some inner -> outer < inner
+    | _ -> false)
+
 (* An at-rule written in brackets wraps the utility rather than selecting it,
    and keeps its own spelling in the class name: reading it as the [supports-]
    variant gave a class the HTML would not match. Its condition is emitted as
@@ -600,6 +629,8 @@ let tests =
     test_case "bracketed at-rule variant" `Quick test_bracketed_at_rule_variant;
     test_case "opacity @supports under a variant" `Quick
       test_opacity_supports_under_variant;
+    test_case "opacity @supports inside an at-rule variant" `Quick
+      test_opacity_supports_inside_at_rule_variant;
     test_case "bare arbitrary selector variant" `Quick
       test_bare_arbitrary_selector_variant;
     test_case "outer variant over child and pseudo-element" `Quick


### PR DESCRIPTION
At-rule variants could leave modern opacity colours outside their color-mix feature query. Preserve that guard under supports, container, and starting-style wrappers.