### PR TITLE
build: merge consecutive container and supports blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,9 @@
 - Merge adjacent media queries with identical conditions during utility
   construction, avoiding redundant wrappers without enabling full stylesheet
   optimization (#668).
+- Merge adjacent `@container` and `@supports` blocks with identical preludes
+  the same way, so a run of utilities sharing one condition is a single wrapper
+  and the sheet is smaller (#682).
 - A project's own theme reaches class generation, so its variants, keyframes,
   layers, static scales, custom breakpoints and v3 dotted `theme()` paths apply
   to the utilities tw generates from the markup, and a routed utility survives a

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -559,18 +559,23 @@ let rule_sets_from_selector_props order_map all_rules =
   sorted |> List.map indexed_rule_to_statement
 
 let utilities_layer ~layers ~statements =
-  (* Statements are already in the correct order, with adjacent equal media
-     conditions merged before the layer is assembled. *)
+  (* Statements are already in the correct order, with adjacent conditional
+     groups of equal prelude merged before the layer is assembled. *)
   if layers then Css.v [ Css.layer ~name:[ "utilities" ] statements ]
   else Css.v statements
 
-(* [@starting-style] carries no condition, so a run of [starting:] utilities is
-   one block in Tailwind's output. Each rule is wrapped on its own here, and
-   cascade collapses the run. *)
+(* Each utility is wrapped in its own conditional group, so a run of utilities
+   sharing one condition arrives here as a run of equal blocks where Tailwind
+   has a single one. Cascade collapses each run. [@starting-style] carries no
+   condition, so adjacency is its whole gate; the other three compare preludes
+   as well. Every pass merges adjacent blocks only, which leaves the rule order
+   the comparator produced untouched. *)
 let statements_of_sorted_rules ?verbatim sorted_rules =
   List.map (indexed_rule_to_statement ?verbatim) sorted_rules
   |> Css.Optimize.merge_consecutive_starting_style
   |> Css.Optimize.merge_consecutive_media
+  |> Css.Optimize.merge_consecutive_supports
+  |> Css.Optimize.merge_consecutive_containers
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)

--- a/test/test_build.ml
+++ b/test/test_build.ml
@@ -779,6 +779,97 @@ let test_container_and_media () =
   check bool "has media queries" true has_media;
   check bool "has container queries" true has_container
 
+(* Conditions of every [@container] block in the sheet, in source order. *)
+let container_conditions css =
+  Css.fold
+    (fun acc stmt ->
+      match Css.as_container stmt with
+      | Some (_, Some cond, _) -> Css.Container.to_string cond :: acc
+      | _ -> acc)
+    [] css
+  |> List.rev
+
+let selectors_in_container ~condition css =
+  Css.fold
+    (fun acc stmt ->
+      match Css.as_container stmt with
+      | Some (_, Some cond, inner)
+        when String.equal (Css.Container.to_string cond) condition ->
+          acc @ List.filter_map Css.statement_selector inner
+      | _ -> acc)
+    [] css
+
+let supports_conditions css =
+  Css.fold
+    (fun acc stmt ->
+      match Css.as_supports stmt with
+      | Some (cond, _) -> Css.Supports.to_string cond :: acc
+      | None -> acc)
+    [] css
+  |> List.rev
+
+let selectors_in_supports ~condition css =
+  Css.fold
+    (fun acc stmt ->
+      match Css.as_supports stmt with
+      | Some (cond, inner)
+        when String.equal (Css.Supports.to_string cond) condition ->
+          acc @ List.filter_map Css.statement_selector inner
+      | Some _ | None -> acc)
+    [] css
+
+(* Two utilities under one container query are a single block in Tailwind's
+   output. Merging is adjacency-only, so it never lifts a rule over another: the
+   merged block holds the selectors in the order the comparator gave them. *)
+let test_container_query_merge () =
+  let css =
+    Tw.Build.to_css
+      [ Tw.Containers.container_sm [ p 4 ]; Tw.Containers.container_sm [ m 2 ] ]
+  in
+  check (list string) "one consecutive container block" [ "(width >= 24rem)" ]
+    (container_conditions css);
+  check
+    (list Test_helpers.selector_testable)
+    "container block keeps rule order"
+    [ Css.Selector.class_ "@sm:m-2"; Css.Selector.class_ "@sm:p-4" ]
+    (selectors_in_container ~condition:"(width >= 24rem)" css)
+
+(* The same for [@supports], whose blocks carry a condition to compare in the
+   same way. *)
+let test_supports_merge () =
+  (* Preflight carries [@supports] blocks of its own, so the sheet is built
+     without the base layer to leave only the two under test. *)
+  let css =
+    Tw.Build.to_css
+      ~config:{ base = false; forms = None; layers = true }
+      [ supports "display:grid" [ p 4 ]; supports "display:grid" [ m 2 ] ]
+  in
+  check (list string) "one consecutive supports block" [ "(display: grid)" ]
+    (supports_conditions css);
+  check
+    (list Test_helpers.selector_testable)
+    "supports block keeps rule order"
+    [
+      Css.Selector.class_ "supports-[display:grid]:m-2";
+      Css.Selector.class_ "supports-[display:grid]:p-4";
+    ]
+    (selectors_in_supports ~condition:"(display: grid)" css)
+
+(* Only equal conditions collapse. Two container queries of different widths are
+   separate blocks whatever order the comparator puts them in. *)
+let test_container_merge_keeps_conditions_apart () =
+  let css =
+    Tw.Build.to_css
+      [
+        Tw.Containers.container_sm [ p 4 ];
+        Tw.Containers.container_md [ p 4 ];
+        Tw.Containers.container_sm [ m 2 ];
+      ]
+  in
+  check (list string) "unequal conditions stay apart"
+    [ "(width >= 24rem)"; "(width >= 28rem)" ]
+    (container_conditions css)
+
 let test_rule_sets () =
   let statements = Tw.Build.rule_sets [ p 4; sm [ m 2 ] ] in
   (* Check that we have statements *)
@@ -1216,6 +1307,10 @@ let tests =
     test_case "md:hover nests the hover gate" `Quick test_md_hover_extra_media;
     test_case "container hover nests the gate" `Quick test_container_hover_nests;
     test_case "container + media together" `Quick test_container_and_media;
+    test_case "consecutive container merge" `Quick test_container_query_merge;
+    test_case "consecutive supports merge" `Quick test_supports_merge;
+    test_case "container merge keeps conditions apart" `Quick
+      test_container_merge_keeps_conditions_apart;
     test_case "media query deduplication" `Quick test_media_query_deduplication;
     test_case "rule_sets" `Quick test_rule_sets;
     test_case "build_utilities_layer" `Quick test_build_utilities_layer;

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -331,6 +331,15 @@ let test_arbitrary_selector_stacking () =
   has "**:[svg]:first:sm:size-4"
     ":is(.\\*\\*\\:\\[svg\\]\\:first\\:sm\\:size-4 *):is(svg):first-child"
 
+let occurrences sub str =
+  let n = String.length sub in
+  let rec go i acc =
+    if i + n > String.length str then acc
+    else if String.sub str i n = sub then go (i + n) (acc + 1)
+    else go (i + 1) acc
+  in
+  go 0 0
+
 (* An opacity colour emits a progressive-enhancement @supports block beside its
    fallback. Under a variant the block used to carry the theme declaration a
    second time, and for the variants that set an order of their own it sorted
@@ -342,15 +351,6 @@ let test_opacity_supports_under_variant () =
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
   let s = css "hover:bg-red-500/50" in
-  let occurrences sub str =
-    let n = String.length sub in
-    let rec go i acc =
-      if i + n > String.length str then acc
-      else if String.sub str i n = sub then go (i + n) (acc + 1)
-      else go (i + 1) acc
-    in
-    go 0 0
-  in
   (* once in @layer theme, not again inside the @supports block *)
   check int "the theme token is declared once" 1
     (occurrences "--color-red-500:oklch" s);
@@ -365,18 +365,26 @@ let test_opacity_supports_under_variant () =
 (* A variant whose own effect is an at-rule wraps both halves of an opacity
    colour. The modern half still needs its inner color-mix feature query; losing
    it makes the nested output differ from Tailwind and leaves the enhancement at
-   the wrong structural depth. *)
+   the wrong structural depth. Tailwind opens the variant's at-rule once and
+   holds the fallback and the feature query inside it, in that order. *)
 let test_opacity_supports_inside_at_rule_variant () =
   let css cls =
     match Tw.of_string cls with
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
+  let modern = "@supports(color:color-mix(in lab,red,red)){" in
   let nested cls wrapper =
+    let s = css cls in
+    let opening = wrapper ^ "{" in
+    check int (cls ^ ": one wrapper") 1 (occurrences opening s);
     check bool cls true
-      (Astring.String.is_infix
-         ~affix:(wrapper ^ "{@supports(color:color-mix(in lab,red,red)){")
-         (css cls))
+      (match
+         ( Astring.String.find_sub ~sub:opening s,
+           Astring.String.find_sub ~sub:modern s )
+       with
+      | Some outer, Some inner -> outer < inner
+      | _ -> false)
   in
   nested "supports-backdrop-filter:bg-black/25"
     "@supports(backdrop-filter:var(--tw))";


### PR DESCRIPTION
Each utility is wrapped in its own conditional group, so a run of utilities sharing one condition left the sheet carrying a wrapper per rule where Tailwind carries one. Cascade already exposed the two passes; nothing here is new CSS behaviour, only fewer duplicate wrappers.

The merges are adjacency-only, so no rule moves: the whole-sheet selector sequence is unchanged and cascade's canonical differ calls the two sheets identical. The nesting test in test_rule.ml read tw's old unmerged shape and now reads Tailwind's.