### PR TITLE
test: assert declarations instead of substrings

### DIFF
--- a/test/helpers/dune
+++ b/test/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name test_helpers)
- (libraries tw tw_tools alcotest astring fmt cascade cascade.diff))
+ (libraries tw tw_tools alcotest astring fmt re cascade cascade.diff))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -129,7 +129,8 @@ let declarations_of_class cls =
       Css.fold
         (fun acc stmt ->
           match Css.as_rule stmt with
-          | Some (sel, decls, _) when Css.Selector.to_string sel <> ":root" ->
+          | Some (sel, decls, _)
+            when String.contains (Css.Selector.to_string sel) '.' ->
               acc @ List.map (Css.Declaration.to_string ~minify:true) decls
           | _ -> acc)
         [] sheet

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -115,6 +115,42 @@ let properties_of_class cls =
              | _ -> acc)
            []
 
+(* [Astring.String.is_infix] accepts more than a test names. The affix
+   [.bg-blue-500] matches the selector [.bg-blue-500\/50], so a test naming a
+   utility passes when only an opacity variant of it reached the sheet, and any
+   affix that is a prefix of a longer generated class behaves the same way.
+   [Alcotest.check bool ... true] then prints neither the class nor the CSS when
+   it fails, so a red test reports only that something is wrong. The helpers
+   below compare whole declarations and name the subject in the failure. *)
+let declarations_of_class cls =
+  match compiled cls with
+  | None -> Alcotest.failf "%s does not parse" cls
+  | Some sheet ->
+      Css.fold
+        (fun acc stmt ->
+          match Css.as_rule stmt with
+          | Some (sel, decls, _) when Css.Selector.to_string sel <> ":root" ->
+              acc @ List.map (Css.Declaration.to_string ~minify:true) decls
+          | _ -> acc)
+        [] sheet
+
+let check_declarations cls expected =
+  Alcotest.(check (list string)) cls expected (declarations_of_class cls)
+
+(* For a value a test cannot spell exactly, a generated hash or a number the
+   suite deliberately leaves open. Anchor the pattern: an unanchored one
+   reintroduces the defect above. *)
+let check_declarations_match cls patterns =
+  let actual = declarations_of_class cls in
+  List.iter
+    (fun pattern ->
+      let re = Re.Pcre.re pattern |> Re.compile in
+      if not (List.exists (fun d -> Re.execp re d) actual) then
+        Alcotest.failf "%s: no declaration matches %s@.declarations: %s" cls
+          pattern
+          (String.concat "; " actual))
+    patterns
+
 (* What a class writes on an element carrying it, as one rule. The theme
    bindings it drags in are left out - every class reading the spacing scale
    writes [--spacing], which says nothing about what two of them do to each

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -32,6 +32,24 @@ val properties_of_class : string -> Css.Declaration.prop_key list
 (** [properties_of_class cls] is every property [cls] declares, custom
     properties included: two utilities can conflict on a [--tw-*] alone. *)
 
+val declarations_of_class : string -> string list
+(** [declarations_of_class cls] is every declaration [cls] writes outside
+    [:root], minified, in source order. Fails the test if [cls] does not parse.
+*)
+
+val check_declarations : string -> string list -> unit
+(** [check_declarations cls expected] checks [cls] writes exactly [expected].
+    Prefer it to a substring search: an affix that is a prefix of a longer
+    generated class matches it, so [.bg-blue-500] is satisfied by
+    [.bg-blue-500\/50] alone, and a [check bool] failure prints neither the
+    class nor the CSS. *)
+
+val check_declarations_match : string -> string list -> unit
+(** [check_declarations_match cls patterns] checks each PCRE in [patterns]
+    matches some declaration of [cls], naming the class and every declaration
+    on failure. For a value that cannot be spelled exactly; anchor the pattern,
+    since an unanchored one accepts a longer class the way a substring does. *)
+
 val interacting_pairs : string list -> (string * string) list
 (** [interacting_pairs classes] pairs up the classes that write on each other.
     An element carrying such a pair is where an ordering difference becomes

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -33,9 +33,11 @@ val properties_of_class : string -> Css.Declaration.prop_key list
     properties included: two utilities can conflict on a [--tw-*] alone. *)
 
 val declarations_of_class : string -> string list
-(** [declarations_of_class cls] is every declaration [cls] writes outside
-    [:root], minified, in source order. Fails the test if [cls] does not parse.
-*)
+(** [declarations_of_class cls] is what [cls] writes on an element carrying it,
+    minified, in source order. Only selectors holding a [.] count, so the theme
+    bindings the class drags in and the [*, ::before] property defaults are left
+    out, the way {!class_rule} reads them. Fails the test if [cls] does not
+    parse. *)
 
 val check_declarations : string -> string list -> unit
 (** [check_declarations cls expected] checks [cls] writes exactly [expected].
@@ -46,8 +48,8 @@ val check_declarations : string -> string list -> unit
 
 val check_declarations_match : string -> string list -> unit
 (** [check_declarations_match cls patterns] checks each PCRE in [patterns]
-    matches some declaration of [cls], naming the class and every declaration
-    on failure. For a value that cannot be spelled exactly; anchor the pattern,
+    matches some declaration of [cls], naming the class and every declaration on
+    failure. For a value that cannot be spelled exactly; anchor the pattern,
     since an unanchored one accepts a longer class the way a substring does. *)
 
 val interacting_pairs : string list -> (string * string) list

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -187,50 +187,26 @@ let test_css_mode_with_colors () =
    edge; named, arbitrary and keyword forms. Widths (border-l-2) still resolve
    via the borders handler. *)
 let test_border_side_color () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.failf "could not parse %S" cls
-  in
-  Alcotest.(check bool)
-    "border-l-[#575959] sets border-left-color" true
-    (Astring.String.is_infix ~affix:"border-left-color: #575959"
-       (css "border-l-[#575959]"));
-  Alcotest.(check bool)
-    "border-b-transparent sets border-bottom-color" true
-    (Astring.String.is_infix ~affix:"border-bottom-color:"
-       (css "border-b-transparent"));
-  Alcotest.(check bool)
-    "border-l-red-500 sets border-left-color" true
-    (Astring.String.is_infix ~affix:"border-left-color:"
-       (css "border-l-red-500"));
-  Alcotest.(check bool)
-    "border-l-2 is still a width" true
-    (Astring.String.is_infix ~affix:"border-left-width: 2px" (css "border-l-2"));
-  Alcotest.(check bool)
-    "border-x-red-500 uses the logical inline color" true
-    (Astring.String.is_infix ~affix:"border-inline-color:"
-       (css "border-x-red-500"));
-  Alcotest.(check bool)
-    "border-y-red-500 uses the logical block color" true
-    (Astring.String.is_infix ~affix:"border-block-color:"
-       (css "border-y-red-500"));
-  Alcotest.(check bool)
-    "border-s-red-500 uses the inline-start color" true
-    (Astring.String.is_infix ~affix:"border-inline-start-color:"
-       (css "border-s-red-500"));
-  Alcotest.(check bool)
-    "border-e-red-500 uses the inline-end color" true
-    (Astring.String.is_infix ~affix:"border-inline-end-color:"
-       (css "border-e-red-500"));
-  Alcotest.(check bool)
-    "border-bs-red-500 uses the block-start color" true
-    (Astring.String.is_infix ~affix:"border-block-start-color:"
-       (css "border-bs-red-500"));
-  Alcotest.(check bool)
-    "border-be-red-500 uses the block-end color" true
-    (Astring.String.is_infix ~affix:"border-block-end-color:"
-       (css "border-be-red-500"))
+  Test_helpers.check_declarations "border-l-[#575959]"
+    [ "border-left-color:#575959" ];
+  Test_helpers.check_declarations "border-b-transparent"
+    [ "border-bottom-color:#0000" ];
+  Test_helpers.check_declarations "border-l-red-500"
+    [ "border-left-color:var(--color-red-500)" ];
+  Test_helpers.check_declarations "border-l-2"
+    [ "border-left-style:var(--tw-border-style)"; "border-left-width:2px" ];
+  Test_helpers.check_declarations "border-x-red-500"
+    [ "border-inline-color:var(--color-red-500)" ];
+  Test_helpers.check_declarations "border-y-red-500"
+    [ "border-block-color:var(--color-red-500)" ];
+  Test_helpers.check_declarations "border-s-red-500"
+    [ "border-inline-start-color:var(--color-red-500)" ];
+  Test_helpers.check_declarations "border-e-red-500"
+    [ "border-inline-end-color:var(--color-red-500)" ];
+  Test_helpers.check_declarations "border-bs-red-500"
+    [ "border-block-start-color:var(--color-red-500)" ];
+  Test_helpers.check_declarations "border-be-red-500"
+    [ "border-block-end-color:var(--color-red-500)" ]
 
 (* Every per-side border colour writes a colour another side writes too, so
    their relative order decides which one wins. Tailwind groups them side-major:
@@ -285,23 +261,12 @@ let test_outline_inherit_order () =
 (* A CSS variable in a border color bracket, and its v4 paren shorthand, resolve
    to var(): border-[var(--x)] and border-(--x) both set border-color. *)
 let test_border_color_var () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.failf "could not parse %S" cls
-  in
-  Alcotest.(check bool)
-    "border-[var(--pattern-fg)] sets border-color: var()" true
-    (Astring.String.is_infix ~affix:"border-color: var(--pattern-fg)"
-       (css "border-[var(--pattern-fg)]"));
-  Alcotest.(check bool)
-    "border-(--pattern-fg) shorthand sets border-color: var()" true
-    (Astring.String.is_infix ~affix:"border-color: var(--pattern-fg)"
-       (css "border-(--pattern-fg)"));
-  Alcotest.(check bool)
-    "border-t-[var(--x)] sets border-top-color: var()" true
-    (Astring.String.is_infix ~affix:"border-top-color: var(--x)"
-       (css "border-t-[var(--x)]"));
+  Test_helpers.check_declarations "border-[var(--pattern-fg)]"
+    [ "border-color:var(--pattern-fg)" ];
+  Test_helpers.check_declarations "border-(--pattern-fg)"
+    [ "border-color:var(--pattern-fg)" ];
+  Test_helpers.check_declarations "border-t-[var(--x)]"
+    [ "border-top-color:var(--x)" ];
   (* the paren shorthand keeps its own class name *)
   Alcotest.(check string)
     "border-(--pattern-fg) round-trips" "border-(--pattern-fg)"

--- a/test/test_columns.ml
+++ b/test/test_columns.ml
@@ -46,14 +46,7 @@ let test_non_decimal_integers () =
 (* columns-[16rem] is a column-WIDTH (columns: 16rem), distinct from the integer
    count form (columns-[3]). *)
 let test_columns_arbitrary_width () =
-  let css =
-    match Tw.of_string "columns-[16rem]" with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error _ -> Alcotest.fail "could not parse columns-[16rem]"
-  in
-  Alcotest.(check bool)
-    "columns-[16rem] sets columns: 16rem" true
-    (Astring.String.is_infix ~affix:"columns:16rem" css)
+  Test_helpers.check_declarations "columns-[16rem]" [ "columns:16rem" ]
 
 (* The typed constructors (newly exposed in tw.mli) must agree with the parser
    on class names, including the [int] argument of [columns]. *)


### PR DESCRIPTION
A substring affix is satisfied by a longer generated class, so a test naming `.bg-blue-500` passes when only `.bg-blue-500/50` reached the sheet, and a `check bool` failure prints neither the class nor the CSS. This adds the two helpers and converts one call site; 908 remain, tracked in the backlog.