### PR TITLE
parse: preserve arbitrary token streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,10 @@
 
 ### Arbitrary values and validation
 
+- Preserve Tailwind's declaration-safe token-stream contract for arbitrary
+  animation, background, divide, filter, shadow, ring, scrollbar, table,
+  transform, transition and typography values, including values that are
+  invalid for the target property (#667).
 - Bracketed `has`, `group-has` and `peer-has` variants retain Tailwind's
   `:is(...)` wrapper for bare type and complex selectors.
 - An arbitrary length in a variant's class name is spelled as the author wrote

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -27,7 +27,7 @@ module Handler = struct
     | Bounce
     (* The author's bracket text travels with the animation it denotes, so the
        class name is spelled exactly as it was written. *)
-    | Bracket of string * Css.animation
+    | Bracket of string * [ `Animation of Css.animation | `Raw of string ]
     | Named of string
 
   let name = "animations"
@@ -266,9 +266,9 @@ module Handler = struct
     | name :: (_ :: _ as rest) -> String.concat " " (rest @ [ name ])
     | _ -> css_value
 
-  (* The animation an [animate-[...]] bracket denotes. [None] is a bracket the
-     animation grammar cannot read, and [of_class] refuses the utility rather
-     than leaving [to_style] to raise. *)
+  (* Parse a valid animation shorthand so keyframe metadata remains available.
+     [None] leaves [of_class] to apply Tailwind's declaration-safe token-stream
+     contract. *)
   let arbitrary_animation value : Css.animation option =
     let cursor = Cascade.Cursor.of_string (animation_shorthand value) in
     match
@@ -277,9 +277,14 @@ module Handler = struct
     | Ok anim -> Some anim
     | Error _ -> None
 
-  let animate_bracket anim =
-    let rules = keyframes_rules (Option.to_list (shorthand_name anim)) in
-    style ~rules [ Css.animation anim ]
+  let animate_bracket = function
+    | `Animation anim ->
+        let rules = keyframes_rules (Option.to_list (shorthand_name anim)) in
+        style ~rules [ Css.animation anim ]
+    | `Raw value -> (
+        match Parse.opaque_declaration "animation" value with
+        | Some decl -> style [ decl ]
+        | None -> assert false)
 
   let animate_named ?theme name =
     let var_name = "animate-" ^ name in
@@ -314,7 +319,7 @@ module Handler = struct
     | Ping -> animate_ping ()
     | Pulse -> animate_pulse ()
     | Bounce -> animate_bounce ()
-    | Bracket (_, anim) -> animate_bracket anim
+    | Bracket (_, value) -> animate_bracket value
     | Named name -> animate_named ~theme name
 
   (* Tailwind emits the animate-* rules in class-name order, with no family
@@ -338,8 +343,11 @@ module Handler = struct
         if Parse.is_bracket_value value then
           let inner = Parse.bracket_inner value in
           match arbitrary_animation inner with
-          | Some anim -> Ok (Bracket (inner, anim))
-          | Option.None -> Error (`Msg "Invalid animation value")
+          | Some anim -> Ok (Bracket (inner, `Animation anim))
+          | Option.None -> (
+              match Parse.arbitrary_declaration_value inner with
+              | Some value -> Ok (Bracket (inner, `Raw value))
+              | None -> Error (`Msg "Invalid animation value"))
         else
           (* Check if it's a named animation with a theme value *)
           let var_name = "animate-" ^ value in

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -92,6 +92,8 @@ module Handler = struct
     | Bg of Color.color * int
     | Bg_gradient_to of direction
     | Gradient_color of gradient_target * Color_source.t
+    | Gradient_raw of
+        gradient_target * string * string * Color.opacity_modifier option
     | Gradient_stop_position of gradient_target * gradient_position_source
     | Via_none (* via-none: clears the gradient's via stops *)
     | Bg_origin_border
@@ -180,6 +182,7 @@ module Handler = struct
     | Bg_conic_angle_interp of int * string * string
     (* -bg-conic-{angle}/interp *)
     | Bg_conic_angle_neg_interp of int * string * string
+    | Bg_conic_bracket of string
     (* bg-radial - bare radial gradient (in oklab) *)
     | Bg_radial
     (* bg-radial/interp - radial gradient with interpolation *)
@@ -265,6 +268,12 @@ module Handler = struct
             in
             prefix ^ p_str ^ "%"
         | Bracket (spelling, _) -> prefix ^ "[" ^ spelling ^ "]")
+    | Gradient_raw (target, spelling, _, opacity) ->
+        let prefix =
+          match target with From -> "from-" | Via -> "via-" | To -> "to-"
+        in
+        prefix ^ "[" ^ spelling ^ "]"
+        ^ Option.fold ~none:"" ~some:Color.opacity_suffix opacity
     | Bg_origin_border -> "bg-origin-border"
     | Bg_origin_padding -> "bg-origin-padding"
     | Bg_origin_content -> "bg-origin-content"
@@ -368,6 +377,7 @@ module Handler = struct
         "bg-conic-" ^ string_of_int n ^ "/" ^ interp
     | Bg_conic_angle_neg_interp (n, interp, _) ->
         "-bg-conic-" ^ string_of_int n ^ "/" ^ interp
+    | Bg_conic_bracket v -> "bg-conic-[" ^ v ^ "]"
     | Bg_radial -> "bg-radial"
     | Bg_radial_interp (interp, _) -> "bg-radial/" ^ interp
     | Bg_radial_bracket v -> "bg-radial-[" ^ v ^ "]"
@@ -398,6 +408,10 @@ module Handler = struct
     | _ -> None
 
   open Style
+
+  (* Bind tw's string formatter before [open Css] shadows [Pp]. *)
+  let pp_float = Pp.float
+
   open Css
 
   let name = "backgrounds"
@@ -420,16 +434,19 @@ module Handler = struct
     | Bg_linear_bracket_neg _ | Bg_conic | Bg_conic_angle _
     | Bg_conic_angle_neg _ | Bg_conic_interp _ | Bg_conic_angle_interp _
     | Bg_conic_angle_neg_interp _ | Bg_radial | Bg_radial_interp _
-    | Bg_radial_bracket _ | Bg_bracket_image_var _ | Bg_bracket_image _
-    | Bg_bracket_linear_gradient _ | Bg_bracket_url _ | Bg_bracket_image_url _
-    | Bg_bracket_url_var _ | Bg_none ->
+    | Bg_conic_bracket _ | Bg_radial_bracket _ | Bg_bracket_image_var _
+    | Bg_bracket_image _ | Bg_bracket_linear_gradient _ | Bg_bracket_url _
+    | Bg_bracket_image_url _ | Bg_bracket_url_var _ | Bg_none ->
         199
     | Via_none -> 202
     | Gradient_color (From, _) -> 203
+    | Gradient_raw (From, _, _, _) -> 203
     | Gradient_stop_position (From, _) -> 204
     | Gradient_color (Via, _) -> 205
+    | Gradient_raw (Via, _, _, _) -> 205
     | Gradient_stop_position (Via, _) -> 206
     | Gradient_color (To, _) -> 207
+    | Gradient_raw (To, _, _, _) -> 207
     | Gradient_stop_position (To, _) -> 208
     | Bg_auto | Bg_cover | Bg_contain | Bg_bracket_contain | Bg_bracket_cover
     | Bg_bracket_size _ | Bg_bracket_length _ | Bg_size_bracket _ ->
@@ -467,7 +484,7 @@ module Handler = struct
       | Bg_gradient_to _ | Bg_linear_bracket _ | Bg_linear_bracket_neg _
       | Bg_conic | Bg_conic_angle _ | Bg_conic_angle_neg _ | Bg_conic_interp _
       | Bg_conic_angle_interp _ | Bg_conic_angle_neg_interp _ | Bg_radial
-      | Bg_radial_interp _ | Bg_radial_bracket _ ->
+      | Bg_conic_bracket _ | Bg_radial_interp _ | Bg_radial_bracket _ ->
           Utility.Property_order.slot rank + 1
       | _ -> Utility.Property_order.last rank
 
@@ -988,6 +1005,20 @@ module Handler = struct
     style ~property_rules:gradient_property_rules
       [ position_decl; Css.background_image (Conic_gradient_var stops_ref) ]
 
+  let bg_conic_bracket' value_str =
+    let css_val = bracket_value_to_css value_str in
+    let position_decl = gradient_position_decl_of_string css_val in
+    let stops_ref : Css.gradient_stop Css.var =
+      Var.bracket
+        ~fallback:
+          (Css.Syntax_fallback
+             (Cascade.Cursor.remaining (Cascade.Cursor.of_string css_val)))
+        "tw-gradient-stops"
+    in
+    style ~property_rules:gradient_property_rules
+      ~metadata:[ Var.metadata gradient_position_var ]
+      [ position_decl; Css.background_image (Conic_gradient_var stops_ref) ]
+
   (** bg-radial/interp - radial gradient with interpolation *)
   let bg_radial_interp' interp_css =
     let position_decl = gradient_position_decl_of_string interp_css in
@@ -1260,6 +1291,25 @@ module Handler = struct
                [ self (extra_decls @ [ fallback_decl ]); supports; self stops ])
           []
 
+  let gradient_raw ~prefix ~set_var value opacity =
+    let value =
+      match opacity with
+      | Stdlib.Option.None -> value
+      | Stdlib.Option.Some opacity ->
+          let percent = Color.opacity_to_percent opacity in
+          "color-mix(in oklab, " ^ value ^ " " ^ pp_float percent
+          ^ "%, transparent)"
+    in
+    let d_stops, d_via_stops_opt = gradient_stops_decls prefix in
+    let stops = stops_as_decls d_stops d_via_stops_opt in
+    let declaration =
+      Css.custom_property ~layer:"utilities" (Var.css_name set_var) value
+    in
+    style
+      ~property_rules:(gradient_all_property_rules ())
+      ~metadata:[ Var.metadata set_var ]
+      (declaration :: stops)
+
   (* Gradient with opacity: either a static value, or a fallback followed by the
      authored mix under [@supports], then the stop composition. *)
   let gradient_with_opacity ~theme ~prefix ~set_var color opacity =
@@ -1391,6 +1441,9 @@ module Handler = struct
             | None -> gradient_simple ~theme ~prefix ~set_var color []
             | Some opacity ->
                 gradient_with_opacity ~theme ~prefix ~set_var color opacity))
+    | Gradient_raw (target, _, value, opacity) ->
+        let prefix, set_var, _ = gradient_target_info target in
+        gradient_raw ~prefix ~set_var value opacity
     | Gradient_stop_position (target, src) -> (
         let _prefix, _set_var, pos_var = gradient_target_info target in
         match src with
@@ -1490,6 +1543,7 @@ module Handler = struct
     | Bg_conic_interp (_, css) -> bg_conic_interp' css
     | Bg_conic_angle_interp (n, _, css) -> bg_conic_angle_interp' n css
     | Bg_conic_angle_neg_interp (n, _, css) -> bg_conic_angle_neg_interp' n css
+    | Bg_conic_bracket value -> bg_conic_bracket' value
     | Bg_radial -> bg_radial' ()
     | Bg_radial_interp (_, css) -> bg_radial_interp' css
     | Bg_radial_bracket v -> bg_radial_bracket' v
@@ -1579,10 +1633,13 @@ module Handler = struct
             else
               match parse_bracket_position_value inner with
               | Some value -> gp (Bracket (inner, value))
-              | None -> Error (`Msg "Invalid gradient stop value"))
+              | None -> (
+                  match Parse.arbitrary_declaration_value inner with
+                  | Some value -> Ok (Gradient_raw (target, inner, value, None))
+                  | None -> Error (`Msg "Invalid gradient stop value")))
         | Color.No_opacity ->
             Error (`Msg "Invalid gradient bracket with opacity")
-        | opacity when Parse.is_bracket_value base ->
+        | opacity when Parse.is_bracket_value base -> (
             let inner = Parse.bracket_inner base in
             if String.length inner > 6 && String.sub inner 0 6 = "color:" then
               let var_str = String.sub inner 6 (String.length inner - 6) in
@@ -1595,7 +1652,11 @@ module Handler = struct
               plain ~opacity (Color_source.Bracket_var inner)
             else if Color.parse_bracket_color inner <> None then
               plain ~opacity (Color_source.Bracket_color inner)
-            else Error (`Msg "Invalid gradient bracket with opacity")
+            else
+              match Parse.arbitrary_declaration_value inner with
+              | Some value ->
+                  Ok (Gradient_raw (target, inner, value, Some opacity))
+              | None -> Error (`Msg "Invalid gradient bracket with opacity"))
         | _ -> (
             (* Named color with opacity *)
             match Color.shade_and_opacity_of_strings ?theme rest with
@@ -1617,7 +1678,10 @@ module Handler = struct
         else
           match parse_bracket_position_value inner with
           | Some value -> gp (Bracket (inner, value))
-          | None -> Error (`Msg "Invalid gradient stop value"))
+          | None -> (
+              match Parse.arbitrary_declaration_value inner with
+              | Some value -> Ok (Gradient_raw (target, inner, value, None))
+              | None -> Error (`Msg "Invalid gradient stop value")))
     (* Named color with opacity via has_opacity on rest *)
     | _ when List.exists has_opacity rest -> (
         match Color.shade_and_opacity_of_strings ?theme rest with
@@ -1748,6 +1812,11 @@ module Handler = struct
         | None, _ -> Error (`Msg ("Invalid -bg-linear angle: " ^ angle_mod)))
     (* bg-conic - bare conic gradient *)
     | [ "bg"; "conic" ] -> Ok Bg_conic
+    | [ "bg"; "conic"; bracket ] when Parse.is_bracket_value bracket -> (
+        let inner = Parse.bracket_inner bracket in
+        match Parse.arbitrary_declaration_value inner with
+        | Some _ -> Ok (Bg_conic_bracket inner)
+        | None -> Error (`Msg ("Invalid bg-conic value: " ^ inner)))
     (* bg-conic/interp - conic gradient with modifier only *)
     | [ "bg"; conic_mod ]
       when String.length conic_mod > 6 && String.sub conic_mod 0 6 = "conic/"

--- a/lib/divide.ml
+++ b/lib/divide.ml
@@ -7,6 +7,10 @@ module Css = Cascade.Css
 
 module Handler = struct
   open Style
+
+  (* Bind tw's string formatter before [open Css] shadows [Pp]. *)
+  let pp_float = Pp.float
+
   open Css
 
   type t =
@@ -14,8 +18,9 @@ module Handler = struct
     | Y of int
     (* The author's bracket text travels with the parsed width so that the class
        name is spelled exactly as it was written. *)
-    | X_arb of string * Css.border_width (* divide-x-[4px] *)
-    | Y_arb of string * Css.border_width
+    | X_arb of string * [ `Width of Css.border_width | `Raw of string ]
+      (* divide-x-[4px] *)
+    | Y_arb of string * [ `Width of Css.border_width | `Raw of string ]
     | X_reverse
     | Y_reverse
     | Named_color of Color.color * int
@@ -26,6 +31,7 @@ module Handler = struct
     | Inherit
     | Bracket_color of string * Css.color
     | Bracket_color_opacity of string * Css.color * Color.opacity_modifier
+    | Raw_color of string * string * Color.opacity_modifier
     | Line_style of Css.border_style
 
   let name = "divide"
@@ -124,6 +130,54 @@ module Handler = struct
         ]
     in
     style ~rules:(Some [ rule ]) ~property_rules:(Css.concat property_rules) []
+
+  let divide_raw_width_style axis ~class_name value =
+    let selector =
+      Css.Selector.(where [ class_ class_name >> not [ Last_child ] ])
+    in
+    let reverse_var, inline_styles, widths =
+      match axis with
+      | `X ->
+          ( divide_x_reverse_var,
+            [ border_inline_style (Var (Var.reference border_style_var)) ],
+            [ "border-inline-start-width"; "border-inline-end-width" ] )
+      | `Y ->
+          ( divide_y_reverse_var,
+            [
+              border_bottom_style (Var (Var.reference border_style_var));
+              border_top_style (Var (Var.reference border_style_var));
+            ],
+            [ "border-top-width"; "border-bottom-width" ] )
+    in
+    let reverse_decl, reverse_ref = Var.binding reverse_var (Css.Num 0.) in
+    let reverse = "var(--" ^ Css.var_name reverse_ref ^ ")" in
+    let width_values =
+      [
+        Parse.wrap_declaration_value ~before:"calc("
+          ~after:(" * " ^ reverse ^ ")")
+          value;
+        Parse.wrap_declaration_value ~before:"calc("
+          ~after:(" * calc(1 - " ^ reverse ^ "))")
+          value;
+      ]
+    in
+    let raw_widths =
+      List.map2
+        (fun property raw ->
+          Option.bind raw (Parse.opaque_declaration property))
+        widths width_values
+      |> List.filter_map Fun.id
+    in
+    if List.length raw_widths <> 2 then style []
+    else
+      let property_rules =
+        [ Var.property_rule reverse_var; Var.property_rule border_style_var ]
+        |> List.filter_map Fun.id |> Css.concat
+      in
+      let rule =
+        Css.rule ~selector ((reverse_decl :: inline_styles) @ raw_widths)
+      in
+      style ~rules:(Some [ rule ]) ~property_rules []
 
   (* divide-x-reverse utility sets --tw-divide-x-reverse: 1 on children *)
   let divide_x_reverse_style () =
@@ -229,6 +283,23 @@ module Handler = struct
         in
         style ~rules:(Some [ rule; supports_block ]) []
 
+  let divide_raw_color_style class_name value opacity =
+    let selector = divide_children_selector class_name in
+    let value =
+      match opacity with
+      | Color.No_opacity -> value
+      | _ ->
+          let percent = Color.opacity_to_percent opacity in
+          "color-mix(in oklab, " ^ value ^ " " ^ pp_float percent
+          ^ "%, transparent)"
+    in
+    let declaration =
+      match Parse.opaque_declaration "border-color" value with
+      | Some declaration -> declaration
+      | None -> assert false
+    in
+    style ~rules:(Some [ Css.rule ~selector [ declaration ] ]) []
+
   let divide_style_of_string (s : string) =
     let open Css in
     let r : border_style option =
@@ -300,6 +371,8 @@ module Handler = struct
     | Bracket_color (v, _) -> "divide-[" ^ v ^ "]"
     | Bracket_color_opacity (v, _, opacity) ->
         "divide-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
+    | Raw_color (v, _, opacity) ->
+        "divide-[" ^ v ^ "]" ^ Color.opacity_suffix opacity
     | Line_style bs -> "divide-" ^ border_style_to_string bs
 
   let to_style theme =
@@ -322,12 +395,20 @@ module Handler = struct
         in
         let w = if n = 1 then theme.Scheme.default_border_width else n in
         divide_y_width_style ~class_name ~width:(Px (float_of_int w))
-    | X_arb (spelling, width) ->
-        let class_name = to_class (X_arb (spelling, width)) in
+    | X_arb (spelling, `Width width) ->
+        let class_name = to_class (X_arb (spelling, `Width width)) in
         divide_x_width_style ~class_name ~width
-    | Y_arb (spelling, width) ->
-        let class_name = to_class (Y_arb (spelling, width)) in
+    | Y_arb (spelling, `Width width) ->
+        let class_name = to_class (Y_arb (spelling, `Width width)) in
         divide_y_width_style ~class_name ~width
+    | X_arb (spelling, `Raw value) ->
+        divide_raw_width_style `X
+          ~class_name:(to_class (X_arb (spelling, `Raw value)))
+          value
+    | Y_arb (spelling, `Raw value) ->
+        divide_raw_width_style `Y
+          ~class_name:(to_class (Y_arb (spelling, `Raw value)))
+          value
     | X_reverse -> divide_x_reverse_style ()
     | Y_reverse -> divide_y_reverse_style ()
     | Named_color (color, shade) -> divide_color_style color shade
@@ -343,6 +424,9 @@ module Handler = struct
     | Bracket_color_opacity (inner, c, opacity) ->
         let class_name = to_class (Bracket_color_opacity (inner, c, opacity)) in
         divide_bracket_color_opacity_style ~theme class_name c opacity
+    | Raw_color (inner, value, opacity) ->
+        let class_name = to_class (Raw_color (inner, value, opacity)) in
+        divide_raw_color_style class_name value opacity
     | Line_style bs -> divide_style_style bs
 
   (* Tailwind's order across the family, read off its own output: divide-x,
@@ -363,7 +447,7 @@ module Handler = struct
     | Line_style _ -> 65_000
     (* All divide color utilities use flat suborder for natural sort *)
     | Named_color _ | Named_color_opacity _ -> 66_000
-    | Bracket_color _ | Bracket_color_opacity _ -> 66_000
+    | Bracket_color _ | Bracket_color_opacity _ | Raw_color _ -> 66_000
     | Current | Current_opacity _ -> 66_000
     | Inherit -> 66_000
     | Transparent -> 66_000
@@ -406,18 +490,30 @@ module Handler = struct
     | [ "divide"; "y"; "reverse" ] -> Ok Y_reverse
     | [ "divide"; "x"; value ] -> (
         match parse_bracket_width value with
-        | Some (spelling, w) -> Ok (X_arb (spelling, w))
+        | Some (spelling, w) -> Ok (X_arb (spelling, `Width w))
         | None -> (
-            match Parse.decimal_int value with
-            | Some n when n >= 0 -> Ok (X n)
-            | _ -> Error (`Msg "Not a divide utility")))
+            if Parse.is_bracket_value value then
+              let spelling = Parse.bracket_inner value in
+              match Parse.arbitrary_declaration_value spelling with
+              | Some raw -> Ok (X_arb (spelling, `Raw raw))
+              | None -> Error (`Msg "Not a divide utility")
+            else
+              match Parse.decimal_int value with
+              | Some n when n >= 0 -> Ok (X n)
+              | _ -> Error (`Msg "Not a divide utility")))
     | [ "divide"; "y"; value ] -> (
         match parse_bracket_width value with
-        | Some (spelling, w) -> Ok (Y_arb (spelling, w))
+        | Some (spelling, w) -> Ok (Y_arb (spelling, `Width w))
         | None -> (
-            match Parse.decimal_int value with
-            | Some n when n >= 0 -> Ok (Y n)
-            | _ -> Error (`Msg "Not a divide utility")))
+            if Parse.is_bracket_value value then
+              let spelling = Parse.bracket_inner value in
+              match Parse.arbitrary_declaration_value spelling with
+              | Some raw -> Ok (Y_arb (spelling, `Raw raw))
+              | None -> Error (`Msg "Not a divide utility")
+            else
+              match Parse.decimal_int value with
+              | Some n when n >= 0 -> Ok (Y n)
+              | _ -> Error (`Msg "Not a divide utility")))
     | [ "divide"; "transparent" ] -> Ok Transparent
     | [ "divide"; "inherit" ] -> Ok Inherit
     | [ "divide"; style_str ]
@@ -442,7 +538,10 @@ module Handler = struct
             match opacity with
             | Color.No_opacity -> Ok (Bracket_color (inner, c))
             | _ -> Ok (Bracket_color_opacity (inner, c, opacity)))
-        | None -> Error (`Msg ("Invalid divide bracket color: " ^ inner)))
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Raw_color (inner, value, opacity))
+            | None -> Error (`Msg ("Invalid divide bracket color: " ^ inner))))
     | "divide" :: color_parts when List.exists has_opacity color_parts -> (
         match Color.shade_and_opacity_of_strings ~theme color_parts with
         | Ok (color, shade, opacity) ->
@@ -493,10 +592,10 @@ let bracket_spelling ~name w =
   | None -> invalid_arg (name ^ ": width has no arbitrary-value spelling")
 
 let divide_x_length w =
-  utility (X_arb (bracket_spelling ~name:"divide_x_length" w, w))
+  utility (X_arb (bracket_spelling ~name:"divide_x_length" w, `Width w))
 
 let divide_y_length w =
