### PR TITLE
parse: read class suffixes as plain decimal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -188,6 +188,12 @@
 - A `var()` reference is read to its end wherever it appears, including inside
   a bracket value, so one carrying its own parentheses or a fallback is not
   truncated (#564).
+- A numeric class suffix is read as plain decimal rather than as an OCaml
+  literal: `stroke-0x4` emitted a `.stroke-4` nobody wrote, `/0x50` rode the
+  opacity modifier onto every colour utility, and `min-[0x600px]` manufactured
+  a working 1536px breakpoint. One fraction reader serves the sizing, position,
+  flex and translate families, so `top-1/7` and `basis-0/2` read like `w-1/7`
+  (#678).
 
 ### Colours and effects
 

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -1614,7 +1614,7 @@ module Handler = struct
     (* Percentage positions: from-0%, from-100% (integer only) *)
     | [ pct_str ] when String.ends_with ~suffix:"%" pct_str -> (
         let num_s = String.sub pct_str 0 (String.length pct_str - 1) in
-        match int_of_string_opt num_s with
+        match Parse.decimal_int num_s with
         | Some p -> gp (Percent (float_of_int p))
         | None -> Error (`Msg "Invalid gradient position"))
     (* Bracket with opacity: [#0088cc]/50, [#0088cc]/[0.5], [var(--x)]/50 *)
@@ -1778,7 +1778,7 @@ module Handler = struct
     (* bg-linear-{angle} and bg-linear-{angle}/interp *)
     | [ "bg"; "linear"; angle_mod ] -> (
         let angle_s, interp_opt = split_mod angle_mod in
-        match (int_of_string_opt angle_s, interp_opt) with
+        match (Parse.decimal_int angle_s, interp_opt) with
         | Some n, None -> Ok (Bg_linear_angle n)
         | Some n, Some interp -> (
             match interp_to_css_string interp with
@@ -1807,7 +1807,7 @@ module Handler = struct
     (* -bg-linear-{angle} and -bg-linear-{angle}/interp *)
     | [ ""; "bg"; "linear"; angle_mod ] -> (
         let angle_s, interp_opt = split_mod angle_mod in
-        match (int_of_string_opt angle_s, interp_opt) with
+        match (Parse.decimal_int angle_s, interp_opt) with
         | Some n, None -> Ok (Bg_linear_angle_neg n)
         | Some n, Some interp -> (
             match interp_to_css_string interp with
@@ -1833,7 +1833,7 @@ module Handler = struct
     (* bg-conic-{angle} and bg-conic-{angle}/interp *)
     | [ "bg"; "conic"; angle_mod ] -> (
         let angle_s, interp_opt = split_mod angle_mod in
-        match (int_of_string_opt angle_s, interp_opt) with
+        match (Parse.decimal_int angle_s, interp_opt) with
         | Some n, None -> Ok (Bg_conic_angle n)
         | Some n, Some interp -> (
             match interp_to_css_string interp with
@@ -1844,7 +1844,7 @@ module Handler = struct
     (* -bg-conic-{angle} and -bg-conic-{angle}/interp *)
     | [ ""; "bg"; "conic"; angle_mod ] -> (
         let angle_s, interp_opt = split_mod angle_mod in
-        match (int_of_string_opt angle_s, interp_opt) with
+        match (Parse.decimal_int angle_s, interp_opt) with
         | Some n, None -> Ok (Bg_conic_angle_neg n)
         | Some n, Some interp -> (
             match interp_to_css_string interp with

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1559,7 +1559,7 @@ let opacity_of_string ?theme opacity_str =
     else None
   else
     (* Numeric value like 50 or 2.5, or named opacity like half/custom *)
-    match float_of_string_opt opacity_str with
+    match Parse.decimal_float opacity_str with
     | Some f when f >= 0. ->
         Some (Opacity_percent { value = f; text = opacity_str })
     | _ ->
@@ -1617,7 +1617,7 @@ let shade_of_strings ?theme parts =
   | [ color_str; shade_str ] -> (
       match of_string color_str with
       | Ok color -> (
-          match int_of_string_opt shade_str with
+          match Parse.decimal_int shade_str with
           | Some shade
             when shade >= 0
                  && (not (is_shadeless color))
@@ -1658,7 +1658,7 @@ let shade_and_opacity_of_strings ?theme parts =
       in
       match of_string color_str with
       | Ok color -> (
-          match int_of_string_opt shade_str with
+          match Parse.decimal_int shade_str with
           | Some shade
             when shade >= 0
                  && (not (is_shadeless color))

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -2921,7 +2921,7 @@ module Handler = struct
     | [ "ring"; "4" ] -> Ok Ring_lg
     | [ "ring"; "8" ] -> Ok Ring_xl
     | [ "ring"; n ]
-      when match int_of_string_opt n with Some w -> w > 0 | None -> false ->
+      when match Parse.decimal_int n with Some w -> w > 0 | None -> false ->
         Ok (Ring_width (int_of_string n))
     | [ "ring"; "inset" ] -> Ok Ring_inset
     | [ "ring"; "transparent" ] -> Ok Ring_transparent

--- a/lib/filters.ml
+++ b/lib/filters.ml
@@ -1672,7 +1672,7 @@ module Handler = struct
         | Some _ -> Ok (Backdrop_opacity_arbitrary s)
         | None -> err_not_utility)
     | [ "backdrop"; "opacity"; n ] -> (
-        match float_of_string_opt n with
+        match Parse.decimal_float n with
         | Some f when f >= 0. -> Ok (Backdrop_opacity f)
         | _ -> err_not_utility)
     | [ "backdrop"; "saturate"; s ] when Parse.is_bracket_value s -> (

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -74,10 +74,13 @@ module Handler = struct
   (* flex-N: flex: N *)
   let flex_n_style n = style [ flex (Grow (Number (float_of_int n))) ]
 
-  (* flex-N/M: flex: (N/M * 100)% - evaluates the fraction *)
+  (* flex-N/M: flex: (N/M * 100)%, folded the way Tailwind folds it. *)
   let flex_fraction_style n m =
-    let pct_value = float_of_int n /. float_of_int m *. 100.0 in
-    style [ flex (Basis (Pct pct_value)) ]
+    style
+      [
+        flex
+          (Basis (Pct (Option.value ~default:0. (Parse.fraction_percent n m))));
+      ]
 
   (* Grow *)
   let flex_grow_utility = style [ flex_grow 1.0 ]
@@ -105,9 +108,10 @@ module Handler = struct
   let basis_full = style [ flex_basis (Pct 100.0) ]
 
   let basis_fraction_style n m =
-    let raw = float_of_int n /. float_of_int m *. 100.0 in
-    let pct_value = Float.round (raw *. 10000.0) /. 10000.0 in
-    style [ flex_basis (Pct pct_value) ]
+    style
+      [
+        flex_basis (Pct (Option.value ~default:0. (Parse.fraction_percent n m)));
+      ]
 
   (* [basis] lists --flex-basis, then --spacing, then --container, so a named
      size reads the first of those the theme defines. *)
@@ -255,14 +259,12 @@ module Handler = struct
 
   let err_not_utility = Error (`Msg "Not a flex property utility")
 
+  (* [basis-1/2] and [flex-1/2] fold the fraction to a percentage, which a zero
+     denominator has none of. Every other numerator and denominator reads. *)
   let parse_fraction s =
-    (* Parse "N/M" into (N, M) *)
-    match String.split_on_char '/' s with
-    | [ n_str; m_str ] -> (
-        match (int_of_string_opt n_str, int_of_string_opt m_str) with
-        | Some n, Some m when n > 0 && m > 0 -> Some (n, m)
-        | _ -> None)
-    | _ -> None
+    match Parse.fraction s with
+    | Some (n, m) when m > 0 -> Some (n, m)
+    | Some _ | None -> None
 
   (* The container scale, whose digit-led names ([2xl], [3xs])
      [is_named_spacing] rejects. *)
@@ -300,7 +302,7 @@ module Handler = struct
         | Some i -> Ok (Flex_grow_arbitrary i)
         | None -> err_not_utility)
     | [ "grow"; n ] -> (
-        match int_of_string_opt n with
+        match Parse.decimal_int n with
         | Some i when i > 0 -> Ok (Flex_grow_n i)
         | _ -> err_not_utility)
     | [ "flex"; "shrink" ] -> Ok Flex_shrink_legacy

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -310,7 +310,7 @@ module Handler = struct
     | [ "auto"; "cols"; "max" ] -> Ok Auto_cols_max
     | [ "auto"; "cols"; "fr" ] -> Ok Auto_cols_fr
     | [ "auto"; "cols"; n ] -> (
-        match float_of_string_opt n with
+        match Parse.decimal_float n with
         | Some f when f >= 0.0 -> Ok (Auto_cols_spacing f)
         | _ ->
             let len = String.length n in
@@ -328,7 +328,7 @@ module Handler = struct
     | [ "auto"; "rows"; "max" ] -> Ok Auto_rows_max
     | [ "auto"; "rows"; "fr" ] -> Ok Auto_rows_fr
     | [ "auto"; "rows"; n ] -> (
-        match float_of_string_opt n with
+        match Parse.decimal_float n with
         | Some f when f >= 0.0 -> Ok (Auto_rows_spacing f)
         | _ ->
             let len = String.length n in

--- a/lib/mask_gradient.ml
+++ b/lib/mask_gradient.ml
@@ -945,12 +945,12 @@ module Handler = struct
     then
       (* Percentage - must be non-negative integer *)
       let num_str = String.sub suffix 0 (String.length suffix - 1) in
-      match int_of_string_opt num_str with
+      match Parse.decimal_int num_str with
       | Some n when n >= 0 -> Option.some (Percent (Float.of_int n))
       | _ -> Option.none
     else
       (* Spacing multiplier - must be non-negative, integer or half *)
-      match float_of_string_opt suffix with
+      match Parse.decimal_float suffix with
       | Some n when is_valid_spacing n -> Option.some (Spacing n)
       | _ -> Option.none
 
@@ -1053,7 +1053,7 @@ module Handler = struct
           let inner = Parse.bracket_inner n in
           Ok (Linear_angle (Arb inner))
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i -> Ok (Linear_angle (Int i))
           | None -> Error (`Msg "Invalid mask-linear angle value"))
     (* -mask-linear-N (negative angle), -mask-linear-[arb] *)
@@ -1062,7 +1062,7 @@ module Handler = struct
           let inner = Parse.bracket_inner n in
           Ok (Linear_angle (Arb_neg inner))
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i -> Ok (Linear_angle (Int (-i)))
           | None -> Error (`Msg "Invalid negative mask-linear angle value"))
     (* mask-radial *)
@@ -1103,7 +1103,7 @@ module Handler = struct
           let inner = Parse.bracket_inner n in
           Ok (Conic_angle (Arb inner))
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i -> Ok (Conic_angle (Int i))
           | None -> Error (`Msg "Invalid mask-conic angle value"))
     (* -mask-conic-N (negative angle), -mask-conic-[arb] *)
@@ -1112,7 +1112,7 @@ module Handler = struct
           let inner = Parse.bracket_inner n in
           Ok (Conic_angle (Arb_neg inner))
         else
-          match int_of_string_opt n with
+          match Parse.decimal_int n with
           | Some i -> Ok (Conic_angle (Int (-i)))
           | None -> Error (`Msg "Invalid negative mask-conic angle value"))
     (* mask-circle, mask-ellipse *)

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1058,15 +1058,21 @@ let parse_css_length s : Style.arbitrary_length option =
     (Parse.arbitrary_length s)
 
 (* Parse a pixel value from a string like "600px" or "600", keeping the
-   spelling: it is what the variant's own class is named after. *)
+   spelling: it is what the variant's own class is named after. The digits are a
+   CSS number, which is not OCaml's: [0x600px] is neither a number nor a length,
+   and reading it as an OCaml float turned [min-[0x600px]] into a live 1536px
+   breakpoint out of a value Tailwind leaves for the browser to drop. *)
 let parse_px_value s =
   let digits =
     if String.ends_with ~suffix:"px" s then String.sub s 0 (String.length s - 2)
     else s
   in
-  match float_of_string_opt digits with
-  | Some px -> Some ({ px; text = s } : Style.arbitrary_px)
-  | None -> None
+  match
+    Cascade.Cursor.try_parse_full_err Css.Values.read_number
+      (Cascade.Cursor.of_string digits)
+  with
+  | Ok (Num px) -> Some ({ px; text = s } : Style.arbitrary_px)
+  | Ok _ | Error _ -> None
 
 (* Parse a has-selector string as a relative CSS selector ([:has()] accepts a
    bare leading combinator, e.g. [>div] or [~img]), with [&] resolved to the

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -31,6 +31,34 @@ let decimal_float s =
   in
   if plain then float_of_string_opt s else None
 
+(* A fraction suffix is two plain decimals around one [/]: [w-1/2], [top-3/8],
+   [basis-13/17]. Neither side carries a sign, neither takes a redundant leading
+   zero, and the denominator is drawn from no fixed list — Tailwind divides
+   whatever it is given. *)
+let fraction s =
+  match String.split_on_char '/' s with
+  | [ n; m ] when is_canonical_digits n && is_canonical_digits m -> (
+      match (int_of_string_opt n, int_of_string_opt m) with
+      | Some n, Some m -> Some (n, m)
+      | Some _, None | None, _ -> None)
+  | _ -> None
+
+(* [n/m] as the percentage Tailwind's [calc(n / m * 100%)] resolves to, folded
+   to the six significant figures its own printer keeps (33.3333, 8.33333). A
+   zero denominator has no percentage: Tailwind writes the division out for the
+   browser to fail on, so a family that folds it here has nothing to write. *)
+let fraction_percent n m =
+  if m = 0 then None
+  else if n = 0 then Some 0.
+  else
+    let pct = float_of_int n /. float_of_int m *. 100. in
+    let digits = 6. -. Float.ceil (Float.log10 pct) in
+    let factor = 10. ** digits in
+    Some (Float.round (pct *. factor) /. factor)
+
+let fraction_pct s =
+  match fraction s with Some (n, m) -> fraction_percent n m | None -> None
+
 let int_any s =
   match decimal_int s with
   | Some n -> Ok n

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -15,6 +15,21 @@ val decimal_float : string -> float option
     Exponents, digit separators, redundant leading or trailing zeroes, and
     missing digits around the decimal point are rejected. *)
 
+val fraction : string -> (int * int) option
+(** [fraction s] reads a fraction suffix such as ["1/2"] or ["13/17"] as its
+    numerator and denominator. Both are plain decimals with no sign and no
+    redundant leading zero; the denominator is drawn from no fixed list, and
+    zero is a value on either side. *)
+
+val fraction_percent : int -> int -> float option
+(** [fraction_percent n m] is the percentage Tailwind's [calc(n / m * 100%)]
+    computes, folded to six significant figures the way Tailwind's printer folds
+    it. A zero denominator is [None]: it has no percentage, and Tailwind writes
+    the division out instead. *)
+
+val fraction_pct : string -> float option
+(** [fraction_pct s] is {!fraction} put through {!fraction_percent}. *)
+
 val int_pos : name:string -> string -> (int, [> `Msg of string ]) result
 (** [int_pos ~name s] parses a non-negative integer from [s]. Returns [Ok n] if
     [s] is a decimal integer >= 0, otherwise [Error (`Msg msg)]. [name] is used

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -152,7 +152,7 @@ end
 let parse_pos_spacing s : Style.spacing option =
   if s = "px" then Some `Px
   else
-    match float_of_string_opt s with
+    match Parse.decimal_float s with
     | Some f when f >= 0. && not (Float.is_integer f) -> Some (`Rem (f *. 0.25))
     | _ -> None
 
@@ -214,30 +214,11 @@ let neg_pos_spacing_style ?theme side (s : Style.spacing) =
   in
   Style.style (decls @ body)
 
-(* A position fraction [n/m] resolves to [n/m * 100%], folded to 6 significant
-   figures like Tailwind (mirrors [Sizing]'s fraction handling, including the
-   supported denominators). *)
-let frac_num_den frac =
-  match String.split_on_char '/' frac with
-  | [ n; m ] -> (
-      match (int_of_string_opt n, int_of_string_opt m) with
-      | Some n, Some m
-        when m > 0 && n > 0 && List.mem m [ 2; 3; 4; 5; 6; 10; 12 ] ->
-          (* An improper fraction (6/5 -> 120%) is a valid position. *)
-          Some (n, m)
-      | _ -> None)
-  | _ -> None
-
-let frac_valid frac = frac_num_den frac <> None
-
-let frac_pct frac =
-  match frac_num_den frac with
-  | Some (n, m) ->
-      let pct = float_of_int n /. float_of_int m *. 100. in
-      let digits = 6. -. Float.ceil (Float.log10 pct) in
-      let factor = 10. ** digits in
-      Float.round (pct *. factor) /. factor
-  | None -> 0.
+(* A position fraction [n/m] resolves to [n/m * 100%], the same reading the
+   sizing families give it: any numerator over any positive denominator, and an
+   improper fraction (6/5 -> 120%) is a position like any other. *)
+let frac_valid frac = Parse.fraction_pct frac <> None
+let frac_pct frac = Option.value ~default:0. (Parse.fraction_pct frac)
 
 module Handler = struct
   open Style

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -85,13 +85,9 @@ module Handler = struct
      the last slot before that boundary, after every floor-n spacing value. The
      natural candidate tiebreak then orders the unbounded denominators. *)
   let fraction_value_order f =
