### PR TITLE
parse: preserve the \_ escape in arbitrary values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,6 +129,9 @@
   animation, background, divide, filter, shadow, ring, scrollbar, table,
   transform, transition and typography values, including values that are
   invalid for the target property (#667).
+- An arbitrary value keeps the underscore its `\_` escape spells, so
+  `font-['My\_Font']`, `[--my\_var:red]` and `data-[foo=bar\_baz]:flex` reach
+  the sheet as written instead of carrying the backslash into the value (#676).
 - Bracketed `has`, `group-has` and `peer-has` variants retain Tailwind's
   `:is(...)` wrapper for bare type and complex selectors.
 - An arbitrary length in a variant's class name is spelled as the author wrote

--- a/lib/animations.ml
+++ b/lib/animations.ml
@@ -261,7 +261,7 @@ module Handler = struct
 
   (* Tailwind moves the animation name to the end of the shorthand. *)
   let animation_shorthand value =
-    let css_value = String.map (fun c -> if c = '_' then ' ' else c) value in
+    let css_value = Parse.decode_underscores value in
     match String.split_on_char ' ' css_value with
     | name :: (_ :: _ as rest) -> String.concat " " (rest @ [ name ])
     | _ -> css_value

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -69,6 +69,11 @@ module Handler = struct
      visibility. *)
   let unclaimed = 38
 
+  (* The class carries the property as it was written, which is where [\_]
+     spells an underscore the value grammar would otherwise read as a space. The
+     name itself has no space to spell, so it keeps every bare [_] it has. *)
+  let declared_property property = Parse.unescape_underscores property
+
   let slot t =
     let property, value =
       match t with
@@ -76,7 +81,8 @@ module Handler = struct
       | Parsed_decl { property; value } -> (property, value)
     in
     match
-      Css.parse_declaration ~layer:"utilities" property
+      Css.parse_declaration ~layer:"utilities"
+        (declared_property property)
         (Parse.decode_arbitrary_value value)
     with
     | None -> None
@@ -234,6 +240,7 @@ module Handler = struct
      typed [Css.var] form (kept in the utilities layer), never a token
      stream. *)
   let color_emitter property : (Css.color -> Css.declaration) option =
+    let property = declared_property property in
     match color_property_of_name property with
     | Some prop -> Some prop
     | None ->
@@ -251,7 +258,8 @@ module Handler = struct
            declaration in the utilities layer (the build's theme/utilities
            filter drops layerless custom properties). *)
         match
-          Css.parse_declaration ~layer:"utilities" property
+          Css.parse_declaration ~layer:"utilities"
+            (declared_property property)
             (Parse.decode_arbitrary_value value)
         with
         | Some decl -> style [ decl ]
@@ -380,7 +388,8 @@ module Handler = struct
                     (* Plain [property:value]: any property whose value cascade
                        can parse becomes a typed declaration. *)
                     match
-                      Css.parse_declaration property
+                      Css.parse_declaration
+                        (declared_property property)
                         (Parse.decode_arbitrary_value value)
                     with
                     | Some _ -> Ok (Parsed_decl { property; value })

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -748,7 +748,7 @@ module Handler = struct
      list. [None] means the bracket is not an image, which [of_class] rejects:
      [bg-[image:nope]] used to parse and then emit an empty rule. *)
   let parse_bracket_image v : Css.background_image option =
-    let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
+    let css_str = Parse.decode_underscores v in
     match Css.parse_background_image css_str with
     | Some [ img ] -> Some (Css.minify_background_image img)
     | Some (_ :: _ as imgs) ->
@@ -844,7 +844,7 @@ module Handler = struct
       letters. Reading the value as a real [<angle>] tells the two apart instead
       of matching on the "rad" suffix, which "grad" also has. *)
   let bracket_value_to_css inner =
-    let decoded = String.map (fun c -> if c = '_' then ' ' else c) inner in
+    let decoded = Parse.decode_underscores inner in
     match
       Cascade.Cursor.try_parse_full_err Css.Values.read_angle
         (Cascade.Cursor.of_string decoded)
@@ -1517,10 +1517,15 @@ module Handler = struct
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style [ Css.background_image (Var var_ref) ]
     | Bg_bracket_image (_, img) -> style [ Css.background_image img ]
+    (* A [url()] is the one place an arbitrary value keeps its bare [_], so only
+       the [\_] escape is undone and a path spelled either way names the same
+       file. *)
     | Bg_bracket_url url ->
-        style [ Css.background_image (Url (strip_outer_quotes url)) ]
+        let url = strip_outer_quotes (Parse.unescape_underscores url) in
+        style [ Css.background_image (Url url) ]
     | Bg_bracket_image_url url ->