-  utility (Y_arb (bracket_spelling ~name:"divide_y_length" w, w))
+  utility (Y_arb (bracket_spelling ~name:"divide_y_length" w, `Width w))
 
 (** {1 Divide Colour Utilities} *)
 

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -58,6 +58,7 @@ module Handler = struct
     | Shadow_2xl
     | Shadow_inner
     | Shadow_arbitrary of string
+    | Shadow_raw of string * string * Color.opacity_modifier
     | Shadow_theme of string (* shadow from a --shadow-* token *)
     | Inset_shadow_theme of string (* shadow from an --inset-shadow-* token *)
     | Shadow_arbitrary_opacity of string * Color.opacity_modifier
@@ -86,6 +87,7 @@ module Handler = struct
     | Inset_shadow_sm
     | Inset_shadow
     | Inset_shadow_arbitrary of string (* For inset-shadow-[12px_12px_#color] *)
+    | Inset_shadow_raw of string * string * Color.opacity_modifier
     | Inset_shadow_arbitrary_opacity of string * Color.opacity_modifier
     | Inset_shadow_shape_opacity of inset_shadow_shape * Color.opacity_modifier
     (* Inset shadow color utilities *)
@@ -164,6 +166,9 @@ module Handler = struct
     | Ring_bracket_var of string
     | Ring_bracket_var_opacity of string * Color.opacity_modifier
     | Ring_bracket_length of string
+    | Ring_raw of string * string * Color.opacity_modifier
+    | Ring_offset_raw of string * string * Color.opacity_modifier
+    | Inset_ring_raw of string * string * Color.opacity_modifier
     (* Mix blend modes *)
     | Mix_blend_normal
     | Mix_blend_multiply
@@ -408,6 +413,72 @@ module Handler = struct
         Css.Var v_ring;
         Css.Var v_shadow;
       ]
+
+  let raw_color_value value = function
+    | Color.No_opacity -> value
+    | opacity ->
+        pp_str
+          [
+            "color-mix(in oklab, ";
+            value;
+            " ";
+            pp_float (Color.opacity_to_percent opacity);
+            "%, transparent)";
+          ]
+
+  (* Tailwind treats one identifier among two to four shadow lengths as the
+     colour token, even when that identifier is not in the CSS named-colour
+     table. Keep the authored token order and route that colour through the
+     family's channel variable. *)
+  let raw_shadow_color ~color_var value opacity =
+    let tokens =
+      String.split_on_char ' ' value |> List.filter (fun token -> token <> "")
+    in
+    let lengths, other =
+      List.partition
+        (fun token ->
+          String.equal token "0"
+          || Option.is_some (Parse.arbitrary_length token))
+        tokens
+    in
+    match other with
+    | [ color ] when List.length lengths >= 2 && List.length lengths <= 4 ->
+        let fallback =
+          match opacity with
+          | Color.No_opacity -> color
+          | _ ->
+              pp_str
+                [
+                  "oklab(from ";
+                  color;
+                  " l a b / ";
+                  opacity_css_value opacity;
+                  ")";
+                ]
+        in
+        let replacement =
+          pp_str [ "var("; Var.css_name color_var; ","; fallback; ")" ]
+        in
+        String.concat " "
+          (List.map
+             (fun token ->
+               if String.equal token color then replacement else token)
+             tokens)
+    | _ -> value
+
+  let shadow_raw value opacity =
+    let value = raw_shadow_color ~color_var:shadow_color_var value opacity in
+    let shadow_decl =
+      Css.custom_property ~layer:"utilities" (Var.css_name shadow_var) value
+    in
+    let declarations =
+      match opacity with
+      | Color.No_opacity -> [ shadow_decl ]
+      | _ -> [ shadow_opacity_decl opacity; shadow_decl ]
+    in
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
+      (declarations @ [ box_shadow_composition (Var.reference shadow_var) ])
 
   let shadow_shape_data (shape : shadow_shape) :
       (Css.length * Css.length * Css.length option * Css.length option * string)
@@ -1177,6 +1248,25 @@ module Handler = struct
         Css.Var v_ring;
         Css.Var v_shadow;
       ]
+
+  let inset_shadow_raw value opacity =
+    let value =
+      raw_shadow_color ~color_var:inset_shadow_color_var value opacity
+    in
+    let shadow_decl =
+      Css.custom_property ~layer:"utilities"
+        (Var.css_name inset_shadow_var)
+        ("inset " ^ value)
+    in
+    let declarations =
+      match opacity with
+      | Color.No_opacity -> [ shadow_decl ]
+      | _ -> [ inset_shadow_opacity_decl opacity; shadow_decl ]
+    in
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
+      (declarations
+      @ [ inset_box_shadow_composition (Var.reference inset_shadow_var) ])
 
   (* Split a string on top-level commas (not inside parentheses) *)
   let split_top_level_commas (s : string) : string list =
@@ -2194,6 +2284,14 @@ module Handler = struct
     Style.style ~merge_key:("ring-" ^ v) ~rules:(Some [ supports_block ])
       [ fallback ]
 
+  let raw_ring_color var value opacity =
+    style ~metadata:shadow_property_metadata
+      ~property_rules:shadow_property_rules
+      [
+        Css.custom_property ~layer:"utilities" (Var.css_name var)
+          (raw_color_value value opacity);
+      ]
+
   let opacity n =
     let value = float_of_int n /. 100.0 in
     style [ opacity (Opacity_number value) ]
@@ -2293,6 +2391,7 @@ module Handler = struct
     | Shadow_2xl -> shadow_2xl
     | Shadow_inner -> shadow_inner
     | Shadow_arbitrary arb -> shadow_arbitrary arb
+    | Shadow_raw (_, value, opacity) -> shadow_raw value opacity
     | Shadow_theme name -> shadow_theme theme name
     | Inset_shadow_theme name -> inset_shadow_theme theme name
     | Shadow_arbitrary_opacity (arb, op) -> shadow_arbitrary_opacity arb op
@@ -2318,6 +2417,7 @@ module Handler = struct
     | Inset_shadow_sm -> inset_shadow_shape_style ~theme Ish_sm
     | Inset_shadow -> inset_shadow_themed ~theme ()
     | Inset_shadow_arbitrary arb -> inset_shadow_arbitrary arb
+    | Inset_shadow_raw (_, value, opacity) -> inset_shadow_raw value opacity
     | Inset_shadow_arbitrary_opacity (arb, op) ->
         inset_shadow_arbitrary_opacity arb op
     | Inset_shadow_shape_opacity (shape, op) ->
@@ -2372,6 +2472,8 @@ module Handler = struct
     | Ring_bracket_color_var_opacity (v, o) -> ring_bracket_cvar_opacity v o
     | Ring_bracket_var v -> ring_bracket_var v
     | Ring_bracket_var_opacity (v, o) -> ring_bracket_var_with_opacity v o
+    | Ring_raw (_, value, opacity) ->
+        raw_ring_color ring_color_var value opacity
     | Ring_bracket_length inner ->
         let width_value = parse_bracket_width inner in
         (* Build ring shadow like ring_internal but with bracket length *)
@@ -2440,6 +2542,8 @@ module Handler = struct
     | Ring_offset_bracket_var v -> ring_offset_bracket_var v
     | Ring_offset_bracket_var_opacity (v, o) ->
         ring_offset_bracket_var_opacity v o
+    | Ring_offset_raw (_, value, opacity) ->
+        raw_ring_color ring_offset_color_var value opacity
     | Inset_ring_color (color, shade) -> inset_ring_color color shade
     | Inset_ring_color_opacity (color, shade, opacity) ->
         inset_ring_color_with_opacity color shade opacity
@@ -2459,6 +2563,8 @@ module Handler = struct
     | Inset_ring_bracket_var v -> inset_ring_bracket_var v
     | Inset_ring_bracket_var_opacity (v, o) ->
         inset_ring_bracket_var_opacity v o
+    | Inset_ring_raw (_, value, opacity) ->
+        raw_ring_color inset_ring_color_var value opacity
     | Inset_ring_default -> inset_ring_default ()
     | Inset_ring_width n -> inset_ring_internal n
     | Inset_ring_bracket_length inner ->
@@ -2574,7 +2680,10 @@ module Handler = struct
             else
               match parse_bracket_width_opt inner with
               | Some _ -> Ok (Ring_bracket_length inner)
-              | None -> err_not_utility))
+              | None -> (
+                  match Parse.arbitrary_declaration_value inner with
+                  | Some value -> Ok (Ring_raw (inner, value, opacity))
+                  | None -> err_not_utility)))
     | `Ring_offset -> (
         match Color.parse_bracket_hint inner with
         | Some (Color.Typed_var var_part) -> (
@@ -2594,7 +2703,10 @@ module Handler = struct
             else
               match parse_bracket_width_opt inner with
               | Some _ -> Ok (Ring_offset_bracket_length inner)
-              | None -> err_not_utility))
+              | None -> (
+                  match Parse.arbitrary_declaration_value inner with
+                  | Some value -> Ok (Ring_offset_raw (inner, value, opacity))
+                  | None -> err_not_utility)))
     | `Inset_ring -> (
         match Color.parse_bracket_hint inner with
         | Some (Color.Typed_var var_part) -> (
@@ -2614,7 +2726,10 @@ module Handler = struct
             else
               match parse_bracket_width_opt inner with
               | Some _ -> Ok (Inset_ring_bracket_length inner)
-              | None -> err_not_utility))
+              | None -> (
+                  match Parse.arbitrary_declaration_value inner with
+                  | Some value -> Ok (Inset_ring_raw (inner, value, opacity))
+                  | None -> err_not_utility)))
 
   let parse_shadow_bracket v =
     let base_str, opacity = Color.parse_opacity_modifier v in
@@ -2636,10 +2751,10 @@ module Handler = struct
           match opacity with
           | Color.No_opacity -> Ok (Shadow_bracket_color (inner, c))
           | _ -> Ok (Shadow_bracket_color_opacity (inner, c, opacity)))
-      | None when not (is_shadow_bracket inner) ->
-          (* Not a shadow, so not a utility: it used to fall back to the zero
-             shadow [0 0 #0000]. *)
-          err_not_utility
+      | None when not (is_shadow_bracket inner) -> (
+          match Parse.arbitrary_declaration_value inner with
+          | Some value -> Ok (Shadow_raw (inner, value, opacity))
+          | None -> err_not_utility)
       | None -> (
           match opacity with
           | Color.No_opacity -> Ok (Shadow_arbitrary inner)
@@ -2665,7 +2780,10 @@ module Handler = struct
           match opacity with
           | Color.No_opacity -> Ok (Inset_shadow_bracket_color (inner, c))
           | _ -> Ok (Inset_shadow_bracket_color_opacity (inner, c, opacity)))
-      | None when not (is_shadow_bracket inner) -> err_not_utility
+      | None when not (is_shadow_bracket inner) -> (
+          match Parse.arbitrary_declaration_value inner with
+          | Some value -> Ok (Inset_shadow_raw (inner, value, opacity))
+          | None -> err_not_utility)
       | None -> (
           match opacity with
           | Color.No_opacity -> Ok (Inset_shadow_arbitrary inner)
@@ -2980,6 +3098,8 @@ module Handler = struct
     | Shadow_2xl -> "shadow-2xl"
     | Shadow_inner -> "shadow-inner"
     | Shadow_arbitrary arb -> "shadow-[" ^ arb ^ "]"
+    | Shadow_raw (spelling, _, opacity) ->
+        "shadow-[" ^ spelling ^ "]" ^ Color.opacity_suffix opacity
     | Shadow_theme name -> "shadow-" ^ name
     | Inset_shadow_theme name -> "inset-shadow-" ^ name
     | Shadow_arbitrary_opacity (arb, op) ->
@@ -3019,6 +3139,8 @@ module Handler = struct
     | Inset_shadow_sm -> "inset-shadow-sm"
     | Inset_shadow -> "inset-shadow"
     | Inset_shadow_arbitrary arb -> "inset-shadow-[" ^ arb ^ "]"
+    | Inset_shadow_raw (spelling, _, opacity) ->
+        "inset-shadow-[" ^ spelling ^ "]" ^ Color.opacity_suffix opacity
     | Inset_shadow_arbitrary_opacity (arb, op) ->
         "inset-shadow-[" ^ arb ^ "]/" ^ Color.pp_opacity op
     | Inset_shadow_shape_opacity (shape, op) ->
@@ -3082,6 +3204,8 @@ module Handler = struct
     | Ring_bracket_var_opacity (v, o) ->
         "ring-[" ^ v ^ "]/" ^ Color.pp_opacity o
     | Ring_bracket_length l -> "ring-[" ^ l ^ "]"
+    | Ring_raw (spelling, _, opacity) ->
+        "ring-[" ^ spelling ^ "]" ^ Color.opacity_suffix opacity
     | Ring_offset_width n -> "ring-offset-" ^ string_of_int n
     | Ring_offset_bracket_length l -> "ring-offset-[" ^ l ^ "]"
     | Ring_offset_color (color, shade) ->
@@ -3105,6 +3229,8 @@ module Handler = struct
     | Ring_offset_bracket_var v -> "ring-offset-[" ^ v ^ "]"
     | Ring_offset_bracket_var_opacity (v, o) ->
         "ring-offset-[" ^ v ^ "]/" ^ Color.pp_opacity o
+    | Ring_offset_raw (spelling, _, opacity) ->
+        "ring-offset-[" ^ spelling ^ "]" ^ Color.opacity_suffix opacity
     | Inset_ring_color (color, shade) ->
         if Color.is_shadeless color then "inset-ring-" ^ Color.pp color
         else "inset-ring-" ^ Color.pp color ^ "-" ^ string_of_int shade
@@ -3129,6 +3255,8 @@ module Handler = struct
     | Inset_ring_bracket_var v -> "inset-ring-[" ^ v ^ "]"
     | Inset_ring_bracket_var_opacity (v, o) ->
         "inset-ring-[" ^ v ^ "]/" ^ Color.pp_opacity o
+    | Inset_ring_raw (spelling, _, opacity) ->
+        "inset-ring-[" ^ spelling ^ "]" ^ Color.opacity_suffix opacity
     | Inset_ring_default -> "inset-ring"
     | Inset_ring_width n -> "inset-ring-" ^ string_of_int n
     | Inset_ring_bracket_length l -> "inset-ring-[" ^ l ^ "]"
@@ -3195,7 +3323,8 @@ module Handler = struct
        within-group order: bracket values ([) sort before named (none/sm/xl) *)
     | Shadow | Shadow_2xs | Shadow_xs | Shadow_2xl | Shadow_inner | Shadow_lg
     | Shadow_md | Shadow_none | Shadow_sm | Shadow_xl | Shadow_arbitrary _
-    | Shadow_bracket_shadow _ | Shadow_bracket_var _ | Shadow_theme _ ->
+    | Shadow_raw _ | Shadow_bracket_shadow _ | Shadow_bracket_var _
+    | Shadow_theme _ ->
         30000
     (* Shadow color utilities *)
     | Shadow_color _ | Shadow_color_opacity _ | Shadow_current
@@ -3224,8 +3353,9 @@ module Handler = struct
     (* Inset shadow shape utilities — all same suborder, natural_compare
        decides *)
     | Inset_shadow | Inset_shadow_2xs | Inset_shadow_xs | Inset_shadow_none
-    | Inset_shadow_sm | Inset_shadow_arbitrary _ | Inset_shadow_bracket_shadow _
-    | Inset_shadow_bracket_var _ | Inset_shadow_theme _ ->
+    | Inset_shadow_sm | Inset_shadow_arbitrary _ | Inset_shadow_raw _
+    | Inset_shadow_bracket_shadow _ | Inset_shadow_bracket_var _
+    | Inset_shadow_theme _ ->
         32000
     (* Inset shadow color utilities *)
     | Inset_shadow_color _ | Inset_shadow_color_opacity _ | Inset_shadow_current
@@ -3282,7 +3412,7 @@ module Handler = struct
     | Ring_transparent | Ring_current | Ring_current_opacity _ | Ring_inherit
     | Ring_bracket_color _ | Ring_bracket_color_opacity _
     | Ring_bracket_color_var _ | Ring_bracket_color_var_opacity _
-    | Ring_bracket_var _ | Ring_bracket_var_opacity _ ->
+    | Ring_bracket_var _ | Ring_bracket_var_opacity _ | Ring_raw _ ->
         41000
     | Ring_inset -> 2000
     | Inset_ring_default -> 33000
@@ -3293,7 +3423,8 @@ module Handler = struct
     | Inset_ring_current_opacity _ | Inset_ring_inherit
     | Inset_ring_bracket_color _ | Inset_ring_bracket_color_opacity _
     | Inset_ring_bracket_color_var _ | Inset_ring_bracket_cvar_opacity _
-    | Inset_ring_bracket_var _ | Inset_ring_bracket_var_opacity _ ->
+    | Inset_ring_bracket_var _ | Inset_ring_bracket_var_opacity _
+    | Inset_ring_raw _ ->
         43000
     | Ring_offset_width n -> 50000 + n
     | Ring_offset_bracket_length _ -> 50100
@@ -3302,7 +3433,8 @@ module Handler = struct
     | Ring_offset_current | Ring_offset_current_opacity _ | Ring_offset_inherit
     | Ring_offset_bracket_color _ | Ring_offset_bracket_color_opacity _
     | Ring_offset_bracket_color_var _ | Ring_offset_bracket_cvar_opacity _
-    | Ring_offset_bracket_var _ | Ring_offset_bracket_var_opacity _ ->
+    | Ring_offset_bracket_var _ | Ring_offset_bracket_var_opacity _
+    | Ring_offset_raw _ ->
         51000
 
   let examples =

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -24,6 +24,7 @@ module Handler = struct
     (* The author's bracket text travels with the length it denotes, so the
        class name is spelled exactly as it was written. *)
     | Blur_arbitrary of string * Css.length
+    | Blur_raw of string * string
     | Blur_theme of string (* radius from a --blur-* token *)
     | Brightness of int
     | Brightness_arbitrary of string
@@ -41,6 +42,7 @@ module Handler = struct
     (* The author's bracket text travels with the angle it denotes, so the class
        name is spelled exactly as it was written. *)
     | Hue_rotate_arbitrary of string * Css.angle
+    | Hue_rotate_raw of string * string
     | Neg_hue_rotate_arbitrary of string * Css.angle
     | Drop_shadow
     | Drop_shadow_xs
@@ -54,6 +56,7 @@ module Handler = struct
     | Drop_shadow_inherit
     | Drop_shadow_named of string
     | Drop_shadow_arbitrary of string * Css.filter
+    | Drop_shadow_raw of string * string
     | Drop_shadow_color of Color.color * int
     | Drop_shadow_color_opacity of Color.color * int * Color.opacity_modifier
     | Drop_shadow_opacity of Color.opacity_modifier
@@ -76,6 +79,7 @@ module Handler = struct
     | Backdrop_blur_2xl
     | Backdrop_blur_3xl
     | Backdrop_blur_arbitrary of string * Css.length
+    | Backdrop_blur_raw of string * string
     | Backdrop_brightness of int
     | Backdrop_brightness_arbitrary of string
     | Backdrop_contrast of int
@@ -92,6 +96,7 @@ module Handler = struct
     | Backdrop_sepia_arbitrary of string
     | Backdrop_hue_rotate of int
     | Backdrop_hue_rotate_arbitrary of string * Css.angle
+    | Backdrop_hue_rotate_raw of string * string
     | Neg_backdrop_hue_rotate_arbitrary of string * Css.angle
 
   let name = "filters"
@@ -284,6 +289,20 @@ module Handler = struct
       ~property_rules:filter_property_rules
       [ filter_var_decl var_name value; filter composable_filter_chain ]
 
+  let set_raw_filter_var var function_name value =
+    match
+      Parse.wrap_declaration_value ~before:(function_name ^ "(") ~after:")"
+        value
+    with
+    | None -> style []
+    | Some wrapped ->
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
+          [
+            Css.custom_property ~layer:"utilities" (Var.css_name var) wrapped;
+            filter composable_filter_chain;
+          ]
+
   (* Generate a theme-layer declaration for a theme variable if its value is
      set. This produces the --name: value entry for the :root, :host block. *)
   let theme_decl_if_set ?theme name =
@@ -443,45 +462,56 @@ module Handler = struct
           (fun f : Css.number_percentage -> Num f)
           (Float.of_string_opt inner)
 
-  (* An arbitrary filter amount is a number, a percentage or a var: anything
-     else is not CSS, and the class is not a utility. *)
-  let is_numpct_bracket s =
-    parse_bracket_numpct_opt (Parse.bracket_inner s) <> Option.None
-
-  let parse_bracket_numpct inner : Css.number_percentage =
-    Option.value (parse_bracket_numpct_opt inner) ~default:(Num 0.)
-
   let blur_arbitrary len = set_filter_var "--tw-blur" (Blur len)
+  let blur_raw value = set_raw_filter_var blur_var "blur" value
 
   let brightness_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_filter_var "--tw-brightness" (Brightness np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_filter_var "--tw-brightness" (Brightness np)
+    | None ->
+        set_raw_filter_var brightness_var "brightness"
+          (Parse.decode_arbitrary_value inner)
 
   let contrast_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_filter_var "--tw-contrast" (Contrast np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_filter_var "--tw-contrast" (Contrast np)
+    | None ->
+        set_raw_filter_var contrast_var "contrast"
+          (Parse.decode_arbitrary_value inner)
 
   let grayscale_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_filter_var "--tw-grayscale" (Grayscale np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_filter_var "--tw-grayscale" (Grayscale np)
+    | None ->
+        set_raw_filter_var grayscale_var "grayscale"
+          (Parse.decode_arbitrary_value inner)
 
   let saturate_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_filter_var "--tw-saturate" (Saturate np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_filter_var "--tw-saturate" (Saturate np)
+    | None ->
+        set_raw_filter_var saturate_var "saturate"
+          (Parse.decode_arbitrary_value inner)
 
   let sepia_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_filter_var "--tw-sepia" (Sepia np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_filter_var "--tw-sepia" (Sepia np)
+    | None ->
+        set_raw_filter_var sepia_var "sepia"
+          (Parse.decode_arbitrary_value inner)
 
   let invert_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_filter_var "--tw-invert" (Invert np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_filter_var "--tw-invert" (Invert np)
+    | None ->
+        set_raw_filter_var invert_var "invert"
+          (Parse.decode_arbitrary_value inner)
 
   let brightness n =
     set_filter_var "--tw-brightness" (Brightness (Pct (float_of_int n)))
@@ -508,6 +538,9 @@ module Handler = struct
 
   let hue_rotate_arbitrary angle =
     set_filter_var "--tw-hue-rotate" (Hue_rotate angle)
+
+  let hue_rotate_raw value =
+    set_raw_filter_var hue_rotate_var "hue-rotate" value
 
   let neg_hue_rotate_arbitrary angle =
     let neg : Css.angle = Calc (Expr (Val angle, Mul, Num (-1.))) in
@@ -793,6 +826,22 @@ module Handler = struct
         filter composable_filter_chain;
       ]
 
+  let drop_shadow_raw value =
+    match
+      Parse.wrap_declaration_value ~before:"drop-shadow(" ~after:")" value
+    with
+    | None -> style []
+    | Some wrapped ->
+        style ~metadata:filter_property_metadata
+          ~property_rules:filter_property_rules
+          [
+            Css.custom_property ~layer:"utilities"
+              (Var.css_name drop_shadow_size_var)
+              wrapped;
+            bind_drop_shadow drop_shadow_size_ref;
+            filter composable_filter_chain;
+          ]
+
   let drop_shadow_inherit_ =
     style ~metadata:filter_property_metadata
       ~property_rules:filter_property_rules
@@ -1038,6 +1087,21 @@ module Handler = struct
         backdrop_filter composable_backdrop_filter_chain;
       ]
 
+  let set_raw_backdrop_var var function_name value =
+    match
+      Parse.wrap_declaration_value ~before:(function_name ^ "(") ~after:")"
+        value
+    with
+    | None -> style []
+    | Some wrapped ->
+        style ~metadata:backdrop_filter_property_metadata
+          ~property_rules:backdrop_filter_property_rules
+          [
+            Css.custom_property ~layer:"utilities" (Var.css_name var) wrapped;
+            Css.webkit_backdrop_filter composable_backdrop_filter_chain;
+            backdrop_filter composable_backdrop_filter_chain;
+          ]
+
   let set_backdrop_var_theme ?theme var_name theme_name
       (make_filter : Css.length -> Css.filter) () =
     (* Tailwind uses themeKeys: ['--backdrop-X', '--X'] fallback. Check
@@ -1129,38 +1193,53 @@ module Handler = struct
   let backdrop_blur_arbitrary len =
     set_backdrop_var "--tw-backdrop-blur" (Blur len)
 
+  let backdrop_blur_raw value =
+    set_raw_backdrop_var backdrop_blur_var "blur" value
+
   let backdrop_brightness n =
     set_backdrop_var "--tw-backdrop-brightness"
       (Brightness (Pct (float_of_int n)))
 
   let backdrop_brightness_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-brightness" (Brightness np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-brightness" (Brightness np)
+    | None ->
+        set_raw_backdrop_var backdrop_brightness_var "brightness"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_contrast n =
     set_backdrop_var "--tw-backdrop-contrast" (Contrast (Pct (float_of_int n)))
 
   let backdrop_contrast_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-contrast" (Contrast np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-contrast" (Contrast np)
+    | None ->
+        set_raw_backdrop_var backdrop_contrast_var "contrast"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_opacity n =
     set_backdrop_var "--tw-backdrop-opacity" (Opacity (Pct n))
 
   let backdrop_opacity_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-opacity" (Opacity np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-opacity" (Opacity np)
+    | None ->
+        set_raw_backdrop_var backdrop_opacity_var "opacity"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_saturate n =
     set_backdrop_var "--tw-backdrop-saturate" (Saturate (Pct (float_of_int n)))
 
   let backdrop_saturate_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-saturate" (Saturate np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-saturate" (Saturate np)
+    | None ->
+        set_raw_backdrop_var backdrop_saturate_var "saturate"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_grayscale_default =
     set_backdrop_var "--tw-backdrop-grayscale" (Grayscale (Pct 100.))
@@ -1171,8 +1250,11 @@ module Handler = struct
 
   let backdrop_grayscale_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-grayscale" (Grayscale np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-grayscale" (Grayscale np)
+    | None ->
+        set_raw_backdrop_var backdrop_grayscale_var "grayscale"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_invert_default =
     set_backdrop_var "--tw-backdrop-invert" (Invert (Pct 100.))
@@ -1182,8 +1264,11 @@ module Handler = struct
 
   let backdrop_invert_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-invert" (Invert np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-invert" (Invert np)
+    | None ->
+        set_raw_backdrop_var backdrop_invert_var "invert"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_sepia_default =
     set_backdrop_var "--tw-backdrop-sepia" (Sepia (Pct 100.))
@@ -1193,14 +1278,20 @@ module Handler = struct
 
   let backdrop_sepia_arbitrary s =
     let inner = Parse.bracket_inner s in
-    let np = parse_bracket_numpct inner in
-    set_backdrop_var "--tw-backdrop-sepia" (Sepia np)
+    match parse_bracket_numpct_opt inner with
+    | Some np -> set_backdrop_var "--tw-backdrop-sepia" (Sepia np)
+    | None ->
+        set_raw_backdrop_var backdrop_sepia_var "sepia"
+          (Parse.decode_arbitrary_value inner)
 
   let backdrop_hue_rotate n =
     set_backdrop_var "--tw-backdrop-hue-rotate" (Hue_rotate (make_angle n))
 
   let backdrop_hue_rotate_arbitrary angle =
     set_backdrop_var "--tw-backdrop-hue-rotate" (Hue_rotate angle)
+
+  let backdrop_hue_rotate_raw value =
+    set_raw_backdrop_var backdrop_hue_rotate_var "hue-rotate" value
 
   let neg_backdrop_hue_rotate_arbitrary angle =
     let neg : Css.angle = Calc (Expr (Val angle, Mul, Num (-1.))) in
@@ -1254,6 +1345,7 @@ module Handler = struct
     | Blur_2xl -> blur_2xl ()
     | Blur_3xl -> blur_3xl ()
     | Blur_arbitrary (_, len) -> blur_arbitrary len
+    | Blur_raw (_, value) -> blur_raw value
     | Brightness n -> brightness n
     | Brightness_arbitrary s -> brightness_arbitrary s
     | Contrast n -> contrast n
@@ -1268,6 +1360,7 @@ module Handler = struct
     | Invert_arbitrary s -> invert_arbitrary s
     | Hue_rotate n -> hue_rotate n
     | Hue_rotate_arbitrary (_, angle) -> hue_rotate_arbitrary angle
+    | Hue_rotate_raw (_, value) -> hue_rotate_raw value
     | Neg_hue_rotate_arbitrary (_, angle) -> neg_hue_rotate_arbitrary angle
     | Drop_shadow -> drop_shadow_ ()
     | Drop_shadow_xs -> drop_shadow_xs_ ()
@@ -1281,6 +1374,7 @@ module Handler = struct
     | Drop_shadow_inherit -> drop_shadow_inherit_
     | Drop_shadow_named name -> drop_shadow_named name
     | Drop_shadow_arbitrary (_, size) -> drop_shadow_arbitrary_impl size
+    | Drop_shadow_raw (_, value) -> drop_shadow_raw value
     | Drop_shadow_color (c, shade) -> drop_shadow_color c shade
     | Drop_shadow_color_opacity (c, shade, op) ->
         drop_shadow_color_opacity c shade op
@@ -1299,6 +1393,7 @@ module Handler = struct
     | Backdrop_blur_2xl -> backdrop_blur_2xl ()
     | Backdrop_blur_3xl -> backdrop_blur_3xl ()
     | Backdrop_blur_arbitrary (_, len) -> backdrop_blur_arbitrary len
+    | Backdrop_blur_raw (_, value) -> backdrop_blur_raw value
     | Backdrop_brightness n -> backdrop_brightness n
     | Backdrop_brightness_arbitrary s -> backdrop_brightness_arbitrary s
     | Backdrop_contrast n -> backdrop_contrast n
@@ -1319,6 +1414,7 @@ module Handler = struct
     | Backdrop_hue_rotate n -> backdrop_hue_rotate n
     | Backdrop_hue_rotate_arbitrary (_, angle) ->
         backdrop_hue_rotate_arbitrary angle
+    | Backdrop_hue_rotate_raw (_, value) -> backdrop_hue_rotate_raw value
     | Neg_backdrop_hue_rotate_arbitrary (_, angle) ->
         neg_backdrop_hue_rotate_arbitrary angle
     | Backdrop_filter -> backdrop_filter_
@@ -1332,8 +1428,8 @@ module Handler = struct
     (* Each filter kind is one property slot. Tailwind uses the natural
        candidate spelling inside it, which handles bare defaults, numeric
        values, arbitrary values and negative angles without per-value keys. *)
-    | Blur | Blur_2xl | Blur_3xl | Blur_arbitrary _ | Blur_lg | Blur_md
-    | Blur_none | Blur_sm | Blur_theme _ | Blur_xl | Blur_xs ->
+    | Blur | Blur_2xl | Blur_3xl | Blur_arbitrary _ | Blur_raw _ | Blur_lg
+    | Blur_md | Blur_none | Blur_sm | Blur_theme _ | Blur_xl | Blur_xs ->
         0
     | Brightness _ | Brightness_arbitrary _ -> 1000
     | Contrast _ | Contrast_arbitrary _ -> 2000
@@ -1342,9 +1438,9 @@ module Handler = struct
     | Drop_shadow -> 2700
     (* All size candidates share one slot: Tailwind orders them by class name,
        including arbitrary and project-defined values. *)
-    | Drop_shadow_2xl | Drop_shadow_arbitrary _ | Drop_shadow_lg
-    | Drop_shadow_md | Drop_shadow_multi | Drop_shadow_named _ | Drop_shadow_sm
-    | Drop_shadow_xs | Drop_shadow_xl ->
+    | Drop_shadow_2xl | Drop_shadow_arbitrary _ | Drop_shadow_raw _
+    | Drop_shadow_lg | Drop_shadow_md | Drop_shadow_multi | Drop_shadow_named _
+    | Drop_shadow_sm | Drop_shadow_xs | Drop_shadow_xl ->
         2703
     | Drop_shadow_none -> 2708
     (* Every drop-shadow colour shares one slot, after the sizes: Tailwind
@@ -1354,21 +1450,24 @@ module Handler = struct
     | Drop_shadow_inherit | Drop_shadow_color _ | Drop_shadow_color_opacity _ ->
         2710
     | Grayscale _ | Grayscale_arbitrary _ -> 4000
-    | Hue_rotate _ | Hue_rotate_arbitrary _ | Neg_hue_rotate_arbitrary _ -> 5000
+    | Hue_rotate _ | Hue_rotate_arbitrary _ | Hue_rotate_raw _
+    | Neg_hue_rotate_arbitrary _ ->
+        5000
     | Invert _ | Invert_arbitrary _ -> 6000
     | Saturate _ | Saturate_arbitrary _ -> 7000
     | Sepia _ | Sepia_arbitrary _ -> 8000
     | Filter | Filter_arbitrary _ | Filter_none -> 9000
     (* Backdrop filters follow the same one-slot-per-kind rule. *)
-    | Backdrop_blur_arbitrary _ | Backdrop_blur_none | Backdrop_blur_xs
-    | Backdrop_blur_sm | Backdrop_blur | Backdrop_blur_md | Backdrop_blur_lg
-    | Backdrop_blur_xl | Backdrop_blur_2xl | Backdrop_blur_3xl ->
+    | Backdrop_blur_arbitrary _ | Backdrop_blur_raw _ | Backdrop_blur_none
+    | Backdrop_blur_xs | Backdrop_blur_sm | Backdrop_blur | Backdrop_blur_md
+    | Backdrop_blur_lg | Backdrop_blur_xl | Backdrop_blur_2xl
+    | Backdrop_blur_3xl ->
         10000
     | Backdrop_brightness _ | Backdrop_brightness_arbitrary _ -> 11000
     | Backdrop_contrast _ | Backdrop_contrast_arbitrary _ -> 12000
     | Backdrop_grayscale _ | Backdrop_grayscale_arbitrary _ -> 14000
     | Neg_backdrop_hue_rotate_arbitrary _ | Backdrop_hue_rotate _
-    | Backdrop_hue_rotate_arbitrary _ ->
+    | Backdrop_hue_rotate_arbitrary _ | Backdrop_hue_rotate_raw _ ->
         15000
     | Backdrop_invert _ | Backdrop_invert_arbitrary _ -> 16000
     | Backdrop_opacity _ | Backdrop_opacity_arbitrary _ -> 17000
@@ -1407,38 +1506,56 @@ module Handler = struct
     | [ "blur"; s ] when Parse.is_bracket_value s -> (
         match arbitrary_blur s with
         | Option.Some len -> Ok (Blur_arbitrary (s, len))
-        | Option.None -> Error (`Msg ("Invalid blur value: " ^ s)))
-    | [ "brightness"; s ] when Parse.is_bracket_value s && is_numpct_bracket s
-      ->
-        Ok (Brightness_arbitrary s)
+        | Option.None -> (
+            match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+            | Some value -> Ok (Blur_raw (s, value))
+            | None -> Error (`Msg ("Invalid blur value: " ^ s))))
+    | [ "brightness"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Brightness_arbitrary s)
+        | None -> err_not_utility)
     | [ "brightness"; n ] ->
         Parse.int_pos ~name:"brightness" n >|= fun x -> Brightness x
-    | [ "contrast"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Contrast_arbitrary s)
+    | [ "contrast"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Contrast_arbitrary s)
+        | None -> err_not_utility)
     | [ "contrast"; n ] ->
         Parse.int_pos ~name:"contrast" n >|= fun x -> Contrast x
-    | [ "grayscale"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Grayscale_arbitrary s)
+    | [ "grayscale"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Grayscale_arbitrary s)
+        | None -> err_not_utility)
     | [ "grayscale"; n ] ->
         Parse.int_pos ~name:"grayscale" n >|= fun x -> Grayscale x
     | [ "grayscale" ] -> Ok (Grayscale 100)
-    | [ "saturate"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Saturate_arbitrary s)
+    | [ "saturate"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Saturate_arbitrary s)
+        | None -> err_not_utility)
     | [ "saturate"; n ] ->
         Parse.int_pos ~name:"saturate" n >|= fun x -> Saturate x
-    | [ "sepia"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Sepia_arbitrary s)
+    | [ "sepia"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Sepia_arbitrary s)
+        | None -> err_not_utility)
     | [ "sepia"; n ] -> Parse.int_pos ~name:"sepia" n >|= fun x -> Sepia x
     | [ "sepia" ] -> Ok (Sepia 100)
-    | [ "invert"; s ] when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Invert_arbitrary s)
+    | [ "invert"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Invert_arbitrary s)
+        | None -> err_not_utility)
     | [ "invert"; n ] -> Parse.int_pos ~name:"invert" n >|= fun x -> Invert x
     | [ "invert" ] -> Ok (Invert 100)
     | [ "hue"; "rotate"; s ] when Parse.is_bracket_value s -> (
         match parse_bracket_angle s with
         | Option.Some angle ->
             Ok (Hue_rotate_arbitrary (Parse.bracket_inner s, angle))
-        | Option.None -> err_not_utility)
+        | Option.None -> (
+            let spelling = Parse.bracket_inner s in
+            match Parse.arbitrary_declaration_value spelling with
+            | Some value -> Ok (Hue_rotate_raw (spelling, value))
+            | None -> err_not_utility))
     | [ "hue"; "rotate"; n ] -> Parse.int_any n >|= fun x -> Hue_rotate x
     (* Negative hue-rotate: -hue-rotate-N or -hue-rotate-[Ndeg] *)
     | [ ""; "hue"; "rotate"; s ] when Parse.is_bracket_value s -> (
@@ -1471,16 +1588,14 @@ module Handler = struct
     | [ "drop"; "shadow"; "transparent" ] ->
         Ok (Drop_shadow_keyword_color (Css.Transparent, "transparent"))
     | [ "drop"; "shadow"; s ] when Parse.is_bracket_value s -> (
-        let inner = Parse.decode_arbitrary_value (Parse.bracket_inner s) in
-        (* A drop-shadow bracket is a shadow or a var(); the docs' [<value>]
-           placeholder is neither, and it used to reach the sheet as the colour
-           of an otherwise empty shadow. *)
-        if not (Parse.is_var inner || Css.parse_shadow inner <> None) then
-          err_not_utility
-        else
-          match drop_shadow_arbitrary_value s with
-          | Option.Some size -> Ok (Drop_shadow_arbitrary (s, size))
-          | Option.None -> err_not_utility)
+        (* Prefer the typed shadow representation, then preserve any safe raw
+           declaration-value token stream. *)
+        match drop_shadow_arbitrary_value s with
+        | Option.Some size -> Ok (Drop_shadow_arbitrary (s, size))
+        | Option.None -> (
+            match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+            | Some value -> Ok (Drop_shadow_raw (s, value))
+            | None -> err_not_utility))
     | "drop" :: "shadow" :: rest -> (
         let full = String.concat "-" rest in
         let base, opacity = Color.parse_opacity_modifier ~theme full in
@@ -1534,48 +1649,58 @@ module Handler = struct
     | [ "backdrop"; "blur"; s ] when Parse.is_bracket_value s -> (
         match arbitrary_blur s with
         | Option.Some len -> Ok (Backdrop_blur_arbitrary (s, len))
-        | Option.None -> Error (`Msg ("Invalid backdrop-blur value: " ^ s)))
-    | [ "backdrop"; "brightness"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_brightness_arbitrary s)
+        | Option.None -> (
+            match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+            | Some value -> Ok (Backdrop_blur_raw (s, value))
+            | None -> Error (`Msg ("Invalid backdrop-blur value: " ^ s))))
+    | [ "backdrop"; "brightness"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_brightness_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "brightness"; n ] ->
         Parse.int_pos ~name:"backdrop-brightness" n >|= fun x ->
         Backdrop_brightness x
-    | [ "backdrop"; "contrast"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_contrast_arbitrary s)
+    | [ "backdrop"; "contrast"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_contrast_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "contrast"; n ] ->
         Parse.int_pos ~name:"backdrop-contrast" n >|= fun x ->
         Backdrop_contrast x
-    | [ "backdrop"; "opacity"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_opacity_arbitrary s)
+    | [ "backdrop"; "opacity"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_opacity_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "opacity"; n ] -> (
         match float_of_string_opt n with
         | Some f when f >= 0. -> Ok (Backdrop_opacity f)
         | _ -> err_not_utility)
-    | [ "backdrop"; "saturate"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_saturate_arbitrary s)
+    | [ "backdrop"; "saturate"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_saturate_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "saturate"; n ] ->
         Parse.int_pos ~name:"backdrop-saturate" n >|= fun x ->
         Backdrop_saturate x
-    | [ "backdrop"; "grayscale"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_grayscale_arbitrary s)
+    | [ "backdrop"; "grayscale"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_grayscale_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "grayscale"; n ] ->
         Parse.int_pos ~name:"backdrop-grayscale" n >|= fun x ->
         Backdrop_grayscale x
     | [ "backdrop"; "grayscale" ] -> Ok (Backdrop_grayscale 100)
-    | [ "backdrop"; "invert"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_invert_arbitrary s)
+    | [ "backdrop"; "invert"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_invert_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "invert"; n ] ->
         Parse.int_pos ~name:"backdrop-invert" n >|= fun x -> Backdrop_invert x
     | [ "backdrop"; "invert" ] -> Ok (Backdrop_invert 100)
-    | [ "backdrop"; "sepia"; s ]
-      when Parse.is_bracket_value s && is_numpct_bracket s ->
-        Ok (Backdrop_sepia_arbitrary s)
+    | [ "backdrop"; "sepia"; s ] when Parse.is_bracket_value s -> (
+        match Parse.arbitrary_declaration_value (Parse.bracket_inner s) with
+        | Some _ -> Ok (Backdrop_sepia_arbitrary s)
+        | None -> err_not_utility)
     | [ "backdrop"; "sepia"; n ] ->
         Parse.int_pos ~name:"backdrop-sepia" n >|= fun x -> Backdrop_sepia x
     | [ "backdrop"; "sepia" ] -> Ok (Backdrop_sepia 100)
@@ -1583,7 +1708,11 @@ module Handler = struct
         match parse_bracket_angle s with
         | Option.Some angle ->
             Ok (Backdrop_hue_rotate_arbitrary (Parse.bracket_inner s, angle))
-        | Option.None -> err_not_utility)
+        | Option.None -> (
+            let spelling = Parse.bracket_inner s in
+            match Parse.arbitrary_declaration_value spelling with
+            | Some value -> Ok (Backdrop_hue_rotate_raw (spelling, value))
+            | None -> err_not_utility))
     | [ "backdrop"; "hue"; "rotate"; n ] ->
         Parse.int_any n >|= fun x -> Backdrop_hue_rotate x
     (* Negative backdrop hue-rotate *)
@@ -1616,6 +1745,7 @@ module Handler = struct
     | Blur_2xl -> "blur-2xl"
     | Blur_3xl -> "blur-3xl"
     | Blur_arbitrary (s, _) -> "blur-" ^ s
+    | Blur_raw (s, _) -> "blur-" ^ s
     | Brightness n -> "brightness-" ^ string_of_int n
     | Brightness_arbitrary s -> "brightness-" ^ s
     | Contrast n -> "contrast-" ^ string_of_int n
@@ -1638,6 +1768,7 @@ module Handler = struct
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "hue-rotate-" ^ string_of_int (abs n)
     | Hue_rotate_arbitrary (spelling, _) -> "hue-rotate-[" ^ spelling ^ "]"
+    | Hue_rotate_raw (spelling, _) -> "hue-rotate-[" ^ spelling ^ "]"
     | Neg_hue_rotate_arbitrary (spelling, _) -> "-hue-rotate-[" ^ spelling ^ "]"
     | Drop_shadow -> "drop-shadow"
     | Drop_shadow_xs -> "drop-shadow-xs"
@@ -1651,6 +1782,7 @@ module Handler = struct
     | Drop_shadow_inherit -> "drop-shadow-inherit"
     | Drop_shadow_named name -> "drop-shadow-" ^ name
     | Drop_shadow_arbitrary (s, _) -> "drop-shadow-" ^ s
+    | Drop_shadow_raw (s, _) -> "drop-shadow-" ^ s
     | Drop_shadow_color (c, shade) ->
         "drop-shadow-" ^ Color.scheme_color_name c shade
     | Drop_shadow_color_opacity (c, shade, op) ->
@@ -1673,6 +1805,7 @@ module Handler = struct
     | Backdrop_blur_2xl -> "backdrop-blur-2xl"
     | Backdrop_blur_3xl -> "backdrop-blur-3xl"
     | Backdrop_blur_arbitrary (s, _) -> "backdrop-blur-" ^ s
+    | Backdrop_blur_raw (s, _) -> "backdrop-blur-" ^ s
     | Backdrop_brightness n -> "backdrop-brightness-" ^ string_of_int n
     | Backdrop_brightness_arbitrary s -> "backdrop-brightness-" ^ s
     | Backdrop_contrast n -> "backdrop-contrast-" ^ string_of_int n
@@ -1701,6 +1834,8 @@ module Handler = struct
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "backdrop-hue-rotate-" ^ string_of_int (abs n)
     | Backdrop_hue_rotate_arbitrary (spelling, _) ->
+        "backdrop-hue-rotate-[" ^ spelling ^ "]"
+    | Backdrop_hue_rotate_raw (spelling, _) ->
         "backdrop-hue-rotate-[" ^ spelling ^ "]"
     | Neg_backdrop_hue_rotate_arbitrary (spelling, _) ->
         "-backdrop-hue-rotate-[" ^ spelling ^ "]"

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -339,6 +339,28 @@ let is_ident = Cascade.Syntax.is_ident
    the thing to refuse. Tailwind refuses the same ones. *)
 let is_declaration_value = Cascade.Css.Declaration.is_declaration_value
 
+let arbitrary_declaration_value s =
+  let value = decode_arbitrary_value s in
+  if value <> "" && is_declaration_value value then Some value else None
+
+let wrap_declaration_value ~before ~after value =
+  if value = "" || not (is_declaration_value value) then None
+  else
+    let wrapped = before ^ value ^ after in
+    if is_declaration_value wrapped then Some wrapped
+    else
+      (* A CSS comment is implicitly closed at EOF. Once the author value is
+         embedded, however, an unterminated comment would consume the wrapper's
+         closing tokens. Close that comment explicitly; the tokeniser drops the
+         comment itself, as it does for the standalone value. *)
+      let closed_comment = before ^ value ^ "*/" ^ after in
+      if is_declaration_value closed_comment then Some closed_comment else None
+
+let opaque_declaration property value =
+  if value <> "" && is_declaration_value value then
+    Cascade.Css.Declaration.parse_opaque_declaration property value
+  else None
+
 (** Check if a string starts with "var(" — works on inner bracket content *)
 let is_var s = String.length s > 4 && String.sub s 0 4 = "var("
 

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -104,6 +104,24 @@ val is_declaration_value : string -> bool
     than emitted. {!Cascade.Css.custom_property} takes the same values and
     raises on the rest. *)
 
+val arbitrary_declaration_value : string -> string option
+(** [arbitrary_declaration_value s] decodes the inside of a Tailwind bracket and
+    returns its non-empty CSS declaration value. Values that can terminate or
+    swallow the declaration are [None]. *)
+
+val wrap_declaration_value :
+  before:string -> after:string -> string -> string option
+(** [wrap_declaration_value ~before ~after value] safely embeds a declaration
+    value between generated tokens. In particular, it closes a comment that was
+    implicitly closed by the end of [value], so that comment cannot swallow
+    [after]. *)
+
+val opaque_declaration : string -> string -> Cascade.Css.declaration option
+(** [opaque_declaration property value] preserves one non-empty,
+    declaration-safe value verbatim. It implements Tailwind's token-stream
+    contract for arbitrary utilities, which deliberately emits some values that
+    are invalid for [property]. *)
+
 val starts_with_math_function : string -> bool
 (** [starts_with_math_function s] is [true] when [s] opens with a CSS math
     function ([calc], [min], [max], [clamp], ...). A utility whose bracket takes

--- a/lib/scrollbar.ml
+++ b/lib/scrollbar.ml
@@ -18,6 +18,7 @@ module Handler = struct
   type color_spec =
     | Theme of Color.color * int * Color.opacity_modifier
     | Bracket of string * Css.color * Color.opacity_modifier
+    | Raw of string * string
     | Current
     | Inherit
     | Transparent
@@ -50,6 +51,7 @@ module Handler = struct
         in
         base ^ Color.opacity_suffix op
     | Bracket (raw, _, op) -> raw ^ Color.opacity_suffix op
+    | Raw (raw, _) -> raw
     | Current -> "current"
     | Inherit -> "inherit"
     | Transparent -> "transparent"
@@ -94,6 +96,7 @@ module Handler = struct
         ([ fst (Var.binding set_var (Css.Transparent : Css.color)) ], [])
     | Current -> ([ keyword "currentcolor" ], [])
     | Inherit -> ([ fst (Var.binding set_var (Css.Inherit : Css.color)) ], [])
+    | Raw (_, value) -> ([ keyword value ], [])
     | Theme (color, shade, Color.No_opacity) ->
         let color_decl, color_ref =
           Var.binding (Color.color_var color shade) (Color.to_css color shade)
@@ -166,8 +169,12 @@ module Handler = struct
       |> List.filter_map (fun x -> x)
       |> Css.concat
     in
+    let metadata =
+      match spec with Raw _ -> [ Var.metadata set_var ] | _ -> []
+    in
     match supports_rules with
-    | [] -> style ~property_rules (main_decls @ [ scrollbar_color_decl ])
+    | [] ->
+        style ~property_rules ~metadata (main_decls @ [ scrollbar_color_decl ])
     | _ ->
         (* Tailwind sets the fallback custom property, then upgrades it inside
            @supports, then applies scrollbar-color in a trailing rule so the
@@ -178,7 +185,7 @@ module Handler = struct
           (self main_decls :: supports_rules)
           @ [ self [ scrollbar_color_decl ] ]
         in
-        style ~property_rules ~rules:(Some ordered) []
+        style ~property_rules ~metadata ~rules:(Some ordered) []
 
   let to_style theme =
     let compose ~set_var s = compose ~theme ~set_var s in
@@ -210,7 +217,10 @@ module Handler = struct
         let inner = Parse.bracket_inner base in
         match Color.parse_bracket_color inner with
         | Some c -> Ok (mk (Bracket (base, c, op)))
-        | None -> Error (`Msg "Not a scrollbar utility"))
+        | None -> (
+            match (op, Parse.arbitrary_declaration_value inner) with
+            | Color.No_opacity, Some value -> Ok (mk (Raw (base, value)))
+            | _ -> Error (`Msg "Not a scrollbar utility")))
     | parts when List.exists has_opacity parts -> (
         match Color.shade_and_opacity_of_strings ?theme parts with
         | Ok (c, shade, op) -> Ok (mk (Theme (c, shade, op)))

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -30,9 +30,9 @@ module Handler = struct
     | Border_spacing_y of float
     (* The author's bracket text travels with the length it denotes, so the
        class name is spelled exactly as it was written. *)
-    | Border_spacing_arb of string * Css.length
-    | Border_spacing_x_arb of string * Css.length
-    | Border_spacing_y_arb of string * Css.length
+    | Border_spacing_arb of string * [ `Length of Css.length | `Raw of string ]
+    | Border_spacing_x_arb of string * [ `Length of Css.length | `Raw of string ]
+    | Border_spacing_y_arb of string * [ `Length of Css.length | `Raw of string ]
     | Table_auto
     | Table_fixed
     | Caption_top
@@ -160,6 +160,30 @@ module Handler = struct
       ~property_rules:(Css.concat property_rules)
       [ decl_y; Css.border_spacing (Lengths [ Var x_ref; Var y_ref ]) ]
 
+  let raw_border_spacing_style axis value =
+    let property_rules =
+      [
+        Var.property_rule border_spacing_x_var;
+        Var.property_rule border_spacing_y_var;
+      ]
+      |> List.filter_map Fun.id |> Css.concat
+    in
+    let x_ref = Var.reference border_spacing_x_var in
+    let y_ref = Var.reference border_spacing_y_var in
+    let raw var =
+      Css.custom_property ~layer:"utilities" (Var.css_name var) value
+    in
+    let bindings =
+      match axis with
+      | `Both -> [ raw border_spacing_x_var; raw border_spacing_y_var ]
+      | `X -> [ raw border_spacing_x_var ]
+      | `Y -> [ raw border_spacing_y_var ]
+    in
+    style ~property_rules
+      ~metadata:
+        [ Var.metadata border_spacing_x_var; Var.metadata border_spacing_y_var ]
+      (bindings @ [ Css.border_spacing (Lengths [ Var x_ref; Var y_ref ]) ])
+
   let to_style theme =
     let border_spacing_style n = border_spacing_style ~theme n in
     let border_spacing_x_style n = border_spacing_x_style ~theme n in
@@ -170,9 +194,12 @@ module Handler = struct
     | Border_spacing n -> border_spacing_style n
     | Border_spacing_x n -> border_spacing_x_style n
     | Border_spacing_y n -> border_spacing_y_style n
-    | Border_spacing_arb (_, len) -> border_spacing_arb_style len
-    | Border_spacing_x_arb (_, len) -> border_spacing_x_arb_style len
-    | Border_spacing_y_arb (_, len) -> border_spacing_y_arb_style len
+    | Border_spacing_arb (_, `Length len) -> border_spacing_arb_style len
+    | Border_spacing_x_arb (_, `Length len) -> border_spacing_x_arb_style len
+    | Border_spacing_y_arb (_, `Length len) -> border_spacing_y_arb_style len
+    | Border_spacing_arb (_, `Raw value) -> raw_border_spacing_style `Both value
+    | Border_spacing_x_arb (_, `Raw value) -> raw_border_spacing_style `X value
+    | Border_spacing_y_arb (_, `Raw value) -> raw_border_spacing_style `Y value
     | Table_auto -> style [ Css.table_layout Auto ]
     | Table_fixed -> style [ Css.table_layout Fixed ]
     | Caption_top -> style [ Css.caption_side Top ]
@@ -198,8 +225,11 @@ module Handler = struct
     | [ "border"; "spacing"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in
         match Parse.arbitrary_length inner with
-        | Some len -> Ok (Border_spacing_arb (inner, len))
-        | None -> err_not_utility)
+        | Some len -> Ok (Border_spacing_arb (inner, `Length len))
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Border_spacing_arb (inner, `Raw value))
+            | None -> err_not_utility))
     | [ "border"; "spacing"; n ] -> (
         match Parse.spacing_value ~name:"border-spacing" n with
         | Ok f when Theme.has_spacing_step ~theme f -> Ok (Border_spacing f)
@@ -207,8 +237,11 @@ module Handler = struct
     | [ "border"; "spacing"; "x"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in
         match Parse.arbitrary_length inner with
-        | Some len -> Ok (Border_spacing_x_arb (inner, len))
-        | None -> err_not_utility)
+        | Some len -> Ok (Border_spacing_x_arb (inner, `Length len))
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Border_spacing_x_arb (inner, `Raw value))
+            | None -> err_not_utility))
     | [ "border"; "spacing"; "x"; n ] -> (
         match Parse.spacing_value ~name:"border-spacing-x" n with
         | Ok f when Theme.has_spacing_step ~theme f -> Ok (Border_spacing_x f)
@@ -216,8 +249,11 @@ module Handler = struct
     | [ "border"; "spacing"; "y"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in
         match Parse.arbitrary_length inner with
-        | Some len -> Ok (Border_spacing_y_arb (inner, len))
-        | None -> err_not_utility)
+        | Some len -> Ok (Border_spacing_y_arb (inner, `Length len))
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Border_spacing_y_arb (inner, `Raw value))
+            | None -> err_not_utility))
     | [ "border"; "spacing"; "y"; n ] -> (
         match Parse.spacing_value ~name:"border-spacing-y" n with
         | Ok f when Theme.has_spacing_step ~theme f -> Ok (Border_spacing_y f)

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -13,6 +13,7 @@ module Handler = struct
     | (* 2D Transforms *)
       Rotate of int
     | Rotate_arbitrary of string * Css.angle
+    | Rotate_raw of string * string
     | Rotate_none
     | Rotate_3d_arbitrary of string * float * float * float * Css.angle
     | Rotate_bare_var of string
@@ -35,12 +36,13 @@ module Handler = struct
     | Scale_y_arbitrary of string * float
     | Scale_raw_1 of string * float
     | Scale_raw_3 of string * float * float * float
+    | Scale_arbitrary_raw of string * string
     | Skew_x of int
-    | Skew_x_arbitrary of string * Css.angle
+    | Skew_x_arbitrary of string * [ `Angle of Css.angle | `Raw of string ]
     | Skew_y of int
-    | Skew_y_arbitrary of string * Css.angle
+    | Skew_y_arbitrary of string * [ `Angle of Css.angle | `Raw of string ]
     | Skew of int
-    | Skew_arbitrary of string * Css.angle
+    | Skew_arbitrary of string * [ `Angle of Css.angle | `Raw of string ]
     | Translate_x_fraction of int * int
     | Translate_y_fraction of int * int
     | (* Combined translate utilities *)
@@ -71,6 +73,8 @@ module Handler = struct
       Translate_z of int
     | Translate_z_step of float (* translate-z-0.5, a half-step scale value *)
     | Translate_z_px
+    | Translate_z_arbitrary of
+        string * [ `Length of Css.length | `Raw of string ]
     | Neg_translate_z_arbitrary of string
     | Neg_translate_z_px
     | Translate_3d
@@ -428,6 +432,11 @@ module Handler = struct
   let rotate n = style [ Css.rotate (Angle (Deg (float_of_int n))) ]
   let rotate_arbitrary angle = style [ Css.rotate (Angle angle) ]
 
+  let opaque_style property value =
+    match Parse.opaque_declaration property value with
+    | Some declaration -> style [ declaration ]
+    | None -> style []
+
   let rotate_3d_arbitrary x y z angle =
     style [ Css.rotate (Axis (x, y, z, angle)) ]
 
@@ -656,6 +665,42 @@ module Handler = struct
   let skew_y deg = transform_with_var tw_skew_y_var (Skew_y (make_angle deg))
   let skew_x_arbitrary angle = transform_with_var tw_skew_x_var (Skew_x angle)
   let skew_y_arbitrary angle = transform_with_var tw_skew_y_var (Skew_y angle)
+
+  let raw_skew_style axes value =
+    let raw var fn =
+      Parse.wrap_declaration_value ~before:(fn ^ "(") ~after:")" value
+      |> Option.map (Css.custom_property ~layer:"utilities" (Var.css_name var))
+    in
+    let bindings, metadata =
+      match axes with
+      | `X ->
+          ( Option.to_list (raw tw_skew_x_var "skewX"),
+            [ Var.metadata tw_skew_x_var ] )
+      | `Y ->
+          ( Option.to_list (raw tw_skew_y_var "skewY"),
+            [ Var.metadata tw_skew_y_var ] )
+      | `Both ->
+          ( List.filter_map Fun.id
+              [ raw tw_skew_x_var "skewX"; raw tw_skew_y_var "skewY" ],
+            [ Var.metadata tw_skew_x_var; Var.metadata tw_skew_y_var ] )
+    in
+    let rotate_x_ref = Var.reference_with_empty_fallback tw_rotate_x_var in
+    let rotate_y_ref = Var.reference_with_empty_fallback tw_rotate_y_var in
+    let rotate_z_ref = Var.reference_with_empty_fallback tw_rotate_z_var in
+    let skew_x_ref = Var.reference_with_empty_fallback tw_skew_x_var in
+    let skew_y_ref = Var.reference_with_empty_fallback tw_skew_y_var in
+    style ~property_rules:rotate_skew_props ~metadata
+      (bindings
+      @ [
+          transforms
+            [
+              Var rotate_x_ref;
+              Var rotate_y_ref;
+              Var rotate_z_ref;
+              Var skew_x_ref;
+              Var skew_y_ref;
+            ];
+        ])
 
   (* Combined translate utilities *)
   let translate_full =
@@ -893,6 +938,21 @@ module Handler = struct
   let translate_z_px =
     let axis_decl, _ = Var.binding tw_translate_z_var (Px 1.0) in
     style ~property_rules:translate_props (axis_decl :: [ translate_xyz_refs ])
+
+  let translate_z_arbitrary = function
+    | `Length length ->
+        let axis_decl, _ = Var.binding tw_translate_z_var length in
+        style ~property_rules:translate_props
+          (axis_decl :: [ translate_xyz_refs ])
+    | `Raw value ->
+        style ~property_rules:translate_props
+          ~metadata:[ Var.metadata tw_translate_z_var ]
+          [
+            Css.custom_property ~layer:"utilities"
+              (Var.css_name tw_translate_z_var)
+              value;
+            translate_xyz_refs;
+          ]
 
   let neg_translate_z_arbitrary_style s =
     let bare_name = Parse.extract_var_name s in
@@ -1237,6 +1297,7 @@ module Handler = struct
     function
     | Rotate n -> rotate n
     | Rotate_arbitrary (_, a) -> rotate_arbitrary a
+    | Rotate_raw (_, value) -> opaque_style "rotate" value
     | Rotate_none -> style [ Css.rotate None ]
     | Rotate_3d_arbitrary (_, x, y, z, a) -> rotate_3d_arbitrary x y z a
     | Rotate_bare_var name -> rotate_bare_var name
@@ -1281,6 +1342,7 @@ module Handler = struct
     | Translate_z n -> translate_z n
     | Translate_z_step f -> translate_z_step f
     | Translate_z_px -> translate_z_px
+    | Translate_z_arbitrary (_, value) -> translate_z_arbitrary value
     | Neg_translate_z_arbitrary s -> neg_translate_z_arbitrary_style s
     | Neg_translate_z_px -> neg_translate_z_px
     | Translate_3d -> translate_3d
@@ -1292,16 +1354,20 @@ module Handler = struct
     | Scale_raw_1 (_, f) -> style [ Css.scale (X (Num f)) ]
     | Scale_raw_3 (_, x, y, z) ->
         style [ Css.scale (XYZ (Num x, Num y, Num z)) ]
+    | Scale_arbitrary_raw (_, value) -> opaque_style "scale" value
     | Scale_z n -> scale_z n
     | Scale_z_arbitrary s -> scale_z_arbitrary s
     | Scale_3d -> scale_3d
     | Scale_none -> style [ Css.scale None ]
     | Skew_x n -> skew_x n
-    | Skew_x_arbitrary (_, a) -> skew_x_arbitrary a
+    | Skew_x_arbitrary (_, `Angle a) -> skew_x_arbitrary a
+    | Skew_x_arbitrary (_, `Raw value) -> raw_skew_style `X value
     | Skew_y n -> skew_y n
-    | Skew_y_arbitrary (_, a) -> skew_y_arbitrary a
+    | Skew_y_arbitrary (_, `Angle a) -> skew_y_arbitrary a
+    | Skew_y_arbitrary (_, `Raw value) -> raw_skew_style `Y value
     | Skew n -> transform_with_both_skew n
-    | Skew_arbitrary (_, a) -> transform_with_both_skew_angle a
+    | Skew_arbitrary (_, `Angle a) -> transform_with_both_skew_angle a
+    | Skew_arbitrary (_, `Raw value) -> raw_skew_style `Both value
     | Rotate_x n -> rotate_x n
     | Rotate_x_arbitrary (_, a) -> rotate_x_arbitrary a
     | Rotate_x_bare_var name -> rotate_x_bare_var name
@@ -1392,11 +1458,13 @@ module Handler = struct
         201
     | Translate_z n when n < 0 -> 300
     | Neg_translate_z_arbitrary _ | Neg_translate_z_px -> 300
-    | Translate_z _ | Translate_z_step _ | Translate_z_px -> 301
+    | Translate_z _ | Translate_z_step _ | Translate_z_px
+    | Translate_z_arbitrary _ ->
+        301
     | Translate_3d | Translate_none -> 302
     (* Scale utilities use the same sign/axis bands. *)
     | Scale n when n < 0 -> 400
-    | Scale _ | Scale_raw_1 _ | Scale_raw_3 _ -> 401
+    | Scale _ | Scale_raw_1 _ | Scale_raw_3 _ | Scale_arbitrary_raw _ -> 401
     | Scale_x n when n < 0 -> 500
     | Scale_x _ | Scale_x_arbitrary _ -> 501
     | Scale_y n when n < 0 -> 600
@@ -1410,7 +1478,8 @@ module Handler = struct
     | Neg_rotate_bare_var _ | Neg_rotate_arbitrary _ -> 799
     | Rotate_bare_var _ -> 800
     | Rotate _ -> 801
-    | Rotate_3d_arbitrary _ | Rotate_arbitrary _ | Rotate_none -> 802
+    | Rotate_3d_arbitrary _ | Rotate_arbitrary _ | Rotate_raw _ | Rotate_none ->
+        802
     | Rotate_x n when n < 0 -> 900
     | Neg_rotate_x_bare_var _ | Neg_rotate_x_arbitrary _ -> 900
     | Rotate_x _ | Rotate_x_bare_var _ | Rotate_x_arbitrary _ -> 901
@@ -1500,7 +1569,7 @@ module Handler = struct
     match parts with
     | [ "rotate"; n ] when Parse.is_bare_var n ->
         Ok (Rotate_bare_var (Parse.bare_var_inner n))
-    | [ "rotate"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "rotate"; n ] when Parse.is_bracket_value n -> (
         let inner = String.sub n 1 (String.length n - 2) in
         (* Check for 3D rotation: x y z angle (underscores as spaces) *)
         let inner_spaced =
@@ -1520,14 +1589,20 @@ module Handler = struct
             | _ -> (
                 match parse_bracket_angle n with
                 | Ok (raw, a) -> Ok (Rotate_arbitrary (raw, a))
-                | Error _ -> err_not_utility))
+                | Error _ -> (
+                    match Parse.arbitrary_declaration_value inner with
+                    | Some value -> Ok (Rotate_raw (inner, value))
+                    | None -> err_not_utility)))
         | _ -> (
             match parse_bracket_angle n with
             | Ok (raw, a) -> Ok (Rotate_arbitrary (raw, a))
-            | Error _ -> err_not_utility))
+            | Error _ -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some value -> Ok (Rotate_raw (inner, value))
+                | None -> err_not_utility)))
     | [ "rotate"; "none" ] -> Ok Rotate_none
     | [ "rotate"; n ] -> Parse.int_any n >|= fun n -> Rotate n
-    | [ "translate"; "x"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "translate"; "x"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_length n with
         | Ok len ->
             Ok
@@ -1542,7 +1617,7 @@ module Handler = struct
     | [ "translate"; "x"; n ] when parse_spacing_step n <> None ->
         Ok (Translate_x_step (Option.get (parse_spacing_step n)))
     | [ "translate"; "x"; n ] -> Parse.int_any n >|= fun n -> Translate_x n
-    | [ "translate"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "translate"; "y"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_length n with
         | Ok len ->
             Ok
@@ -1557,6 +1632,14 @@ module Handler = struct
     | [ "translate"; "y"; n ] when parse_spacing_step n <> None ->
         Ok (Translate_y_step (Option.get (parse_spacing_step n)))
     | [ "translate"; "y"; n ] -> Parse.int_any n >|= fun n -> Translate_y n
+    | [ "translate"; "z"; n ] when Parse.is_bracket_value n -> (
+        let inner = Parse.bracket_inner n in
+        match Parse.arbitrary_length inner with
+        | Some length -> Ok (Translate_z_arbitrary (inner, `Length length))
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Translate_z_arbitrary (inner, `Raw value))
+            | None -> err_not_utility))
     | [ "translate"; "z"; "px" ] -> Ok Translate_z_px
     | [ "translate"; "z"; n ] when parse_spacing_step n <> None ->
         Ok (Translate_z_step (Option.get (parse_spacing_step n)))
@@ -1632,7 +1715,7 @@ module Handler = struct
         Ok (Translate_z_step (-.Option.get (parse_spacing_step n)))
     | [ ""; "translate"; "z"; n ] ->
         Parse.int_pos ~name:"translate-z" n >|= fun n -> Translate_z (-n)
-    | [ "scale"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "scale"; n ] when Parse.is_bracket_value n -> (
         let inner = String.sub n 1 (String.length n - 2) in
         (* Check for multi-value: x_y_z *)
         let parts =
@@ -1646,22 +1729,31 @@ module Handler = struct
                 Float.of_string_opt z )
             with
             | Some fx, Some fy, Some fz -> Ok (Scale_raw_3 (inner, fx, fy, fz))
-            | _ -> err_not_utility)
+            | _ -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some value -> Ok (Scale_arbitrary_raw (inner, value))
+                | None -> err_not_utility))
         | [ _ ] -> (
             match Float.of_string_opt inner with
             | Some f -> Ok (Scale_raw_1 (inner, f))
-            | None -> err_not_utility)
-        | _ -> err_not_utility)
+            | None -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some value -> Ok (Scale_arbitrary_raw (inner, value))
+                | None -> err_not_utility))
+        | _ -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Scale_arbitrary_raw (inner, value))
+            | None -> err_not_utility))
     | [ "scale"; "3d" ] -> Ok Scale_3d
     | [ "scale"; "none" ] -> Ok Scale_none
     | [ "scale"; n ] -> Parse.int_pos ~name:"scale" n >|= fun n -> Scale n
-    | [ "scale"; "x"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "scale"; "x"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_number n with
         | Ok (raw, f) -> Ok (Scale_x_arbitrary (raw, f))
         | Error _ -> err_not_utility)
     | [ "scale"; "x"; n ] ->
         Parse.int_pos ~name:"scale-x" n >|= fun n -> Scale_x n
-    | [ "scale"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "scale"; "y"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_number n with
         | Ok (raw, f) -> Ok (Scale_y_arbitrary (raw, f))
         | Error _ -> err_not_utility)
@@ -1674,38 +1766,50 @@ module Handler = struct
         Ok (Scale_z_arbitrary (Parse.bracket_inner n))
     | [ "scale"; "z"; n ] ->
         Parse.int_pos ~name:"scale-z" n >|= fun n -> Scale_z n
-    | [ "skew"; "x"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "skew"; "x"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
-        | Ok (raw, a) -> Ok (Skew_x_arbitrary (raw, a))
-        | Error _ -> err_not_utility)
+        | Ok (raw, a) -> Ok (Skew_x_arbitrary (raw, `Angle a))
+        | Error _ -> (
+            let raw = Parse.bracket_inner n in
+            match Parse.arbitrary_declaration_value raw with
+            | Some value -> Ok (Skew_x_arbitrary (raw, `Raw value))
+            | None -> err_not_utility))
     | [ "skew"; "x"; n ] -> Parse.int_any n >|= fun n -> Skew_x n
-    | [ "skew"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "skew"; "y"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
-        | Ok (raw, a) -> Ok (Skew_y_arbitrary (raw, a))
-        | Error _ -> err_not_utility)
+        | Ok (raw, a) -> Ok (Skew_y_arbitrary (raw, `Angle a))
+        | Error _ -> (
+            let raw = Parse.bracket_inner n in
+            match Parse.arbitrary_declaration_value raw with
+            | Some value -> Ok (Skew_y_arbitrary (raw, `Raw value))
+            | None -> err_not_utility))
     | [ "skew"; "y"; n ] -> Parse.int_any n >|= fun n -> Skew_y n
-    | [ "skew"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "skew"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
-        | Ok (raw, a) -> Ok (Skew_arbitrary (raw, a))
-        | Error _ -> err_not_utility)
+        | Ok (raw, a) -> Ok (Skew_arbitrary (raw, `Angle a))
+        | Error _ -> (
+            let raw = Parse.bracket_inner n in
+            match Parse.arbitrary_declaration_value raw with
+            | Some value -> Ok (Skew_arbitrary (raw, `Raw value))
+            | None -> err_not_utility))
     | [ "skew"; n ] -> Parse.int_any n >|= fun n -> Skew n
     | [ "rotate"; "x"; n ] when Parse.is_bare_var n ->
         Ok (Rotate_x_bare_var (Parse.bare_var_inner n))
-    | [ "rotate"; "x"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "rotate"; "x"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Rotate_x_arbitrary (raw, a))
         | Error _ -> err_not_utility)
     | [ "rotate"; "x"; n ] -> Parse.int_any n >|= fun n -> Rotate_x n
     | [ "rotate"; "y"; n ] when Parse.is_bare_var n ->
         Ok (Rotate_y_bare_var (Parse.bare_var_inner n))
-    | [ "rotate"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "rotate"; "y"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Rotate_y_arbitrary (raw, a))
         | Error _ -> err_not_utility)
     | [ "rotate"; "y"; n ] -> Parse.int_any n >|= fun n -> Rotate_y n
     | [ "rotate"; "z"; n ] when Parse.is_bare_var n ->
         Ok (Rotate_z_bare_var (Parse.bare_var_inner n))
-    | [ "rotate"; "z"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ "rotate"; "z"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Rotate_z_arbitrary (raw, a))
         | Error _ -> err_not_utility)
@@ -1713,7 +1817,7 @@ module Handler = struct
     (* Negative rotate: -rotate-N, -rotate-(--var), -rotate-[123deg] *)
     | [ ""; "rotate"; n ] when Parse.is_bare_var n ->
         Ok (Neg_rotate_bare_var (Parse.bare_var_inner n))
-    | [ ""; "rotate"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ ""; "rotate"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Neg_rotate_arbitrary (raw, a))
         | Error _ -> err_not_utility)
@@ -1721,7 +1825,7 @@ module Handler = struct
         Parse.int_pos ~name:"rotate" n >|= fun n -> Rotate (-n)
     | [ ""; "rotate"; "x"; n ] when Parse.is_bare_var n ->
         Ok (Neg_rotate_x_bare_var (Parse.bare_var_inner n))
-    | [ ""; "rotate"; "x"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ ""; "rotate"; "x"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Neg_rotate_x_arbitrary (raw, a))
         | Error _ -> err_not_utility)
@@ -1729,7 +1833,7 @@ module Handler = struct
         Parse.int_pos ~name:"rotate-x" n >|= fun n -> Rotate_x (-n)
     | [ ""; "rotate"; "y"; n ] when Parse.is_bare_var n ->
         Ok (Neg_rotate_y_bare_var (Parse.bare_var_inner n))
-    | [ ""; "rotate"; "y"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ ""; "rotate"; "y"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Neg_rotate_y_arbitrary (raw, a))
         | Error _ -> err_not_utility)
@@ -1737,7 +1841,7 @@ module Handler = struct
         Parse.int_pos ~name:"rotate-y" n >|= fun n -> Rotate_y (-n)
     | [ ""; "rotate"; "z"; n ] when Parse.is_bare_var n ->
         Ok (Neg_rotate_z_bare_var (Parse.bare_var_inner n))
-    | [ ""; "rotate"; "z"; n ] when String.length n > 0 && n.[0] = '[' -> (
+    | [ ""; "rotate"; "z"; n ] when Parse.is_bracket_value n -> (
         match parse_bracket_angle n with
         | Ok (raw, a) -> Ok (Neg_rotate_z_arbitrary (raw, a))
         | Error _ -> err_not_utility)
@@ -1861,6 +1965,7 @@ module Handler = struct
   let to_class = function
     | Rotate n -> neg_class "rotate-" n
     | Rotate_arbitrary (raw, _) -> "rotate-" ^ "[" ^ raw ^ "]"
+    | Rotate_raw (raw, _) -> "rotate-[" ^ raw ^ "]"
     | Rotate_none -> "rotate-none"
     | Rotate_3d_arbitrary (raw, _, _, _, _) -> "rotate-[" ^ raw ^ "]"
     | Rotate_bare_var name -> "rotate-(" ^ name ^ ")"
@@ -1883,6 +1988,7 @@ module Handler = struct
     | Translate_z n -> neg_class "translate-z-" n
     | Translate_z_step f -> step_class "translate-z" f
     | Translate_z_px -> "translate-z-px"
+    | Translate_z_arbitrary (raw, _) -> "translate-z-[" ^ raw ^ "]"
     | Neg_translate_z_arbitrary s -> "-translate-z-[" ^ s ^ "]"
     | Neg_translate_z_px -> "-translate-z-px"
     | Translate_3d -> "translate-3d"
@@ -1919,6 +2025,7 @@ module Handler = struct
     | Scale_y_arbitrary (raw, _) -> "scale-y-[" ^ raw ^ "]"
     | Scale_raw_1 (raw, _) -> "scale-[" ^ raw ^ "]"
     | Scale_raw_3 (raw, _, _, _) -> "scale-[" ^ raw ^ "]"
+    | Scale_arbitrary_raw (raw, _) -> "scale-[" ^ raw ^ "]"
     | Scale_z n -> neg_class "scale-z-" n
     | Scale_z_arbitrary s -> "scale-z-[" ^ s ^ "]"
     | Scale_3d -> "scale-3d"

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -29,7 +29,8 @@ module Handler = struct
     | Transition_arbitrary of string
     | Duration of int
     | Duration_initial
-    | Duration_arbitrary of string * Css.duration
+    | Duration_arbitrary of
+        string * [ `Duration of Css.duration | `Raw of string ]
     | Delay of int
     | Delay_arbitrary of string * Css.duration
     | Ease_linear
@@ -39,7 +40,8 @@ module Handler = struct
     | Ease_initial
     (* The author's bracket text travels with the timing function it denotes, so
        the class name is spelled exactly as it was written. *)
-    | Ease_arbitrary of string * Css.timing_function
+    | Ease_arbitrary of
+        string * [ `Timing_function of Css.timing_function | `Raw of string ]
     | Ease_theme of string (* timing function from an --ease-* token *)
 
   let name = "transitions"
@@ -273,9 +275,10 @@ module Handler = struct
           Css.transition_duration (Css.Var duration_ref);
         ])
 
-  let transition_arbitrary ?theme s =
-    if Parse.is_var s then
-      let bare_name = Parse.extract_var_name s in
+  let transition_arbitrary ?theme spelling =
+    let value = Parse.decode_arbitrary_value spelling in
+    if Parse.is_var value then
+      let bare_name = Parse.extract_var_name value in
       let ref_ : Css.transition_property_value Css.var =
         Var.bracket bare_name
       in
@@ -286,11 +289,14 @@ module Handler = struct
             Css.transition_timing_function (Css.Var ease_ref);
             Css.transition_duration (Css.Var duration_ref);
           ])
-    else
+    else if
+      String.split_on_char ',' value
+      |> List.map String.trim
+      |> List.for_all Parse.is_ident
+    then
       (* Raw property list like "color,background-color" *)
-      let raw = String.map (fun c -> if c = '_' then ' ' else c) s in
       let props =
-        String.split_on_char ',' raw
+        String.split_on_char ',' value
         |> List.map (fun p -> Css.Property (String.trim p))
       in
       style
@@ -300,6 +306,17 @@ module Handler = struct
             Css.transition_timing_function (Css.Var ease_ref);
             Css.transition_duration (Css.Var duration_ref);
           ])
+    else
+      match Parse.opaque_declaration "transition-property" value with
+      | None -> assert false
+      | Some transition_property ->
+          style
+            (default_theme_decls ?theme ()
+            @ [
+                transition_property;
+                Css.transition_timing_function (Css.Var ease_ref);
+                Css.transition_duration (Css.Var duration_ref);
+              ])
 
   (* Transition behavior (CSS Transitions Level 2) *)
   let transition_behavior_normal = style [ Css.transition_behavior Normal ]
@@ -450,12 +467,63 @@ module Handler = struct
       | Ok tf -> Some tf
       | Error _ -> None
 
-  let ease_arbitrary tf =
-    let tw_ease_decl, _ = Var.binding tw_ease_var tf in
-    let property_rules =
-      match Var.property_rule tw_ease_var with Some r -> r | None -> Css.empty
-    in
-    style ~property_rules [ tw_ease_decl; Css.transition_timing_function tf ]
+  let ease_arbitrary = function
+    | `Timing_function tf ->
+        let tw_ease_decl, _ = Var.binding tw_ease_var tf in
+        let property_rules =
+          match Var.property_rule tw_ease_var with
+          | Some r -> r
+          | None -> Css.empty
+        in
+        style ~property_rules
+          [ tw_ease_decl; Css.transition_timing_function tf ]
+    | `Raw raw ->
+        let property_rules =
+          match Var.property_rule tw_ease_var with
+          | Some r -> r
+          | None -> Css.empty
+        in
+        let timing =
+          match Parse.opaque_declaration "transition-timing-function" raw with
+          | Some declaration -> declaration
+          | None -> assert false
+        in
+        style ~property_rules
+          ~metadata:[ Var.metadata tw_ease_var ]
+          [
+            Css.custom_property ~layer:"utilities" (Var.css_name tw_ease_var)
+              raw;
+            timing;
+          ]
+
+  let duration_arbitrary = function
+    | `Duration d ->
+        let tw_duration_decl, _ = Var.binding tw_duration_var d in
+        let property_rules =
+          match Var.property_rule tw_duration_var with
+          | Some r -> r
+          | None -> Css.empty
+        in
+        style ~property_rules [ tw_duration_decl; Css.transition_duration d ]
+    | `Raw raw ->
+        let property_rules =
+          match Var.property_rule tw_duration_var with
+          | Some r -> r
+          | None -> Css.empty
+        in
+        let duration =
+          match Parse.opaque_declaration "transition-duration" raw with
+          | Some declaration -> declaration
+          | None -> assert false
+        in
+        style ~property_rules
+          ~metadata:[ Var.metadata tw_duration_var ]
+          [
+            Css.custom_property ~layer:"utilities"
+              (Var.css_name tw_duration_var)
+              raw;
+            duration;
+          ]
 
   let ease_theme theme name =
     match Scheme.theme_value (Some theme) ("ease-" ^ name) with
@@ -481,14 +549,6 @@ module Handler = struct
   let delay n = style [ Css.transition_delay (Css.Ms (float_of_int n)) ]
   let delay_arbitrary d = style [ Css.transition_delay d ]
 
-  let duration_arbitrary d =
-    let tw_duration_decl, _ = Var.binding tw_duration_var d in
-    let prop_rule = Var.property_rule tw_duration_var in
-    let property_rules =
-      match prop_rule with Some r -> r | None -> Css.empty
-    in
-    style ~property_rules [ tw_duration_decl; Css.transition_duration d ]
-
   let to_style theme =
     let transition_all () = transition_all ~theme () in
     let transition_colors () = transition_colors ~theme () in
@@ -511,7 +571,7 @@ module Handler = struct
     | Transition_arbitrary s -> transition_arbitrary s
     | Duration n -> duration n
     | Duration_initial -> duration_initial
-    | Duration_arbitrary (_, d) -> duration_arbitrary d
+    | Duration_arbitrary (_, value) -> duration_arbitrary value
     | Delay n -> delay n
     | Delay_arbitrary (_, d) -> delay_arbitrary d
     | Ease_linear -> ease_linear ()
@@ -519,7 +579,7 @@ module Handler = struct
     | Ease_out -> ease_out
     | Ease_in_out -> ease_in_out
     | Ease_initial -> ease_initial
-    | Ease_arbitrary (_, tf) -> ease_arbitrary tf
+    | Ease_arbitrary (_, value) -> ease_arbitrary value
     | Ease_theme name -> ease_theme theme name
 
   let suborder = function
@@ -539,10 +599,10 @@ module Handler = struct
     | Delay _ | Delay_arbitrary _ -> 100
     | Duration n -> 200 + n
     | Duration_initial -> 89_000_001
-    | Duration_arbitrary _ -> 200000
-    (* Ease utilities come after Duration. Tailwind orders: duration then ease.
-       Use a high base to ensure even duration-5000 (suborder 5200) < ease.
-       Within ease, Tailwind orders alphabetically: in, in-out, linear, out. *)
+    | Duration_arbitrary _ -> 99998
+    (* Arbitrary duration and ease share Tailwind's candidate band, with
+       duration immediately before ease. Named easing values then follow in
+       alphabetical order: in, in-out, linear, out. *)
     | Ease_in -> 100000
     | Ease_in_out -> 100001
     | Ease_linear -> 100002
@@ -567,18 +627,13 @@ module Handler = struct
         Ok Transition_behavior_allow_discrete
     | [ "transition"; "normal" ] -> Ok Transition_behavior_normal
     | [ "transition"; "discrete" ] -> Ok Transition_behavior_allow_discrete
-    | [ "transition"; value ] when Parse.is_bracket_value value ->
+    | [ "transition"; value ] when Parse.is_bracket_value value -> (
         let inner = Parse.bracket_inner value in
-        (* [transition-property] takes property names, so anything that is not
-           an identifier - the docs' [<value>] placeholder included - is not
-           one. *)
-        if
-          Parse.is_var inner
-          || String.split_on_char ',' inner
-             |> List.map String.trim
-             |> List.for_all Parse.is_ident
-        then Ok (Transition_arbitrary inner)
-        else Error (`Msg "Invalid transition property")
+        (* Tailwind accepts any declaration-safe token stream here, including
+           values that are not valid transition-property lists. *)
+        match Parse.arbitrary_declaration_value inner with
+        | Some _ -> Ok (Transition_arbitrary inner)
+        | None -> Error (`Msg "Invalid transition property"))
     | [ "transition" ] -> Ok Transition
     | [ "duration"; n ] when String.length n > 0 && n.[0] = '[' ->
         (* Arbitrary duration: duration-[300ms] *)
@@ -589,15 +644,28 @@ module Handler = struct
             let num = String.sub inner 0 (String.length inner - 2) in
             match float_of_string_opt num with
             | Some _ ->
-                Ok (Duration_arbitrary (inner, Css.Ms (float_of_string num)))
-            | None -> Error (`Msg "Invalid duration value")
+                Ok
+                  (Duration_arbitrary
+                     (inner, `Duration (Css.Ms (float_of_string num))))
+            | None -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some value -> Ok (Duration_arbitrary (inner, `Raw value))
+                | None -> Error (`Msg "Invalid duration value"))
           else if String.ends_with ~suffix:"s" inner then
             let num = String.sub inner 0 (String.length inner - 1) in
             match float_of_string_opt num with
             | Some _ ->
-                Ok (Duration_arbitrary (inner, Css.S (float_of_string num)))
-            | None -> Error (`Msg "Invalid duration value")
-          else Error (`Msg "Invalid duration unit")
+                Ok
+                  (Duration_arbitrary
+                     (inner, `Duration (Css.S (float_of_string num))))
+            | None -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some value -> Ok (Duration_arbitrary (inner, `Raw value))
+                | None -> Error (`Msg "Invalid duration value"))
+          else
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Duration_arbitrary (inner, `Raw value))
+            | None -> Error (`Msg "Invalid duration unit")
         else Error (`Msg "Invalid arbitrary syntax")
     | [ "duration"; "initial" ] -> Ok Duration_initial
     | [ "duration"; n ] ->
@@ -638,8 +706,11 @@ module Handler = struct
     | [ "ease"; value ] when Parse.is_bracket_value value -> (
         let inner = Parse.bracket_inner value in
         match arbitrary_timing_function inner with
-        | Some tf -> Ok (Ease_arbitrary (inner, tf))
-        | None -> Error (`Msg "Invalid ease value"))
+        | Some tf -> Ok (Ease_arbitrary (inner, `Timing_function tf))
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Ease_arbitrary (inner, `Raw value))
+            | None -> Error (`Msg "Invalid ease value")))
     | _ -> Error (`Msg "Not a transition utility")
 
   let to_class = function

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -420,6 +420,7 @@ module Typography_early = struct
        class name is spelled exactly as it was written. *)
     | Leading_bracket of
         string * Css.line_height (* leading-[1.8], leading-[24px], etc. *)
+    | Leading_raw of string * string
     | (* Font-size with explicit line-height modifier (text-sm/6) *)
       Text_named_lh of string * lh_modifier
     | (* Font size named by a project [--text-*] token (text-huge) *)
@@ -746,7 +747,10 @@ module Typography_early = struct
         else
           match parse_bracket_leading inner with
           | Stdlib.Option.Some lh -> Ok (Leading_bracket (inner, lh))
-          | Stdlib.Option.None -> err_not_utility)
+          | Stdlib.Option.None -> (
+              match Parse.arbitrary_declaration_value inner with
+              | Some value -> Ok (Leading_raw (inner, value))
+              | None -> err_not_utility))
     | "leading" :: (_ :: _ as rest)
       when is_theme_leading theme (String.concat "-" rest) ->
         Ok (Leading_theme (String.concat "-" rest))
