### PR TITLE
position: align start-* and end-* with Tailwind

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,10 @@
   any shape, and a negated arbitrary inset accepts a parenthesised calc body,
   so `-left-6/5`, `-top-2.5`, `-left-[(var(--a)+var(--b))]` and `translate-2`
   work alongside the numeric steps (#160, #166, #172, #186, #210, #646).
+- `start-*` and `end-*` carry the same inset scale as the physical sides and
+  keep the `calc(var(--spacing) * n)` Tailwind writes for every step, so
+  `start-px`, `start-0.5` and `start-1/2` resolve and `start-0` no longer drops
+  `--spacing` from the theme layer (#677).
 - Transforms, backgrounds, grids and typography take the keywords Tailwind
   documents: `translate-none`, `rotate-none`, `scale-none`, `perspective-near`,
   `duration-initial`, `ease-initial`, `via-none`, `grow-3`, `indent-px` and a

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -116,10 +116,19 @@ let named_inset_value name : Css.declaration * Css.length =
 let spacing_value ?theme n : Css.declaration * Css.length =
   Theme.spacing_calc ?theme n
 
-(* The physical/axis inset sides that take the spacing scale, so a fractional
-   step (top-2.5) or the px step (left-px) can share one constructor. *)
+(* The inset sides that take the spacing scale, so a fractional step (top-2.5)
+   or the px step (left-px) can share one constructor. *)
 module Side = struct
-  type t = Top | Right | Bottom | Left | Inset | Inset_x | Inset_y
+  type t =
+    | Top
+    | Right
+    | Bottom
+    | Left
+    | Inset
+    | Inset_x
+    | Inset_y
+    | Start
+    | End
 
   let name = function
     | Top -> "top"
@@ -129,6 +138,13 @@ module Side = struct
     | Inset -> "inset"
     | Inset_x -> "inset-x"
     | Inset_y -> "inset-y"
+    | Start -> "start"
+    | End -> "end"
+
+  (* Tailwind folds the zero and unit multipliers of the spacing scale to [0px]
+     and [var(--spacing)], but its [start]/[end] handler resolves the step
+     itself and keeps [calc(var(--spacing) * n)] for every step. *)
+  let folds_spacing_scale = function Start | End -> false | _ -> true
 end
 
 (* [top-2.5] / [right-0.5] / [left-px]: a spacing token that is not a plain
@@ -142,18 +158,23 @@ let parse_pos_spacing s : Style.spacing option =
 
 (* Resolve a spacing token to (optional --spacing binding, length), mirroring
    the padding family so the px and fractional steps render identically. *)
-let len_of_pos_spacing ?theme (s : Style.spacing) :
+let len_of_pos_spacing ?theme side (s : Style.spacing) :
     Css.declaration option * Css.length =
   match s with
   | `Rem f ->
-      let decl, len = Theme.spacing_calc_float ?theme (f /. 0.25) in
+      let step = f /. 0.25 in
+      let decl, len =
+        if Side.folds_spacing_scale side then
+          Theme.spacing_calc_float ?theme step
+        else Theme.spacing_product ?theme step
+      in
       (Some decl, len)
   | `Px -> (None, Css.Px 1.)
   | `Full -> (None, Css.Pct 100.)
   | `Named name -> (None, Css.Var (Var.theme_ref ("spacing-" ^ name)))
 
 let pos_spacing_style ?theme side (s : Style.spacing) =
-  let decl_opt, len = len_of_pos_spacing ?theme s in
+  let decl_opt, len = len_of_pos_spacing ?theme side s in
   let decls = Option.to_list decl_opt in
   let body =
     match side with
@@ -164,6 +185,8 @@ let pos_spacing_style ?theme side (s : Style.spacing) =
     | Side.Inset -> [ Css.inset [ len ] ]
     | Side.Inset_x -> [ Css.inset_inline [ len ] ]
     | Side.Inset_y -> [ Css.inset_block [ len ] ]
+    | Side.Start -> [ Css.inset_inline_start len ]
+    | Side.End -> [ Css.inset_inline_end len ]
   in
   Style.style (decls @ body)
 
@@ -174,7 +197,7 @@ let neg_pos_spacing_style ?theme side (s : Style.spacing) =
   let negated : Style.spacing =
     match s with `Rem f -> `Rem (-.f) | other -> other
   in
-  let decl_opt, len = len_of_pos_spacing ?theme negated in
+  let decl_opt, len = len_of_pos_spacing ?theme side negated in
   let len = match s with `Px -> negate_length len | _ -> len in
   let decls = Option.to_list decl_opt in
   let body =
@@ -186,6 +209,8 @@ let neg_pos_spacing_style ?theme side (s : Style.spacing) =
     | Side.Inset -> [ Css.inset [ len ] ]
     | Side.Inset_x -> [ Css.inset_inline [ len ] ]
     | Side.Inset_y -> [ Css.inset_block [ len ] ]
+    | Side.Start -> [ Css.inset_inline_start len ]
+    | Side.End -> [ Css.inset_inline_end len ]
   in
   Style.style (decls @ body)
 
@@ -316,14 +341,16 @@ module Handler = struct
     | Neg_left_arbitrary of string * Css.length
       (* raw bracket suffix kept for the class name; value is negated *)
     | Left_named of string
-    | Start of int
     | Start_auto
     | Start_full
-    | Start_3_4
-    | End of int
+    | Neg_start_full
+    | Start_fraction of string
+    | Neg_start_fraction of string
     | End_auto
     | End_full
-    | End_3_4
+    | Neg_end_full
+    | End_fraction of string
+    | Neg_end_fraction of string
 
   (** Extensible variant for position utilities *)
 
@@ -485,18 +512,17 @@ module Handler = struct
     | Left_named name ->
         let decl, value = named_inset_value name in
         style (decl :: [ Css.left value ])
-    | Start n ->
-        let decl, value = spacing_value n in
-        style (decl :: [ Css.inset_inline_start value ])
     | Start_auto -> style [ Css.inset_inline_start Auto ]
     | Start_full -> style [ Css.inset_inline_start (Pct 100.0) ]
-    | Start_3_4 -> style [ Css.inset_inline_start (Pct 75.0) ]
-    | End n ->
-        let decl, value = spacing_value n in
-        style (decl :: [ Css.inset_inline_end value ])
+    | Neg_start_full -> style [ Css.inset_inline_start (Pct (-100.0)) ]
+    | Start_fraction f -> style [ Css.inset_inline_start (Pct (frac_pct f)) ]
+    | Neg_start_fraction f ->
+        style [ Css.inset_inline_start (Pct (-.frac_pct f)) ]
     | End_auto -> style [ Css.inset_inline_end Auto ]
     | End_full -> style [ Css.inset_inline_end (Pct 100.0) ]
-    | End_3_4 -> style [ Css.inset_inline_end (Pct 75.0) ]
+    | Neg_end_full -> style [ Css.inset_inline_end (Pct (-100.0)) ]
+    | End_fraction f -> style [ Css.inset_inline_end (Pct (frac_pct f)) ]
+    | Neg_end_fraction f -> style [ Css.inset_inline_end (Pct (-.frac_pct f)) ]
 
   let int_of_string_with_sign = Parse.int_any
 
@@ -539,13 +565,17 @@ module Handler = struct
     | Inset_y_0 | Inset_y_auto | Inset_y_full | Neg_inset_y_full | Inset_y_3_4
     | Inset_y _ | Inset_y_arbitrary _ | Inset_y_named _ ->
         inset_y
+    | Pos_spacing (Side.Start, _)
+    | Neg_pos_spacing (Side.Start, _)
     | Inset_s _ | Inset_s_arbitrary _ | Inset_s_named _ | Inset_s_auto
-    | Inset_s_full | Neg_inset_s_full | Inset_s_3_4 | Start _ | Start_auto
-    | Start_full | Start_3_4 ->
+    | Inset_s_full | Neg_inset_s_full | Inset_s_3_4 | Start_auto | Start_full
+    | Neg_start_full | Start_fraction _ | Neg_start_fraction _ ->
         start
+    | Pos_spacing (Side.End, _)
+    | Neg_pos_spacing (Side.End, _)
     | Inset_e _ | Inset_e_arbitrary _ | Inset_e_named _ | Inset_e_auto
-    | Inset_e_full | Neg_inset_e_full | Inset_e_3_4 | End _ | End_auto
-    | End_full | End_3_4 ->
+    | Inset_e_full | Neg_inset_e_full | Inset_e_3_4 | End_auto | End_full
+    | Neg_end_full | End_fraction _ | Neg_end_fraction _ ->
         e
     | Inset_bs _ | Inset_bs_arbitrary _ | Inset_bs_named _ | Inset_bs_auto
     | Inset_bs_full | Neg_inset_bs_full | Inset_bs_3_4 ->
@@ -597,6 +627,14 @@ module Handler = struct
       | Some (`Rem f) when not (Theme.has_spacing_step ~theme (f /. 0.25)) ->
           None
       | parsed -> parsed
+    in
+    (* [start-4] and [start-0.5] share one constructor: the logical inline sides
+       have no separate integer step, so their reader spans the scale. *)
+    let parse_scale_step n : Style.spacing option =
+      match int_of_string_with_sign n with
+      | Ok x when x >= 0 -> Some (`Rem (float_of_int x *. 0.25))
+      | Ok _ -> None
+      | Error _ -> parse_pos_spacing n
     in
     let parts = Parse.split_class class_name in
     match parts with
@@ -855,19 +893,32 @@ module Handler = struct
                 match parse_pos_spacing n with
                 | Some sp -> Ok (Neg_pos_spacing (Side.Left, sp))
                 | None -> Error (`Msg "invalid"))))