-        style [ Css.background_image (Url (strip_outer_quotes url)) ]
+        let url = strip_outer_quotes (Parse.unescape_underscores url) in
+        style [ Css.background_image (Url url) ]
     | Bg_bracket_url_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -873,9 +873,7 @@ let of_string = function
         else Error (`Msg ("Unknown color: " ^ s))
       else if len >= 3 && s.[0] = '[' && s.[len - 1] = ']' then
         let inner = String.sub s 1 (len - 2) in
-        let normalized =
-          String.map (fun c -> if c = '_' then ' ' else c) inner
-        in
+        let normalized = Parse.decode_underscores inner in
         if Parse.is_css_color_fn normalized then
           match Css.parse_color normalized with
           | Some c -> Ok (Css c)
@@ -2026,9 +2024,7 @@ module Handler = struct
              red-500 palette entry); fall back to the palette only if CSS does
              not know it. *)
           let color =
-            let normalized =
-              String.map (fun c -> if c = '_' then ' ' else c) color_str
-            in
+            let normalized = Parse.decode_underscores color_str in
             match Css.parse_color normalized with
             | Some c -> Some c
             | None -> parse_bracket_color color_str
@@ -2045,9 +2041,7 @@ module Handler = struct
           let starts_with_hash = String.length inner > 0 && inner.[0] = '#' in
           if starts_with_hash then Css.hex_opt inner
           else
-            let normalized =
-              String.map (fun c -> if c = '_' then ' ' else c) inner
-            in
+            let normalized = Parse.decode_underscores inner in
             (* Any colour CSS knows wins over the palette, keywords and system
                colours included: [[Field]] and [[light-dark(a,b)]] are values,
                not palette names. The guard used to admit only functions. *)

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -621,7 +621,7 @@ module Handler = struct
 
   (* Parse arbitrary shadow value like "12px_12px_#0088cc" *)
   let parse_arbitrary_shadow (s : string) : arbitrary_shadow option =
-    let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
+    let normalized = Parse.decode_underscores s in
     let parts = String.split_on_char ' ' normalized in
     let rec find_color_and_lengths acc (parts : string list) :
         string list * arbitrary =
@@ -696,11 +696,10 @@ module Handler = struct
   let is_shadow_bracket inner =
     Parse.is_var inner
     || parse_arbitrary_shadow inner <> None
-    || Css.parse_shadow (String.map (fun c -> if c = '_' then ' ' else c) inner)
-       <> None
+    || Css.parse_shadow (Parse.decode_underscores inner) <> None
 
   let shadow_arbitrary (arb : string) =
-    let normalized = String.map (fun c -> if c = '_' then ' ' else c) arb in
+    let normalized = Parse.decode_underscores arb in
     (* The reading below takes one shadow, so anything with a comma - a layer
        list, or a colour function carrying one - goes to the value parser
        instead. *)

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -311,11 +311,12 @@ module Handler = struct
   let err_not_utility = Error (`Msg "Not a grid item utility")
 
   let parse_arbitrary s =
-    (* Parse [value] to value, replacing underscores with spaces *)
+    (* The bracket text, decoded: [_] is a space and [\_] a literal
+       underscore. *)
     let len = String.length s in
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
-      Some (String.map (fun c -> if c = '_' then ' ' else c) inner)
+      Some (Parse.decode_underscores inner)
     else None
 
   let of_class theme class_name =
@@ -468,8 +469,9 @@ module Handler = struct
     | _ -> err_not_utility
 
   let to_class_arbitrary s =
-    (* Convert value to arbitrary format: replace spaces with underscores *)
-    "[" ^ String.map (fun c -> if c = ' ' then '_' else c) s ^ "]"
+    (* The value is held decoded, so the bracket it goes back into spells a
+       space [_] and an underscore [\_]. *)
+    "[" ^ Parse.encode_underscores s ^ "]"
 
   let to_class = function
     (* Column *)

--- a/lib/interactivity.ml
+++ b/lib/interactivity.ml
@@ -214,7 +214,7 @@ module Handler = struct
           let bare_name = Parse.extract_var_name s in
           style [ will_change (Var (Var.bracket bare_name)) ]
         else
-          let raw = String.map (fun c -> if c = '_' then ' ' else c) s in
+          let raw = Parse.decode_underscores s in
           let props = String.split_on_char ',' raw |> List.map String.trim in
           style [ will_change (Properties props) ]
     | Group -> group_s
@@ -306,9 +306,7 @@ module Handler = struct
           || String.split_on_char ',' inner
              |> List.map String.trim
              |> List.for_all (fun p ->
-                 Parse.is_ident
-                   (String.map (fun c -> if c = '_' then ' ' else c) p
-                   |> String.trim))
+                 Parse.is_ident (Parse.decode_underscores p |> String.trim))
         then Ok (Will_change_arbitrary inner)
         else err_not_utility
     | [ "group" ] -> Ok Group

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -1128,10 +1128,7 @@ module Handler = struct
     (* mask-radial-[size] - arbitrary size *)
     | [ "mask"; "radial"; arb ] when Parse.is_bracket_value arb ->
         let size_value = Parse.bracket_inner arb in
