### PR TITLE
transitions: give delay the arbitrary values duration takes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,9 @@
 
 ### Arbitrary values and validation
 
+- `delay-[...]` takes the arbitrary token streams `duration-[...]` already
+  took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
+  a `var()` fallback in either family decodes its underscores (#PR).
 - Preserve Tailwind's declaration-safe token-stream contract for arbitrary
   animation, background, divide, filter, shadow, ring, scrollbar, table,
   transform, transition and typography values, including values that are

--- a/lib/transitions.ml
+++ b/lib/transitions.ml
@@ -32,7 +32,7 @@ module Handler = struct
     | Duration_arbitrary of
         string * [ `Duration of Css.duration | `Raw of string ]
     | Delay of int
-    | Delay_arbitrary of string * Css.duration
+    | Delay_arbitrary of string * [ `Duration of Css.duration | `Raw of string ]
     | Ease_linear
     | Ease_in
     | Ease_out
@@ -547,7 +547,11 @@ module Handler = struct
               ])
 
   let delay n = style [ Css.transition_delay (Css.Ms (float_of_int n)) ]
-  let delay_arbitrary d = style [ Css.transition_delay d ]
+
+  let delay_arbitrary = function
+    | `Duration d -> style [ Css.transition_delay d ]
+    | `Raw raw ->
+        style (Option.to_list (Parse.opaque_declaration "transition-delay" raw))
 
   let to_style theme =
     let transition_all () = transition_all ~theme () in
@@ -613,6 +617,29 @@ module Handler = struct
 
   let ( >|= ) = Parse.( >|= )
 
+  (* [duration-] and [delay-] read a bracket the same way: a bare time keeps its
+     unit as a typed duration, and anything else Tailwind would accept passes
+     through as a declaration-safe token stream. *)
+  let arbitrary_time inner =
+    let timed suffix unit =
+      let num =
+        String.sub inner 0 (String.length inner - String.length suffix)
+      in
+      Option.map (fun f -> `Duration (unit f)) (float_of_string_opt num)
+    in
+    let typed =
+      if String.ends_with ~suffix:"ms" inner then timed "ms" (fun f -> Css.Ms f)
+      else if String.ends_with ~suffix:"s" inner then
+        timed "s" (fun f -> Css.S f)
+      else None
+    in
+    match typed with
+    | Some _ as value -> value
+    | None ->
+        Option.map
+          (fun value -> `Raw value)
+          (Parse.arbitrary_declaration_value inner)
+
   let of_class theme class_name =
     let parts = Parse.split_class class_name in
     match parts with
@@ -635,65 +662,21 @@ module Handler = struct
         | Some _ -> Ok (Transition_arbitrary inner)
         | None -> Error (`Msg "Invalid transition property"))
     | [ "transition" ] -> Ok Transition
-    | [ "duration"; n ] when String.length n > 0 && n.[0] = '[' ->
-        (* Arbitrary duration: duration-[300ms] *)
-        let len = String.length n in
-        if len > 2 && n.[len - 1] = ']' then
-          let inner = String.sub n 1 (len - 2) in
-          if String.ends_with ~suffix:"ms" inner then
-            let num = String.sub inner 0 (String.length inner - 2) in
-            match float_of_string_opt num with
-            | Some _ ->
-                Ok
-                  (Duration_arbitrary
-                     (inner, `Duration (Css.Ms (float_of_string num))))
-            | None -> (
-                match Parse.arbitrary_declaration_value inner with
-                | Some value -> Ok (Duration_arbitrary (inner, `Raw value))
-                | None -> Error (`Msg "Invalid duration value"))
-          else if String.ends_with ~suffix:"s" inner then
-            let num = String.sub inner 0 (String.length inner - 1) in
-            match float_of_string_opt num with
-            | Some _ ->
-                Ok
-                  (Duration_arbitrary
-                     (inner, `Duration (Css.S (float_of_string num))))
-            | None -> (
-                match Parse.arbitrary_declaration_value inner with
-                | Some value -> Ok (Duration_arbitrary (inner, `Raw value))
-                | None -> Error (`Msg "Invalid duration value"))
-          else
-            match Parse.arbitrary_declaration_value inner with
-            | Some value -> Ok (Duration_arbitrary (inner, `Raw value))
-            | None -> Error (`Msg "Invalid duration unit")
-        else Error (`Msg "Invalid arbitrary syntax")
+    | [ "duration"; n ] when Parse.is_bracket_value n -> (
+        (* Arbitrary duration: duration-[300ms], duration-[calc(1s+2s)] *)
+        let inner = Parse.bracket_inner n in
+        match arbitrary_time inner with
+        | Some value -> Ok (Duration_arbitrary (inner, value))
+        | None -> Error (`Msg "Invalid duration value"))
     | [ "duration"; "initial" ] -> Ok Duration_initial
     | [ "duration"; n ] ->
         Parse.int_pos ~name:"duration" n >|= fun n -> Duration n
-    | [ "delay"; n ] when String.length n > 0 && n.[0] = '[' ->
-        (* Arbitrary delay: delay-[300ms], delay-[var(--d)] *)
-        let len = String.length n in
-        if len > 2 && n.[len - 1] = ']' then
-          let inner = String.sub n 1 (len - 2) in
-          if Parse.is_var inner then
-            let dref : Css.duration Css.var =
-              Var.bracket (Parse.extract_var_name inner)
-            in
-            Ok (Delay_arbitrary (inner, (Css.Var dref : Css.duration)))
-          else if String.ends_with ~suffix:"ms" inner then
-            let num = String.sub inner 0 (String.length inner - 2) in
-            match float_of_string_opt num with
-            | Some _ ->
-                Ok (Delay_arbitrary (inner, Css.Ms (float_of_string num)))
-            | None -> Error (`Msg "Invalid delay value")
-          else if String.ends_with ~suffix:"s" inner then
-            let num = String.sub inner 0 (String.length inner - 1) in
-            match float_of_string_opt num with
-            | Some _ ->
-                Ok (Delay_arbitrary (inner, Css.S (float_of_string num)))
-            | None -> Error (`Msg "Invalid delay value")
-          else Error (`Msg "Invalid delay unit")
-        else Error (`Msg "Invalid arbitrary syntax")
+    | [ "delay"; n ] when Parse.is_bracket_value n -> (
+        (* Arbitrary delay: delay-[300ms], delay-[calc(1s+2s)] *)
+        let inner = Parse.bracket_inner n in
+        match arbitrary_time inner with
+        | Some value -> Ok (Delay_arbitrary (inner, value))
+        | None -> Error (`Msg "Invalid delay value"))
     | [ "delay"; n ] -> Parse.int_pos ~name:"delay" n >|= fun n -> Delay n
     | [ "ease"; "linear" ] -> Ok Ease_linear
     | [ "ease"; "in" ] -> Ok Ease_in

