### PR TITLE
sort: preserve custom dark order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -252,8 +252,9 @@
 - Stacked and compound variants sort by what they contain rather than by their
   prefix text. A compound carries its inner value, a recursive compound follows
   its whole path, an arbitrary variant orders by its selector, data variants
-  group by predicate, a negated breakpoint retains its responsive order, and
-  repeated element variants collapse to one key (#564, #672).
+  group by predicate, a negated breakpoint retains its responsive order, a
+  project dark override keeps the built-in dark slot, and repeated element
+  variants collapse to one key (#564, #672, #673).
 - Blocks group the way Tailwind groups them. A run of `@starting-style`
   utilities emits as one block, the utilities one `@apply` pulls in land in a
   single rule, the `@property` an applied utility brings is hoisted and

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -2600,7 +2600,10 @@ let variant_inner_token token =
 let variant_order_of_prefix ?theme prefix =
   match theme with
   | Some theme when Option.is_some (try_custom_variant theme prefix) ->
-      Slot.rank Slot.Custom
+      (* Tailwind registers [dark] before it reads [@custom-variant]. Replacing
+         that exact registration changes its body but retains its slot. *)
+      if String.equal prefix "dark" then Slot.rank Slot.Dark
+      else Slot.rank Slot.Custom
   | Some _ | None -> (
       match slot_of_prefix prefix with Some slot -> Slot.rank slot | None -> 0)
 

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -747,9 +747,10 @@ val variant_order_of_prefix : ?theme:Scheme.t -> string -> int
     prefix string in the Tailwind v4 variant cascade. The prefix is one modifier
     of a class name, the part between two ":" (e.g. ["hover"],
     ["group-has-checked"], ["@min-[64rem]"]). When [theme] is supplied, its
-    exact custom-variant names take precedence over the built-in prefix grammar.
-    Returns 0 for a token that names no variant, which
-    {!Sort.compare_indexed_rules} reads as "this rule carries no variant". *)
+    exact custom-variant names take precedence over the built-in prefix grammar;
+    re-registering [dark] retains its pre-existing built-in position. Returns 0
+    for a token that names no variant, which {!Sort.compare_indexed_rules} reads
+    as "this rule carries no variant". *)
 
 val variant_inner_order : string -> int
 (** [variant_inner_order token] returns what separates [token] from another

--- a/test/parity/sheet_order.ml
+++ b/test/parity/sheet_order.ml
@@ -34,7 +34,7 @@ module Tailwind_gen = Tw_tools.Tailwind_gen
    would otherwise have nothing left to be out of order, and the gate would read
    that as a pass. *)
 let pinned =
-  [ ("utilities", `Moves 2, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
+  [ ("utilities", `Moves 0, `Pairs 3900); ("components", `Moves 0, `Pairs 45) ]
 
 (* Skipping is right on a machine with no Tailwind CLI and wrong in CI, where it
    reports a sheet as correctly ordered because nothing looked. Set

--- a/test/test_sort.ml
+++ b/test/test_sort.ml
@@ -2400,6 +2400,32 @@ let test_custom_variant_supports_companion_order () =
     ]
     (emitted_classes css classes)
 
+(* Re-registering an exact built-in variant changes what it emits, not where it
+   sits in Tailwind's variant order. A class-based dark variant therefore stays
+   before starting and print instead of moving to the generic custom slot. *)
+let test_custom_dark_keeps_builtin_slot () =
+  let defs = [ ("dark", "&:where(.dark,.dark *){@slot;}") ] in
+  let classes = [ "dark:hidden"; "starting:hidden"; "print:hidden" ] in
+  let _, extra, _ =
+    Tw_tools.Entrypoint.custom_routed_utilities ~theme:Tw.Scheme.default ~defs
+      ~udefs:[] [ "dark:hidden" ]
+  in
+  let utilities =
+    [ "starting:hidden"; "print:hidden" ]
+    |> List.map (fun cls -> Result.get_ok (Tw.of_string cls))
+  in
+  let custom = Tw.Scheme.{ values = [ ("", "&") ]; template = "{}" } in
+  let theme =
+    { Tw.Scheme.default with custom_variants = [ ("dark", custom) ] }
+  in
+  let css =
+    Tw.to_css ~theme ~base:false ~extra utilities
+    |> Css.to_string ~minify:true ~lossless:true
+  in
+  Alcotest.(check (list string))
+    "custom dark retains the built-in slot" classes
+    (emitted_classes css classes)
+
 let test_margin_value_order () =
   (* Margin values sort by raw suffix: numeric, then arbitrary ('['), then
      keywords auto < full < px. -ml-4 and -ml-px conflict on margin-left, so the
@@ -3152,6 +3178,8 @@ let tests =
       test_color_mix_supports_companion_order;
     test_case "custom variant branches stay with their candidate" `Quick
       test_custom_variant_supports_companion_order;
+    test_case "custom dark keeps its built-in slot" `Quick
+      test_custom_dark_keeps_builtin_slot;
     test_case "margin value order" `Slow test_margin_value_order;
     test_case "prose margin order" `Slow test_prose_margin_order;
     test_case "variant same-suborder tiebreak" `Slow


### PR DESCRIPTION
Redefining dark via @custom-variant moved its generated rules into the generic custom slot after starting and print. Retain Tailwind's pre-registered dark slot while leaving other custom names unchanged.