-        (* Replace underscores with spaces *)
-        let size_value =
-          String.map (fun c -> if c = '_' then ' ' else c) size_value
-        in
+        let size_value = Parse.decode_underscores size_value in
         if not (Parse.is_declaration_value size_value) then
           Error (`Msg ("Invalid mask-radial size: " ^ size_value))
         else Ok (Radial_size (Arbitrary_size size_value))
@@ -1187,8 +1184,9 @@ module Handler = struct
     | Radial_size Farthest_corner -> "mask-radial-farthest-corner"
     | Radial_size Farthest_side -> "mask-radial-farthest-side"
     | Radial_size (Arbitrary_size s) ->
-        let escaped = String.map (fun c -> if c = ' ' then '_' else c) s in
-        "mask-radial-[" ^ escaped ^ "]"
+        (* The size is held decoded, so the bracket it goes back into spells a
+           space [_] and an underscore [\_]. *)
+        "mask-radial-[" ^ Parse.encode_underscores s ^ "]"
 
   let examples = [ Linear_angle (Int 0) ]
 end

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -364,7 +364,7 @@ module Handler = struct
             Css.mask_image (Var var_ref);
           ]
     | Bracket_image v -> (
-        let css_str = String.map (fun c -> if c = '_' then ' ' else c) v in
+        let css_str = Parse.decode_underscores v in
         match Css.parse_background_image css_str with
         | Some (img :: _) ->
             style [ Css.webkit_mask_image img; Css.mask_image img ]
@@ -433,7 +433,7 @@ module Handler = struct
      whether the value parser accepts it, not which gradient function it
      names. *)
   let is_image_value inner =
-    let css_str = String.map (fun c -> if c = '_' then ' ' else c) inner in
+    let css_str = Parse.decode_underscores inner in
     match Css.parse_background_image css_str with
     | Some (_ :: _) -> true
     | _ -> false

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -40,7 +40,7 @@ let class_pseudo prefix cls pseudo =
     content uses underscores for spaces, e.g. "2n+1_of_.foo" → nth = 2n+1, of_ =
     Some [Class "foo"]. *)
 let parse_nth_selector expr =
-  let spaced = String.map (fun c -> if c = '_' then ' ' else c) expr in
+  let spaced = Parse.decode_underscores expr in
   Css.Selector.read_nth_selector (Cascade.Cursor.of_string spaced)
 
 (** Helper: breakpoint name for responsive modifiers *)
@@ -178,8 +178,7 @@ let nest_selector ~parent template =
     ":where(.group):hover" *)
 let parse_arbitrary_selector_content content anchor =
   let open Css.Selector in
-  (* Replace _ with space for Tailwind convention *)
-  let s = String.map (fun c -> if c = '_' then ' ' else c) content in
+  let s = Parse.decode_underscores content in
   combine (nest_selector ~parent:(where [ anchor ]) s) Descendant universal
 
 (** Build an anchor-based variant selector: :where(.anchor):pseudo combinator *)
@@ -991,7 +990,7 @@ let try_has_shorthand s =
    a compound and [[p_~_span]] is not, and only the grammar separates them. [_]
    stands for a space here, the decoding {!nest_selector} applies. *)
 let is_compound_selector inner =
-  let s = String.map (fun c -> if c = '_' then ' ' else c) inner in
+  let s = Parse.decode_underscores inner in
   let cursor = Cascade.Cursor.of_string s in
   match Css.Selector.read_strict_selector_list cursor with
   | exception (Cascade.Cursor.Parse_error _ | Invalid_argument _) -> false
@@ -1019,7 +1018,7 @@ let is_plain_ident str =
    selector browsers parse and keep although nothing ever matches it, so it is
    not a variant. An underscore stands for a space, so it is empty as well. *)
 let names_attribute expr =
-  let decoded = String.map (fun c -> if c = '_' then ' ' else c) expr in
+  let decoded = Parse.decode_underscores expr in
   decoded <> "" && String.equal decoded (String.trim decoded)
 
 (* [group-data-dragging] is [group-data-[dragging]] with a different spelling,
@@ -1112,8 +1111,6 @@ let data_match_operator raw_expr =
   in
   go 0
 
-let decode_underscores s = String.map (fun c -> if c = '_' then ' ' else c) s
-
 (* Split a trailing case-sensitivity flag off a decoded value remainder:
    Selectors 4 requires whitespace before [i]/[s], which is what Tailwind's own
    underscore convention spells too once the underscore before the flag decodes
@@ -1165,12 +1162,12 @@ let data_attribute_of_bracket bracket =
 let parse_data_expr raw_expr =
   match data_match_operator raw_expr with
   | None ->
-      let name = String.trim (decode_underscores raw_expr) in
+      let name = String.trim (Parse.decode_underscores raw_expr) in
       data_attribute_of_bracket ("[data-" ^ name ^ "]")
   | Some (op_pos, op_len) ->
       let len = String.length raw_expr in
       let name =
-        String.trim (decode_underscores (String.sub raw_expr 0 op_pos))
+        String.trim (Parse.decode_underscores (String.sub raw_expr 0 op_pos))
       in
       (* Validated here, on its own: folded straight into the reconstructed text
          below, a name ending in one of [$ ^ * ~ |] would recombine with the
@@ -1182,7 +1179,7 @@ let parse_data_expr raw_expr =
       let op_text = String.sub raw_expr op_pos op_len in
       let rest =
         String.trim
-          (decode_underscores
+          (Parse.decode_underscores
              (String.sub raw_expr (op_pos + op_len) (len - op_pos - op_len)))
       in
       let value, flag_text = split_trailing_flag rest in
@@ -1212,8 +1209,7 @@ let try_bracket_at_rule s =
   else None
 
 let normalize_supports_condition condition_str =
-  (* Convert underscores to spaces (Tailwind bracket notation) *)
-  let cond = String.map (fun c -> if c = '_' then ' ' else c) condition_str in
+  let cond = Parse.decode_underscores condition_str in
   if
     String.length cond > 2
     && cond.[0] = '-'
@@ -1679,7 +1675,7 @@ let is_not_compatible = function
    so the cursor has to be exhausted too: a trailing remainder would otherwise
    be dropped and the rule would negate less than the class says. *)
 let reads_as_selector content =
-  let s = String.map (fun c -> if c = '_' then ' ' else c) content in
+  let s = Parse.decode_underscores content in
   let cursor = Cascade.Cursor.of_string s in
   match Css.Selector.read cursor with
   | exception (Cascade.Cursor.Parse_error _ | Invalid_argument _) -> false

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -111,8 +111,9 @@ let bracket_inner s =
   if is_bracket_value s then String.sub s 1 (String.length s - 2) else s
 
 (* In an arbitrary value [_] stands for a space, and [\_] for a literal
-   underscore — otherwise a value that needs one could not be written. *)
-let decode_underscores s =
+   underscore — otherwise a value that needs one could not be written. The two
+   readings differ only in what a bare [_] stands for, which [plain] carries. *)
+let read_underscores ~plain s =
   let len = String.length s in
   let buf = Buffer.create len in
   let rec go i =
@@ -122,11 +123,29 @@ let decode_underscores s =
       go (i + 2)
     end
     else begin
-      Buffer.add_char buf (if s.[i] = '_' then ' ' else s.[i]);
+      Buffer.add_char buf (if s.[i] = '_' then plain else s.[i]);
       go (i + 1)
     end
   in
   go 0;
+  Buffer.contents buf
+
+let decode_underscores s = read_underscores ~plain:' ' s
+
+(* A property name has no spaces to spell, so its underscores stand for
+   themselves and only the escape is undone. *)
+let unescape_underscores s = read_underscores ~plain:'_' s
+
+(* The inverse: a utility holding a decoded value writes its class name back,
+   and the name has to read as the value it came from. *)
+let encode_underscores s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (function
+      | ' ' -> Buffer.add_char buf '_'
+      | '_' -> Buffer.add_string buf {|\_|}
+      | c -> Buffer.add_char buf c)
+    s;
   Buffer.contents buf
 
 let function_name_before s i =

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -64,6 +64,18 @@ val decode_underscores : string -> string
 (** [decode_underscores s] turns the [_] of an arbitrary value into a space, and
     [\_] into a literal underscore. *)
 
+val unescape_underscores : string -> string
+(** [unescape_underscores s] turns the [\_] of an arbitrary value into a literal
+    underscore and leaves a bare [_] alone. This is the reading a property name
+    takes: [[--my\_var:red]] and [[--my_var:red]] both declare [--my_var], where
+    {!decode_underscores} would give the first a space. *)
+
+val encode_underscores : string -> string
+(** [encode_underscores s] writes a decoded value back into the arbitrary
+    spelling a class name carries, turning a space into [_] and an underscore
+    into [\_]. It is the inverse of {!decode_underscores}, which is what a
+    utility holding its value decoded needs to name itself. *)
+
 val decode_arbitrary_value : string -> string
 (** [decode_arbitrary_value s] decodes Tailwind arbitrary-value syntax into a
     CSS value string suitable for Cascade readers. This converts underscores to

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -765,10 +765,10 @@ let route_has_modifier modifier ~selector base_class props =
 
 (* Parse an aria expression string into an attribute name and match. "modal" →
    ("aria-modal", Presence) "valuenow=1" → ("aria-valuenow", Exact "1")
-   "invalid=spelling" → ("aria-invalid", Exact "spelling") Underscores in values
-   are replaced with spaces. *)
+   "invalid=spelling" → ("aria-invalid", Exact "spelling") The expression is an
+   arbitrary value, so [_] is a space in it and [\_] a literal underscore. *)
 let parse_aria_expr expr =
-  let expr = String.map (fun c -> if c = '_' then ' ' else c) expr in
+  let expr = Parse.decode_underscores expr in
   let expr = String.trim expr in
   match String.index_opt expr '=' with
   | None -> ("aria-" ^ expr, Css.Selector.Presence)
@@ -777,11 +777,16 @@ let parse_aria_expr expr =
       let raw_value =
         String.trim (String.sub expr (i + 1) (String.length expr - i - 1))
       in
-      (* Strip surrounding quotes if present *)
+      (* The quotes an author writes around the value are the attribute
+         selector's own, which the printer puts back; either style spells the
+         same value. *)
       let value =
         let len = String.length raw_value in
-        if len >= 2 && raw_value.[0] = '"' && raw_value.[len - 1] = '"' then
-          String.sub raw_value 1 (len - 2)
+        if
+          len >= 2
+          && (raw_value.[0] = '"' || raw_value.[0] = '\'')
+          && raw_value.[len - 1] = raw_value.[0]
+        then String.sub raw_value 1 (len - 2)
         else raw_value
       in
       ("aria-" ^ attr, Css.Selector.Exact value)
@@ -1184,8 +1189,7 @@ let handle_not_modifier ?theme inner_modifier base_class selector props =
     appropriate negated media condition. Handles double negation: not of "not
     (cond)" → positive cond. *)
 let parse_bracket_media content =
-  (* Convert underscores to spaces (Tailwind bracket convention) *)
-  let s = String.map (fun c -> if c = '_' then ' ' else c) content in
+  let s = Parse.decode_underscores content in
   (* Strip @media prefix *)
   let rest =
     String.trim
@@ -1317,7 +1321,7 @@ let handle_not_bracket content base_class props =
        [:not(.os-macos <star>)]. Parse the transformed string as a selector so
        combinators and compounds flatten, rather than escaping it as a single
        class name. *)
-    let sel_str = String.map (fun c -> if c = '_' then ' ' else c) content in
+    let sel_str = Parse.decode_underscores content in
     let inner =
       Cascade.Nest.substitute ~parent:Css.Selector.universal
         (Css.Selector.read (Cascade.Cursor.of_string sel_str))
@@ -1544,7 +1548,7 @@ let rec attach_to_subject extra sel =
 let arbitrary_selector_rule content base_class selector props =
   let open Css.Selector in
   (* In arbitrary variants, [_] denotes a space. *)
-  let s = String.map (fun c -> if c = '_' then ' ' else c) content in
+  let s = Parse.decode_underscores content in
   let modified_class = "[" ^ content ^ "]:" ^ base_class in
   (* What the inner rule compounded onto its own class, if that class is still
      the subject. Anything else (an inner variant that moved the subject) has no

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -124,7 +124,7 @@ module Handler = struct
      length, so a colour spelled any other way lands in a length slot. *)
   let scan_verbatim_colour (s : string) :
       (length * length * length option * arb_color) option =
-    let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
+    let normalized = Parse.decode_underscores s in
     let parts = String.split_on_char ' ' normalized in
     let rec find_color_and_lengths acc (parts : string list) :
         string list * arb_color =
@@ -165,7 +165,7 @@ module Handler = struct
     match scan_verbatim_colour s with
     | Some _ as shadow -> shadow
     | Stdlib.Option.None -> (
-        let normalized = String.map (fun c -> if c = '_' then ' ' else c) s in
+        let normalized = Parse.decode_underscores s in
         match Css.parse_shadow normalized with
         (* CSS text-shadow has no spread, so a body carrying one is not one. *)
         | Some

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1571,17 +1571,20 @@ module Handler = struct
         Ok (Rotate_bare_var (Parse.bare_var_inner n))
     | [ "rotate"; n ] when Parse.is_bracket_value n -> (
         let inner = String.sub n 1 (String.length n - 2) in
-        (* Check for 3D rotation: x y z angle (underscores as spaces) *)
-        let inner_spaced =
-          String.map (fun c -> if c = '_' then ' ' else c) inner
+        (* The 3D form is four components, [x y z <angle>]. [_] separates them
+           and [\_] is a literal underscore inside one, so the value is decoded
+           before it is split. What the axes take is a CSS number, which OCaml's
+           own float reader is wider than: it reads [1_2] as 12, where the value
+           is meant to reach the sheet as written. *)
+        let parts_3d =
+          String.split_on_char ' ' (Parse.decode_underscores inner)
         in
-        let parts_3d = String.split_on_char ' ' inner_spaced in
         match parts_3d with
         | [ x; y; z; a ] -> (
             match
-              ( Float.of_string_opt x,
-                Float.of_string_opt y,
-                Float.of_string_opt z,
+              ( Parse.decimal_float x,
+                Parse.decimal_float y,
+                Parse.decimal_float z,
                 parse_bracket_angle ("[" ^ a ^ "]") )
             with
             | Some fx, Some fy, Some fz, Ok (_, angle) ->

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -695,12 +695,16 @@ module Typography_early = struct
           | None ->
               if Parse.is_var inner then
                 Ok (Font_bracket_weight_var (inner, inner))
-                (* A family name is a list of idents or quoted strings; the
-                   docs' [<value>] placeholder is neither, and it used to be
-                   quoted into [font-family: "<value>"]. *)
-              else if is_font_family_value inner then
-                Ok (Font_bracket_family_name (inner, inner))
-              else err_not_utility)
+              else
+                (* A family name is a list of idents or quoted strings, so the
+                   docs' [<value>] placeholder is not one. [_] separates the
+                   words of a name and [\_] is a literal underscore inside one,
+                   so the stack is read decoded while the class keeps the
+                   spelling it was written with. *)
+                let decoded = Parse.decode_underscores inner in
+                if is_font_family_value decoded then
+                  Ok (Font_bracket_family_name (inner, decoded))
+                else err_not_utility)
     | [ "font"; "features"; v ] when Parse.is_bracket_value v ->
         let inner = Parse.bracket_inner v in
         if Parse.is_var inner then Ok (Font_features_var inner)
@@ -2130,7 +2134,7 @@ module Typography_late = struct
           && String.get joined (String.length joined - 1) = ']'
         then begin
           let inner = String.sub joined 1 (String.length joined - 2) in
-          let spaced = String.map (fun c -> if c = '_' then ' ' else c) inner in
+          let spaced = Parse.decode_underscores inner in
           match
             Cascade.Cursor.try_parse_full_err Css.Properties.read_content
               (Cascade.Cursor.of_string spaced)
@@ -2983,8 +2987,7 @@ module Typography_late = struct
     style [ content_decl; content None ]
 
   let content s =
-    (* Convert underscores to spaces in content values *)
-    let value = String.map (fun c -> if c = '_' then ' ' else c) s in
+    let value = Parse.decode_underscores s in
     let content_decl, content_ref = Var.binding content_var (String value) in
     let property_rules = Var.property_rules content_var in
     style ~property_rules [ content_decl; content (Css.Var content_ref) ]

--- a/test/test_animations.ml
+++ b/test/test_animations.ml
@@ -227,8 +227,24 @@ let test_theme_animation_sorts_by_name () =
     ]
     (Test_helpers.selectors_in_layer "utilities" css)
 
+(* An animation shorthand separates its parts with the [_] that stands for a
+   space, so a keyframe name carrying an underscore of its own is written [\_]
+   and keeps the character. *)
+let test_shorthand_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the keyframe name" true
+    (Astring.String.is_infix ~affix:"animation: wiggle_x 1s infinite"
+       (css {|animate-[wiggle\_x_1s_infinite]|}))
+
 let tests =
   [
+    test_case "animation shorthand underscore escape" `Quick
+      test_shorthand_underscore_escape;
     test_case "transitions" `Quick test_transitions;
     test_case "animations" `Quick animate_utilities;
     test_case "duration + delay" `Quick test_duration_delay;

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -309,8 +309,24 @@ let test_sorts_by_declared_property () =
   Test_helpers.check_class_order ~test_name:"arbitrary property slots"
     [ "[order:3]"; "m-4"; "[display:grid]"; "p-4"; "[color:red]" ]
 
+(* A property name keeps the underscores it is written with, and [\_] is the
+   escape that spells one where the value grammar would read a space. Both
+   spellings name the same custom property; the backslash reached the sheet as a
+   character of the name. *)
+let test_property_underscore_escape () =
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " declares " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|[--my\_var:red]|} "--my_var: red";
+  has "[--my_var:red]" "--my_var: red"
+
 let tests =
   [
+    test_case "property name underscore escape" `Quick
+      test_property_underscore_escape;
     test_case "sorts by the property it declares" `Quick
       test_sorts_by_declared_property;
     test_case "invalid hex value" `Quick test_invalid_hex_value;

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -548,8 +548,28 @@ let test_gradient_interpolation () =
   has "bg-linear-45/foo" "--tw-gradient-position: 45deg in foo";
   has "bg-linear-to-r/foo" "--tw-gradient-position: to right in foo"
 
+(* An arbitrary value writes a space as [_] and a literal underscore as [\_], so
+   a file name or a gradient position carrying an underscore is written with the
+   escape rather than losing the character. *)
+let test_arbitrary_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|bg-[url('a\_b.png')]|} "background-image: url(a_b.png)";
+  has {|bg-linear-[to\_bottom]|} "--tw-gradient-position: to_bottom"
+
 let tests =
   [
+    test_case "arbitrary underscore escape" `Quick
+      test_arbitrary_underscore_escape;
     test_case "gradient interpolation" `Quick test_gradient_interpolation;
     test_case "gradient stop position units" `Quick
       test_gradient_stop_position_units;

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -1035,8 +1035,24 @@ let test_removed_mix_token_stays_runtime () =
     "removed theme token is not resolved through the default palette" false
     (Astring.String.is_infix ~affix:"oklch(63.7% .237 25.331)" css)
 
+(* A bracket colour reads [_] as a space, so a variable name carrying an
+   underscore is written [\_] and keeps the character. *)
+let test_bracket_colour_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the variable name" true
+    (Astring.String.is_infix ~affix:"color: light-dark(var(--a_b), red)"
+       (css {|text-[light-dark(var(--a\_b),red)]|}))
+
 let tests =
   [
+    ( "Bracket colour underscore escape",
+      `Quick,
+      test_bracket_colour_underscore_escape );
     ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
     ( "Colour variable name is one ident",
       `Quick,

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -570,8 +570,23 @@ let test_project_shadow_tokens () =
     "an undeclared shadow name is rejected" true
     (Result.is_error (Tw.of_string ~theme "shadow-nope"))
 
+(* A shadow's parts are separated by the [_] that stands for a space, so a
+   variable name carrying an underscore of its own is written [\_]. *)
+let test_shadow_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the variable name" true
+    (Astring.String.is_infix
+       ~affix:"0 0 0 1px var(--tw-shadow-color, var(--a_b))"
+       (css {|shadow-[0_0_0_1px_var(--a\_b)]|}))
+
 let tests =
   [
+    test_case "shadow underscore escape" `Quick test_shadow_underscore_escape;
     test_case "arbitrary bracket color token stream" `Quick
       test_arbitrary_bracket_color_token_stream;
     test_case "project shadow tokens" `Quick test_project_shadow_tokens;

--- a/test/test_grid_item.ml
+++ b/test/test_grid_item.ml
@@ -157,8 +157,23 @@ let test_invalid_arbitrary_grid_line () =
   renders "col-start-[7]";
   renders "row-end-[3]"
 
+(* A grid line is an arbitrary value: [_] is a space and [\_] a literal
+   underscore, so a variable name carrying one keeps the character. *)
+let test_grid_line_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the variable name" true
+    (Astring.String.is_infix ~affix:"grid-column-start: var(--a_b)"
+       (css {|col-start-[var(--a\_b)]|}))
+
 let tests =
   [
+    test_case "grid line underscore escape" `Quick
+      test_grid_line_underscore_escape;
     test_case "grid_item of_string - valid values" `Quick of_string_valid;
     test_case "grid_item of_string - invalid values" `Quick of_string_invalid;
     test_case "invalid arbitrary span" `Quick test_invalid_arbitrary_span;

--- a/test/test_interactivity.ml
+++ b/test/test_interactivity.ml
@@ -111,8 +111,24 @@ let test_invalid_arbitrary_will_change () =
   accepted "will-change-[opacity,transform]";
   accepted "will-change-[var(--x)]"
 
+(* A property name is an identifier, and an identifier may carry an underscore.
+   The arbitrary value spells that one [\_], so the class both parses and keeps
+   the character. *)
+let test_will_change_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the property name" true
+    (Astring.String.is_infix ~affix:"will-change: a_b"
+       (css {|will-change-[a\_b]|}))
+
 let tests =
   [
+    test_case "will-change underscore escape" `Quick
+      test_will_change_underscore_escape;
     test_case "select" `Quick test_select;
     test_case "scroll+snap" `Quick test_scroll_snap;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;

--- a/test/test_mask_gradient.ml
+++ b/test/test_mask_gradient.ml
@@ -118,9 +118,16 @@ let test_arbitrary_angle () =
   has "mask-linear-45" "--tw-mask-linear-position: calc(1deg * 45);";
   has "mask-linear-1" "--tw-mask-linear-position: 1deg;"
 
+(* A radial size is an arbitrary value: [_] is a space and [\_] a literal
+   underscore, so a variable name carrying one keeps the character. *)
+let test_radial_size_underscore_escape () =
+  has {|mask-radial-[var(--a\_b)]|} "--tw-mask-radial-size: var(--a_b);"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
+      Alcotest.test_case "radial size underscore escape" `Quick
+        test_radial_size_underscore_escape;
       Alcotest.test_case "from-0 keeps its px unit" `Quick
         test_from_zero_keeps_unit;
       Alcotest.test_case "colour stops" `Quick test_stop_colors;

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -160,9 +160,24 @@ let order_matches_tailwind () =
   Test_helpers.check_ordering_matches ~test_name:"mask order matches Tailwind"
     (Test_helpers.shuffle utilities)
 
+(* A mask image is an arbitrary value, so [_] is a space and [\_] a literal
+   underscore: a file name carrying one is written with the escape. *)
+let test_bracket_image_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the file name" true
+    (Astring.String.is_infix ~affix:"mask-image: url('a_b.png')"
+       (css {|mask-[url('a\_b.png')]|}))
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
+      Alcotest.test_case "mask image underscore escape" `Quick
+        test_bracket_image_underscore_escape;
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
       Alcotest.test_case "arbitrary mask layer list" `Quick

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -1385,10 +1385,35 @@ let test_silent_empty_variants_rejected () =
   check bool "not-hover still parses" true
     (Result.is_ok (Tw.of_string "not-hover:flex"))
 
+(* A variant's bracket is an arbitrary value too: [_] is a space and [\_] a
+   literal underscore. An attribute value, a [@supports] condition and a
+   selector each carry the escape into a different part of the rule. *)
+let test_variant_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    check bool
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|data-[foo=bar\_baz]:flex|} {|[data-foo="bar_baz"]|};
+  has {|supports-[--a\_b]:flex|} "@supports (--a_b: var(--tw))";
+  has {|[.a\_b]:flex|} ".a_b";
+  has {|group-[.a\_b_&]:flex|} ":is(.a_b :where(.group) *)";
+  has {|nth-[2n+1_of_.a\_b]:flex|} ":nth-child(2n+1 of .a_b)";
+  (* A bare [_] still stands for a space. *)
+  has "data-[foo=bar_baz]:flex" {|[data-foo="bar baz"]|}
+
 (* Extend the suite with new tests *)
 let tests =
   tests
   @ [
+      test_case "variant underscore escape" `Quick
+        test_variant_underscore_escape;
       test_case "invalid bracket modifiers" `Quick
         test_invalid_bracket_modifiers;
       test_case "valid bracket modifiers" `Quick test_valid_bracket_modifiers;

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -201,9 +201,22 @@ let test_spacing_shorthand_ignored_in_quotes () =
     (Astring.String.is_infix ~affix:{|content: "--spacing(1)"|}
        (css {|[content:"--spacing(1)"]|}))
 
+(* An arbitrary value writes a space as [_] and a literal underscore as [\_].
+   Every family reads its bracket through this, so the two spellings have to
+   stay apart wherever a value reaches the sheet. *)
+let test_underscore_escape () =
+  let reads name input expected =
+    Alcotest.(check string) name expected (Tw.Parse.decode_underscores input)
+  in
+  reads "a bare underscore is a space" "a_b" "a b";
+  reads "an escaped underscore is literal" {|a\_b|} "a_b";
+  reads "another escape is left alone" {|a\.b|} {|a\.b|};
+  reads "a trailing backslash is kept" {|a\|} {|a\|}
+
 let tests =
   Alcotest.
     [
+      test_case "underscore escape" `Quick test_underscore_escape;
       test_case "parse backslash escape in selector" `Quick
         test_escape_in_selector;
       test_case "double bracket class rejected" `Quick

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -615,8 +615,31 @@ let test_variant_outside_starting_style () =
       "dark:starting:opacity-50";
     ]
 
+(* The selector a variant's bracket spells reads [_] as a space and [\_] as a
+   literal underscore, so a class or an attribute value carrying one is written
+   with the escape. *)
+let test_selector_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|aria-[label=a\_b]:flex|} {|[aria-label="a_b"]|};
+  has {|not-[.a\_b]:flex|} ":not(.a_b)";
+  has {|[.a\_b_&]:flex|} ".a_b .";
+  (* A bare [_] still stands for a space. *)
+  has "aria-[label=a_b]:flex" {|[aria-label="a b"]|}
+
 let tests =
   [
+    test_case "selector underscore escape" `Quick
+      test_selector_underscore_escape;
     test_case "arbitrary selector combinator variants" `Quick
       test_arbitrary_selector_combinator;
     test_case "arbitrary anchor inside a quoted value" `Quick

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -233,10 +233,25 @@ let test_colour_hint_takes_a_colour () =
   (* The hint survives into the class name, so the class reads back. *)
   has "text-shadow-[color:red]" ".text-shadow-\\[color\\:red\\]"
 
+(* The shadow's parts are separated by the [_] that stands for a space, so a
+   variable name carrying an underscore of its own is written [\_]. *)
+let test_underscore_escape () =
+  let value cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  Alcotest.(check bool)
+    "an escaped underscore stays in the variable name" true
+    (Astring.String.is_infix
+       ~affix:"text-shadow: 0 0 1px var(--tw-text-shadow-color, var(--a_b))"
+       (value {|text-shadow-[0_0_1px_var(--a\_b)]|}))
+
 let tests =
   [
     Alcotest.test_case "colour hint takes a colour" `Quick
       test_colour_hint_takes_a_colour;
+    Alcotest.test_case "underscore escape" `Quick test_underscore_escape;
   ]
   @ Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -435,8 +435,28 @@ let test_property_rules_belong_to_transform () =
     "rotate-x-30 declares its own" true
     (property_rules "rotate-x-30" > 0)
 
+(* The 3D form of [rotate] is four space-separated components, and the [\_] that
+   spells a literal underscore belongs inside one of them rather than splitting
+   it. A component carrying one is not a CSS number, so the value stays as
+   written instead of being read as an axis and an angle. *)
+let test_rotate_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|rotate-[1_1_1\_2_45deg]|} "rotate: 1 1 1_2 45deg";
+  has {|rotate-[var(--a\_b)]|} "rotate: var(--a_b)"
+
 let tests =
   [
+    test_case "rotate underscore escape" `Quick test_rotate_underscore_escape;
     test_case "property rules belong to transform" `Quick
       test_property_rules_belong_to_transform;
     test_case "invalid arbitrary transform" `Quick

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -1202,8 +1202,33 @@ let test_project_tracking_token () =
     "an undeclared tracking name is rejected" true
     (Result.is_error (Tw.of_string ~theme "tracking-nope"))
 
+(* An arbitrary value writes a space as [_] and a literal underscore as [\_].
+   Both readings have to reach the value: a family name and a content string are
+   written by hand, so either character can be the one meant. *)
+let test_arbitrary_underscore_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|font-['My\_Font']|} "font-family: My_Font";
+  has "font-[Arial_Black]" {|font-family: "Arial Black"|};
+  has {|content-["hello\_world"]|} {|--tw-content: "hello_world"|};
+  has {|content-[attr(a\_b)]|} "--tw-content: attr(a_b)";
+  (* The single-quoted spelling already reads both, and stays that way. *)
+  has {|content-['hello\_world']|} {|--tw-content: 'hello_world'|};
+  has {|content-['hello_world']|} {|--tw-content: 'hello world'|}
+
 let tests =
   [
+    test_case "arbitrary underscore escape" `Quick
+      test_arbitrary_underscore_escape;
     test_case "invalid decoration bracket hex" `Quick
       test_invalid_decoration_bracket_hex;
     test_case "non-decimal integers" `Quick test_non_decimal_integers;


### PR DESCRIPTION
An arbitrary value spells a space as `_` and a literal underscore as `\_`.
Every family read only the first, so the backslash reached the sheet as a
character of the value and `font-['My\_Font']`, `[--my\_var:red]` and
`data-[foo=bar\_baz]:flex` named something the author never wrote.

A property name and a `url()` keep their bare underscores, so those two read
the same escape without turning `_` into a space.
