### PR TITLE
tables: preserve border-spacing property order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,8 @@
   #222, #265).
 - A named spacing token declares the variable it references. Padding and gap
   emitted `var(--spacing-<name>)` with nothing declaring it (#261).
+- Border-spacing candidates keep their property order across the whole theme
+  scale, including arbitrary values (#670).
 - Accept a value the project named in its own `@theme` wherever Tailwind does:
   shadows, blur radii, timing functions, font weights, line heights, letter
   spacing, corner radii, font sizes, perspectives, aspect ratios and max-widths

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -210,12 +210,12 @@ module Handler = struct
     | Caption_bottom | Caption_top -> 1
     | Border_collapse -> 30
     | Border_separate -> 31
-    | Border_spacing n -> 32 + int_of_float (n *. 10.)
-    | Border_spacing_arb _ -> 1000
-    | Border_spacing_x n -> 1032 + int_of_float (n *. 10.)
-    | Border_spacing_x_arb _ -> 2000
-    | Border_spacing_y n -> 2032 + int_of_float (n *. 10.)
-    | Border_spacing_y_arb _ -> 3000
+    (* Values share their property's slot and use the candidate-name tiebreaker.
+       Encoding a spacing magnitude in the suborder lets a large theme step
+       escape its family and cross transform-origin. *)
+    | Border_spacing _ | Border_spacing_arb _ -> 32
+    | Border_spacing_x _ | Border_spacing_x_arb _ -> 33
+    | Border_spacing_y _ | Border_spacing_y_arb _ -> 34
 
   let of_class theme class_name =
     let parts = Parse.split_class class_name in

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -34,7 +34,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 6, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 4, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_tables.ml
+++ b/test/test_tables.ml
@@ -56,6 +56,20 @@ let arbitrary_border_spacing_token_streams () =
   accepted "border-spacing-x-[12px3]";
   accepted "border-spacing-y-[<length>]"
 
+(* Every border-spacing candidate belongs before transform-origin in Tailwind's
+   property order, including an arbitrary axis value. *)
+let border_spacing_axis_order () =
+  Test_helpers.check_class_order ~test_name:"border-spacing axis order"
+    [
+      "origin-bottom";
+      "border-spacing-y-[1.5vw]";
+      "border-spacing-x-[2em]";
+      "border-spacing-y-96";
+      "border-spacing-x-96";
+      "border-spacing-[1rem]";
+      "border-spacing-4";
+    ]
+
 let tests =
   [
     test_case "basic tables" `Quick basic_tables;
@@ -63,6 +77,7 @@ let tests =
     test_case "arbitrary border-spacing" `Quick arbitrary_border_spacing;
     test_case "arbitrary token streams" `Quick
       arbitrary_border_spacing_token_streams;
+    test_case "border-spacing axis order" `Slow border_spacing_axis_order;
   ]
 
 let suite = ("tables", tests)


### PR DESCRIPTION
Large theme steps could push border-spacing axis utilities past transform-origin in the generated cascade. Keep each border-spacing property in one candidate-sorted slot.