### PR TITLE
parse: route arbitrary values through the full pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,9 @@
   animation, background, divide, filter, shadow, ring, scrollbar, table,
   transform, transition and typography values, including values that are
   invalid for the target property (#667).
+- `mask-[url(...)]` keeps the bare underscore a file name carries, the way
+  `bg-[url(...)]` already does: it named a different file, with a space in it
+  (#PR).
 - An arbitrary value keeps the underscore its `\_` escape spells, so
   `font-['My\_Font']`, `[--my\_var:red]` and `data-[foo=bar\_baz]:flex` reach
   the sheet as written instead of carrying the backslash into the value (#676).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -145,7 +145,7 @@
 - `gap-`, `margin-` and the inset families read a bracket value through the
   whole arbitrary decoder rather than its last stage alone, so
   `gap-[calc(1px_+_1px)]`, `mx-[--spacing(4)]` and `top-[calc(1px_+_1px)]`
-  reach the sheet (#PR).
+  reach the sheet (#688).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).
@@ -156,10 +156,10 @@
 - A `theme()` naming a key the resolved theme does not carry makes the class no
   utility, the way Tailwind emits no rule for it. `shadow-[0_0_0_1px_theme(a_b)]`
   compiled with the call written through into the declaration, and a fallback
-  argument now stands in for the missing key (#PR).
+  argument now stands in for the missing key (#688).
 - `mask-[url(...)]` keeps the bare underscore a file name carries, the way
   `bg-[url(...)]` already does: it named a different file, with a space in it
-  (#PR).
+  (#688).
 - An arbitrary value keeps the underscore its `\_` escape spells, so
   `font-['My\_Font']`, `[--my\_var:red]` and `data-[foo=bar\_baz]:flex` reach
   the sheet as written instead of carrying the backslash into the value (#676).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,10 @@
   siblings reach the sheet. A bracket only OCaml's number reader accepts is no
   longer folded to a different value: `tab-[0x4]` writes `tab-size: 0x4` rather
   than `4`, and `grid-cols-[0x4]` writes `0x4` rather than `4px` (#690).
+- `gap-`, `margin-` and the inset families read a bracket value through the
+  whole arbitrary decoder rather than its last stage alone, so
+  `gap-[calc(1px_+_1px)]`, `mx-[--spacing(4)]` and `top-[calc(1px_+_1px)]`
+  reach the sheet (#PR).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,10 @@
   animation, background, divide, filter, shadow, ring, scrollbar, table,
   transform, transition and typography values, including values that are
   invalid for the target property (#667).
+- A `theme()` naming a key the resolved theme does not carry makes the class no
+  utility, the way Tailwind emits no rule for it. `shadow-[0_0_0_1px_theme(a_b)]`
+  compiled with the call written through into the declaration, and a fallback
+  argument now stands in for the missing key (#PR).
 - `mask-[url(...)]` keeps the bare underscore a file name carries, the way
   `bg-[url(...)]` already does: it named a different file, with a space in it
   (#PR).

--- a/lib/gap.ml
+++ b/lib/gap.ml
@@ -396,10 +396,10 @@ module Handler = struct
       let inner = String.sub s 1 (len - 2) in
       if Parse.is_var inner then Some (Arbitrary_var inner)
       else
-        (* Route the value through the full length grammar (percent,
-           container-query units, calc), keeping the raw token for
-           round-trip. *)
-        match Css.parse_length (Parse.normalize_css_math_operators inner) with
+        (* Route the value through the whole arbitrary decoder and the full
+           length grammar (percent, container-query units, calc), keeping the
+           raw token for round-trip. *)
+        match Parse.arbitrary_length inner with
         | Some l -> Some (Arbitrary (inner, l))
         | None -> None
     else None

--- a/lib/margin.ml
+++ b/lib/margin.ml
@@ -193,13 +193,14 @@ module Handler = struct
   let parse_arbitrary s : signed option =
     (* Parse [4px], [1rem], [50%], [-5cqw], [calc(...)], or [var(--value)]. The
        raw inner is kept verbatim for the class name; the value goes through the
-       full length grammar so any unit or calc() is accepted. *)
+       whole arbitrary decoder and the full length grammar so any unit or calc()
+       is accepted. *)
     let len = String.length s in
     if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
       let inner = String.sub s 1 (len - 2) in
       if Parse.is_var inner then Some (Arbitrary_var inner)
       else
-        match Css.parse_length (Parse.normalize_css_math_operators inner) with
+        match Parse.arbitrary_length inner with
         | Some l -> Some (Arbitrary (inner, l))
         | None -> None
     else None

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -283,6 +283,22 @@ module Handler = struct
   let mask_position_style positions =
     style [ Css.webkit_mask_position positions; Css.mask_position positions ]
 
+  (* A whole value that is one [url()]: the first [)] closes it, so no second
+     layer hides behind a comma. *)
+  let is_single_url inner =
+    let n = String.length inner in
+    n > 5
+    && String.sub inner 0 4 = "url("
+    && inner.[n - 1] = ')'
+    && not (String.contains (String.sub inner 4 (n - 5)) ')')
+
+  (* Tailwind keeps a bare [_] inside [url()], where it is part of the file
+     name, and undoes only the [\_] escape; everywhere else in an arbitrary
+     value an underscore is a space. *)
+  let image_source inner =
+    if is_single_url inner then Parse.unescape_underscores inner
+    else Parse.decode_underscores inner
+
   let to_style _theme = function
     | No_mask -> mask_none
     | Add -> mask_add
@@ -364,8 +380,7 @@ module Handler = struct
             Css.mask_image (Var var_ref);
           ]
     | Bracket_image v -> (
-        let css_str = Parse.decode_underscores v in
-        match Css.parse_background_image css_str with
+        match Css.parse_background_image (image_source v) with
         | Some (img :: _) ->
             style [ Css.webkit_mask_image img; Css.mask_image img ]
         | _ ->
@@ -433,8 +448,7 @@ module Handler = struct
      whether the value parser accepts it, not which gradient function it
      names. *)
   let is_image_value inner =
-    let css_str = Parse.decode_underscores inner in
-    match Css.parse_background_image css_str with
+    match Css.parse_background_image (image_source inner) with
     | Some (_ :: _) -> true
     | _ -> false
 

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -153,34 +153,23 @@ let theme_color_with_alpha base a =
               Cascade.Css.Transparent))
   | _ -> None
 
-(* Resolve a Tailwind theme() dot-path to its static value:
-   colors.<name>.<shade> (optionally with a /<alpha> suffix) becomes the
-   colour's value mixed with the alpha, and spacing.<n> becomes <n * 0.25>rem.
-   Returns None for paths not resolved. *)
-let theme_resolve_path ~theme inner =
-  let path, alpha =
-    match String.index_opt inner '/' with
-    | Some k ->
-        ( String.sub inner 0 k,
-          Some (String.sub inner (k + 1) (String.length inner - k - 1)) )
-    | None -> (inner, None)
-  in
+(* The value the theme binds a [theme()] dot path to, before any alpha:
+   [colors.<name>.<shade>] is the palette entry, [spacing.<n>] the spacing
+   product. [None] is a path this does not resolve, which is not the same
+   question as whether the theme carries the key. *)
+let theme_key_value ~theme path =
   match String.split_on_char '.' path with
   | [ "colors"; name; shade ] -> (
-      match (Color.of_string name, int_of_string_opt shade) with
-      | Ok c, Some sh -> (
-          (* A project that renames a palette entry in its [@theme] gets its own
-             value back here, the way [bg-<name>-<shade>] already does. *)
-          let token = String.concat "-" [ "color"; name; shade ] in
-          let base =
-            match Scheme.theme_value (Some theme) token with
-            | Some v -> v
-            | None -> Color.to_oklch_css c sh
-          in
-          match alpha with
-          | Some a -> theme_color_with_alpha base a
-          | None -> Some base)
-      | _ -> None)
+      (* A project that renames or adds a palette entry in its [@theme] gets its
+         own value back here, the way [bg-<name>-<shade>] already does. *)
+      let token = String.concat "-" [ "color"; name; shade ] in
+      match Scheme.theme_value (Some theme) token with
+      | Some _ as v -> v
+      | None -> (
+          match (Color.of_string name, int_of_string_opt shade) with
+          | Ok c, Some sh when Color.is_valid_shade c sh ->
+              Some (Color.to_oklch_css c sh)
+          | _ -> None))
   | [ "spacing"; n ] ->
       (* The step here is Tailwind's own 0.25rem and not whatever [--spacing]
          the project set: checked against the CLI with [@theme { --spacing:
@@ -191,14 +180,68 @@ let theme_resolve_path ~theme inner =
       Stdlib.Option.bind (float_of_string_opt n) Theme.spacing_times
   | _ -> None
 
+(* Resolve one theme() argument.
+
+   [`Value] is the key resolved, mixed with the [/<alpha>] it carries when it
+   has one. [`Missing] is a key the theme provably does not carry, which
+   Tailwind answers with no rule at all: a bare segment names no namespace, and
+   the palette namespace is one tw resolves in full, so an entry missing from it
+   is missing. [`Verbatim] is everything else - an alpha naming no number, the
+   [--<token>] spelling, and a namespace tw does not resolve - where there is no
+   table saying the key is absent and Tailwind emits a rule for the ones it
+   knows. *)
+let theme_resolve_key ~theme key =
+  let path, alpha =
+    match String.index_opt key '/' with
+    | Some k ->
+        ( String.sub key 0 k,
+          Some (String.sub key (k + 1) (String.length key - k - 1)) )
+    | None -> (key, None)
+  in
+  match theme_key_value ~theme path with
+  | Some base -> (
+      match alpha with
+      | None -> `Value base
+      | Some a -> (
+          match theme_color_with_alpha base a with
+          | Some v -> `Value v
+          | None -> `Verbatim))
+  | None -> (
+      match String.split_on_char '.' path with
+      | "colors" :: _ -> `Missing
+      | [ token ]
+        when not (String.length token > 2 && String.sub token 0 2 = "--") ->
+          `Missing
+      | _ -> `Verbatim)
+
+(* Split a theme() argument into its key and the fallback after the first
+   top-level comma, which stands in whenever the key resolves to nothing. *)
+let theme_call_fallback inner =
+  let n = String.length inner in
+  let rec go i depth =
+    if i >= n then (inner, None)
+    else
+      match inner.[i] with
+      | '(' -> go (i + 1) (depth + 1)
+      | ')' -> go (i + 1) (depth - 1)
+      | ',' when depth = 0 ->
+          (String.sub inner 0 i, Some (String.sub inner (i + 1) (n - i - 1)))
+      | _ -> go (i + 1) depth
+  in
+  go 0 0
+
 (* Replace each theme(<path>) in a class string with its resolved value, written
    back in the spelling an arbitrary value is read in: a space becomes [_] and
    an underscore [\_], so a project that binds a token to [var(--brand_red)]
-   keeps the variable it named. Unresolved theme() calls are left verbatim. *)
+   keeps the variable it named. [None] is a call naming a key the theme does not
+   carry and offering no fallback: Tailwind emits no rule for such a class, so
+   it is not a utility. *)
 let resolve_theme_functions ~theme s =
   let buf = Buffer.create (String.length s) in
   let n = String.length s in
+  let missing = ref false in
   let i = ref 0 in
+  let resolved v = Buffer.add_string buf (Parse.encode_underscores v) in
   while !i < n do
     if !i + 6 <= n && String.sub s !i 6 = "theme(" then begin
       let j = ref (!i + 6) and depth = ref 1 in
@@ -208,15 +251,24 @@ let resolve_theme_functions ~theme s =
       done;
       (* [!j] is the closing paren, or [n] when the call never closed - a
          truncated attribute or template artefact in scanned markup. An
-         unterminated call has no path to resolve, so the rest of the string is
+         unterminated call has no key to read, so the rest of the string is
          copied through and the class stays unresolved. *)
       let closed = !depth = 0 in
       let inner = String.sub s (!i + 6) (!j - (!i + 6)) in
-      (match if closed then theme_resolve_path ~theme inner else None with
-      | Some v -> Buffer.add_string buf (Parse.encode_underscores v)
-      | None ->
-          let stop = if closed then !j + 1 else n in
-          Buffer.add_string buf (String.sub s !i (stop - !i)));
+      let verbatim () =
+        let stop = if closed then !j + 1 else n in
+        Buffer.add_string buf (String.sub s !i (stop - !i))
+      in
+      (if not closed then verbatim ()
+       else
+         let key, fallback = theme_call_fallback inner in
+         match theme_resolve_key ~theme key with
+         | `Value v -> resolved v
+         | `Verbatim -> verbatim ()
+         | `Missing -> (
+             match fallback with
+             | Some f -> Buffer.add_string buf f
+             | None -> missing := true));
       i := if closed then !j + 1 else n
     end
     else begin
@@ -224,7 +276,7 @@ let resolve_theme_functions ~theme s =
       incr i
     end
   done;
-  Buffer.contents buf
+  if !missing then None else Some (Buffer.contents buf)
 
 (* The rejection a class gets once no handler has claimed it. A bracket class
    that looks like an arbitrary property but that nothing accepted is malformed
@@ -267,26 +319,29 @@ let of_string ?(theme = Scheme.default) class_str =
     | Some u -> Ok u
     | None -> Error (`Msg ("Unknown modifier in: " ^ class_str))
   in
-  (* Resolve theme() dot-paths for dispatch, keeping the original spelling as
-     the class-name alias so the utility still round-trips. *)
-  let resolved_base = resolve_theme_functions ~theme base_class in
-  let theme_alias =
-    if resolved_base = base_class then None else Some base_class
-  in
-  match Utility.base_of_class theme resolved_base with
-  | Ok base_utility -> finish ?alias:theme_alias base_utility
-  | Error _ -> (
-      (* Fallback: the v4 [prop-(--x)] shorthand for handlers that accept the
-         [prop-[var(--x)]] form but not the paren spelling directly. Handlers
-         that support [(--x)] natively (e.g. rotate) already matched above, so
-         this never overrides them. The original spelling is kept via the
-         alias. *)
-      match normalize_paren_var base_class with
-      | Some normalized -> (
-          match Utility.base_of_class theme normalized with
-          | Ok base_utility -> finish ~alias:base_class base_utility
-          | Error _ -> Error (`Msg ("Unknown class: " ^ class_str)))
-      | None -> unknown_class_error ~base_class class_str)
+  (* Resolve theme() calls for dispatch, keeping the original spelling as the
+     class-name alias so the utility still round-trips. A call naming no key
+     leaves nothing to dispatch on. *)
+  match resolve_theme_functions ~theme base_class with
+  | None -> unknown_class_error ~base_class class_str
+  | Some resolved_base -> (
+      let theme_alias =
+        if resolved_base = base_class then None else Some base_class
+      in
+      match Utility.base_of_class theme resolved_base with
+      | Ok base_utility -> finish ?alias:theme_alias base_utility
+      | Error _ -> (
+          (* Fallback: the v4 [prop-(--x)] shorthand for handlers that accept
+             the [prop-[var(--x)]] form but not the paren spelling directly.
+             Handlers that support [(--x)] natively (e.g. rotate) already
+             matched above, so this never overrides them. The original spelling
+             is kept via the alias. *)
+          match normalize_paren_var base_class with
+          | Some normalized -> (
+              match Utility.base_of_class theme normalized with
+              | Ok base_utility -> finish ~alias:base_class base_utility
+              | Error _ -> Error (`Msg ("Unknown class: " ^ class_str)))
+          | None -> unknown_class_error ~base_class class_str))
 
 (* A name the parser rejects may be a typo or a deliberate non-tw class - a
    framework hook, a JS selector - and nothing here can tell the two apart. So

--- a/test/test_gap.ml
+++ b/test/test_gap.ml
@@ -133,6 +133,19 @@ let test_arbitrary_length_grammar () =
   check "gap-[inherit]";
   check "gap-[4px]"
 
+(* An arbitrary value is read by the whole decoder, not by its last stage alone:
+   [_] is a space, [--spacing(n)] expands to the spacing product, and only then
+   are the math operators re-spaced. Tailwind emits all of these. *)
+let test_arbitrary_value_decoder_stages () =
+  Test_helpers.check_declarations "gap-[calc(1px_+_1px)]"
+    [ "gap:calc(1px + 1px)" ];
+  Test_helpers.check_declarations "gap-x-[calc(1px_+_1px)]"
+    [ "column-gap:calc(1px + 1px)" ];
+  Test_helpers.check_declarations "gap-y-[calc(1px_+_1px)]"
+    [ "row-gap:calc(1px + 1px)" ];
+  Test_helpers.check_declarations "gap-[--spacing(4)]"
+    [ "gap:calc(var(--spacing)*4)" ]
+
 (* The paren shorthand is Tailwind's first candidate value and literal px its
    last; numeric and bracket values stay between those boundaries. *)
 let test_gap_candidate_boundaries () =
@@ -165,6 +178,8 @@ let tests =
     test_case "space-px CSS values" `Quick test_space_px_values;
     test_case "gap CSS values" `Quick test_css_values;
     test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
+    test_case "arbitrary value decoder stages" `Quick
+      test_arbitrary_value_decoder_stages;
     test_case "gap candidate boundaries" `Quick test_gap_candidate_boundaries;
   ]
 

--- a/test/test_margin.ml
+++ b/test/test_margin.ml
@@ -199,6 +199,14 @@ let test_arbitrary_length_grammar () =
   check "ml-[50%]";
   check "mb-[-5cqw]"
 
+(* An arbitrary value is read by the whole decoder, not by its last stage alone:
+   [_] is a space, [--spacing(n)] expands to the spacing product, and only then
+   are the math operators re-spaced. Tailwind emits all of these. *)
+let test_arbitrary_value_decoder_stages () =
+  check_declarations "mx-[calc(1px_+_1px)]" [ "margin-inline:calc(1px + 1px)" ];
+  check_declarations "mt-[calc(1px_+_1px)]" [ "margin-top:calc(1px + 1px)" ];
+  check_declarations "m-[--spacing(4)]" [ "margin:calc(var(--spacing)*4)" ]
+
 (* The [']-suffixed sibling of each int constructor takes a half-step float (and
    still supports negative values); the int base keeps emitting what it always
    did. *)
@@ -229,6 +237,8 @@ let tests =
       margin_side_bands_match_tailwind;
     test_case "margin CSS values" `Quick test_css_values;
     test_case "arbitrary length grammar" `Quick test_arbitrary_length_grammar;
+    test_case "arbitrary value decoder stages" `Quick
+      test_arbitrary_value_decoder_stages;
     test_case "margins render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -173,11 +173,23 @@ let test_bracket_image_underscore_escape () =
     (Astring.String.is_infix ~affix:"mask-image: url('a_b.png')"
        (css {|mask-[url('a\_b.png')]|}))
 
+(* Tailwind leaves a bare [_] alone inside [url()], where it is part of the file
+   name rather than an encoded space, so [mask-[url('a_b.png')]] names
+   [a_b.png]. Only the [\_] escape is undone, the way the background family
+   already reads it. The quotes are the minifier's to drop, on both sides. *)
+let test_bracket_url_keeps_underscores () =
+  Test_helpers.check_declarations "mask-[url('a_b.png')]"
+    [ "-webkit-mask-image:url(a_b.png)"; "mask-image:url(a_b.png)" ];
+  Test_helpers.check_declarations "mask-[url(a_b.png)]"
+    [ "-webkit-mask-image:url(a_b.png)"; "mask-image:url(a_b.png)" ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
       Alcotest.test_case "mask image underscore escape" `Quick
         test_bracket_image_underscore_escape;
+      Alcotest.test_case "bracket url keeps underscores" `Quick
+        test_bracket_url_keeps_underscores;
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
       Alcotest.test_case "arbitrary mask layer list" `Quick

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -178,6 +178,26 @@ let test_arbitrary_calc () =
        (css "left-[calc(50%+var(--offset))]"));
   check "left-[calc(5%-2px)]"
 
+(* An arbitrary value is read by the whole decoder, not by its last stage alone:
+   [_] is a space, [--spacing(n)] expands to the spacing product, and only then
+   are the math operators re-spaced. The bare suffix keeps its own reading,
+   where a step OCaml's number reader accepts but Tailwind does not ([top-0x4],
+   [top-1_0]) is still no utility. *)
+let test_arbitrary_value_decoder_stages () =
+  Test_helpers.check_declarations "top-[calc(1px_+_1px)]"
+    [ "top:calc(1px + 1px)" ];
+  Test_helpers.check_declarations "inset-[calc(1px_+_1px)]"
+    [ "inset:calc(1px + 1px)" ];
+  Test_helpers.check_declarations "left-[--spacing(4)]"
+    [ "left:calc(var(--spacing)*4)" ];
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  rejected "top-0x4";
+  rejected "top-1_0"
+
 (* An arbitrary inset whose body is not a whole calc expression is not a
    utility. In [-left-[0)/*1]] the stray ')' closes nothing and the '/*' opens a
    comment that never ends, so Tailwind emits no rule for it. *)
@@ -475,6 +495,8 @@ let tests =
     test_case "arbitrary var insets" `Quick test_arbitrary_var;
     test_case "spacing steps (fractional + px)" `Quick test_spacing_steps;
     test_case "arbitrary calc insets" `Quick test_arbitrary_calc;
+    test_case "arbitrary value decoder stages" `Quick
+      test_arbitrary_value_decoder_stages;
     test_case "unbalanced arbitrary inset rejected" `Quick
       test_unbalanced_arbitrary_rejected;
     test_case "position suborder matches Tailwind" `Quick

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -542,6 +542,34 @@ let theme_function_keeps_an_underscore () =
         "the class is the one the source spells" "[color:theme(colors.red.500)]"
         (Tw.to_classes [ u ])
 
+(* Tailwind emits no rule at all for a [theme()] naming a key its resolved theme
+   does not carry, so a class carrying one is not a utility. A bare segment
+   names no namespace and the palette namespace is known in full, so both are
+   provably missing. A key the theme does carry still resolves, alone or inside
+   a longer value, and a fallback argument stands in for a missing key. *)
+let theme_function_rejects_an_unknown_key () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  rejected "shadow-[0_0_0_1px_theme(a_b)]";
+  rejected {|shadow-[0_0_0_1px_theme(a\_b)]|};
+  rejected "[color:theme(colors.nope.500)]";
+  rejected "[color:theme(colors.red.999)]";
+  rejected "[color:theme(colors.red)]";
+  (* a key the theme carries still resolves *)
+  Test_helpers.check_declarations "p-[theme(spacing.4)]" [ "padding:1rem" ];
+  Test_helpers.check_declarations "[color:theme(colors.red.500)]"
+    [ "color:oklch(63.7%.237 25.331)" ];
+  (* and inside a longer value *)
+  Test_helpers.check_declarations "p-[calc(theme(spacing.4)_*_2)]"
+    [ "padding:calc(1rem*2)" ];
+  (* a missing key with a fallback takes the fallback, the way Tailwind does *)
+  Test_helpers.check_declarations "[color:theme(nope,blue)]" [ "color:blue" ];
+  Test_helpers.check_declarations "[color:theme(colors.nope.500,blue)]"
+    [ "color:blue" ]
+
 let custom_breakpoint_theme_is_local () =
   let theme : Tw.Scheme.t =
     { Tw.Scheme.default with breakpoints = [ ("10xl", 1600.) ] }
@@ -1540,6 +1568,8 @@ let core_tests =
     test_case "style combination" `Slow style_combination;
     test_case "paren var shorthand" `Quick paren_var_shorthand;
     test_case "unterminated theme() call" `Quick unterminated_theme_call;
+    test_case "theme() rejects an unknown key" `Quick
+      theme_function_rejects_an_unknown_key;
     test_case "arbitrary property rejection message" `Quick
       arbitrary_property_rejection_message;
     test_case "responsive classes" `Slow responsive_classes;


### PR DESCRIPTION
Three arbitrary-value defects, one commit pair each.

`gap`, `margin` and the inset families read a bracket value through the last
stage of `Parse.decode_arbitrary_value` alone, so `gap-[calc(1px_+_1px)]`,
`mx-[--spacing(4)]` and `top-[calc(1px_+_1px)]` were refused where Tailwind
emits a rule. Each site now calls `Parse.arbitrary_length`, the helper the
padding and sizing families already use. The bare suffix keeps its own decimal
reader, so `top-0x4` is still no utility.

A mask image was decoded with the underscore-to-space rule applied to the whole
value, so `mask-[url('a_b.png')]` named a file with a space in it. Tailwind
leaves a `url()` body alone but for the `\_` escape, which is the reading
`bg-[url(...)]` already takes.

A `theme()` naming a key the resolved theme does not carry now makes the class
no utility, matching Tailwind, which emits nothing for it. Rejection is limited
to the spellings tw knows in full: a bare segment names no namespace, and the
palette namespace is resolved here, so `theme(a_b)`, `theme(colors.nope.500)`
and `theme(colors.red.999)` are provably missing. Every other spelling is still
written through, and a fallback argument stands in for a missing key.
