### PR TITLE
entrypoint: emit one property fallback block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,6 +141,10 @@
 - An arbitrary value keeps the underscore its `\_` escape spells, so
   `font-['My\_Font']`, `[--my\_var:red]` and `data-[foo=bar\_baz]:flex` reach
   the sheet as written instead of carrying the backslash into the value (#676).
+- A `theme()` call resolves to the value the project bound, underscores and
+  all. The resolved value was written back into the class string unescaped, so
+  a palette entry bound to `var(--brand_red)` named `var(--brand red)` and an
+  arbitrary property carrying it was dropped (#PR).
 - Bracketed `has`, `group-has` and `peer-has` variants retain Tailwind's
   `:is(...)` wrapper for bare type and complex selectors.
 - An arbitrary length in a variant's class name is spelled as the author wrote

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,7 +144,7 @@
 - A `theme()` call resolves to the value the project bound, underscores and
   all. The resolved value was written back into the class string unescaped, so
   a palette entry bound to `var(--brand_red)` named `var(--brand red)` and an
-  arbitrary property carrying it was dropped (#PR).
+  arbitrary property carrying it was dropped (#687).
 - Bracketed `has`, `group-has` and `peer-has` variants retain Tailwind's
   `:is(...)` wrapper for bare type and complex selectors.
 - An arbitrary length in a variant's class name is spelled as the author wrote
@@ -306,7 +306,7 @@
 - The initial values of the utility variables emit as one `@supports` block.
   Every `@apply` and every declared utility hoisted a block of its own beside
   the generated sheet's, so a project stylesheet re-declared variables the
-  sheet had already initialised (#XXX).
+  sheet had already initialised (#687).
 
 ### Public OCaml API
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -299,6 +299,10 @@
 - A declared utility's own rules come before the ones its variants wrap in an
   at-rule, and one whose first property has no order slot sorts among the
   built-ins instead of opening a second `@layer utilities` (#550).
+- The initial values of the utility variables emit as one `@supports` block.
+  Every `@apply` and every declared utility hoisted a block of its own beside
+  the generated sheet's, so a project stylesheet re-declared variables the
+  sheet had already initialised (#XXX).
 
 ### Public OCaml API
 

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -1860,6 +1860,33 @@ let merge_named_layers stmts =
         | _ -> stmt)
       merged
 
+(* Every [@apply] and every declared utility hoists a [@layer properties] block
+   of its own, holding the initial values of the variables its utilities set,
+   and the generated sheet hoists one too. Folded into the single layer the
+   sheet declares, they line up as a run of [@supports] blocks over one
+   condition and one universal selector, each repeating variables the others
+   already declare. Tailwind writes one block. Joining the run leaves every
+   variable on the value the last block in it gave it, which is the value it
+   held before. *)
+let join_fallback_rules stmts =
+  merge_same_selector stmts
+  |> List.map (fun stmt ->
+      match Css.as_rule stmt with
+      | Some (selector, decls, []) ->
+          Css.rule ~selector (Css.Optimize.deduplicate_declarations decls)
+      | _ -> stmt)
+
+let collapse_property_fallbacks stmts =
+  List.map
+    (fun stmt ->
+      match Css.as_layer stmt with
+      | Some (Some name, inner) when equal_layer name [ "properties" ] ->
+          Css.layer ~name
+            (Css.Optimize.merge_consecutive_supports
+               ~optimize_merged_block:join_fallback_rules inner)
+      | _ -> stmt)
+    stmts
+
 let layer_block_name stmt =
   match Css.layer_block_name stmt with Some [] | None -> None | name -> name
 
@@ -2115,7 +2142,8 @@ let splice_into_entrypoint ~theme ~path generated =
                 ->
                   Css.statements generated
               | s -> [ s ])
-          |> merge_named_layers |> hoist_layer_blocks
+          |> merge_named_layers |> collapse_property_fallbacks
+          |> hoist_layer_blocks
           |> drop_unread_inline_tokens ~theme
           |> collect_properties_at_end |> Css.v)
 

--- a/lib/tools/entrypoint.ml
+++ b/lib/tools/entrypoint.ml
@@ -2005,58 +2005,58 @@ let collect_properties_at_end stmts =
    [flatten_nesting] has made every element rule flat by the time this runs, so
    splitting one declaration into a rule/query pair preserves its exact place
    among the author's declarations. *)
-let authored_color_mix_fallbacks ~theme stmts =
-  let fallback_declaration declaration =
-    let value = Css.declaration_value ~minify:true declaration in
-    match Css.parse_color value with
-    | None -> None
-    | Some color -> (
-        match Tw.Color.pre_color_mix_fallback theme color with
-        | None -> None
-        | Some fallback ->
-            let fallback_value =
-              Css.color fallback |> Css.Declaration.normalize
-              |> Css.declaration_value ~minify:true
-            in
-            let layer = Css.Declaration.custom_declaration_layer declaration in
-            Css.Declaration.parse_declaration ?layer
-              (Css.declaration_name declaration)
-              fallback_value
-            |> Option.map (fun fallback ->
-                if Css.declaration_is_important declaration then
-                  Css.important fallback
-                else fallback))
-  in
-  let lower_rule selector declarations =
-    let rec loop pending emitted = function
-      | [] ->
-          let emitted =
-            match pending with
-            | [] -> emitted
-            | _ -> Css.rule ~selector (List.rev pending) :: emitted
+let fallback_declaration ~theme declaration =
+  let value = Css.declaration_value ~minify:true declaration in
+  match Css.parse_color value with
+  | None -> None
+  | Some color -> (
+      match Tw.Color.pre_color_mix_fallback theme color with
+      | None -> None
+      | Some fallback ->
+          let fallback_value =
+            Css.color fallback |> Css.Declaration.normalize
+            |> Css.declaration_value ~minify:true
           in
-          List.rev emitted
-      | declaration :: rest -> (
-          match fallback_declaration declaration with
-          | None -> loop (declaration :: pending) emitted rest
-          | Some fallback ->
-              let base_declarations =
-                match pending with
-                | previous :: _
-                  when Css.Declaration.equal_declaration previous fallback ->
-                    List.rev pending
-                | _ -> List.rev (fallback :: pending)
-              in
-              let base = Css.rule ~selector base_declarations in
-              let enhanced = Css.rule ~selector [ declaration ] in
-              let supports =
-                Css.supports ~condition:Tw.Color.color_mix_supports_condition
-                  [ enhanced ]
-              in
-              loop [] (supports :: base :: emitted) rest)
-    in
-    loop [] [] declarations
+          let layer = Css.Declaration.custom_declaration_layer declaration in
+          Css.Declaration.parse_declaration ?layer
+            (Css.declaration_name declaration)
+            fallback_value
+          |> Option.map (fun fallback ->
+              if Css.declaration_is_important declaration then
+                Css.important fallback
+              else fallback))
+
+let lower_color_mix_rule ~theme selector declarations =
+  let rec loop pending emitted = function
+    | [] ->
+        let emitted =
+          match pending with
+          | [] -> emitted
+          | _ -> Css.rule ~selector (List.rev pending) :: emitted
+        in
+        List.rev emitted
+    | declaration :: rest -> (
+        match fallback_declaration ~theme declaration with
+        | None -> loop (declaration :: pending) emitted rest
+        | Some fallback ->
+            let base_declarations =
+              match pending with
+              | previous :: _
+                when Css.Declaration.equal_declaration previous fallback ->
+                  List.rev pending
+              | _ -> List.rev (fallback :: pending)
+            in
+            let base = Css.rule ~selector base_declarations in
+            let enhanced = Css.rule ~selector [ declaration ] in
+            let supports =
+              Css.supports ~condition:Tw.Color.color_mix_supports_condition
+                [ enhanced ]
+            in
+            loop [] (supports :: base :: emitted) rest)
   in
+  loop [] [] declarations
+
+let authored_color_mix_fallbacks ~theme stmts =
   let rec lower_block stmts =
     List.concat_map
       (fun statement ->
@@ -2071,7 +2071,7 @@ let authored_color_mix_fallbacks ~theme stmts =
             in
             match Css.as_rule statement with
             | Some (selector, declarations, []) ->
-                lower_rule selector declarations
+                lower_color_mix_rule ~theme selector declarations
             | _ -> [ statement ]))
       stmts
   in

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -191,9 +191,10 @@ let theme_resolve_path ~theme inner =
       Stdlib.Option.bind (float_of_string_opt n) Theme.spacing_times
   | _ -> None
 
-(* Replace each theme(<path>) in a class string with its resolved value, spaces
-   re-encoded as [_] so downstream arbitrary-value decoding treats them as
-   spaces. Unresolved theme() calls are left verbatim. *)
+(* Replace each theme(<path>) in a class string with its resolved value, written
+   back in the spelling an arbitrary value is read in: a space becomes [_] and
+   an underscore [\_], so a project that binds a token to [var(--brand_red)]
+   keeps the variable it named. Unresolved theme() calls are left verbatim. *)
 let resolve_theme_functions ~theme s =
   let buf = Buffer.create (String.length s) in
   let n = String.length s in
@@ -212,9 +213,7 @@ let resolve_theme_functions ~theme s =
       let closed = !depth = 0 in
       let inner = String.sub s (!i + 6) (!j - (!i + 6)) in
       (match if closed then theme_resolve_path ~theme inner else None with
-      | Some v ->
-          Buffer.add_string buf
-            (String.map (fun c -> if c = ' ' then '_' else c) v)
+      | Some v -> Buffer.add_string buf (Parse.encode_underscores v)
       | None ->
           let stop = if closed then !j + 1 else n in
           Buffer.add_string buf (String.sub s !i (stop - !i)));

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -519,6 +519,29 @@ let theme_function_alpha_reads_any_palette_value () =
     (Astring.String.is_infix ~affix:"theme(colors.red"
        (css "[color:theme(colors.red.500/abc)]"))
 
+(* [theme()] resolves against the project's own binding and the resolved value
+   is written back into the class string, which reads a bare [_] as a space. A
+   project that binds a palette entry to a variable whose name carries an
+   underscore lost it: [var(--brand_red)] came back as [var(--brand red)], which
+   names a different variable, and an arbitrary property carrying it was dropped
+   outright. Tailwind v4.3.3 emits [var(--brand_red)] for the same theme, under
+   the class the source spells. *)
+let theme_function_keeps_an_underscore () =
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default
+      [ ("color-red-500", "var(--brand_red)") ]
+  in
+  match Tw.of_string ~theme "[color:theme(colors.red.500)]" with
+  | Error (`Msg m) -> Alcotest.failf "[color:theme(colors.red.500)]: %s" m
+  | Ok u ->
+      let css = Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string in
+      Alcotest.(check bool)
+        "the variable name keeps its underscore" true
+        (Astring.String.is_infix ~affix:"var(--brand_red)" css);
+      Alcotest.(check string)
+        "the class is the one the source spells" "[color:theme(colors.red.500)]"
+        (Tw.to_classes [ u ])
+
 let custom_breakpoint_theme_is_local () =
   let theme : Tw.Scheme.t =
     { Tw.Scheme.default with breakpoints = [ ("10xl", 1600.) ] }
@@ -1453,6 +1476,8 @@ let core_tests =
       theme_function_reads_the_project_palette;
     test_case "theme() alpha reads any palette value" `Quick
       theme_function_alpha_reads_any_palette_value;
+    test_case "theme() keeps an underscore" `Quick
+      theme_function_keeps_an_underscore;
     test_case "layout" `Slow layout;
     test_case "opacity" `Slow opacity_effects;
     test_case "extended colors" `Slow extended_colors;

--- a/test/tools/test_entrypoint.ml
+++ b/test/tools/test_entrypoint.ml
@@ -283,6 +283,64 @@ let test_apply_hoists_each_property_once () =
     (List.sort_uniq String.compare names)
     (List.sort String.compare names)
 
+(* The initial values of the variables the utilities set. [@layer properties]
+   holds them, on the universal selector, under one browser-detection
+   [@supports] condition. *)
+let property_fallbacks sheet =
+  Cascade.Css.statements sheet
+  |> List.concat_map (fun stmt ->
+      match Cascade.Css.as_layer stmt with
+      | Some (Some name, inner)
+        when Cascade.Css.Stylesheet.equal_layer_name name [ "properties" ] ->
+          inner
+      | _ -> [])
+
+let fallback_names stmts =
+  List.concat_map
+    (fun stmt ->
+      match Cascade.Css.as_supports stmt with
+      | None -> []
+      | Some (_, inner) ->
+          List.concat_map
+            (fun stmt ->
+              match Cascade.Css.as_rule stmt with
+              | Some (_, decls, _) ->
+                  List.map Cascade.Css.Declaration.property_name decls
+              | None -> [])
+            inner)
+    stmts
+
+(* The generated sheet hoists a [@layer properties] block and so does every
+   [@apply], and the two overlap whenever they name utilities that set the same
+   variables. Folded into the single layer Tailwind writes, they arrive as a run
+   of [@supports] blocks over one condition and one universal selector, each
+   repeating what the others already declare. Tailwind v4.3.3 writes one block
+   for the same input and declares each variable once. *)
+let test_property_fallbacks_in_one_block () =
+  let path = "property-fallback-entry.css" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc "@import \"tailwindcss\";\n.a { @apply shadow-md; }\n");
+  let generated =
+    Tw.to_css ~theme:Tw.Scheme.default ~base:false ~forms:false
+      [ Tw.shadow_lg; Tw.blur_sm ]
+  in
+  let out =
+    Fun.protect
+      ~finally:(fun () -> Sys.remove path)
+      (fun () ->
+        splice_into_entrypoint ~theme:Tw.Scheme.default ~path generated)
+  in
+  let fallbacks = property_fallbacks out in
+  check int "one block, the way Tailwind writes it" 1 (List.length fallbacks);
+  let names = fallback_names fallbacks in
+  check bool "the fallbacks are there" true (names <> []);
+  check string_list "each variable initialised once"
+    (List.sort_uniq String.compare names)
+    (List.sort String.compare names)
+
 (* Tailwind emits a declared utility as one block, its own nesting intact:
    [.line-y { padding: 5px; &::before { color: red } }]. Flattened into two
    rules, the second sorts by the property it writes and an unrelated utility
@@ -522,6 +580,8 @@ let tests =
       test_authored_color_mix_fallbacks;
     test_case "@apply hoists each property once" `Quick
       test_apply_hoists_each_property_once;
+    test_case "property fallbacks in one block" `Quick
+      test_property_fallbacks_in_one_block;
     test_case "declared utility keeps its nesting" `Quick
       test_declared_utility_keeps_its_nesting;
     test_case "complex custom variant keeps its candidate" `Quick


### PR DESCRIPTION
`@layer properties` carried sixteen `@supports` blocks over the tailwindcss.com class list, one per hoisting site, where Tailwind writes one; forty-five variables were initialised more than once. The canonical differ dedupes `@property`, so no parity gate saw it. The sheet's resolved value for all 123 variables is unchanged and everything outside the layer is byte-identical; it is 4329 bytes smaller.

Also fixes a `theme()` defect found while retiring a stale backlog entry: the resolved value went back into the class string with spaces mapped to underscores and nothing else, so a project binding `--color-red-500` to `var(--brand_red)` got `var(--brand red)`, and an arbitrary property carrying it was dropped.