-    | [ "start"; "3/4" ] -> Ok Start_3_4
     | [ "start"; "auto" ] -> Ok Start_auto
     | [ "start"; "full" ] -> Ok Start_full
-    | [ "start"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Start x)
-    | [ ""; "start"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Start (-x))
-    | [ "end"; "3/4" ] -> Ok End_3_4
+    | [ ""; "start"; "full" ] -> Ok Neg_start_full
+    | [ "start"; frac ] when frac_valid frac -> Ok (Start_fraction frac)
+    | [ ""; "start"; frac ] when frac_valid frac -> Ok (Neg_start_fraction frac)
+    | [ "start"; n ] -> (
+        match parse_scale_step n with
+        | Some sp -> Ok (Pos_spacing (Side.Start, sp))
+        | None -> Error (`Msg "invalid"))
+    | [ ""; "start"; n ] -> (
+        match parse_scale_step n with
+        | Some sp -> Ok (Neg_pos_spacing (Side.Start, sp))
+        | None -> Error (`Msg "invalid"))
     | [ "end"; "auto" ] -> Ok End_auto
     | [ "end"; "full" ] -> Ok End_full
-    | [ "end"; n ] -> int_of_string_with_sign n |> Result.map (fun x -> End x)
-    | [ ""; "end"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> End (-x))
+    | [ ""; "end"; "full" ] -> Ok Neg_end_full
+    | [ "end"; frac ] when frac_valid frac -> Ok (End_fraction frac)
+    | [ ""; "end"; frac ] when frac_valid frac -> Ok (Neg_end_fraction frac)
+    | [ "end"; n ] -> (
+        match parse_scale_step n with
+        | Some sp -> Ok (Pos_spacing (Side.End, sp))
+        | None -> Error (`Msg "invalid"))
+    | [ ""; "end"; n ] -> (
+        match parse_scale_step n with
+        | Some sp -> Ok (Neg_pos_spacing (Side.End, sp))
+        | None -> Error (`Msg "invalid"))
     | _ -> Error (`Msg "Not a position utility")
 
   let to_class = function
@@ -992,18 +1043,16 @@ module Handler = struct
     | Left_arbitrary (raw, _) -> "left-" ^ raw
     | Neg_left_arbitrary (raw, _) -> "-left-" ^ raw
     | Left_named name -> "left-" ^ name
-    | Start_3_4 -> "start-3/4"
     | Start_auto -> "start-auto"
     | Start_full -> "start-full"
-    | Start n ->
-        let prefix = if n < 0 then "-" else "" in
-        prefix ^ "start-" ^ string_of_int (abs n)
-    | End_3_4 -> "end-3/4"
+    | Neg_start_full -> "-start-full"
+    | Start_fraction f -> "start-" ^ f
+    | Neg_start_fraction f -> "-start-" ^ f
     | End_auto -> "end-auto"
     | End_full -> "end-full"
-    | End n ->
-        let prefix = if n < 0 then "-" else "" in
-        prefix ^ "end-" ^ string_of_int (abs n)
+    | Neg_end_full -> "-end-full"
+    | End_fraction f -> "end-" ^ f
+    | Neg_end_fraction f -> "-end-" ^ f
 
   let examples =
     [

--- a/lib/theme.ml
+++ b/lib/theme.ml
@@ -60,28 +60,53 @@ let has_spacing_step ?theme n =
   && explicit_spacing scheme (int_of_float (Float.abs n)) <> None
   || Scheme.token scheme (Var.name spacing_var) <> None
 
+(* The step the scheme binds outright, as var(--spacing-|n|) with a negative
+   multiplier folded into calc(... * -1). None when the scheme binds no such
+   step, or when the step is not a whole one: only whole steps get a token. *)
+let explicit_spacing_length ?theme (n : float) =
+  let abs_n = Float.abs n in
+  if not (Float.is_integer abs_n) then None
+  else
+    let abs_n = int_of_float abs_n in
+    match explicit_spacing (resolve_scheme theme) abs_n with
+    | None -> None
+    | Some explicit_length ->
+        let spacing_n = spacing_n_var abs_n in
+        let decl, spacing_ref = Var.binding spacing_n explicit_length in
+        if n < 0.0 then
+          (* Negative: wrap in calc(... * -1) *)
+          let neg_len : Css.length =
+            Css.Calc
+              (Css.Calc.mul
+                 (Css.Calc.length (Css.Var spacing_ref))
+                 (Css.Calc.float (-1.0)))
+          in
+          Some (decl, neg_len)
+        else Some (decl, (Css.Var spacing_ref : Css.length))
+
+(* The spacing step times [n], written out as calc(var(--spacing) * n). The
+   product is what a utility emits when the scheme binds no token for the step
+   and the multiplier is not one Tailwind folds. *)
+let spacing_product ?theme (n : float) : Css.declaration * Css.length =
+  match explicit_spacing_length ?theme n with
+  | Some result -> result
+  | None ->
+      let decl, spacing_ref = Var.binding spacing_var spacing_base in
+      let len : Css.length =
+        Css.Calc
+          (Css.Calc.mul
+             (Css.Calc.length (Css.Var spacing_ref))
+             (Css.Calc.float n))
+      in
+      (decl, len)
+
 (* Create a spacing length value. When scheme has explicit spacing for |n|,
    returns var(--spacing-|n|) or calc(var(--spacing-|n|) * -1) for negatives.
-   Otherwise returns calc(var(--spacing) * n). Returns the theme declaration and
-   the length. *)
+   Otherwise returns calc(var(--spacing) * n), with the zero and unit
+   multipliers folded the way Tailwind folds them. *)
 let spacing_calc ?theme n : Css.declaration * Css.length =
-  let abs_n = abs n in
-  let is_negative = n < 0 in
-  match explicit_spacing (resolve_scheme theme) abs_n with
-  | Some explicit_length ->
-      (* Scheme has explicit spacing: use var(--spacing-|n|) *)
-      let spacing_n = spacing_n_var abs_n in
-      let decl, spacing_ref = Var.binding spacing_n explicit_length in
-      if is_negative then
-        (* Negative: wrap in calc(... * -1) *)
-        let neg_len : Css.length =
-          Css.Calc
-            (Css.Calc.mul
-               (Css.Calc.length (Css.Var spacing_ref))
-               (Css.Calc.float (-1.0)))
-        in
-        (decl, neg_len)
-      else (decl, (Css.Var spacing_ref : Css.length))
+  match explicit_spacing_length ?theme (float_of_int n) with
+  | Some result -> result
   | None ->
       (* Default: calc(var(--spacing) * n). For the unit multiplier we emit a
          bare var(--spacing) rather than calc(var(--spacing) * 1). This shortcut
@@ -98,41 +123,22 @@ let spacing_calc ?theme n : Css.declaration * Css.length =
          initial value, whereas calc(var(--spacing) * 1) would still compute
          (4px). We inherit this fragility from Tailwind. cascade must not
          perform the equivalent calc(var(--spacing)) -> var(--spacing) rewrite,
-         because it optimises arbitrary CSS and cannot assume that contract. *)
-      let decl, spacing_ref = Var.binding spacing_var spacing_base in
-      (* The zero step is a plain [0px], as Tailwind emits it: the scale factor
+         because it optimises arbitrary CSS and cannot assume that contract.
+
+         The zero step is a plain [0px], as Tailwind emits it: the scale factor
          makes [calc(var(--spacing) * 0)] zero for any spacing, and only the
          optimiser can see that once [--spacing] is a literal. *)
-      if n = 0 then (decl, (Px 0. : Css.length))
-      else if n = 1 then (decl, (Css.Var spacing_ref : Css.length))
+      if n <> 0 && n <> 1 then spacing_product ?theme (float_of_int n)
       else
-        let len : Css.length =
-          Css.Calc
-            (Css.Calc.mul
-               (Css.Calc.length (Css.Var spacing_ref))
-               (Css.Calc.float (float_of_int n)))
-        in
-        (decl, len)
+        let decl, spacing_ref = Var.binding spacing_var spacing_base in
+        if n = 0 then (decl, (Px 0. : Css.length))
+        else (decl, (Css.Var spacing_ref : Css.length))
 
 (* Create a spacing length value for float multipliers like 2.5. For integer
    values, checks scheme for explicit spacing. Otherwise uses calc. This handles
    cases like my-2.5 which need calc(var(--spacing) * 2.5). *)
 let spacing_calc_float ?theme (n : float) : Css.declaration * Css.length =
-  let abs_n = Float.abs n in
-  let is_negative = n < 0.0 in
-  (* Check if this is an integer value that might have explicit spacing *)
-  let is_integer = Float.is_integer abs_n in
-  if is_integer then
-    (* Use integer version which checks scheme *)
-    spacing_calc ?theme (int_of_float n)
-  else
-    (* Fractional value: always use calc *)
-    let decl, spacing_ref = Var.binding spacing_var spacing_base in
-    let mult = if is_negative then -.abs_n else abs_n in
-    let len : Css.length =
-      Css.Calc
-        (Css.Calc.mul
-           (Css.Calc.length (Css.Var spacing_ref))
-           (Css.Calc.float mult))
-    in
-    (decl, len)
+  (* Only an integer step can be bound outright by the scheme, and only an
+     integer step folds. *)
+  if Float.is_integer n then spacing_calc ?theme (int_of_float n)
+  else spacing_product ?theme n

--- a/lib/theme.mli
+++ b/lib/theme.mli
@@ -38,3 +38,10 @@ val spacing_calc_float :
   ?theme:Scheme.t -> float -> Css.declaration * Css.length
 (** [spacing_calc_float ?theme n] is like {!spacing_calc} but accepts float
     multipliers such as [2.5] for classes like [my-2.5]. *)
+
+val spacing_product : ?theme:Scheme.t -> float -> Css.declaration * Css.length
+(** [spacing_product ?theme n] is {!spacing_calc_float} without the folding:
+    [calc(var(--spacing) * n)] for every multiplier, the zero and unit ones
+    included. A scheme that binds the step outright still wins, as it does for
+    {!spacing_calc}. Tailwind's [start-*] and [end-*] utilities resolve the step
+    themselves and write the product out in full. *)

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -244,6 +244,80 @@ let typed_prime () =
   check_class "top-4" (top 4);
   check_class "-top-4" (top (-4))
 
+(* Tailwind's start-* / end-* handler resolves the spacing step itself and
+   writes the product out in full, so the zero and unit multipliers keep
+   calc(var(--spacing) * n) where the physical sides fold them to 0px and
+   var(--spacing). The folded zero stops referencing --spacing, which also drops
+   the declaration the utility reads from the theme layer. *)
+let logical_inline_keeps_the_spacing_product () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let check_css cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  check_css "start-0" "inset-inline-start:calc(var(--spacing)*0)";
+  check_css "start-1" "inset-inline-start:calc(var(--spacing)*1)";
+  check_css "start-2" "inset-inline-start:calc(var(--spacing)*2)";
+  check_css "-start-4" "inset-inline-start:calc(var(--spacing)*-4)";
+  check_css "end-0" "inset-inline-end:calc(var(--spacing)*0)";
+  check_css "end-1" "inset-inline-end:calc(var(--spacing)*1)";
+  check_css "start-0" "--spacing:.25rem";
+  check_css "end-0" "--spacing:.25rem"
+
+(* The logical inline sides carry the same scale as the physical ones: the px
+   step, the fractional steps and the fractions, in both signs. *)
+let logical_inline_scale_steps () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let check_css cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  check_css "start-px" "inset-inline-start:1px";
+  check_css "-start-px" "inset-inline-start:-1px";
+  check_css "end-px" "inset-inline-end:1px";
+  check_css "start-0.5" "inset-inline-start:calc(var(--spacing)*.5)";
+  check_css "-start-0.5" "inset-inline-start:calc(var(--spacing)*-.5)";
+  check_css "end-0.5" "inset-inline-end:calc(var(--spacing)*.5)";
+  check_css "start-1/2" "inset-inline-start:50%";
+  check_css "-start-1/2" "inset-inline-start:-50%";
+  check_css "-start-full" "inset-inline-start:-100%";
+  check_css "-end-full" "inset-inline-end:-100%";
+  check "start-px";
+  check "end-px";
+  check "start-0.5";
+  check "start-1/2";
+  check "start-3/4";
+  check "start-2";
+  check "-start-4";
+  check "-start-full"
+
+(* Neither logical inline side is a utility without a scale value: a stray
+   source token, the negative of a keyword Tailwind only defines positive, and a
+   zero denominator are all rejected. *)
+let logical_inline_rejects_non_utilities () =
+  let reject c =
+    match Tw.of_string c with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s should not be a utility" c
+  in
+  reject "start-junk";
+  reject "end-junk";
+  reject "-start-auto";
+  reject "start-1/0";
+  reject "start-"
+
 let tests =
   [
     test_case "inset and z" `Quick test_inset_and_z;
@@ -267,6 +341,11 @@ let tests =
       inset_value_order_matches_tailwind;
     test_case "position candidate bands match Tailwind" `Quick
       position_candidate_bands_match_tailwind;
+    test_case "logical inline sides keep the spacing product" `Quick
+      logical_inline_keeps_the_spacing_product;
+    test_case "logical inline scale steps" `Quick logical_inline_scale_steps;
+    test_case "logical inline rejects non-utilities" `Quick
+      logical_inline_rejects_non_utilities;
   ]
 
 let suite = ("position", tests)


### PR DESCRIPTION
start-* and end-* folded the zero and unit spacing multipliers Tailwind writes out, which also dropped --spacing from the theme layer, and they rejected the px, fractional and fraction steps the physical inset sides accept.

Replaces #674, which GitHub auto-closed as merged during a restack while nothing landed on main.