### PR TITLE
tools: follow cascade 1.2.0 API changes

### DIFF
--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -140,7 +140,7 @@ let theme_tokens body =
           Some
             ( decl.Cascade.Component.loc.Cascade.Loc.start_pos,
               ( String.sub name 2 (String.length name - 2),
-                Cascade.Parser.to_string_custom value ) )
+                Cascade.Parser.string_of_components value ) )
         else None)
   in
   List.stable_sort

--- a/test/parity/measure.sh
+++ b/test/parity/measure.sh
@@ -39,7 +39,7 @@ dune build --root "$root" bin/main.exe cascade/bin/main.exe
 # report that reads as parity. Propagate it instead.
 status=0
 "$root"/_build/default/cascade/bin/main.exe \
-  diff --diff=canonical --depth=max "$out"/tw_all.css "$out"/ref_local.css \
+  diff --diff=canonical --limit=none "$out"/tw_all.css "$out"/ref_local.css \
   > "$out"/diff.txt 2>&1 || status=$?
 
 if [ "$status" -gt 1 ]; then


### PR DESCRIPTION
Cascade dropped `Parser.to_string_custom` for its identical twin `string_of_components`, and replaced the differ's `--depth=max` with `--limit=none`. tw pins cascade to its main branch, so both broke the build and the parity harness.