@@ -859,6 +863,7 @@ module Typography_early = struct
         "leading-" ^ Spacing.pp_spacing_suffix (`Rem (f *. 0.25))
     | Leading_var v -> "leading-[" ^ v ^ "]"
     | Leading_bracket (v, _) -> "leading-[" ^ v ^ "]"
+    | Leading_raw (v, _) -> "leading-[" ^ v ^ "]"
     | Text_named_lh (name, lh) -> "text-" ^ name ^ "/" ^ lh_to_string lh
     | Text_theme name -> "text-" ^ name
     | Text_theme_lh (name, lh) -> "text-" ^ name ^ "/" ^ lh_to_string lh
@@ -939,6 +944,7 @@ module Typography_early = struct
     | Leading_step f -> 3000 + int_of_float (f *. 10.)
     | Leading_var _ -> 3100
     | Leading_bracket _ -> 3100
+    | Leading_raw _ -> 3100
     | Leading_loose -> 3201
     | Leading_none -> 3202
     | Leading_normal -> 3203
@@ -1536,6 +1542,21 @@ module Typography_early = struct
           Var.property_rule leading_var |> Option.to_list |> Css.concat
         in
         style ~property_rules [ channel_decl; line_height lh ]
+    | Leading_raw (_, value) ->
+        let channel_decl =
+          Css.custom_property ~layer:"utilities" (Var.css_name leading_var)
+            value
+        in
+        let property_rules =
+          Var.property_rule leading_var |> Option.to_list |> Css.concat
+        in
+        let declarations =
+          channel_decl
+          :: Option.to_list (Parse.opaque_declaration "line-height" value)
+        in
+        style
+          ~metadata:[ Var.metadata leading_var ]
+          ~property_rules declarations
     | Text_named_lh (name, lh_mod) ->
         let fs_decl, lh_decls = text_named_with_lh theme name lh_mod in
         style (fs_decl @ lh_decls)
@@ -1618,6 +1639,8 @@ module Typography_late = struct
          class name is spelled exactly as it was written. *)
       Tracking_arbitrary of string * Css.length
     | Neg_tracking_arbitrary of string * Css.length
+    | Tracking_raw of string * string
+    | Neg_tracking_raw of string * string
     | Tracking_var of string
     | Neg_tracking_var of string
     | Tracking_tighter
@@ -1731,12 +1754,13 @@ module Typography_late = struct
     | Indent_neg_arbitrary of string
     | Line_clamp of int
     | Line_clamp_arbitrary of int
+    | Line_clamp_raw of string * string
     | Line_clamp_none
     | (* Content *)
       Content_none
     | Content of string
     | Content_squote of string (* single-quoted arbitrary: content-['x'] *)
-    | Content_raw of string * Css.content
+    | Content_raw of string * [ `Content of Css.content | `Raw of string ]
       (* unquoted arbitrary: content-[attr(before)]; raw class text + value *)
     | Content_named of string (* content-<token> defined in the @theme *)
 
@@ -1756,7 +1780,9 @@ module Typography_late = struct
         11
     (* line-clamp (rank 26) sits between box-sizing and the display family, so
        it shares box-sizing's priority and sorts after it on suborder. *)
-    | Line_clamp _ | Line_clamp_arbitrary _ | Line_clamp_none -> 3
+    | Line_clamp _ | Line_clamp_arbitrary _ | Line_clamp_raw _ | Line_clamp_none
+      ->
+        3
     | Truncate -> 17
     | Indent _ | Indent_neg _ | Indent_px | Indent_neg_px | Indent_arbitrary _
     | Indent_neg_arbitrary _ | Align_baseline | Align_top | Align_middle
@@ -1889,7 +1915,10 @@ module Typography_late = struct
         else
           match arbitrary_tracking inner with
           | Some len -> Ok (Tracking_arbitrary (inner, len))
-          | None -> Error (`Msg ("Invalid tracking length: " ^ inner)))
+          | None -> (
+              match Parse.arbitrary_declaration_value inner with
+              | Some value -> Ok (Tracking_raw (inner, value))
+              | None -> Error (`Msg ("Invalid tracking value: " ^ inner))))
     | "" :: "tracking" :: rest when rest <> [] -> (
         let value = String.concat "-" rest in
         if not (Parse.is_bracket_value value) then err_not_utility
@@ -1899,7 +1928,10 @@ module Typography_late = struct
           else
             match arbitrary_tracking inner with
             | Some len -> Ok (Neg_tracking_arbitrary (inner, len))
-            | None -> Error (`Msg ("Invalid tracking length: " ^ inner)))
+            | None -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some value -> Ok (Neg_tracking_raw (inner, value))
+                | None -> Error (`Msg ("Invalid tracking value: " ^ inner))))
     | [ "tracking"; "tighter" ] -> Ok Tracking_tighter
     | [ "tracking"; "tight" ] -> Ok Tracking_tight
     | [ "tracking"; "normal" ] -> Ok Tracking_normal
@@ -2061,7 +2093,10 @@ module Typography_late = struct
         let inner = Parse.bracket_inner n in
         match Parse.decimal_int inner with
         | Some i -> Ok (Line_clamp_arbitrary i)
-        | None -> err_not_utility)
+        | None -> (
+            match Parse.arbitrary_declaration_value inner with
+            | Some value -> Ok (Line_clamp_raw (inner, value))
+            | None -> err_not_utility))
     | [ "line"; "clamp"; n ] ->
         Parse.int_bounded ~name:"line-clamp" ~min:0 ~max:999 n >|= fun i ->
         Line_clamp i
@@ -2100,8 +2135,11 @@ module Typography_late = struct
             Cascade.Cursor.try_parse_full_err Css.Properties.read_content
               (Cascade.Cursor.of_string spaced)
           with
-          | Ok value -> Ok (Content_raw (inner, value))
-          | Error _ -> err_not_utility
+          | Ok value -> Ok (Content_raw (inner, `Content value))
+          | Error _ -> (
+              match Parse.arbitrary_declaration_value inner with
+              | Some value -> Ok (Content_raw (inner, `Raw value))
+              | None -> err_not_utility)
         end
         else err_not_utility
     | _ -> err_not_utility
@@ -2149,6 +2187,8 @@ module Typography_late = struct
     | Decoration_bracket_pct_var v -> "decoration-[percentage:" ^ v ^ "]"
     | Tracking_arbitrary (v, _) -> "tracking-[" ^ v ^ "]"
     | Neg_tracking_arbitrary (v, _) -> "-tracking-[" ^ v ^ "]"
+    | Tracking_raw (v, _) -> "tracking-[" ^ v ^ "]"
+    | Neg_tracking_raw (v, _) -> "-tracking-[" ^ v ^ "]"
     | Tracking_var v -> "tracking-[" ^ v ^ "]"
     | Neg_tracking_var v -> "-tracking-[" ^ v ^ "]"
     | Tracking_tighter -> "tracking-tighter"
@@ -2264,6 +2304,7 @@ module Typography_late = struct
     | Indent_neg_arbitrary s -> "-indent-[" ^ s ^ "]"
     | Line_clamp n -> "line-clamp-" ^ string_of_int n
     | Line_clamp_arbitrary n -> "line-clamp-[" ^ string_of_int n ^ "]"
+    | Line_clamp_raw (spelling, _) -> "line-clamp-[" ^ spelling ^ "]"
     | Line_clamp_none -> "line-clamp-none"
     | Content_none -> "content-none"
     | Content s -> "content-[\"" ^ s ^ "\"]"
@@ -2314,8 +2355,10 @@ module Typography_late = struct
     | Decoration_from_font -> 30010
     (* Tracking — negative first, then arbitrary, then named *)
     | Neg_tracking_arbitrary _ -> 8245
+    | Neg_tracking_raw _ -> 8245
     | Neg_tracking_var _ -> 8250
     | Tracking_arbitrary _ -> 8255
+    | Tracking_raw _ -> 8255
     | Tracking_var _ -> 8260
     (* Alphabetical by class name: normal, tight, tighter, wide, wider,
        widest *)
@@ -2465,7 +2508,7 @@ module Typography_late = struct
     | Indent_neg_arbitrary _ ->
         1100
     | Line_clamp n -> 10000 + n
-    | Line_clamp_arbitrary _ -> 11000
+    | Line_clamp_arbitrary _ | Line_clamp_raw _ -> 11000
     | Line_clamp_none -> 12000
     (* Content *)
     | Content_none -> 13000
@@ -2791,6 +2834,20 @@ module Typography_late = struct
     in
     style ~property_rules [ channel_decl; letter_spacing len ]
 
+  let tracking_raw ?(negative = false) value =
+    let value = if negative then "calc(" ^ value ^ " * -1)" else value in
+    let channel_decl =
+      Css.custom_property ~layer:"utilities" (Var.css_name tracking_var) value
+    in
+    let property_rules =
+      Var.property_rule tracking_var |> Option.to_list |> Css.concat
+    in
+    let declarations =
+      channel_decl
+      :: Option.to_list (Parse.opaque_declaration "letter-spacing" value)
+    in
+    style ~metadata:[ Var.metadata tracking_var ] ~property_rules declarations
+
   let negate_length : Css.length -> Css.length = function
     | Px n -> Px (-.n)
     | Em n -> Em (-.n)
@@ -2873,6 +2930,14 @@ module Typography_late = struct
         display Webkit_box;
         overflow Hidden;
       ]
+
+  let line_clamp_raw value =
+    let clamp =
+      Option.to_list (Parse.opaque_declaration "-webkit-line-clamp" value)
+    in
+    style
+      (clamp
+      @ [ webkit_box_orient Vertical; display Webkit_box; overflow Hidden ])
 
   (* A project [@theme] token is a namespace key, not a value Tailwind type-
      checks at build time: any override of [--line-clamp-none], decimal or not,
@@ -2966,6 +3031,17 @@ module Typography_late = struct
     let content_decl, content_ref = Var.binding content_var value in
     let property_rules = Var.property_rules content_var in
     style ~property_rules [ content_decl; Css.content (Css.Var content_ref) ]
+
+  let content_raw_value value =
+    let content_decl =
+      Css.custom_property ~layer:"utilities" (Var.css_name content_var) value
+    in
+    let content_ref = Var.reference content_var in
+    let property_rules = Var.property_rules content_var in
+    style
+      ~metadata:[ Var.metadata content_var ]
+      ~property_rules
+      [ content_decl; Css.content (Css.Var content_ref) ]
 
   let align_baseline = style [ vertical_align Baseline ]
   let align_top = style [ vertical_align Top ]
@@ -3201,6 +3277,8 @@ module Typography_late = struct
     | Decoration_bracket_pct_var v -> decoration_bracket_pct_var v
     | Tracking_arbitrary (_, len) -> tracking_arbitrary len
     | Neg_tracking_arbitrary (_, len) -> neg_tracking_arbitrary len
+    | Tracking_raw (_, value) -> tracking_raw value
+    | Neg_tracking_raw (_, value) -> tracking_raw ~negative:true value
     | Tracking_var v ->
         let bare_name = Parse.extract_var_name v in
         let var_ref : Css.length Css.var = Var.bracket bare_name in
@@ -3336,10 +3414,12 @@ module Typography_late = struct
     | Indent_neg_arbitrary s -> indent_neg_arbitrary s
     | Line_clamp n -> line_clamp n
     | Line_clamp_arbitrary n -> line_clamp n
+    | Line_clamp_raw (_, value) -> line_clamp_raw value
     | Line_clamp_none -> line_clamp_none_style ()
     | Content_none -> content_none
     | Content s -> content s
-    | Content_raw (_, c) -> content_raw c
+    | Content_raw (_, `Content c) -> content_raw c
+    | Content_raw (_, `Raw value) -> content_raw_value value
     | Content_squote s -> content_squote s
     | Content_named name -> content_named name
 

--- a/test/cli/placeholder.t
+++ b/test/cli/placeholder.t
@@ -1,8 +1,6 @@
-A class can parse yet fail to render, as the docs' [prop-[<value>]]
-placeholders do: [animate-[<value>]] and [backdrop-blur-[<value>]] are
-accepted by their handlers but raise when they render an arbitrary value
-they cannot serialise. Such a class produces no rule, so it is dropped
-rather than aborting the whole sheet.
+Documentation placeholders are safe arbitrary-value token streams. Tailwind
+emits them even when the browser will reject the value for the property, so tw
+must preserve them too.
 
   $ cat > docs.mdx <<'EOF'
   > A table of utilities:
@@ -11,10 +9,14 @@ rather than aborting the whole sheet.
   > And a real class: <div class="p-4"></div>
   > EOF
 
-The placeholder classes do not crash generation, and the real class
-still lands in the output:
+The placeholder classes and the real class all land in the output:
 
-  $ tw --minify --no-base docs.mdx | grep -c '\.p-4{padding:'
+  $ tw --minify --no-base docs.mdx > generated.css
+  $ grep -c '\.animate-.*{animation:<value>}' generated.css
+  1
+  $ grep -c '\.backdrop-blur-.*--tw-backdrop-blur:blur(<value>)' generated.css
+  1
+  $ grep -c '\.p-4{padding:' generated.css
   1
 
 An arbitrary value that is valid still renders:

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -20,8 +20,8 @@
 
 module Tailwind_gen = Tw_tools.Tailwind_gen
 
-(* Measured 2026-08-30 over [classlist.txt], 4825 classes of tailwindcss.com,
-   against cascade main at e829b2d6. Both keys and grouping come out of
+(* Measured 2026-09-03 over [classlist.txt], 4825 classes of tailwindcss.com,
+   against cascade main at 3a007e5b. Both keys and grouping come out of
    cascade's printer, so the number is only comparable against the cascade a run
    was built with, and every run prints which one that was. CI pins cascade main
    through opam; a local [cascade/] symlink sitting on someone's branch is the
@@ -31,7 +31,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 0, `Pairs 3800); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 2, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test.ml
+++ b/test/test.ml
@@ -52,6 +52,7 @@ let () =
       Test_effects.suite;
       Test_clipping.suite;
       Test_animations.suite;
+      Test_arbitrary_values.suite;
       Test_backgrounds.suite;
       Test_containers.suite;
       Test_style.suite;

--- a/test/test_animations.ml
+++ b/test/test_animations.ml
@@ -103,24 +103,18 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"animations suborder matches Tailwind" shuffled
 
-(* [animate-[...]] takes an animation shorthand. A bracket the animation grammar
-   cannot read is accepted and then raises out of [to_css], a pure conversion,
-   so the rejection belongs at parse time. *)
-let test_invalid_arbitrary_animation () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
+(* [animate-[...]] forwards a safe declaration value. Typed animation values
+   still provide keyframe metadata; opaque values simply have none. *)
+let test_arbitrary_animation_token_streams () =
   let renders cls =
     match Tw.of_string cls with
     | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "animate-[#fff]";
-  rejected "animate-[50%]";
-  rejected "animate-[1/2]";
-  rejected "animate-[calc(1px_+_2px)]";
+  renders "animate-[#fff]";
+  renders "animate-[50%]";
+  renders "animate-[1/2]";
+  renders "animate-[calc(1px_+_2px)]";
   renders "animate-[spin_1s_linear_infinite]";
   renders "animate-[bounce_1s]"
 
@@ -242,8 +236,8 @@ let tests =
     test_case "transition CSS output" `Quick test_transition_css;
     test_case "animations suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
-    test_case "invalid arbitrary animation" `Quick
-      test_invalid_arbitrary_animation;
+    test_case "arbitrary animation token streams" `Quick
+      test_arbitrary_animation_token_streams;
     test_case "keyframes follow the animation name" `Quick
       test_keyframes_follow_the_animation_name;
     test_case "keyframes for theme and bracket names" `Quick

--- a/test/test_arbitrary_values.ml
+++ b/test/test_arbitrary_values.ml
@@ -1,0 +1,103 @@
+open Alcotest
+
+(* Tailwind's arbitrary-value contract is token-stream based: a candidate is
+   generated when its bracket contains one safe CSS declaration value, even when
+   the browser will reject that value for the utility's property. The generated
+   documentation corpus uses [<value>] to exercise this boundary. *)
+let generated_placeholders () =
+  let cases =
+    [
+      ("border-spacing-[<value>]", "--tw-border-spacing-x:<value>");
+      ("border-spacing-x-[<value>]", "--tw-border-spacing-x:<value>");
+      ("border-spacing-y-[<value>]", "--tw-border-spacing-y:<value>");
+      ("ease-[<value>]", "--tw-ease:<value>");
+      ("from-[<value>]", "--tw-gradient-from:<value>");
+      ("inset-ring-[<value>]", "--tw-inset-ring-color:<value>");
+      ("ring-[<value>]", "--tw-ring-color:<value>");
+      ("skew-[<value>]", "--tw-skew-x:skewX(<value>)");
+      ("skew-x-[<value>]", "--tw-skew-x:skewX(<value>)");
+      ("skew-y-[<value>]", "--tw-skew-y:skewY(<value>)");
+      ("line-clamp-[<value>]", "-webkit-box-orient:vertical");
+      ("translate-z-[<value>]", "--tw-translate-z:<value>");
+      ("divide-x-[<value>]", "--tw-divide-x-reverse:0");
+      ("divide-y-[<value>]", "--tw-divide-y-reverse:0");
+      ("scrollbar-thumb-[<value>]", "--tw-scrollbar-thumb:<value>");
+      ("scrollbar-track-[<value>]", "--tw-scrollbar-track:<value>");
+      ("via-[<value>]", "--tw-gradient-via:<value>");
+      ("backdrop-blur-[<value>]", "--tw-backdrop-blur:blur(<value>)");
+      ( "backdrop-brightness-[<value>]",
+        "--tw-backdrop-brightness:brightness(<value>)" );
+      ("backdrop-contrast-[<value>]", "--tw-backdrop-contrast:contrast(<value>)");
+      ( "backdrop-grayscale-[<value>]",
+        "--tw-backdrop-grayscale:grayscale(<value>)" );
+      ( "backdrop-hue-rotate-[<value>]",
+        "--tw-backdrop-hue-rotate:hue-rotate(<value>)" );
+      ("backdrop-invert-[<value>]", "--tw-backdrop-invert:invert(<value>)");
+      ("backdrop-opacity-[<value>]", "--tw-backdrop-opacity:opacity(<value>)");
+      ("backdrop-saturate-[<value>]", "--tw-backdrop-saturate:saturate(<value>)");
+      ("backdrop-sepia-[<value>]", "--tw-backdrop-sepia:sepia(<value>)");
+      ("bg-conic-[<value>]", "--tw-gradient-position:<value>");
+      ("blur-[<value>]", "--tw-blur:blur(<value>)");
+      ("brightness-[<value>]", "--tw-brightness:brightness(<value>)");
+      ("content-[<value>]", "--tw-content:<value>");
+      ("content-[attr(<name>)]", "--tw-content:attr(<name>)");
+      ("contrast-[<value>]", "--tw-contrast:contrast(<value>)");
+      ("drop-shadow-[<value>]", "--tw-drop-shadow-size:drop-shadow(<value>)");
+      ("grayscale-[<value>]", "--tw-grayscale:grayscale(<value>)");
+      ("hue-rotate-[<value>]", "--tw-hue-rotate:hue-rotate(<value>)");
+      ("inset-shadow-[<value>]", "--tw-inset-shadow:inset <value>");
+      ("invert-[<value>]", "--tw-invert:invert(<value>)");
+      ("saturate-[<value>]", "--tw-saturate:saturate(<value>)");
+      ("sepia-[<value>]", "--tw-sepia:sepia(<value>)");
+      ("shadow-[<value>]", "--tw-shadow:<value>");
+      ("leading-[<value>]", "--tw-leading:<value>");
+      ("tracking-[<value>]", "--tw-tracking:<value>");
+      ("transition-[<value>]", "transition-property:<value>");
+      ("duration-[<value>]", "--tw-duration:<value>");
+      ("to-[<value>]", "--tw-gradient-to:<value>");
+      ("animate-[<value>]", "animation:<value>");
+    ]
+  in
+  List.iter
+    (fun (cls, fragment) ->
+      match Tw.of_string cls with
+      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+      | Ok utility ->
+          Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp utility);
+          let css =
+            Tw.to_css ~base:false [ utility ] |> Tw.Css.to_string ~minify:true
+          in
+          Alcotest.(check bool)
+            (cls ^ " emits its arbitrary value")
+            true
+            (Astring.String.is_infix ~affix:fragment css))
+    cases
+
+(* Semantic nonsense is still one declaration value; syntax that can start a
+   second declaration or close the current rule is not. *)
+let unsafe_values_are_rejected () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok utility ->
+          Alcotest.failf "expected %s to be rejected, got %s" cls
+            (Tw.pp utility)
+      | Error _ -> ())
+    [
+      "border-spacing-[x;y]";
+      "ease-[linear;color:red]";
+      "content-[attr(x);display:block]";
+      "animate-[spin;display:block]";
+      "rotate-[123deg]/foo";
+      "scale-[123]/foo";
+      "skew-[123deg]/foo";
+      "skew-x-[123deg]/foo";
+      "skew-y-[123deg]/foo";
+    ]
+
+let suite =
+  ( "arbitrary_values",
+    [
+      test_case "generated placeholders" `Quick generated_placeholders;
+      test_case "unsafe values are rejected" `Quick unsafe_values_are_rejected;
+    ] )

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -431,8 +431,8 @@ let test_bg_var_opacity () =
        ~affix:"color-mix(in oklab, var(--x) 50%, transparent)"
        (css_of "bg-[var(--x)]/50"))
 
-(* A safe arbitrary stop that has no typed colour or position representation is
-   still forwarded as a colour token stream. *)
+(* Tailwind forwards a declaration-safe arbitrary stop even when it is neither a
+   valid colour nor a valid stop position. *)
 let test_gradient_stop_token_stream () =
   let accepted cls =
     match Tw.of_string cls with

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -431,50 +431,39 @@ let test_bg_var_opacity () =
        ~affix:"color-mix(in oklab, var(--x) 50%, transparent)"
        (css_of "bg-[var(--x)]/50"))
 
-(* A gradient stop bracket is a colour or a stop position; the docs' [<value>]
-   placeholder is neither, and it used to land as [0%]. *)
-let test_invalid_gradient_stop () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
+(* A safe arbitrary stop that has no typed colour or position representation is
+   still forwarded as a colour token stream. *)
+let test_gradient_stop_token_stream () =
   let accepted cls =
     match Tw.of_string cls with
     | Ok _ -> ()
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "from-[<value>]";
-  rejected "via-[<value>]";
-  rejected "to-[<value>]";
+  accepted "from-[<value>]";
+  accepted "via-[<value>]";
+  accepted "to-[<value>]";
   accepted "from-[25%]";
   accepted "from-[var(--x)]";
   accepted "from-[#0088cc]"
 
-(* A [#] gradient stop is only a colour when what follows is a hex spelling. The
-   stop reader kept the text after the [#] as-is and the raising constructor saw
-   it when the sheet was rendered, so a malformed hex escaped as an exception
-   instead of failing the parse. *)
-let test_invalid_bracket_hex () =
+(* A malformed colour can still be one safe declaration value, so Tailwind
+   forwards it and leaves rejection to the browser. *)
+let test_arbitrary_bracket_color_token_stream () =
   let css cls =
     match Tw.of_string cls with
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
+  let accepted cls = ignore (css cls) in
   let emits cls affix =
     Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
   in
   List.iter
     (fun prefix ->
-      rejected (prefix ^ "-[#zz]");
-      rejected (prefix ^ "-[#]");
-      rejected (prefix ^ "-[#12345]");
-      rejected (prefix ^ "-[#zz]/50"))
+      accepted (prefix ^ "-[#zz]");
+      accepted (prefix ^ "-[#]");
+      accepted (prefix ^ "-[#12345]");
+      accepted (prefix ^ "-[#zz]/50"))
     [ "from"; "via"; "to" ];
   emits "from-[#fff]" "--tw-gradient-from:#fff";
   emits "via-[#abc]" "--tw-gradient-via:#abc";
@@ -505,23 +494,20 @@ let test_gradient_stop_position_units () =
     "from-[1rem] round-trips" "from-[1rem]"
     (Tw.pp (Result.get_ok (Tw.of_string "from-[1rem]")))
 
-(* A bracket that is not a length-percentage is not a stop position. Tailwind
-   reads those as a colour, which has no typed spelling here, so the class is
-   refused rather than rendered as a zero position. *)
-let test_gradient_stop_position_not_a_length () =
-  let rejected cls =
+(* A bracket that is not a length-percentage is forwarded through the colour
+   channel, matching Tailwind's arbitrary token-stream behavior. *)
+let test_gradient_stop_position_token_stream () =
+  let accepted cls =
     match Tw.of_string cls with
-    | Ok u ->
-        Alcotest.failf "expected %s to be rejected, got %s" cls
-          (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
-    | Error _ -> ()
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "from-[fit-content]";
-  rejected "from-[none]";
-  rejected "to-[max-content]";
-  rejected "from-[0]";
-  rejected "from-[1zz]";
-  rejected "via-[12px3]"
+  accepted "from-[fit-content]";
+  accepted "from-[none]";
+  accepted "to-[max-content]";
+  accepted "from-[0]";
+  accepted "from-[1zz]";
+  accepted "via-[12px3]"
 
 (* A gradient interpolation modifier names a colour space. Tailwind writes an
    unknown one through as [in <space>], so only the shapes it refuses are
@@ -567,11 +553,13 @@ let tests =
     test_case "gradient interpolation" `Quick test_gradient_interpolation;
     test_case "gradient stop position units" `Quick
       test_gradient_stop_position_units;
-    test_case "gradient stop position is a length-percentage" `Quick
-      test_gradient_stop_position_not_a_length;
-    test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+    test_case "gradient stop position token stream" `Quick
+      test_gradient_stop_position_token_stream;
+    test_case "arbitrary bracket color token stream" `Quick
+      test_arbitrary_bracket_color_token_stream;
     test_case "bg colors" `Quick test_bg_colors;
-    test_case "invalid gradient stop" `Quick test_invalid_gradient_stop;
+    test_case "gradient stop token stream" `Quick
+      test_gradient_stop_token_stream;
     test_case "bg var color with opacity" `Quick test_bg_var_opacity;
     test_case "bg arbitrary url quoting" `Quick test_bg_arbitrary_url;
     test_case "arbitrary rgba gradient stop" `Quick test_gradient_rgba_stop;

--- a/test/test_divide.ml
+++ b/test/test_divide.ml
@@ -18,16 +18,7 @@ let test_roundtrip () =
 
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide";
-  Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-foo";
-  (* A bracket with no number is not a length, so it is refused rather than read
-     as a bare identifier. Tailwind passes the bracket through unread and emits
-     border-inline-start-width: calc(rem * ...), which no browser accepts. *)
-  Test_helpers.check_invalid_input
-    ~why:
-      (Test_helpers.Diverges
-         "Tailwind passes the bracket through unread and emits calc(rem * ...)")
-    (module Tw.Divide.Handler)
-    "divide-x-[rem]"
+  Test_helpers.check_invalid_input (module Tw.Divide.Handler) "divide-foo"
 
 (* divide-x-[2em] and divide-y-[3vw] used to be refused: the width reader only
    knew px and rem, so an em or a vw stop fell through to "not a divide utility"
@@ -205,21 +196,15 @@ let rendering_matches_tailwind () =
    The divide reader handed everything after the [#] to the raising constructor
    from inside [of_class], so a malformed hex escaped the parser as an exception
    instead of failing the match. *)
-let test_invalid_bracket_hex () =
+let test_arbitrary_bracket_color_token_stream () =
   let css cls =
     match Tw.of_string cls with
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
-  rejected "divide-[#zz]";
-  rejected "divide-[#]";
-  rejected "divide-[#12345]";
-  rejected "divide-[#zz]/50";
+  List.iter
+    (fun cls -> ignore (css cls))
+    [ "divide-[#zz]"; "divide-[#]"; "divide-[#12345]"; "divide-[#zz]/50" ];
   Alcotest.(check bool)
     "divide-[#ff0000] still emits the colour" true
     (Astring.String.is_infix ~affix:"border-color:#f00" (css "divide-[#ff0000]"))
@@ -256,10 +241,9 @@ let test_bracket_named_color () =
     "divide-[rebeccapurple]/50 is divide-[#663399]/50"
     (value "divide-[#663399]/50")
     (value "divide-[rebeccapurple]/50");
-  (* a bracket naming no colour is still not a class *)
-  Alcotest.(check bool)
-    "divide-[notacolour] is not a class" true
-    (Result.is_error (Tw.of_string "divide-[notacolour]"))
+  (* Tailwind forwards a safe token stream even when the browser will not
+     recognise it as a colour. *)
+  emits "border-color:notacolour" "divide-[notacolour]"
 
 (* The divide width suffix is a plain decimal integer. [divide-x-0x10] was read
    as 16 and emitted a rule selecting [.divide-x-16], a class the author never
@@ -292,7 +276,8 @@ let tests =
         class_order_matches_tailwind;
       Alcotest.test_case "renders like Tailwind" `Slow
         rendering_matches_tailwind;
-      Alcotest.test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+      Alcotest.test_case "arbitrary bracket color token stream" `Quick
+        test_arbitrary_bracket_color_token_stream;
       Alcotest.test_case "non-decimal widths" `Quick test_non_decimal_widths;
       Alcotest.test_case "bracket named colour" `Quick test_bracket_named_color;
     ]

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -444,8 +444,8 @@ let test_shadow_bracket_alpha_tracking () =
   has "shadow-lg/[25%]" "--tw-shadow-alpha:25%";
   has "shadow-lg/50" "--tw-shadow-alpha:50%"
 
-(* A safe arbitrary shadow token stream is forwarded even when Cascade's typed
-   shadow grammar cannot interpret it. *)
+(* Tailwind forwards a declaration-safe arbitrary shadow token stream even when
+   it is not a valid shadow value. *)
 let test_arbitrary_shadow_token_stream () =
   let accepted cls =
     match Tw.of_string cls with

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -345,9 +345,12 @@ let test_arbitrary_shadow_lengths () =
     "--tw-inset-shadow: inset 0 1px 2px 3px var(--tw-inset-shadow-color, \
      #000000)"
     "inset-shadow-[0_1px_2px_3px_#000]";
-  match Tw.of_string "shadow-[0_bogus_2px]" with
-  | Ok _ -> Alcotest.fail "expected shadow-[0_bogus_2px] to be rejected"
-  | Error _ -> ()
+  emits "--tw-shadow: 0 var(--tw-shadow-color,bogus) 2px" "shadow-[0_bogus_2px]";
+  emits
+    "--tw-shadow: 0 var(--tw-shadow-color,oklab(from bogus l a b / 50%)) 2px"
+    "shadow-[0_bogus_2px]/50";
+  emits "--tw-inset-shadow: inset 0 var(--tw-inset-shadow-color,bogus) 2px"
+    "inset-shadow-[0_bogus_2px]"
 
 let test_arbitrary_shadow_colour_opacity () =
   let css cls =
@@ -441,21 +444,16 @@ let test_shadow_bracket_alpha_tracking () =
   has "shadow-lg/[25%]" "--tw-shadow-alpha:25%";
   has "shadow-lg/50" "--tw-shadow-alpha:50%"
 
-(* An arbitrary shadow that is not a shadow is not a utility: it used to fall
-   back to the zero shadow. *)
-let test_invalid_arbitrary_shadow () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
+(* A safe arbitrary shadow token stream is forwarded even when Cascade's typed
+   shadow grammar cannot interpret it. *)
+let test_arbitrary_shadow_token_stream () =
   let accepted cls =
     match Tw.of_string cls with
     | Ok _ -> ()
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "shadow-[<value>]";
-  rejected "inset-shadow-[<value>]";
+  accepted "shadow-[<value>]";
+  accepted "inset-shadow-[<value>]";
   accepted "shadow-[0_1px_2px_#000]";
   accepted "inset-shadow-[0_1px_2px_#000]"
 
@@ -463,32 +461,27 @@ let test_invalid_arbitrary_shadow () =
    spelling. The bracket-colour reader handed everything after the [#] to the
    raising constructor from inside [of_class], so a malformed hex escaped the
    parser as an exception instead of failing the match. *)
-let test_invalid_bracket_hex () =
+let test_arbitrary_bracket_color_token_stream () =
   let css cls =
     match Tw.of_string cls with
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
   in
   let emits cls affix =
     Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
   in
   List.iter
     (fun prefix ->
-      rejected (prefix ^ "-[#zz]");
-      rejected (prefix ^ "-[#]");
-      rejected (prefix ^ "-[#12345]");
-      rejected (prefix ^ "-[#zz]/50"))
+      ignore (css (prefix ^ "-[#zz]"));
+      ignore (css (prefix ^ "-[#]"));
+      ignore (css (prefix ^ "-[#12345]"));
+      ignore (css (prefix ^ "-[#zz]/50")))
     [ "shadow"; "ring"; "inset-shadow"; "inset-ring"; "ring-offset" ];
   (* The colour of an arbitrary shadow is read the same way. *)
-  rejected "shadow-[0_1px_2px_#zz]";
-  rejected "shadow-[0_1px_2px_#12345]";
-  rejected "shadow-[0_1px_2px_#zz]/50";
-  rejected "inset-shadow-[0_1px_2px_#zz]";
+  ignore (css "shadow-[0_1px_2px_#zz]");
+  ignore (css "shadow-[0_1px_2px_#12345]");
+  ignore (css "shadow-[0_1px_2px_#zz]/50");
+  ignore (css "inset-shadow-[0_1px_2px_#zz]");
   emits "shadow-[#abc]" "--tw-shadow-color:#abc";
   emits "ring-[#123456]" "--tw-ring-color:#123456";
   emits "inset-shadow-[#abc]" "--tw-inset-shadow-color:#abc";
@@ -579,7 +572,8 @@ let test_project_shadow_tokens () =
 
 let tests =
   [
-    test_case "invalid bracket hex" `Quick test_invalid_bracket_hex;
+    test_case "arbitrary bracket color token stream" `Quick
+      test_arbitrary_bracket_color_token_stream;
     test_case "project shadow tokens" `Quick test_project_shadow_tokens;
     test_case "shadow bracket alpha tracking" `Quick
       test_shadow_bracket_alpha_tracking;
@@ -598,7 +592,8 @@ let tests =
       test_bracket_hex_opacity_var;
     test_case "shadow bracket alpha tracking" `Quick
       test_shadow_bracket_alpha_tracking;
-    test_case "invalid arbitrary shadow" `Quick test_invalid_arbitrary_shadow;
+    test_case "arbitrary shadow token stream" `Quick
+      test_arbitrary_shadow_token_stream;
     test_case "shadow-2xl default alpha" `Quick test_shadow_2xl_alpha;
     test_case "shadow-2xs/xs small sizes" `Quick test_shadow_small_sizes;
     test_case "inset-shadow roundtrip" `Quick test_inset_shadow_roundtrip;

--- a/test/test_filters.ml
+++ b/test/test_filters.ml
@@ -262,21 +262,30 @@ let test_drop_shadow_keyword_and_alpha () =
     (Astring.String.is_infix ~affix:"--drop-shadow-xl:"
        (css "drop-shadow-xl/25"))
 
-(* An arbitrary filter amount that is not a number, a percentage or a var used
-   to be coerced to zero, so brightness-[abc] emitted brightness(0). *)
-let test_invalid_arbitrary_amount () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
-  rejected "brightness-[abc]";
-  rejected "invert-[xyz]";
-  rejected "backdrop-sepia-[nope]";
-  rejected "drop-shadow-[<value>]";
+(* Arbitrary filter arguments are safe token streams; the browser, rather than
+   the generator, applies the function's value grammar. *)
+let test_arbitrary_amount_token_streams () =
+  check "brightness-[abc]";
+  check "invert-[xyz]";
+  check "backdrop-sepia-[nope]";
+  check "drop-shadow-[<value>]";
   check "brightness-[1.5]";
   check "saturate-[150%]";
   check "brightness-[var(--x)]"
+
+(* An unterminated comment is complete at the end of an arbitrary value. When
+   the value is embedded in a filter function, the generated closing parenthesis
+   must remain outside that comment. *)
+let test_arbitrary_amount_unterminated_comment () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "unterminated comment cannot swallow the wrapper" true
+    (Astring.String.is_infix ~affix:"brightness(1px)"
+       (css "backdrop-brightness-[1px/*x]"))
 
 (* An arbitrary filter spells its spaces with [_], so a multi-function chain
    like filter-[blur(4px)_saturate(150%)] has to be decoded before it is parsed.
@@ -377,38 +386,32 @@ let test_arbitrary_angle_class_name () =
       "-backdrop-hue-rotate-[1turn]";
     ]
 
-(* A bracket that is not an angle is refused. *)
-let test_invalid_arbitrary_angle () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
-    | Error _ -> ()
-  in
-  rejected "hue-rotate-[2]";
-  rejected "hue-rotate-[2zz]";
-  rejected "hue-rotate-[deg]";
-  rejected "backdrop-hue-rotate-[2px]"
+(* The arbitrary hue-rotate argument is forwarded even when it is not a typed
+   angle. *)
+let test_arbitrary_angle_token_streams () =
+  List.iter check
+    [
+      "hue-rotate-[2]";
+      "hue-rotate-[2zz]";
+      "hue-rotate-[deg]";
+      "backdrop-hue-rotate-[2px]";
+    ]
 
 (* [blur-[...]] takes a length. A bracket the length grammar cannot read was
    accepted and then raised out of [to_css], which is a pure conversion. Reading
    the bracket with cascade's grammar also earns [calc()] and the units the
    hand-rolled reader never took. *)
-let test_invalid_arbitrary_blur () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
-    | Error _ -> ()
-  in
+let test_arbitrary_blur_token_streams () =
   let renders cls =
     match Tw.of_string cls with
     | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "blur-[foo]";
-  rejected "blur-[red]";
-  rejected "blur-[1]";
-  rejected "backdrop-blur-[foo]";
-  rejected "backdrop-blur-[a,b]";
+  renders "blur-[foo]";
+  renders "blur-[red]";
+  renders "blur-[1]";
+  renders "backdrop-blur-[foo]";
+  renders "backdrop-blur-[a,b]";
   renders "blur-[4px]";
   renders "blur-[.5rem]";
   renders "blur-[calc(1px_+_2px)]";
@@ -444,13 +447,18 @@ let tests =
   [
     test_case "arbitrary angle class name" `Quick
       test_arbitrary_angle_class_name;
-    test_case "invalid arbitrary angle" `Quick test_invalid_arbitrary_angle;
-    test_case "invalid arbitrary blur" `Quick test_invalid_arbitrary_blur;
+    test_case "arbitrary angle token streams" `Quick
+      test_arbitrary_angle_token_streams;
+    test_case "arbitrary blur token streams" `Quick
+      test_arbitrary_blur_token_streams;
     test_case "drop-shadow keyword color and alpha" `Quick
       test_drop_shadow_keyword_and_alpha;
     test_case "filters render like Tailwind" `Slow rendering_matches_tailwind;
     test_case "blur" `Quick test_blur;
-    test_case "invalid arbitrary amount" `Quick test_invalid_arbitrary_amount;
+    test_case "arbitrary amount token streams" `Quick
+      test_arbitrary_amount_token_streams;
+    test_case "arbitrary amount unterminated comment" `Quick
+      test_arbitrary_amount_unterminated_comment;
     test_case "arbitrary filter chain" `Quick test_arbitrary_filter_chain;
     test_case "unparseable arbitrary filter rejected" `Quick
       test_unparseable_arbitrary_filter_rejected;

--- a/test/test_tables.ml
+++ b/test/test_tables.ml
@@ -44,23 +44,25 @@ let arbitrary_border_spacing () =
       "border-spacing-y-[1.5vw]";
     ]
 
-(* A bracket that is not a length is not a border-spacing. *)
-let invalid_border_spacing () =
-  let rejected cls =
+(* Tailwind forwards a safe arbitrary token stream even when it is not a CSS
+   length; the browser decides whether the declaration applies. *)
+let arbitrary_border_spacing_token_streams () =
+  let accepted cls =
     match Tw.of_string cls with
-    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
-    | Error _ -> ()
+    | Ok u -> Alcotest.(check string) cls cls (Tw.pp u)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "border-spacing-[1zz]";
-  rejected "border-spacing-x-[12px3]";
-  rejected "border-spacing-y-[<length>]"
+  accepted "border-spacing-[1zz]";
+  accepted "border-spacing-x-[12px3]";
+  accepted "border-spacing-y-[<length>]"
 
 let tests =
   [
     test_case "basic tables" `Quick basic_tables;
     test_case "border-spacing half-step" `Quick border_spacing_prime;
     test_case "arbitrary border-spacing" `Quick arbitrary_border_spacing;
-    test_case "invalid border-spacing" `Quick invalid_border_spacing;
+    test_case "arbitrary token streams" `Quick
+      arbitrary_border_spacing_token_streams;
   ]
 
 let suite = ("tables", tests)

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -368,9 +368,9 @@ let test_arbitrary_transform_spelling () =
       "perspective-[100px]";
     ]
 
-(* Arbitrary transforms are safe declaration-value token streams even when the
-   property's typed grammar rejects them. The browser decides whether the
-   resulting declaration has a valid transform value. *)
+(* Tailwind forwards declaration-safe arbitrary transform token streams even
+   when they are invalid for the target property. The browser then discards the
+   invalid declaration. *)
 let test_arbitrary_transform_token_streams () =
   let css cls =
     match Tw.of_string cls with

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -368,14 +368,24 @@ let test_arbitrary_transform_spelling () =
       "perspective-[100px]";
     ]
 
-(* The bracket holds a number or an angle, so a word is not a transform. *)
-let test_arbitrary_transform_rejects_non_number () =
-  List.iter
-    (fun cls ->
-      match Tw.of_string cls with
-      | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u)
-      | Error (`Msg _) -> ())
-    [ "scale-[abc]"; "rotate-[abc]"; "skew-[1.5]"; "rotate-[1.5px]" ]
+(* Arbitrary transforms are safe declaration-value token streams even when the
+   property's typed grammar rejects them. The browser decides whether the
+   resulting declaration has a valid transform value. *)
+let test_arbitrary_transform_token_streams () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls fragment =
+    Alcotest.(check bool)
+      cls true
+      (Astring.String.is_infix ~affix:fragment (css cls))
+  in
+  emits "scale-[abc]" "scale:abc";
+  emits "rotate-[abc]" "rotate:abc";
+  emits "rotate-[1.5px]" "rotate:1.5px";
+  emits "skew-[1.5]" "--tw-skew-x:skewX(1.5)"
 
 (* A [--perspective-*] token the project declared in its [@theme] names a depth
    the built-in scale has no slot for. Tailwind generates the utility from it;
@@ -453,8 +463,8 @@ let tests =
       suborder_matches_tailwind;
     test_case "arbitrary transform spelling" `Quick
       test_arbitrary_transform_spelling;
-    test_case "arbitrary transform rejects non-number" `Quick
-      test_arbitrary_transform_rejects_non_number;
+    test_case "arbitrary transform token streams" `Quick
+      test_arbitrary_transform_token_streams;
     test_case "project perspective token" `Quick test_project_perspective_token;
     test_case "transforms render like Tailwind" `Slow rendering_matches_tailwind;
   ]

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -44,28 +44,22 @@ let test_initial_resets () =
     "ease-initial sets --tw-ease:initial" true
     (Astring.String.is_infix ~affix:"--tw-ease:initial" (css "ease-initial"))
 
-(* [transition-[...]] takes property names, so the docs' [<value>] placeholder
-   is not one; it used to reach the sheet as transition-property: <value>. *)
-let test_invalid_arbitrary_property () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
+(* The arbitrary transition property is a safe token stream, not necessarily a
+   value Cascade's typed property-name grammar knows. *)
+let test_arbitrary_property_token_stream () =
   let accepted cls =
     match Tw.of_string cls with
     | Ok _ -> ()
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "transition-[<value>]";
+  accepted "transition-[<value>]";
   accepted "transition-[opacity]";
   accepted "transition-[opacity,transform]";
   accepted "transition-[var(--x)]"
 
-(* [ease-[...]] takes a timing function. A bracket the timing-function grammar
-   cannot read used to be accepted and then raise out of [to_css], which is a
-   pure conversion. *)
-let test_invalid_arbitrary_ease () =
+(* Safe arbitrary easing token streams are forwarded; an empty bracket still
+   names no declaration value. *)
+let test_arbitrary_ease_token_stream () =
   let rejected cls =
     match Tw.of_string cls with
     | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
@@ -76,9 +70,9 @@ let test_invalid_arbitrary_ease () =
     | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "ease-[foo]";
-  rejected "ease-[1]";
-  rejected "ease-[50%]";
+  renders "ease-[foo]";
+  renders "ease-[1]";
+  renders "ease-[50%]";
   rejected "ease-[]";
   renders "ease-[linear]";
   renders "ease-[cubic-bezier(0.4,0,0.2,1)]";
@@ -163,8 +157,10 @@ let test_delay_candidate_band () =
   Test_helpers.check_class_order ~test_name:"delay candidate band"
     [
       "duration-150";
+      "duration-[<value>]";
       "delay-700";
       "ease-in";
+      "ease-[<value>]";
       "delay-150";
       "transition";
       "duration-300";
@@ -190,10 +186,10 @@ let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "initial resets" `Quick test_initial_resets;
-      Alcotest.test_case "invalid arbitrary property" `Quick
-        test_invalid_arbitrary_property;
-      Alcotest.test_case "invalid arbitrary ease" `Quick
-        test_invalid_arbitrary_ease;
+      Alcotest.test_case "arbitrary property token stream" `Quick
+        test_arbitrary_property_token_stream;
+      Alcotest.test_case "arbitrary ease token stream" `Quick
+        test_arbitrary_ease_token_stream;
       Alcotest.test_case "arbitrary ease steps default position" `Quick
         test_arbitrary_ease_steps_default_position;
       Alcotest.test_case "project ease token" `Quick test_project_ease_token;

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -44,8 +44,8 @@ let test_initial_resets () =
     "ease-initial sets --tw-ease:initial" true
     (Astring.String.is_infix ~affix:"--tw-ease:initial" (css "ease-initial"))
 
-(* The arbitrary transition property is a safe token stream, not necessarily a
-   value Cascade's typed property-name grammar knows. *)
+(* Tailwind forwards a declaration-safe arbitrary transition-property token
+   stream even when it is not a valid property-name list. *)
 let test_arbitrary_property_token_stream () =
   let accepted cls =
     match Tw.of_string cls with

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -504,9 +504,9 @@ let test_arbitrary_leading () =
     "text-lg/[2em] round-trips" "text-lg/[2em]"
     (Tw.pp (Result.get_ok (Tw.of_string "text-lg/[2em]")))
 
-(* A bracket that is not a line-height is refused by both, rather than accepted
-   and rendered as a zero. *)
-let test_arbitrary_leading_invalid () =
+(* A standalone arbitrary leading utility forwards a safe token stream. Font
+   size modifiers remain typed line-height values. *)
+let test_arbitrary_leading_token_stream () =
   let rejected cls =
     match Tw.of_string cls with
     | Ok u ->
@@ -514,34 +514,29 @@ let test_arbitrary_leading_invalid () =
           (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
     | Error _ -> ()
   in
-  rejected "leading-[red]";
-  rejected "leading-[1zz]";
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  accepted "leading-[red]";
+  accepted "leading-[1zz]";
   rejected "text-lg/[red]";
   rejected "text-lg/[1zz]"
 
-(* [tracking-[...]] takes a length. A bracket the length grammar cannot read was
-   accepted and then raised out of [to_css], which is a pure conversion. Reading
-   the bracket with cascade's grammar also earns [calc()], which the old reader
-   could not take. *)
-let test_arbitrary_tracking_invalid () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok u ->
-        Alcotest.failf "expected %s to be rejected, got %s" cls
-          (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
-    | Error _ -> ()
-  in
+(* [tracking-[...]] forwards any safe declaration value. *)
+let test_arbitrary_tracking_token_stream () =
   let renders cls =
     match Tw.of_string cls with
     | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "tracking-[foo]";
-  rejected "tracking-[red]";
-  rejected "tracking-[45deg]";
-  rejected "tracking-[1e]";
-  rejected "tracking-[a,b]";
-  rejected "-tracking-[foo]";
+  renders "tracking-[foo]";
+  renders "tracking-[red]";
+  renders "tracking-[45deg]";
+  renders "tracking-[1e]";
+  renders "tracking-[a,b]";
+  renders "-tracking-[foo]";
   renders "tracking-[1px]";
   renders "tracking-[.5em]";
   renders "tracking-[-1px]";
@@ -612,6 +607,15 @@ let of_string_invalid () =
 (* line-clamp sits between box-sizing and the display family in Tailwind's
    order, not among the typography utilities its class name suggests. *)
 let line_clamp_sorts_with_box_sizing () =
+  let order cls =
+    Tw.Utility.base_of_class Tw.Scheme.default cls
+    |> Result.get_ok |> Tw.Utility.order
+  in
+  let named_priority, _ = order "line-clamp-2" in
+  let arbitrary_priority, _ = order "line-clamp-[<value>]" in
+  Alcotest.(check int)
+    "arbitrary line-clamp stays in the line-clamp property band" named_priority
+    arbitrary_priority;
   let classes =
     [ "indent-4"; "line-clamp-2"; "block"; "box-border"; "ml-auto" ]
   in
@@ -1142,8 +1146,13 @@ let test_non_decimal_integers () =
   in
   rejected "text-lg/0x10";
   rejected "font-[0x10]";
-  rejected "line-clamp-[0x10]";
-  rejected "line-clamp-[1_0]"
+  let accepted cls =
+    match Tw.of_string cls with
+    | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  accepted "line-clamp-[0x10]";
+  accepted "line-clamp-[1_0]"
 
 (* A [--font-weight-*] or [--leading-*] token the project declared in its
    [@theme] names a value the built-in scale has no slot for. Tailwind generates
@@ -1256,9 +1265,10 @@ let tests =
       test_text_bracket_size_invalid;
     test_case "bracket length units" `Quick test_bracket_length_units;
     test_case "arbitrary leading" `Quick test_arbitrary_leading;
-    test_case "arbitrary leading invalid" `Quick test_arbitrary_leading_invalid;
-    test_case "arbitrary tracking invalid" `Quick
-      test_arbitrary_tracking_invalid;
+    test_case "arbitrary leading token stream" `Quick
+      test_arbitrary_leading_token_stream;
+    test_case "arbitrary tracking token stream" `Quick
+      test_arbitrary_tracking_token_stream;
     test_case "text-[--spacing()/--alpha()] functions" `Quick
       test_text_bracket_functions;
     test_case "named font family from the theme" `Quick test_named_font_family;


### PR DESCRIPTION
Preserve Tailwind's declaration-safe arbitrary token-stream contract, including generated placeholder values that are invalid for the target property. This covers animations, backgrounds, divide, filters, shadows and rings, scrollbars, tables, transforms, transitions, and typography.