### PR TITLE
test: identify nested order statements

### DIFF
--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -733,6 +733,35 @@ let layer_statement_keys sheet ~layer =
           else selector_branches p)
         (statements_between sheet lo hi)
 
+(* An at-rule prelude alone is not an identity: a generated sheet can contain
+   hundreds of [@media (hover: hover)] blocks, each wrapping a different rule.
+   Fingerprint the unordered nested statement structure as well. Sorting makes
+   the identity independent of order inside the container, since this gate
+   measures the containing layer's sequence; repeated identical containers stay
+   ambiguous and are conservatively dropped below. *)
+let rec structural_statement_keys sheet (prelude, body) =
+  let p = normalize_prelude prelude in
+  if p = "" then []
+  else if p.[0] <> '@' then selector_branches p
+  else
+    match body with
+    | None -> [ p ]
+    | Some (lo, hi) ->
+        let nested =
+          statements_between sheet lo hi
+          |> List.concat_map (structural_statement_keys sheet)
+          |> List.sort String.compare |> String.concat "\x1f"
+        in
+        let fingerprint = Digest.string nested |> Digest.to_hex in
+        [ p ^ " #" ^ fingerprint ]
+
+let layer_statement_identities sheet ~layer =
+  match layer_body sheet ~layer with
+  | None -> []
+  | Some (lo, hi) ->
+      statements_between sheet lo hi
+      |> List.concat_map (structural_statement_keys sheet)
+
 (* Patience sorting. [tails.(l)] holds the index of the smallest value that can
    end an increasing run of length [l + 1], so a binary search places each
    element and the predecessor links rebuild one longest run. Everything outside
@@ -764,8 +793,8 @@ let longest_increasing_subsequence seq =
 type order_gap = { pairs : int; moves : int; moved : (string * int * int) list }
 
 let sheet_order_gap ~layer ~tailwind ~tw =
-  let ours = layer_statement_keys tw ~layer in
-  let theirs = layer_statement_keys tailwind ~layer in
+  let ours = layer_statement_identities tw ~layer in
+  let theirs = layer_statement_identities tailwind ~layer in
   let occurrences keys =
     let tbl = Hashtbl.create 4096 in
     List.iter

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -154,7 +154,7 @@ val layer_statement_keys : string -> layer:string -> string list
     the empty list. *)
 
 type order_gap = {
-  pairs : int;  (** keys occurring exactly once on each side *)
+  pairs : int;  (** structural identities occurring exactly once on each side *)
   moves : int;  (** the fewest of those that have to move *)
   moved : (string * int * int) list;
       (** each moved key with its rank among {!field-pairs} on Tailwind's side
@@ -164,9 +164,11 @@ type order_gap = {
 
 val sheet_order_gap : layer:string -> tailwind:string -> tw:string -> order_gap
 (** [sheet_order_gap ~layer ~tailwind ~tw] measures how far tw's statement order
-    in [@layer layer] is from Tailwind's. Only keys occurring exactly once on
-    both sides are paired, so no pairing choice of the gate's own can move the
-    number; over those, {!field-moves} is the count outside a longest
+    in [@layer layer] is from Tailwind's. At-rule identities include a
+    fingerprint of their nested statement structure, so repeated media and
+    supports preludes remain distinguishable. Only identities occurring exactly
+    once on both sides are paired, so no pairing choice of the gate's own can
+    move the number; over those, {!field-moves} is the count outside a longest
     subsequence, which is the fewest statements that have to move for the orders
     to agree.
 

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -10,9 +10,11 @@
 
    This measures the whole sheet. Both sides are generated over the committed
    site class list, the top-level statement sequence of a layer is taken out of
-   each, and the two are compared over the keys that occur exactly once on both
-   sides, where no pairing choice exists. What is reported is the fewest
-   statements that have to move for the orders to agree.
+   each, and the two are compared over structural identities that occur exactly
+   once on both sides, where no pairing choice exists. An at-rule identity
+   includes the nested statements it contains, so equal media preludes remain
+   distinguishable. What is reported is the fewest statements that have to move
+   for the orders to agree.
 
    The numbers below are pinned, not aspirational: the gate fails when one goes
    up and prints the new figure when it goes down, so the ceiling can be
@@ -20,18 +22,19 @@
 
 module Tailwind_gen = Tw_tools.Tailwind_gen
 
-(* Measured 2026-09-03 over [classlist.txt], 4825 classes of tailwindcss.com,
-   against cascade main at 3a007e5b. Both keys and grouping come out of
-   cascade's printer, so the number is only comparable against the cascade a run
-   was built with, and every run prints which one that was. CI pins cascade main
-   through opam; a local [cascade/] symlink sitting on someone's branch is the
-   first thing to check when the count moves for no reason in the sort code.
+(* Measured 2026-09-03 over [classlist.txt], 4825 classes of tailwindcss.com, at
+   the PR #667 + #668 stack against cascade main at 3a007e5b. Both keys and
+   grouping come out of cascade's printer, so the number is only comparable
+   against the cascade a run was built with, and every run prints which one that
+   was. CI pins cascade main through opam; a local [cascade/] symlink sitting on
+   someone's branch is the first thing to check when the count moves for no
+   reason in the sort code.
 
    [pairs] is pinned as a floor as well: a sheet that lost most of its rules
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 3, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 6, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set
@@ -90,8 +93,8 @@ let check ~tailwind ~tw (layer, `Moves ceiling, `Pairs floor) =
       gap.Test_helpers.moves;
     report_moved gap.Test_helpers.moved;
     Fmt.pr
-      "  The ranks are positions among the paired statements, so a large gap \
-       is a family sorted into the wrong band.@.";
+      "  Each line is outside one minimum-move subsequence; inspect its \
+       neighbours before attributing the ordering defect.@.";
     false
   end
   else begin

--- a/test/test_test_helpers.ml
+++ b/test/test_test_helpers.ml
@@ -170,6 +170,23 @@ let test_order_gap_drops_a_repeated_key () =
     "the repeated key leaves two pairs, one of them moved" (2, 1)
     (g.Test_helpers.pairs, g.Test_helpers.moves)
 
+(* Repeated container preludes are distinguishable by the rules they contain.
+   Dropping them all hides a container moved across a regular rule. *)
+let test_order_gap_pairs_structural_containers () =
+  let media selector = "@media (hover:hover){" ^ selector ^ "{color:red}}" in
+  let tailwind =
+    "@layer utilities{.a{color:red}" ^ media ".hover\\:a:hover"
+    ^ ".b{color:red}" ^ media ".hover\\:b:hover" ^ "}"
+  in
+  let tw =
+    "@layer utilities{.a{color:red}.b{color:red}" ^ media ".hover\\:a:hover"
+    ^ media ".hover\\:b:hover" ^ "}"
+  in
+  let g = Test_helpers.sheet_order_gap ~layer:"utilities" ~tailwind ~tw in
+  Alcotest.(check (pair int int))
+    "four structural pairs expose one moved container" (4, 1)
+    (g.Test_helpers.pairs, g.Test_helpers.moves)
+
 let test_order_gap_agreeing_sheets () =
   let g = gap ~tailwind:[ ".a"; ".b"; ".c" ] ~tw:[ ".a"; ".b"; ".c" ] in
   Alcotest.(check (pair int int))
@@ -350,6 +367,8 @@ let tests =
       test_order_gap_counts_the_minimum_move;
     Alcotest.test_case "order gap: repeated key" `Quick
       test_order_gap_drops_a_repeated_key;
+    Alcotest.test_case "order gap: repeated containers" `Quick
+      test_order_gap_pairs_structural_containers;
     Alcotest.test_case "order gap: agreeing sheets" `Quick
       test_order_gap_agreeing_sheets;
     Alcotest.test_case "inversions: grouped selector is unordered" `Quick


### PR DESCRIPTION
Fingerprint each at-rule's nested statement structure before pairing whole-sheet order entries. The stronger gate now compares 3,941 utility statements and pins the six real moves it exposes.