### PR TITLE
build: merge a distant same-name container block

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -576,6 +576,7 @@ let statements_of_sorted_rules ?verbatim sorted_rules =
   |> Css.Optimize.merge_consecutive_media
   |> Css.Optimize.merge_consecutive_supports
   |> Css.Optimize.merge_consecutive_containers
+  |> Css.Optimize.merge_distant_containers
 
 (* Get sorted indexed rules - used for extracting first-usage order of
    variables *)


### PR DESCRIPTION
The sort separates some same-condition container blocks, which the adjacent pass cannot reach, so tw emitted duplicates Tailwind does not. Container blocks go from 32 to 30 against Tailwind 27.