-    match String.split_on_char '/' f with
-    | [ n; m ] -> (
-        match (int_of_string_opt n, int_of_string_opt m) with
-        | Some n, Some _ ->
-            ((spacing_suborder (float_of_int n *. 0.25) + 4) * 100) - 1
-        | _ -> 490000)
-    | _ -> 490000
+    match Parse.fraction f with
+    | Some (n, _) -> ((spacing_suborder (float_of_int n *. 0.25) + 4) * 100) - 1
+    | None -> 490000
 
   (* Within a family: spacing and fractions interleaved by magnitude, then an
      arbitrary value, then the keywords. *)
@@ -123,24 +119,10 @@ module Handler = struct
   let min_inline_base = 130_000_000
   let logical_priority = 38
 
-  (* A Tailwind sizing fraction [n/m] resolves to [n/m * 100%]. Tailwind emits
-     calc(n / m * 100%) and folds it to 6 significant figures (e.g. 33.3333,
-     8.33333); we emit the percentage rounded the same way so the two match. *)
-  let fraction_pct frac =
-    match String.split_on_char '/' frac with
-    | [ n; m ] -> (
-        match (int_of_string_opt n, int_of_string_opt m) with
-        (* Any nonnegative numerator over a positive denominator: Tailwind reads
-           [w-<number>/<number>] as a percentage, not from a fixed scale. *)
-        | Some n, Some m when m > 0 && n >= 0 ->
-            let pct = float_of_int n /. float_of_int m *. 100. in
-            if n = 0 then Some 0.
-            else
-              let digits = 6. -. Float.ceil (Float.log10 pct) in
-              let factor = 10. ** digits in
-              Some (Float.round (pct *. factor) /. factor)
-        | _ -> None)
-    | _ -> None
+  (* A Tailwind sizing fraction [n/m] resolves to [n/m * 100%]: any numerator
+     over any positive denominator, read as a percentage rather than off a fixed
+     scale. *)
+  let fraction_pct = Parse.fraction_pct
 
   (* Container size theme variables - ordered from smallest to largest *)
   let container_3xs = Var.theme Css.Length "container-3xs" ~order:(5, 0)
