### PR TITLE
build: merge consecutive media blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@
   `@apply` and `@variant` (#136, #138, #139, #140, #141, #143, #195, #206).
 - Authored input receives browser-compatibility prefixes even when full CSS
   optimization is disabled, preserving the CLI's target coverage (#665).
+- Merge adjacent media queries with identical conditions during utility
+  construction, avoiding redundant wrappers without enabling full stylesheet
+  optimization (#668).
 - A project's own theme reaches class generation, so its variants, keyframes,
   layers, static scales, custom breakpoints and v3 dotted `theme()` paths apply
   to the utilities tw generates from the markup, and a routed utility survives a

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -559,9 +559,8 @@ let rule_sets_from_selector_props order_map all_rules =
   sorted |> List.map indexed_rule_to_statement
 
 let utilities_layer ~layers ~statements =
-  (* Statements are already in the correct order with media queries interleaved.
-     Consecutive media queries with the same condition will be merged by the
-     optimizer (css/optimize.ml) while preserving cascade order. *)
+  (* Statements are already in the correct order, with adjacent equal media
+     conditions merged before the layer is assembled. *)
   if layers then Css.v [ Css.layer ~name:[ "utilities" ] statements ]
   else Css.v statements
 
@@ -571,6 +570,7 @@ let utilities_layer ~layers ~statements =
 let statements_of_sorted_rules ?verbatim sorted_rules =
   List.map (indexed_rule_to_statement ?verbatim) sorted_rules
   |> Css.Optimize.merge_consecutive_starting_style
+  |> Css.Optimize.merge_consecutive_media
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)

--- a/test/cli/variants.t
+++ b/test/cli/variants.t
@@ -116,7 +116,7 @@ around the project's selector.
   $ cat > lgdark.html <<EOF
   > <div class="lg:dark:flex lg:dark:hover:block"></div>
   > EOF
-  $ tw --minify --input-css darkclass.css lgdark.html | grep -cF '@media(min-width:64rem){.lg\:dark\:flex:where(.dark,.dark *){display:flex}}'
+  $ tw --minify --input-css darkclass.css lgdark.html | grep -cF '@media(min-width:64rem){.lg\:dark\:flex:where(.dark,.dark *){display:flex}'
   1
   $ tw --minify --input-css darkclass.css lgdark.html | grep -cF '.lg\:dark\:hover\:block:where(.dark,.dark *):hover{display:block}'
   1

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -31,7 +31,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 2, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 3, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -632,6 +632,12 @@ let test_rule_sets_md_media () =
   in
   check bool "has (min-width: 48rem) media query" true
     (has_media_condition "(min-width: 48rem)" css);
+  let md_blocks =
+    media_conditions css
+    |> List.filter (String.equal "(min-width: 48rem)")
+    |> List.length
+  in
+  check int "one consecutive md media block" 1 md_blocks;
 
   (* Collect md media blocks and verify both selectors are under md. CSS
      optimization may merge these blocks, but tw no longer depends on that. *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -624,7 +624,8 @@ let test_rule_sets_hover_media () =
 
 let test_rule_sets_md_media () =
   (* Multiple md[...] utilities should group under a single min-width media
-     block without relying on Cascade optimization. *)
+     block during utility construction, without requiring whole-stylesheet
+     optimization. *)
   let css =
     Tw.Build.to_css
       ~config:{ base = true; forms = None; layers = true }
@@ -639,8 +640,7 @@ let test_rule_sets_md_media () =
   in
   check int "one consecutive md media block" 1 md_blocks;
 
-  (* Collect md media blocks and verify both selectors are under md. CSS
-     optimization may merge these blocks, but tw no longer depends on that. *)
+  (* Collect the md media block and verify both selectors remain under md. *)
   let selectors =
     Css.fold
       (fun acc stmt ->


### PR DESCRIPTION
Merge adjacent media blocks with identical conditions after utility sorting. This removes redundant wrappers without reordering rules or enabling the full optimizer.