### PR TITLE
parse: read quoted brackets and decode bracket contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,11 +150,11 @@
   `transform-` decode their bracket the way every other family does, so
   `flex-[calc(1+2)]` and `origin-[--spacing(4)_--spacing(2)]` reach the sheet.
   Reading the text with OCaml's number reader instead folded `flex-[0x4]` to
-  `flex: 4` under the class name `.flex-\[4\]` (#PR).
+  `flex: 4` under the class name `.flex-\[4\]` (#689).
 - A `]` written inside a quoted or escaped part of an arbitrary value belongs
   to the value, so `bg-[url('a]b')]`, `font-['My]Font']`, `mask-[url('a]b')]`,
   `shadow-[0_0_0_'a]b']` and `list-image-[url('a]b')]` reach the sheet. An
-  unterminated string still refuses the class, as it does in Tailwind (#PR).
+  unterminated string still refuses the class, as it does in Tailwind (#689).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -146,6 +146,10 @@
   whole arbitrary decoder rather than its last stage alone, so
   `gap-[calc(1px_+_1px)]`, `mx-[--spacing(4)]` and `top-[calc(1px_+_1px)]`
   reach the sheet (#688).
+- A `]` written inside a quoted or escaped part of an arbitrary value belongs
+  to the value, so `bg-[url('a]b')]`, `font-['My]Font']`, `mask-[url('a]b')]`,
+  `shadow-[0_0_0_'a]b']` and `list-image-[url('a]b')]` reach the sheet. An
+  unterminated string still refuses the class, as it does in Tailwind (#PR).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -146,6 +146,11 @@
   whole arbitrary decoder rather than its last stage alone, so
   `gap-[calc(1px_+_1px)]`, `mx-[--spacing(4)]` and `top-[calc(1px_+_1px)]`
   reach the sheet (#688).
+- `flex-`, `grow-`, `shrink-`, `order-`, `origin-`, `perspective-origin-` and
+  `transform-` decode their bracket the way every other family does, so
+  `flex-[calc(1+2)]` and `origin-[--spacing(4)_--spacing(2)]` reach the sheet.
+  Reading the text with OCaml's number reader instead folded `flex-[0x4]` to
+  `flex: 4` under the class name `.flex-\[4\]` (#PR).
 - A `]` written inside a quoted or escaped part of an arbitrary value belongs
   to the value, so `bg-[url('a]b')]`, `font-['My]Font']`, `mask-[url('a]b')]`,
   `shadow-[0_0_0_'a]b']` and `list-image-[url('a]b')]` reach the sheet. An

--- a/lib/flex_props.ml
+++ b/lib/flex_props.ml
@@ -19,18 +19,21 @@ module Handler = struct
     | Flex_none
     | Flex_n of int (* flex-N where N is any integer *)
     | Flex_fraction of int * int (* flex-N/M where N/M is a fraction *)
-    | Flex_arbitrary of int (* flex-[123] *)
+    | Flex_arbitrary of string * [ `Flex of Css.flex | `Raw of string ]
+    (* flex-[123] *)
     (* Grow *)
     | Flex_grow
     | Flex_grow_0
     | Flex_grow_n of int (* grow-N where N is any integer *)
-    | Flex_grow_arbitrary of int (* grow-[123] *)
+    | Flex_grow_arbitrary of string * [ `Number of float | `Raw of string ]
+      (* grow-[123] *)
     | Flex_grow_legacy (* flex-grow (deprecated alias, keeps its class name) *)
     | Flex_grow_0_legacy (* flex-grow-0 *)
     (* Shrink *)
     | Flex_shrink
     | Flex_shrink_0
-    | Flex_shrink_arbitrary of int (* shrink-[123] *)
+    | Flex_shrink_arbitrary of string * [ `Number of float | `Raw of string ]
+      (* shrink-[123] *)
     | Flex_shrink_legacy (* flex-shrink *)
     | Flex_shrink_0_legacy (* flex-shrink-0 *)
     (* Basis *)
@@ -81,6 +84,11 @@ module Handler = struct
         flex
           (Basis (Pct (Option.value ~default:0. (Parse.fraction_percent n m))));
       ]
+
+  (* A bracket no property grammar reads is still a value Tailwind writes out,
+     so it reaches the sheet as the token stream it is. *)
+  let opaque property raw =
+    style (Option.to_list (Parse.opaque_declaration property raw))
 
   (* Grow *)
   let flex_grow_utility = style [ flex_grow 1.0 ]
@@ -180,16 +188,19 @@ module Handler = struct
     | Flex_none -> flex_none
     | Flex_n n -> flex_n_style n
     | Flex_fraction (n, m) -> flex_fraction_style n m
-    | Flex_arbitrary n -> flex_n_style n
+    | Flex_arbitrary (_, `Flex v) -> style [ flex v ]
+    | Flex_arbitrary (_, `Raw raw) -> opaque "flex" raw
     | Flex_grow -> flex_grow_utility
     | Flex_grow_0 -> flex_grow_0_utility
     | Flex_grow_n n -> style [ flex_grow (float_of_int n) ]
-    | Flex_grow_arbitrary n -> style [ flex_grow (float_of_int n) ]
+    | Flex_grow_arbitrary (_, `Number f) -> style [ flex_grow f ]
+    | Flex_grow_arbitrary (_, `Raw raw) -> opaque "flex-grow" raw
     | Flex_grow_legacy -> flex_grow_utility
     | Flex_grow_0_legacy -> flex_grow_0_utility
     | Flex_shrink -> flex_shrink_utility
     | Flex_shrink_0 -> flex_shrink_0_utility
-    | Flex_shrink_arbitrary n -> style [ flex_shrink (float_of_int n) ]
+    | Flex_shrink_arbitrary (_, `Number f) -> style [ flex_shrink f ]
+    | Flex_shrink_arbitrary (_, `Raw raw) -> opaque "flex-shrink" raw
     | Flex_shrink_legacy -> flex_shrink_utility
     | Flex_shrink_0_legacy -> flex_shrink_0_utility
     | Basis_0 -> basis_0
@@ -228,8 +239,11 @@ module Handler = struct
     | Flex_fraction (n, m) -> 1020 + (n * 100) + m
     (* flex-N values: after fractions, ordered by value *)
     | Flex_n n -> 5000 + n
-    (* Arbitrary flex values - after regular numbers *)
-    | Flex_arbitrary n -> 6000 + n
+    (* Arbitrary flex values - after the numbered ones, ordered by the grow
+       factor the bracket denotes, and a bracket denoting none last: Tailwind
+       sorts flex-[2] before flex-[10] before flex-[<value>]. *)
+    | Flex_arbitrary (_, `Flex (Grow (Number f))) -> 6000 + int_of_float f
+    | Flex_arbitrary _ -> 9000
     (* Named shortcuts come last *)
     | Flex_auto -> 10000
     | Flex_initial -> 10001
@@ -239,14 +253,18 @@ module Handler = struct
     | Flex_shrink_0_legacy -> 19999
     | Flex_shrink -> 20000
     | Flex_shrink_0 -> 20001
-    | Flex_shrink_arbitrary _ -> 20002
+    | Flex_shrink_arbitrary (_, `Number f) -> 20002 + int_of_float f
+    | Flex_shrink_arbitrary _ -> 25000
     (* Grow - legacy flex-grow* sorts before the canonical grow* *)
     | Flex_grow_legacy -> 29998
     | Flex_grow_0_legacy -> 29999
     | Flex_grow -> 30000
     | Flex_grow_0 -> 30001
     | Flex_grow_n n -> 30000 + n
-    | Flex_grow_arbitrary _ -> 30002
+    (* Arbitrary grow values sort after every numbered one, the way Tailwind
+       lists grow, grow-0, grow-3, grow-7, grow-[2], grow-[<value>]. *)
+    | Flex_grow_arbitrary (_, `Number f) -> 35000 + int_of_float f
+    | Flex_grow_arbitrary _ -> 39000
     (* Basis: fractions → arbitrary → keywords alphabetical → named *)
     | Basis_fraction (n, m) -> 40000 + (n * 10) + m
     | Basis_arbitrary _ -> 42000
@@ -274,16 +292,45 @@ module Handler = struct
         true
     | _ -> false
 
+  (* A bracket read with the grammar cascade has for the property, off the
+     arbitrary-value pipeline every other family reads: [_] stands for a space,
+     [--spacing(n)] expands, and a binary [+] gets the spaces CSS math wants, so
+     [calc(1+2)] is a value rather than a parse error. *)
+  let arbitrary_typed read inner =
+    let cursor =
+      Cascade.Cursor.of_string (Parse.decode_arbitrary_value inner)
+    in
+    match Cascade.Cursor.try_parse_full_err read cursor with
+    | Ok v -> Some v
+    | Error _ -> None
+
   (* The order an [order-[...]] bracket denotes. [None] is a bracket the order
      grammar cannot read, and [of_class] refuses the utility rather than leaving
      [to_style] to raise. *)
   let arbitrary_order inner : Css.order option =
-    let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
-    match
-      Cascade.Cursor.try_parse_full_err Css.Properties.read_order cursor
-    with
-    | Ok o -> Some o
-    | Error _ -> None
+    arbitrary_typed Css.Properties.read_order inner
+
+  (* [flex-], [grow-] and [shrink-] take the same two readings [duration-] does:
+     a value the property's own grammar accepts keeps its typed form, and
+     anything else Tailwind writes out passes through as a declaration-safe
+     token stream. OCaml's number reader serves neither - it reads [0x4] as 4,
+     so the class named itself after a value nobody wrote, and it refuses
+     [calc(1+2)], which is a value once the pipeline has spaced it out. *)
+  let arbitrary_raw inner =
+    Option.map (fun v -> `Raw v) (Parse.arbitrary_declaration_value inner)
+
+  let arbitrary_flex inner =
+    match arbitrary_typed Css.Properties.read_flex inner with
+    | Some v -> Some (`Flex v)
+    | None -> arbitrary_raw inner
+
+  let arbitrary_factor inner =
+    let typed : Css.flex_factor option =
+      arbitrary_typed Css.Properties.read_flex_factor inner
+    in
+    match typed with
+    | Some (Number f) -> Some (`Number f)
+    | Some _ | None -> arbitrary_raw inner
 
   let of_class _theme class_name =
     let parts = Parse.split_class class_name in
@@ -298,8 +345,8 @@ module Handler = struct
     | [ "grow"; "0" ] -> Ok Flex_grow_0
     | [ "grow"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in
-        match int_of_string_opt inner with
-        | Some i -> Ok (Flex_grow_arbitrary i)
+        match arbitrary_factor inner with
+        | Some v -> Ok (Flex_grow_arbitrary (inner, v))
         | None -> err_not_utility)
     | [ "grow"; n ] -> (
         match Parse.decimal_int n with
@@ -311,8 +358,8 @@ module Handler = struct
     | [ "shrink"; "0" ] -> Ok Flex_shrink_0
     | [ "shrink"; n ] when Parse.is_bracket_value n -> (
         let inner = Parse.bracket_inner n in
-        match int_of_string_opt inner with
-        | Some i -> Ok (Flex_shrink_arbitrary i)
+        match arbitrary_factor inner with
+        | Some v -> Ok (Flex_shrink_arbitrary (inner, v))
         | None -> err_not_utility)
     | [ "basis"; "0" ] -> Ok Basis_0
     | [ "basis"; "1" ] -> Ok Basis_1
@@ -351,12 +398,8 @@ module Handler = struct
     | [ "order"; "none" ] -> Ok Order_none
     | "order" :: rest when rest <> [] -> (
         let value = String.concat "-" rest in
-        if
-          String.length value > 2
-          && value.[0] = '['
-          && value.[String.length value - 1] = ']'
-        then
-          let inner = String.sub value 1 (String.length value - 2) in
+        if Parse.is_bracket_value value then
+          let inner = Parse.bracket_inner value in
           match arbitrary_order inner with
           | Some o -> Ok (Order_arbitrary (inner, o))
           | None -> err_not_utility
@@ -367,12 +410,8 @@ module Handler = struct
     | "" :: "order" :: rest when rest <> [] -> (
         (* Negative order: -order-4, -order-[var(--value)] *)
         let value = String.concat "-" rest in
-        if
-          String.length value > 2
-          && value.[0] = '['
-          && value.[String.length value - 1] = ']'
-        then
-          let inner = String.sub value 1 (String.length value - 2) in
+        if Parse.is_bracket_value value then
+          let inner = Parse.bracket_inner value in
           match arbitrary_order inner with
           | Some o -> Ok (Neg_order_arbitrary (inner, o))
           | None -> err_not_utility
@@ -380,15 +419,12 @@ module Handler = struct
           match Parse.decimal_int value with
           | Some n when n >= 1 -> Ok (Neg_order n)
           | _ -> err_not_utility)
-    | [ "flex"; value ] when String.length value > 0 && value.[0] = '[' ->
+    | [ "flex"; value ] when Parse.is_bracket_value value -> (
         (* Arbitrary flex: flex-[123] *)
-        let len = String.length value in
-        if len > 2 && value.[len - 1] = ']' then
-          let inner = String.sub value 1 (len - 2) in
-          match int_of_string_opt inner with
-          | Some n -> Ok (Flex_arbitrary n)
-          | None -> err_not_utility
-        else err_not_utility
+        let inner = Parse.bracket_inner value in
+        match arbitrary_flex inner with
+        | Some v -> Ok (Flex_arbitrary (inner, v))
+        | None -> err_not_utility)
     | [ "flex"; value ] -> (
         (* Try fraction first (e.g., "1/2") *)
         match parse_fraction value with
@@ -408,19 +444,19 @@ module Handler = struct
     | Flex_none -> "flex-none"
     | Flex_n n -> "flex-" ^ string_of_int n
     | Flex_fraction (n, m) -> "flex-" ^ string_of_int n ^ "/" ^ string_of_int m
-    | Flex_arbitrary n -> "flex-[" ^ string_of_int n ^ "]"
+    | Flex_arbitrary (raw, _) -> "flex-[" ^ raw ^ "]"
     (* Grow - Tailwind v4 uses shorter names; the flex-* spellings are kept as
        deprecated aliases that preserve their class name *)
     | Flex_grow -> "grow"
     | Flex_grow_0 -> "grow-0"
     | Flex_grow_n n -> "grow-" ^ string_of_int n
-    | Flex_grow_arbitrary n -> "grow-[" ^ string_of_int n ^ "]"
+    | Flex_grow_arbitrary (raw, _) -> "grow-[" ^ raw ^ "]"
     | Flex_grow_legacy -> "flex-grow"
     | Flex_grow_0_legacy -> "flex-grow-0"
     (* Shrink - Tailwind v4 uses shorter names *)
     | Flex_shrink -> "shrink"
     | Flex_shrink_0 -> "shrink-0"
-    | Flex_shrink_arbitrary n -> "shrink-[" ^ string_of_int n ^ "]"
+    | Flex_shrink_arbitrary (raw, _) -> "shrink-[" ^ raw ^ "]"
     | Flex_shrink_legacy -> "flex-shrink"
     | Flex_shrink_0_legacy -> "flex-shrink-0"
     (* Basis *)

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -121,16 +121,30 @@ let extract_var_name s =
 (* One bracket, not two: the closing bracket has to be the last character. A
    suffix carrying a second bracket - one bracket with a bracket modifier, or
    two brackets in a row - would otherwise read as one bracket whose inner text
-   has a stray bracket in it, which no declaration value takes. *)
+   has a stray bracket in it, which no declaration value takes.
+
+   A []] the value quotes or escapes is part of the value, so the scan tokenises
+   strings and the [\] escape the way CSS Syntax 3 sec. 4.3 does:
+   [bg-[url('a]b')]] is one bracket whose text carries a []]. A string the value
+   leaves open runs to the end of the input, as it does in the tokeniser, so no
+   []] after it closes the bracket and the suffix is refused - which is what
+   Tailwind does with [bg-[url('a)]]. *)
 let is_bracket_value s =
   let len = String.length s in
   let rec close i depth =
     if i >= len then false
     else
       match s.[i] with
+      | '\\' -> close (i + 2) depth
+      | '\'' | '"' -> in_string (i + 1) depth s.[i]
       | '[' -> close (i + 1) (depth + 1)
       | ']' -> if depth = 0 then i = len - 1 else close (i + 1) (depth - 1)
       | _ -> close (i + 1) depth
+  and in_string i depth quote =
+    if i >= len then false
+    else if s.[i] = '\\' then in_string (i + 2) depth quote
+    else if s.[i] = quote then close (i + 1) depth
+    else in_string (i + 1) depth quote
   in
   len > 2 && s.[0] = '[' && close 1 0
 

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -69,7 +69,13 @@ val is_bracket_value : string -> bool
 (** [is_bracket_value s] returns [true] if [s] is one bracket-wrapped value. The
     closing bracket has to be the last character, so a suffix carrying a second
     bracket - one bracket with a bracket modifier, or two brackets in a row - is
-    not one bracket value. *)
+    not one bracket value.
+
+    A closing bracket the value quotes or escapes belongs to the value: strings
+    and the backslash escape are read as CSS Syntax 3 sec. 4.3 reads them, so a
+    quoted [url()] argument carrying one is still one bracket value. A string
+    left open runs to the end of [s], so nothing after it can close the bracket
+    and [s] is not one. *)
 
 val bracket_inner : string -> string
 (** [bracket_inner s] extracts the inner content from ["[foo]"], returning

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -1555,10 +1555,15 @@ module Handler = struct
   let parse_fraction = Parse.fraction
 
   (* The value a bracket denotes, read with the grammar cascade already has for
-     the property. [None] is a bracket that grammar refuses, and [of_class]
-     declines the utility rather than leaving [to_style] to raise. *)
+     the property, off the arbitrary-value pipeline every other family reads:
+     [_] stands for a space, [--spacing(n)] expands, and a binary [+] gets the
+     spaces CSS math wants, so [calc(1px+1px)] is a value rather than a parse
+     error. [None] is a bracket that grammar refuses, and [of_class] declines
+     the utility rather than leaving [to_style] to raise. *)
   let arbitrary_value read inner =
-    let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
+    let cursor =
+      Cascade.Cursor.of_string (Parse.decode_arbitrary_value inner)
+    in
     match Cascade.Cursor.try_parse_full_err read cursor with
     | Ok v -> Some v
     | Error _ -> None
@@ -1895,9 +1900,8 @@ module Handler = struct
         Ok Perspective_origin_bottom_right
     | "perspective" :: "origin" :: rest when List.length rest > 0 ->
         let value = String.concat "-" rest in
-        let len = String.length value in
-        if len > 2 && value.[0] = '[' && value.[len - 1] = ']' then
-          let inner = String.sub value 1 (len - 2) in
+        if Parse.is_bracket_value value then
+          let inner = Parse.bracket_inner value in
           match
             arbitrary_value Css.Properties.read_perspective_origin inner
           with
@@ -1941,9 +1945,8 @@ module Handler = struct
     | [ "origin"; "bottom"; "right" ] -> Ok Origin_bottom_right
     | "origin" :: rest when List.length rest > 0 ->
         let value = String.concat "-" rest in
-        let len = String.length value in
-        if len > 2 && value.[0] = '[' && value.[len - 1] = ']' then
-          let inner = String.sub value 1 (len - 2) in
+        if Parse.is_bracket_value value then
+          let inner = Parse.bracket_inner value in
           match arbitrary_value Css.Properties.read_transform_origin inner with
           | Some t -> Ok (Origin_arbitrary (inner, t))
           | None ->

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -217,6 +217,30 @@ let test_arbitrary_order_reads_the_whole_bracket () =
     [ "order:calc(var(--spacing)*4)" ];
   check "order-[calc(1+2)]"
 
+(* An arbitrary bracket sorts after every numbered utility of its family, and a
+   bracket no grammar reads sorts after one that denotes a factor. Tailwind
+   lists grow, grow-0, grow-3, grow-7, grow-[2], grow-[<value>]. *)
+let test_arbitrary_flex_order () =
+  Test_helpers.check_class_order ~test_name:"arbitrary flex order"
+    [
+      "grow";
+      "grow-0";
+      "grow-3";
+      "grow-7";
+      "grow-[2]";
+      "grow-[<value>]";
+      "shrink";
+      "shrink-0";
+      "shrink-[2]";
+      "shrink-[<value>]";
+      "flex-1";
+      "flex-3";
+      "flex-[2]";
+      "flex-[10]";
+      "flex-[<value>]";
+      "flex-auto";
+    ]
+
 let tests =
   [
     test_case "basis-* prefers --spacing-*" `Quick
@@ -231,6 +255,7 @@ let tests =
       test_arbitrary_flex_reads_the_whole_bracket;
     test_case "arbitrary order reads the whole bracket" `Quick
       test_arbitrary_order_reads_the_whole_bracket;
+    test_case "arbitrary flex order" `Quick test_arbitrary_flex_order;
     test_case "basis-[...] keeps the authored spelling" `Quick
       test_basis_arbitrary_keeps_the_authored_spelling;
   ]

--- a/test/test_flex_props.ml
+++ b/test/test_flex_props.ml
@@ -183,6 +183,40 @@ let test_invalid_arbitrary_order () =
   renders "-order-[13]";
   renders "-order-[var(--x)]"
 
+(* [flex-], [grow-] and [shrink-] read their bracket through the arbitrary-value
+   pipeline, which puts the spaces CSS math wants around a binary [+] and
+   expands [--spacing()]. Reading the text with OCaml's number reader instead
+   refused [calc(1+2)] outright and folded [0x4] to 4, so the class named itself
+   after a value nobody wrote. What that reader refuses is not invalid: Tailwind
+   writes a bracket out as the token stream it is. *)
+let test_arbitrary_flex_reads_the_whole_bracket () =
+  Test_helpers.check_declarations "flex-[calc(1+2)]" [ "flex:calc(1 + 2)" ];
+  Test_helpers.check_declarations "grow-[calc(1+2)]" [ "flex-grow:calc(1 + 2)" ];
+  Test_helpers.check_declarations "shrink-[calc(1+2)]"
+    [ "flex-shrink:calc(1 + 2)" ];
+  Test_helpers.check_declarations "flex-[--spacing(4)]"
+    [ "flex:calc(var(--spacing)*4)" ];
+  (* a value no property grammar reads still reaches the sheet as written *)
+  Test_helpers.check_declarations "flex-[0x4]" [ "flex:0x4" ];
+  Test_helpers.check_declarations "grow-[0x4]" [ "flex-grow:0x4" ];
+  Test_helpers.check_declarations "shrink-[0x4]" [ "flex-shrink:0x4" ];
+  Test_helpers.check_declarations "grow-[var(--x)]" [ "flex-grow:var(--x)" ];
+  (* and the class keeps the spelling it was written with *)
+  check "flex-[0x4]";
+  check "grow-[0x4]";
+  check "shrink-[0x4]";
+  check "flex-[calc(1+2)]"
+
+(* [order-[...]] reads the same pipeline: [calc(1+2)] is a value the order
+   grammar takes once the operator spacing is normalised. *)
+let test_arbitrary_order_reads_the_whole_bracket () =
+  (* cascade folds a constant calc, which the canonical differ accepts; Tailwind
+     writes [order:calc(1 + 2)]. *)
+  Test_helpers.check_declarations "order-[calc(1+2)]" [ "order:3" ];
+  Test_helpers.check_declarations "order-[--spacing(4)]"
+    [ "order:calc(var(--spacing)*4)" ];
+  check "order-[calc(1+2)]"
+
 let tests =
   [
     test_case "basis-* prefers --spacing-*" `Quick
@@ -193,6 +227,10 @@ let tests =
     test_case "flex_props suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "invalid arbitrary order" `Quick test_invalid_arbitrary_order;
+    test_case "arbitrary flex reads the whole bracket" `Quick
+      test_arbitrary_flex_reads_the_whole_bracket;
+    test_case "arbitrary order reads the whole bracket" `Quick
+      test_arbitrary_order_reads_the_whole_bracket;
     test_case "basis-[...] keeps the authored spelling" `Quick
       test_basis_arbitrary_keeps_the_authored_spelling;
   ]

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -341,10 +341,61 @@ let test_underscore_escape () =
   reads "another escape is left alone" {|a\.b|} {|a\.b|};
   reads "a trailing backslash is kept" {|a\|} {|a\|}
 
+(* A quoted []] belongs to the value, not to the bracket wrapping it, so
+   [is_bracket_value] tokenises CSS strings and the backslash escape the way CSS
+   Syntax 3 sec. 4.3 does. Every family reads its bracket through that one
+   answer, which is why the families below span the whole library. A string left
+   open runs to the end of the input, so no []] after it closes the value and
+   the class is refused, which is what Tailwind does with an unclosed [url(]
+   argument. *)
+let test_quoted_bracket_stays_inside_the_value () =
+  let holds name input expected =
+    Alcotest.(check bool) name expected (Tw.Parse.is_bracket_value input)
+  in
+  holds "a quoted bracket does not close the value" {|[url('a]b')]|} true;
+  holds "a double-quoted bracket does not close it either" {|['My]Font']|} true;
+  holds "an escaped bracket does not close it" {|[url(a\]b)]|} true;
+  holds "an escaped quote keeps the string open" {|['a\']b']|} true;
+  holds "a plain value still reads" "[10px]" true;
+  holds "an unclosed string swallows the closing bracket" {|[url('a]b)]|} false;
+  holds "an unclosed string with no bracket in it also swallows it"
+    {|[url('a)]|} false;
+  holds "a trailing backslash escapes the closing bracket" {|[a\]|} false;
+  holds "two brackets are not one value" "[10px][20px]" false;
+  holds "a quoted bracket does not hide a second bracket" {|[url('a]b')][20px]|}
+    false;
+  (* cascade writes a CSS string with double quotes and a url() unquoted, both
+     of which the canonical differ reads as the value Tailwind writes. *)
+  Test_helpers.check_declarations {|bg-[url('a]b')]|}
+    [ {|background-image:url(a]b)|} ];
+  Test_helpers.check_declarations {|font-['My]Font']|}
+    [ {|font-family:"My]Font"|} ];
+  Test_helpers.check_declarations {|font-["My]Font"]|}
+    [ {|font-family:"My]Font"|} ];
+  Test_helpers.check_declarations {|mask-[url('a]b')]|}
+    [ {|-webkit-mask-image:url(a]b)|}; {|mask-image:url(a]b)|} ];
+  Test_helpers.check_declarations {|list-image-[url('a]b')]|}
+    [ {|list-style-image:url(a]b)|} ];
+  Test_helpers.check_declarations {|after:content-['a]b']|}
+    [ {|--tw-content:"a]b"|}; "content:var(--tw-content)" ];
+  round_trips {|shadow-[0_0_0_'a]b']|};
+  (* an unclosed string, and a second bracket the string does not hide *)
+  List.iter unknown
+    [
+      {|bg-[url('a]b)]|};
+      {|bg-[url('a)]|};
+      {|font-['My]Font]|};
+      "w-[10px][20px]";
+      "text-[12px][14px]";
+      {|bg-[url(a\]b)][20px]|};
+    ]
+
 let tests =
   Alcotest.
     [
       test_case "underscore escape" `Quick test_underscore_escape;
+      test_case "a quoted bracket stays inside the value" `Quick
+        test_quoted_bracket_stays_inside_the_value;
       test_case "parse backslash escape in selector" `Quick
         test_escape_in_selector;
       test_case "double bracket class rejected" `Quick

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -476,6 +476,21 @@ let test_arbitrary_scale_axis_token_stream () =
   Test_helpers.check_declarations "scale-y-[0x4]"
     [ "--tw-scale-y:0x4"; "scale:var(--tw-scale-x)var(--tw-scale-y)" ]
 
+(* [origin-], [perspective-origin-] and [transform-] read their bracket through
+   the arbitrary-value pipeline. Applying underscore decoding alone leaves
+   [calc(1px+1px)] without the spaces CSS math wants and [--spacing(4)]
+   unexpanded, so cascade's grammar refuses the value and the class with it. *)
+let test_arbitrary_transform_reads_the_whole_bracket () =
+  Test_helpers.check_declarations "origin-[calc(1px+1px)_calc(2px+2px)]"
+    [ "transform-origin:calc(1px + 1px) calc(2px + 2px)" ];
+  Test_helpers.check_declarations "origin-[--spacing(4)_--spacing(2)]"
+    [ "transform-origin:calc(var(--spacing)*4) calc(var(--spacing)*2)" ];
+  Test_helpers.check_declarations
+    "perspective-origin-[calc(1px+1px)_calc(2px+2px)]"
+    [ "perspective-origin:calc(1px + 1px) calc(2px + 2px)" ];
+  Test_helpers.check_declarations "transform-[translateX(calc(1px+1px))]"
+    [ "transform:translateX(calc(1px + 1px))" ]
+
 let tests =
   [
     test_case "rotate underscore escape" `Quick test_rotate_underscore_escape;
@@ -506,6 +521,8 @@ let tests =
       suborder_matches_tailwind;
     test_case "arbitrary transform spelling" `Quick
       test_arbitrary_transform_spelling;
+    test_case "arbitrary transform reads the whole bracket" `Quick
+      test_arbitrary_transform_reads_the_whole_bracket;
     test_case "arbitrary transform token streams" `Quick
       test_arbitrary_transform_token_streams;
     test_case "arbitrary scale axis token stream" `Quick


### PR DESCRIPTION
Two bracket-reading defects, one in the shared primitive and one in the
families that never reached it.

`Parse.is_bracket_value` scanned for `[`/`]` without tracking CSS strings, so a
legitimate arbitrary value carrying a `]` inside quotes was refused. 125 call
sites read that one answer, which is why `bg-[url('a]b')]`, `font-['My]Font']`,
`mask-[url('a]b')]`, `shadow-[0_0_0_'a]b']` and `list-image-[url('a]b')]` were
all unknown classes where the pinned `@tailwindcss/cli` 4.3.3 emits a rule. The
scan now tokenises strings and the backslash escape the way CSS Syntax 3 sec.
4.3 does. A string left open runs to the end of the input, so nothing after it
closes the bracket and the class stays refused, which is what Tailwind does
with `bg-[url('a)]`. Two brackets in a row are still refused.

`flex-`, `grow-`, `shrink-`, `order-`, `origin-`, `perspective-origin-` and
`transform-` read their bracket with OCaml's number reader or with underscore
decoding alone, so they never reached the spacing-function expansion or the CSS
math normalisation the other 35 sites get: `flex-[calc(1+2)]` and
`origin-[--spacing(4)_--spacing(2)]` were refused, and `flex-[0x4]` was folded
to `flex: 4` under the class name `.flex-\[4\]`. They read the arbitrary-value
pipeline now, and a bracket no property grammar reads passes through as the
declaration-safe token stream Tailwind writes out, the way `duration-` and
`delay-` already do. Bare suffixes keep going through `Parse.decimal_int` and
`Parse.decimal_float`.

Sorting follows: an arbitrary bracket goes after every numbered utility of its
family, so `grow-[<value>]` lands where the site sheet-order gate expects it.

Not fixed here, because they live outside the files this branch touches:
`arbitrary.ml` hand-rolls the same string-blind bracket scan, so
`[content:'a]b']`, `[--x:'a]b']` and `[background-image:url('a]b')]` are still
refused; `cursor.ml` supports no arbitrary bracket at all, so
`cursor-[url('a]b'),pointer]` is unknown for a reason unrelated to quoting; and
`z-`, `opacity-`, `col-span-`, `grid-cols-`, `aspect-`, `columns-` and `tab-`
still read their bracket with the number reader.
