### PR TITLE
sort: preserve negated breakpoint order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -252,7 +252,8 @@
 - Stacked and compound variants sort by what they contain rather than by their
   prefix text. A compound carries its inner value, a recursive compound follows
   its whole path, an arbitrary variant orders by its selector, data variants
-  group by predicate, and repeated element variants collapse to one key (#564).
+  group by predicate, a negated breakpoint retains its responsive order, and
+  repeated element variants collapse to one key (#564, #672).
 - Blocks group the way Tailwind groups them. A run of `@starting-style`
   utilities emits as one block, the utilities one `@apply` pulls in land in a
   single rule, the `@property` an applied utility brings is hoisted and

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -36,6 +36,7 @@ type selector_kind =
 type variant_component = {
   slot : int;
   breakpoint : Css.Media.key option;
+  reverse_breakpoint : bool;
   wrapped : int list;
   value_key : string option;
 }
@@ -387,6 +388,7 @@ let accessibility_preference_group =
 (* The rank the variant table gives a breakpoint prefix. Read back from the
    table for the same reason as the two groups above. *)
 let responsive_variant_order = Modifiers.variant_order_of_prefix "sm"
+let negation_variant_order = Modifiers.variant_order_of_prefix "not-hover"
 
 (** Compare two media conditions within the same group *)
 let compare_media_conditions group1 sub1 sub2 cond1 cond2 key1 key2 =
@@ -1113,7 +1115,9 @@ let compare_variant_components a b =
   else
     let bp_cmp =
       match (a.breakpoint, b.breakpoint) with
-      | Some k1, Some k2 -> Css.Media.compare_keys k1 k2
+      | Some k1, Some k2 ->
+          let c = Css.Media.compare_keys k1 k2 in
+          if a.reverse_breakpoint && b.reverse_breakpoint then -c else c
       | Some _, None | None, Some _ | None, None -> 0
     in
     if bp_cmp <> 0 then bp_cmp
@@ -1157,11 +1161,21 @@ let rec variant_value_key token =
 let token_order_key ?theme ~breakpoint token =
   let slot = Modifiers.variant_order_of_prefix ?theme token in
   let wrapped = Modifiers.variant_inner_order_path ?theme token in
+  let reverse_breakpoint =
+    slot = negation_variant_order
+    &&
+    match Modifiers.variant_inner_token token with
+    | Some inner ->
+        Modifiers.variant_order_of_prefix ?theme inner
+        = responsive_variant_order
+    | None -> false
+  in
   let breakpoint =
-    if slot = responsive_variant_order then breakpoint else None
+    if slot = responsive_variant_order || reverse_breakpoint then breakpoint
+    else None
   in
   let value_key = variant_value_key token in
-  { slot; breakpoint; wrapped; value_key }
+  { slot; breakpoint; reverse_breakpoint; wrapped; value_key }
 
 (* The variant order keys of a class's modifier stack, sorted descending.
    Tailwind sorts a candidate by this list compared lexicographically ascending,
@@ -1190,6 +1204,7 @@ let variant_order_list ?theme base_class variant_order breakpoint =
         {
           slot = variant_order;
           breakpoint = None;
+          reverse_breakpoint = false;
           wrapped = [];
           value_key = None;
         };

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -28,6 +28,9 @@ type variant_component = {
   breakpoint : Css.Media.key option;
       (** The width a breakpoint token names, so [sm] and [md] do not collapse
           onto one key. [None] for every other token. *)
+  reverse_breakpoint : bool;
+      (** [true] when a [not-*] token negates the breakpoint it names. The
+          rendered query reverses direction, but its variant order does not. *)
   wrapped : int list;
       (** The recursive path of variants a compound token wraps, so
           [group-has-indeterminate] and [group-has-focus] keep their inner state

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -34,7 +34,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 4, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 2, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2149,6 +2149,13 @@ let test_not_supports_variant_order () =
   Test_helpers.check_ordering_matches
     ~test_name:"not-supports variants follow base utilities" utilities
 
+(* Negating a breakpoint changes its media condition, not its place in the
+   responsive scale. Tailwind therefore keeps not-sm, not-md, and not-xl in
+   ascending breakpoint order. *)
+let test_not_breakpoint_order () =
+  Test_helpers.check_class_order ~test_name:"not-breakpoint order"
+    [ "not-xl:hidden"; "not-sm:hidden"; "not-md:hidden" ]
+
 let test_breakpoint_groups_stacked_variants () =
   (* A stacked variant sorts under its breakpoint, so first:sm:m-2 stays with
      the other sm rules instead of falling past md:block. Tailwind's order for
@@ -3131,6 +3138,7 @@ let tests =
     test_case "stacked variant outline order" `Slow
       test_stacked_variant_outline_order;
     test_case "not-supports variant order" `Slow test_not_supports_variant_order;
+    test_case "not-breakpoint order" `Slow test_not_breakpoint_order;
     test_case "variant table emission order" `Slow
       test_variant_table_emission_order;
     test_case "stacked responsive variant order" `Slow


### PR DESCRIPTION
Negated responsive variants inherited the reversed order of their rendered max-width queries. Keep the inner breakpoint key so not-sm, not-md, and not-xl follow the responsive scale.