@@ -802,10 +784,13 @@ module Handler = struct
      not. *)
   let is_quarter_multiple f = f >= 0. && Float.rem f 0.25 = 0.
 
-  let parse_aspect_ratio s mk =
+  (* [read] is how the two spellings of a ratio differ. A bare [aspect-4/3] is a
+     class suffix, so each part is a plain decimal; inside a bracket the author
+     writes CSS, which Tailwind hands to the browser however it is spelled. *)
+  let parse_aspect_ratio ~read s mk =
     match String.split_on_char '/' s with
     | [ w; h ] -> (
-        match (float_of_string_opt w, float_of_string_opt h) with
+        match (read w, read h) with
         | Some w, Some h when is_quarter_multiple w && is_quarter_multiple h ->
             Ok (mk w h)
         | _ -> err_not_utility)
@@ -834,7 +819,8 @@ module Handler = struct
     | [ "aspect"; value ] when Parse.is_bracket_value value -> (
         let inner = Parse.bracket_inner value in
         match
-          parse_aspect_ratio inner (fun w h -> Aspect_bracket (inner, w, h))
+          parse_aspect_ratio ~read:float_of_string_opt inner (fun w h ->
+              Aspect_bracket (inner, w, h))
         with
         | Ok _ as ok -> ok
         | Error _ -> (
@@ -846,7 +832,8 @@ module Handler = struct
     | [ "aspect"; value ] when is_theme_aspect theme value ->
         Ok (Aspect_theme value)
     | [ "aspect"; value ] ->
-        parse_aspect_ratio value (fun w h -> Aspect_ratio (w, h))
+        parse_aspect_ratio ~read:Parse.decimal_float value (fun w h ->
+            Aspect_ratio (w, h))
     | _ -> err_not_utility
 
   let suborder = function

--- a/lib/svg.ml
+++ b/lib/svg.ml
@@ -408,7 +408,7 @@ module Handler = struct
     | [ "stroke"; "0" ] -> Ok Stroke_0
     | [ "stroke"; "1" ] -> Ok Stroke_1
     | [ "stroke"; "2" ] -> Ok Stroke_2
-    | [ "stroke"; n ] when int_of_string_opt n <> None ->
+    | [ "stroke"; n ] when Parse.decimal_int n <> None ->
         Ok (Stroke_width (int_of_string n))
     | "stroke" :: color_parts when List.exists has_opacity color_parts -> (
         match Color.shade_and_opacity_of_strings ~theme color_parts with

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -38,7 +38,7 @@ module Handler = struct
   let of_class _theme class_name =
     match Parse.split_class class_name with
     | [ "tab"; n ] -> (
-        match int_of_string_opt n with
+        match Parse.decimal_int n with
         | Some i -> Ok (Tab i)
         | None -> (
             match parse_arbitrary n with

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1539,21 +1539,15 @@ module Handler = struct
 
   (* A fractional spacing step: [0.5], [2.5]. Integers keep the existing
      path. *)
-
-  (** Parse a fraction string like "1/2", "2/3", etc. Returns (numerator,
-      denominator) or None. *)
   let parse_spacing_step s =
-    match float_of_string_opt s with
+    match Parse.decimal_float s with
     | Some f when f > 0. && not (Float.is_integer f) -> Some f
     | _ -> None
 
-  let parse_fraction s =
-    match String.split_on_char '/' s with
-    | [ num_s; denom_s ] -> (
-        match (int_of_string_opt num_s, int_of_string_opt denom_s) with
-        | Some num, Some denom when num > 0 && denom > 0 -> Some (num, denom)
-        | _ -> None)
-    | _ -> None
+  (* The translate family writes [calc(n / m * 100%)] out rather than folding
+     it, so it takes every fraction Tailwind reads, a zero on either side
+     included. *)
+  let parse_fraction = Parse.fraction
 
   (* The value a bracket denotes, read with the grammar cascade already has for
      the property. [None] is a bracket that grammar refuses, and [of_class]

--- a/lib/typography.ml
+++ b/lib/typography.ml
@@ -2013,7 +2013,7 @@ module Typography_late = struct
           | Some len -> Ok (Underline_offset_arbitrary (inner, len))
           | None -> err_not_utility)
     | [ "underline"; "offset"; n ] -> (
-        match float_of_string_opt n with
+        match Parse.decimal_float n with
         | Some px -> Ok (Underline_offset_px px)
         | None -> err_not_utility)
     | [ ""; "underline"; "offset"; n ] when Parse.is_bracket_value n -> (
@@ -2024,7 +2024,7 @@ module Typography_late = struct
           | Some len -> Ok (Underline_offset_neg_arbitrary (inner, len))
           | None -> err_not_utility)
     | [ ""; "underline"; "offset"; n ] -> (
-        match float_of_string_opt n with
+        match Parse.decimal_float n with
         | Some px -> Ok (Underline_offset_neg_px px)
         | None -> err_not_utility)
     | [ "antialiased" ] -> Ok Antialiased

--- a/lib/zoom.ml
+++ b/lib/zoom.ml
@@ -61,7 +61,7 @@ module Handler = struct
     match Parse.split_class class_name with
     | [ "zoom"; value ] when Parse.is_bare_var value -> Ok (Bare_var value)
     | [ "zoom"; n ] -> (
-        match int_of_string_opt n with
+        match Parse.decimal_int n with
         | Some i -> Ok (Percent (float_of_int i))
         | None -> (
             match parse_arbitrary n with

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -92,6 +92,24 @@ let test_of_string_invalid () =
   (* Missing color *)
   test_invalid [ "to"; "xyz" ];
 
+  (* Gradient positions, gradient angles and the opacity modifier are all plain
+     decimal: read as OCaml literals, [from-0x50%] named itself [.from-80%] and
+     [bg-red-500/0x50] mixed at 80%. *)
+  let invalid =
+    Test_helpers.check_invalid_input (module Tw.Backgrounds.Handler)
+  in
+  invalid "from-0x50%";
+  invalid "from-050%";
+  invalid "via-1_0%";
+  invalid "bg-linear-0x45";
+  invalid "bg-linear-045";
+  invalid "bg-conic-0x45";
+  invalid "bg-red-500/0x50";
+  invalid "bg-red-500/1_0";
+  invalid "bg-red-500/04";
+  invalid "bg-red-500/1.50";
+  invalid "bg-red-0500";
+
   (* Invalid color *)
 
   (* Invalid prefixes *)

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -70,7 +70,11 @@ let of_string_invalid () =
 
 (* [basis-*] and [flex-*] read the same fraction the sizing families do: any
    numerator, zero included, over any positive denominator. Requiring a positive
-   numerator refused [basis-0/2], which the CLI emits. *)
+   numerator refused [basis-0/2], which the CLI emits.
+
+   [flex-0/2] is the one whose sheets do not compare equal: tw writes the [0%]
+   that Tailwind's [calc(0/2 * 100%)] computes to, and cascade reads the two
+   spellings of that declaration differently. *)
 let test_any_fraction_numerator () =
   check "basis-0/2";
   check "basis-1/7";

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -68,6 +68,23 @@ let of_string_invalid () =
   fail_maybe [ "order" ];
   fail_maybe []
 
+(* [basis-*] and [flex-*] read the same fraction the sizing families do: any
+   numerator, zero included, over any positive denominator. Requiring a positive
+   numerator refused [basis-0/2], which the CLI emits. *)
+let test_any_fraction_numerator () =
+  check "basis-0/2";
+  check "basis-1/7";
+  check "basis-13/17";
+  check "flex-0/2";
+  check "flex-1/7";
+  Test_helpers.check_invalid_input
+    ~why:
+      (Test_helpers.Diverges
+         "Tailwind passes a zero denominator through as calc(1 / 0 * 100%), \
+          which no browser can compute; tw refuses the class instead")
+    (module Tw.Flex_props.Handler)
+    "basis-1/0"
+
 let suborder_matches_tailwind () =
   let open Tw in
   let utilities =
@@ -168,6 +185,7 @@ let tests =
       test_basis_named_prefers_spacing;
     test_case "flex_props of_string - valid values" `Quick of_string_valid;
     test_case "flex_props of_string - invalid values" `Quick of_string_invalid;
+    test_case "any fraction numerator" `Quick test_any_fraction_numerator;
     test_case "flex_props suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "invalid arbitrary order" `Quick test_invalid_arbitrary_order;

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -399,6 +399,27 @@ let test_arbitrary_breakpoint_rejects_non_length () =
       | Error (`Msg _) -> ())
     [ "min-[abc]:flex"; "max-[abc]:flex"; "min-[]:flex" ]
 
+(* The number in front of the unit is a CSS number, not an OCaml one. Reading it
+   with [float_of_string_opt] turned [min-[0x600px]] into a live [(min-width:
+   1536px)] breakpoint: a query the browser honours, built out of a value
+   Tailwind passes through verbatim for the browser to drop. Nothing here is a
+   length either, so tw declines the whole class. *)
+let test_arbitrary_breakpoint_rejects_ocaml_literals () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok u ->
+          Alcotest.failf "%s parsed as %s emitting %s" cls (Tw.pp u)
+            (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
+      | Error (`Msg _) -> ())
+    [
+      "min-[0x600px]:p-4";
+      "max-[0x600px]:p-4";
+      "min-[0x600]:p-4";
+      "min-[1_000px]:p-4";
+      "min-[+600px]:p-4";
+    ]
+
 (* A [@custom-variant] belongs to the [@theme] block that declared it. Two
    stylesheets built in one process read different themes, so a variant the
    first declared must be unknown to the second. *)
@@ -1467,6 +1488,8 @@ let tests =
       test_case "nth spelling" `Quick test_nth_spelling;
       test_case "arbitrary breakpoint rejects non-length" `Quick
         test_arbitrary_breakpoint_rejects_non_length;
+      test_case "arbitrary breakpoint rejects OCaml literals" `Quick
+        test_arbitrary_breakpoint_rejects_ocaml_literals;
       test_case "custom variant is theme-local" `Quick
         test_custom_variant_is_theme_local;
       test_case "container variant is theme-local" `Quick

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -347,6 +347,7 @@ let test_arbitrary_breakpoint_spelling () =
       "min-[0600px]:flex";
       "min-[1e3px]:flex";
       "min-[600]:flex";
+      "min-[+600px]:flex";
       "min-[.5rem]:flex";
       "max-[48rem]:flex";
       "max-[37.50px]:flex";
@@ -416,8 +417,8 @@ let test_arbitrary_breakpoint_rejects_ocaml_literals () =
       "min-[0x600px]:p-4";
       "max-[0x600px]:p-4";
       "min-[0x600]:p-4";
+      "min-[0o17px]:p-4";
       "min-[1_000px]:p-4";
-      "min-[+600px]:p-4";
     ]
 
 (* A [@custom-variant] belongs to the [@theme] block that declared it. Two

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -91,6 +91,134 @@ let test_decimal_class_suffixes_round_trip () =
 let test_redundant_zero_spellings_are_rejected () =
   List.iter unknown [ "p-04"; "p-4.0"; "p-1.50" ]
 
+(* The families that read their own suffix rather than going through the readers
+   above. Checked against the pinned CLI: Tailwind emits for none of these. The
+   integer ones rename the rule they emit, so the author writes [stroke-0x4] and
+   gets a [.stroke-4] that matches nothing. *)
+let test_family_int_suffixes_reject_non_decimal_spellings () =
+  List.iter unknown
+    [
+      "stroke-0x4";
+      "stroke-04";
+      "stroke-1_0";
+      "tab-0x4";
+      "tab-04";
+      "grow-0x4";
+      "grow-04";
+      "ring-0x4";
+      "ring-04";
+      "zoom-0x4";
+      "zoom-04";
+      "from-0x50%";
+      "from-050%";
+      "via-0x50%";
+      "to-0x50%";
+      "bg-linear-0x45";
+      "bg-linear-045";
+      "bg-conic-0x45";
+      "bg-conic-045";
+      "-bg-linear-0x45";
+      "-bg-conic-045";
+      "mask-linear-0x45";
+      "mask-linear-045";
+      "mask-conic-0x45";
+      "-mask-linear-045";
+      "mask-x-from-0x50%";
+      "mask-x-from-050%";
+    ]
+
+(* The same for the families whose suffix is a decimal. *)
+let test_family_decimal_suffixes_reject_non_decimal_spellings () =
+  List.iter unknown
+    [
+      "underline-offset-0x4";
+      "underline-offset-04";
+      "underline-offset-4.50";
+      "-underline-offset-0x4";
+      "backdrop-opacity-0x50";
+      "backdrop-opacity-050";
+      "auto-cols-0x4";
+      "auto-cols-04";
+      "auto-rows-0x4";
+      "mask-x-from-02";
+      "mask-x-from-2.50";
+      "top-1_5";
+      "inset-1.50";
+      "translate-x-1.50";
+      "aspect-0x4/3";
+      "aspect-04/3";
+      "aspect-4.0/3";
+      "aspect-1.50/3";
+    ]
+
+(* The opacity modifier rides on every colour utility, so one reader that admits
+   an OCaml literal admits it across the whole palette. The shade is the same
+   suffix a step earlier: [bg-red-0500] emitted [.bg-red-500]. *)
+let test_colour_modifier_rejects_non_decimal_spellings () =
+  List.iter unknown
+    [
+      "bg-red-500/0x50";
+      "bg-red-500/1_0";
+      "bg-red-500/04";
+      "bg-red-500/1.50";
+      "text-red-500/0x50";
+      "border-red-500/1_0";
+      "stroke-red-500/04";
+      "bg-red-0500";
+      "border-red-1_00";
+      "text-red-0x500";
+    ]
+
+(* A fraction is two plain decimals: [w-04/2] emitted [width: 200%] for a class
+   Tailwind does not emit at all. *)
+let test_fraction_suffixes_reject_non_decimal_spellings () =
+  List.iter unknown
+    [
+      "w-04/2";
+      "w-1_0/2";
+      "w-0x2/4";
+      "w-1/02";
+      "h-04/2";
+      "top-04/2";
+      "inset-04/2";
+      "basis-01/2";
+      "flex-01/2";
+      "translate-x-01/2";
+      "-translate-x-01/2";
+    ]
+
+(* What the families above have to keep emitting. *)
+let test_family_suffixes_round_trip () =
+  List.iter round_trips
+    [
+      "stroke-4";
+      "tab-4";
+      "grow-4";
+      "ring-4";
+      "zoom-4";
+      "from-50%";
+      "bg-linear-45";
+      "bg-conic-45";
+      "mask-linear-45";
+      "mask-x-from-50%";
+      "mask-x-from-2.5";
+      "underline-offset-4";
+      "backdrop-opacity-50";
+      "backdrop-opacity-5.5";
+      "auto-cols-4";
+      "aspect-4/3";
+      "aspect-8.5/11";
+      "top-2.5";
+      "inset-0.5";
+      "translate-x-0.5";
+      "bg-red-500/50";
+      "bg-red-500/2.5";
+      "w-1/2";
+      "basis-1/2";
+      "flex-1/2";
+      "translate-x-1/2";
+    ]
+
 (* [Parse.split_class] remembers the split of the last class name it was given,
    because every handler in turn splits the same one. A parse must therefore not
    depend on what was parsed before it, nor on whether two equal class names are
@@ -231,6 +359,16 @@ let tests =
         test_decimal_class_suffixes_round_trip;
       test_case "redundant zero suffixes are rejected" `Quick
         test_redundant_zero_spellings_are_rejected;
+      test_case "family int suffixes reject non-decimal spellings" `Quick
+        test_family_int_suffixes_reject_non_decimal_spellings;
+      test_case "family decimal suffixes reject non-decimal spellings" `Quick
+        test_family_decimal_suffixes_reject_non_decimal_spellings;
+      test_case "colour modifier rejects non-decimal spellings" `Quick
+        test_colour_modifier_rejects_non_decimal_spellings;
+      test_case "fraction suffixes reject non-decimal spellings" `Quick
+        test_fraction_suffixes_reject_non_decimal_spellings;
+      test_case "family suffixes round-trip" `Quick
+        test_family_suffixes_round_trip;
       test_case "parsing is independent of parse history" `Quick
         test_parse_is_independent_of_history;
       test_case "var name reads one complete reference" `Quick

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -53,6 +53,35 @@ let test_negative_and_improper_fractions () =
     "-inset-x-1/2 is -50%" true
     (Astring.String.is_infix ~affix:"inset-inline: -50%" (css "-inset-x-1/2"))
 
+(* Tailwind reads any numerator over any denominator, the same rule the sizing
+   families follow: [top-1/7] and [top-3/8] are as good as [top-1/2], and a zero
+   numerator is a position of its own. Restricting the denominator to a hand
+   picked list refused classes the CLI emits. *)
+let test_any_fraction_denominator () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " contains " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "top-1/7" "top: 14.2857%";
+  has "top-3/8" "top: 37.5%";
+  has "top-1/13" "top: 7.69231%";
+  has "inset-0/2" "inset: 0%";
+  has "left-13/17" "left: 76.4706%";
+  Test_helpers.check_invalid_input
+    ~why:
+      (Test_helpers.Diverges
+         "Tailwind passes a zero denominator through as calc(1 / 0 * 100%), \
+          which no browser can compute; tw refuses the class instead")
+    (module Tw.Position.Handler)
+    "top-1/0"
+
 (* Arbitrary values round-trip verbatim in the class name: the leading zero of
    0.67rem (and the sign of negatives) is preserved, not re-serialised to a
    normalised .67rem that would no longer match the HTML class. *)
@@ -328,6 +357,7 @@ let tests =
     test_case "position fractions" `Quick test_fractions;
     test_case "negative and improper fractions" `Quick
       test_negative_and_improper_fractions;
+    test_case "any fraction denominator" `Quick test_any_fraction_denominator;
     test_case "named inset requires theme token" `Quick
       named_inset_requires_theme_token;
     test_case "arbitrary var insets" `Quick test_arbitrary_var;

--- a/test/test_svg.ml
+++ b/test/test_svg.ml
@@ -82,6 +82,19 @@ let stroke_arbitrary_width_invalid () =
   rejected "stroke-[.]";
   rejected "stroke-[-]"
 
+(* A stroke width is written in plain decimal. Read as an OCaml literal,
+   [stroke-0x4] parsed and then named itself [.stroke-4]: a rule the author
+   never wrote, matching nothing in the markup. *)
+let stroke_width_rejects_ocaml_literals () =
+  List.iter
+    (fun cls ->
+      match Tw.of_string cls with
+      | Ok u ->
+          Alcotest.failf "expected %s to be rejected, got %s" cls
+            (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true)
+      | Error _ -> ())
+    [ "stroke-0x4"; "stroke-04"; "stroke-1_0" ]
+
 (* A bracket colour CSS names without spelling it as a function - a named
    colour, a keyword - is a stroke colour too. The stroke reader told colours
    from widths by looking for a [#] or a colour function, so
@@ -154,6 +167,8 @@ let tests =
     test_case "stroke arbitrary width units" `Quick stroke_arbitrary_width_units;
     test_case "stroke arbitrary width invalid" `Quick
       stroke_arbitrary_width_invalid;
+    test_case "stroke width rejects OCaml literals" `Quick
+      stroke_width_rejects_ocaml_literals;
   ]
 
 let suite = ("svg", tests)

--- a/test/test_tab.ml
+++ b/test/test_tab.ml
@@ -9,7 +9,11 @@ let test_roundtrip () =
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab";
   Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-2.5";
-  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-unknown"
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-unknown";
+  (* A tab size is written in plain decimal: [tab-0x4] named itself [.tab-4]. *)
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-0x4";
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-04";
+  Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-1_0"
 
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -79,6 +79,16 @@ let test_perspective_candidate_order () =
       "perspective-midrange";
     ]
 
+(* A translate fraction is any numerator over any denominator, and the translate
+   family writes the division out rather than folding it, so even the zero
+   denominator Tailwind emits reads here. *)
+let test_any_translate_fraction () =
+  check "translate-x-0/2";
+  check "translate-x-1/7";
+  check "translate-y-13/17";
+  check "translate-1/0";
+  check "-translate-x-0/2"
+
 let test_of_string_invalid () =
   (* Invalid transform utilities *)
   let test_invalid input =
@@ -477,6 +487,7 @@ let tests =
       test_perspective_candidate_order;
     test_case "translate-px and negative arbitrary" `Quick
       test_translate_px_and_neg_arbitrary;
+    test_case "any translate fraction" `Quick test_any_translate_fraction;
     test_case "of_string invalid cases" `Quick test_of_string_invalid;
     test_case "typed constructors" `Quick test_typed;
     test_case "transforms suborder matches Tailwind" `Quick

--- a/test/test_zoom.ml
+++ b/test/test_zoom.ml
@@ -8,7 +8,11 @@ let test_roundtrip () =
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom";
   Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-1.5";
-  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-unknown"
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-unknown";
+  (* A zoom percentage is written in plain decimal. *)
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-0x4";
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-04";
+  Test_helpers.check_invalid_input (module Tw.Zoom.Handler) "zoom-1_0"
 
 (* Tailwind emits [zoom-*] between the transforms and the animations. It sorted
    with the margins instead, at the priority a family gets when nobody has


### PR DESCRIPTION
Class suffixes went to OCaml's number readers, which accept 0x, 0o, 0b, digit separators and hex-float exponents, so stroke-0x4 emitted a renamed .stroke-4 rule and min-[0x600px] manufactured a working 1536px breakpoint. Bracket contents are unaffected: Tailwind passes those through unvalidated.