--- a/test/test_transitions.ml
+++ b/test/test_transitions.ml
@@ -12,9 +12,11 @@ let test_roundtrip () =
   check "duration-300";
   check "delay-150";
   check "delay-300";
-  (* Arbitrary delay accepts both time units and var(). *)
+  (* Arbitrary delay and duration take the same bracket values. *)
   check "delay-[300ms]";
   check "delay-[var(--d)]";
+  check "delay-[calc(1s+2s)]";
+  check "duration-[calc(1s+2s)]";
   check "ease-linear";
   check "ease-in";
   check "ease-out";
@@ -43,6 +45,36 @@ let test_initial_resets () =
   Alcotest.(check bool)
     "ease-initial sets --tw-ease:initial" true
     (Astring.String.is_infix ~affix:"--tw-ease:initial" (css "ease-initial"))
+
+(* Tailwind takes the same arbitrary token streams for [duration-] and [delay-]:
+   a math function, a theme function call and a var() reference all reach the
+   declaration, with underscores decoded to spaces. Only [duration-] also
+   mirrors the value into its channel variable. *)
+let test_arbitrary_token_streams_agree () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:false
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let emits cls affix =
+    Alcotest.(check bool)
+      (Fmt.str "%s emits %s" cls affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  emits "duration-150" "transition-duration: 150ms";
+  emits "delay-150" "transition-delay: 150ms";
+  emits "duration-[calc(1s+2s)]" "transition-duration: calc(1s + 2s)";
+  emits "delay-[calc(1s+2s)]" "transition-delay: calc(1s + 2s)";
+  emits "duration-[--spacing(1)]" "transition-duration: var(--spacing)";
+  emits "delay-[--spacing(1)]" "transition-delay: var(--spacing)";
+  emits "duration-[var(--x,_3s)]" "transition-duration: var(--x, 3s)";
+  emits "delay-[var(--x,_3s)]" "transition-delay: var(--x, 3s)";
+  (* The channel variable carries the same value, and only for duration. *)
+  emits "duration-[calc(1s+2s)]" "--tw-duration: calc(1s + 2s)";
+  Alcotest.(check bool)
+    "delay sets no duration channel" false
+    (Astring.String.is_infix ~affix:"--tw-duration" (css "delay-[calc(1s+2s)]"))
 
 (* Tailwind forwards a declaration-safe arbitrary transition-property token
    stream even when it is not a valid property-name list. *)
@@ -186,6 +218,8 @@ let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "initial resets" `Quick test_initial_resets;
+      Alcotest.test_case "arbitrary token streams agree" `Quick
+        test_arbitrary_token_streams_agree;
       Alcotest.test_case "arbitrary property token stream" `Quick
         test_arbitrary_property_token_stream;
       Alcotest.test_case "arbitrary ease token stream" `Quick


### PR DESCRIPTION
The delay arms had no fallback to the arbitrary declaration value, so delay-[calc(1s+2s)] and delay-[--spacing(1)] were dropped while the duration equivalents worked.