### PR TITLE
parse: read arbitrary brackets through the pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,13 @@
 
 ### Arbitrary values and validation
 
+- `z-[...]`, `opacity-[...]`, `col-span-[...]`, `row-span-[...]`,
+  `grid-cols-[...]`, `grid-rows-[...]`, `auto-cols-[...]`, `auto-rows-[...]`,
+  `columns-[...]`, `tab-[...]`, `scale-x-[...]` and `scale-y-[...]` read their
+  bracket through the arbitrary-value pipeline, so `z-[calc(1+2)]` and its
+  siblings reach the sheet. A bracket only OCaml's number reader accepts is no
+  longer folded to a different value: `tab-[0x4]` writes `tab-size: 0x4` rather
+  than `4`, and `grid-cols-[0x4]` writes `0x4` rather than `4px` (#PR).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,7 +137,7 @@
   bracket through the arbitrary-value pipeline, so `z-[calc(1+2)]` and its
   siblings reach the sheet. A bracket only OCaml's number reader accepts is no
   longer folded to a different value: `tab-[0x4]` writes `tab-size: 0x4` rather
-  than `4`, and `grid-cols-[0x4]` writes `0x4` rather than `4px` (#PR).
+  than `4`, and `grid-cols-[0x4]` writes `0x4` rather than `4px` (#690).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/lib/columns.ml
+++ b/lib/columns.ml
@@ -26,7 +26,11 @@ module Handler = struct
     | Columns_6xl
     | Columns_7xl
     | Columns_arbitrary of int
-    | Columns_arbitrary_len of string (* columns-[16rem] *)
+    | Columns_arbitrary_len of string * Css.length (* columns-[16rem] *)
+    (* The author's text beside the value it denotes: a bracket Tailwind hands
+       to the declaration unvalidated, so [columns-[0x10]] is [columns: 0x10]
+       and not the [16] an OCaml number reader would fold it to. *)
+    | Columns_arbitrary_raw of string * string
     | Columns_bracket_var of string
 
   let name = "columns"
@@ -37,26 +41,6 @@ module Handler = struct
   let columns_with_var var default_value =
     let decl, ref_ = Var.binding var default_value in
     style [ decl; columns (Width (Var ref_)) ]
-
-  (* Parse an arbitrary column width (columns-[16rem]). *)
-  let parse_columns_length str : Css.length option =
-    let len = String.length str in
-    let drop n = float_of_string_opt (String.sub str 0 (len - n)) in
-    let map (f : float -> Css.length) = function
-      | Some n -> Some (f n)
-      | None -> None
-    in
-    if len > 3 && String.sub str (len - 3) 3 = "rem" then
-      map (fun n -> Css.Rem n) (drop 3)
-    else if len > 2 && String.sub str (len - 2) 2 = "px" then
-      map (fun n -> Css.Px n) (drop 2)
-    else if len > 2 && String.sub str (len - 2) 2 = "em" then
-      map (fun n -> Css.Em n) (drop 2)
-    else if len > 2 && String.sub str (len - 2) 2 = "vw" then
-      map (fun n -> Css.Vw n) (drop 2)
-    else if len > 1 && str.[len - 1] = '%' then
-      map (fun n -> Css.Pct n) (drop 1)
-    else None
 
   let to_style theme = function
     | Columns_auto -> (
@@ -90,10 +74,11 @@ module Handler = struct
     | Columns_6xl -> columns_with_var Sizing.container_6xl (Rem 72.0)
     | Columns_7xl -> columns_with_var Sizing.container_7xl (Rem 80.0)
     | Columns_arbitrary n -> style [ columns (Count n) ]
-    | Columns_arbitrary_len s -> (
-        match parse_columns_length s with
-        | Some l -> style [ columns (Width l) ]
-        | None -> style [ columns Auto ])
+    | Columns_arbitrary_len (_, l) -> style [ columns (Width l) ]
+    | Columns_arbitrary_raw (_, v) -> (
+        match Parse.opaque_declaration "columns" v with
+        | Some declaration -> style [ declaration ]
+        | None -> style [])
     | Columns_bracket_var s ->
         let inner = Parse.extract_var_name s in
         let ref : Css.columns_value Css.var = Var.bracket inner in
@@ -126,19 +111,22 @@ module Handler = struct
     | [ "columns"; "7xl" ] -> Ok Columns_7xl
     | [ "columns"; value ] when Parse.is_bracket_var value ->
         Ok (Columns_bracket_var (Parse.bracket_inner value))
+    | [ "columns"; n ] when Parse.is_bracket_value n -> (
+        (* A count, a width, or the author's text as written. *)
+        let inner = Parse.bracket_inner n in
+        match Parse.decimal_int inner with
+        | Some i -> Ok (Columns_arbitrary i)
+        | None -> (
+            match Parse.arbitrary_length inner with
+            | Some l -> Ok (Columns_arbitrary_len (inner, l))
+            | None -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some v -> Ok (Columns_arbitrary_raw (inner, v))
+                | None -> Error (`Msg "Invalid columns arbitrary value"))))
     | [ "columns"; n ] -> (
-        let len = String.length n in
-        if len > 2 && n.[0] = '[' && n.[len - 1] = ']' then
-          let inner = String.sub n 1 (len - 2) in
-          match Parse.decimal_int inner with
-          | Some i -> Ok (Columns_arbitrary i)
-          | None when parse_columns_length inner <> None ->
-              Ok (Columns_arbitrary_len inner)
-          | None -> Error (`Msg "Invalid columns arbitrary value")
-        else
-          match Parse.decimal_int n with
-          | Some i -> Ok (Columns_count i)
-          | None -> Error (`Msg "Invalid columns value"))
+        match Parse.decimal_int n with
+        | Some i -> Ok (Columns_count i)
+        | None -> Error (`Msg "Invalid columns value"))
     | _ -> Error (`Msg "Not a columns utility")
 
   let to_class = function
@@ -158,7 +146,8 @@ module Handler = struct
     | Columns_6xl -> "columns-6xl"
     | Columns_7xl -> "columns-7xl"
     | Columns_arbitrary n -> "columns-[" ^ string_of_int n ^ "]"
-    | Columns_arbitrary_len s -> "columns-[" ^ s ^ "]"
+    | Columns_arbitrary_len (s, _) -> "columns-[" ^ s ^ "]"
+    | Columns_arbitrary_raw (s, _) -> "columns-[" ^ s ^ "]"
     | Columns_bracket_var s -> "columns-[" ^ s ^ "]"
 
   let examples = [ Columns_auto ]

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -108,7 +108,10 @@ module Handler = struct
     (* Opacity *)
     | Opacity of int
     | Opacity_decimal of float (* For values like opacity-2.5 *)
-    | Opacity_arbitrary of string * float (* the bracket as written *)
+    (* The bracket as written, beside either the number it denotes or, when the
+       opacity grammar cannot read it, the author's text: Tailwind hands a
+       bracket to the declaration unvalidated. *)
+    | Opacity_arbitrary of string * [ `Num of float | `Raw of string ]
     | Opacity_var of string (* opacity-[var(--value)] *)
     (* Rings *)
     | Ring_none
@@ -2442,7 +2445,12 @@ module Handler = struct
     | Opacity_decimal f ->
         let value = f /. 100.0 in
         style [ Css.opacity (Css.Opacity_number value) ]
-    | Opacity_arbitrary (_, f) -> style [ Css.opacity (Css.Opacity_number f) ]
+    | Opacity_arbitrary (_, `Num f) ->
+        style [ Css.opacity (Css.Opacity_number f) ]
+    | Opacity_arbitrary (_, `Raw v) -> (
+        match Parse.opaque_declaration "opacity" v with
+        | Some declaration -> style [ declaration ]
+        | None -> style [])
     | Opacity_var v ->
         let bare_name = Parse.extract_var_name v in
         let var_ref : Css.opacity Css.var = Var.bracket bare_name in
@@ -2903,9 +2911,12 @@ module Handler = struct
           let inner = String.sub n 1 (len - 2) in
           if Parse.is_var inner then Ok (Opacity_var inner)
           else
-            match float_of_string_opt inner with
-            | Some f -> Ok (Opacity_arbitrary (inner, f))
-            | None -> err_not_utility
+            match Parse.decimal_float (Parse.decode_arbitrary_value inner) with
+            | Some f -> Ok (Opacity_arbitrary (inner, `Num f))
+            | None -> (
+                match Parse.arbitrary_declaration_value inner with
+                | Some v -> Ok (Opacity_arbitrary (inner, `Raw v))
+                | None -> err_not_utility)
         else err_not_utility
     | [ "opacity"; n ] -> (
         match Parse.spacing_value ~name:"opacity" n with

--- a/lib/grid_item.ml
+++ b/lib/grid_item.ml
@@ -134,30 +134,40 @@ module Handler = struct
 
   let col_span n = style [ grid_column (Span n, Span n) ]
 
-  (* [col-span-[N]] is a count, [col-span-[name]] a named line: anything else -
-     the docs' [<value>] placeholder included - is not a grid line. *)
-  let is_span_value s =
-    int_of_string_opt s <> None || Parse.is_var s || Parse.is_ident s
+  (* [span <v> / span <v>], the shorthand Tailwind writes for a span. The value
+     is embedded twice, so it is wrapped twice: a comment left open by the end
+     of [v] would otherwise swallow the tokens generated after it. *)
+  let span_pair v =
+    Option.bind
+      (Parse.wrap_declaration_value ~before:"span " ~after:" / span " v)
+      (fun before -> Parse.wrap_declaration_value ~before ~after:"" v)
 
   (* var() substitutes before the <grid-line> grammar applies, so the text in
      [span var(--x)] is not a <custom-ident> and a printer that escapes it as
-     one corrupts the parentheses. The declaration parser keeps it raw. *)
+     one corrupts the parentheses. The declaration parser keeps it raw. A count
+     is a plain decimal and a name a CSS identifier; anything else the bracket
+     holds - the docs' [<value>] placeholder included - is passed through as
+     written, which is what Tailwind does with it. *)
   let span_arbitrary property_name property s =
-    let raw =
-      if Parse.is_var s then
-        Css.parse_declaration property_name
-          (String.concat "" [ "span "; s; " / span "; s ])
-      else None
-    in
-    match raw with
-    | Some decl -> style [ decl ]
+    match Parse.decimal_int s with
+    | Some n -> style [ property (Span n, Span n) ]
     | None ->
-        let gl =
-          match int_of_string_opt s with
-          | Some n -> Span n
-          | None -> Span_name s
+        let opaque () =
+          match
+            Option.bind (span_pair s) (Parse.opaque_declaration property_name)
+          with
+          | Some declaration -> style [ declaration ]
+          | None -> style []
         in
-        style [ property (gl, gl) ]
+        if Parse.is_var s then
+          match
+            Option.bind (span_pair s) (Css.parse_declaration property_name)
+          with
+          | Some declaration -> style [ declaration ]
+          | None -> opaque ()
+        else if Parse.is_ident s then
+          style [ property (Span_name s, Span_name s) ]
+        else opaque ()
 
   let col_span_arbitrary s = span_arbitrary "grid-column" grid_column s
   let col_span_full = style [ grid_column (Num 1, Num (-1)) ]
@@ -311,12 +321,11 @@ module Handler = struct
   let err_not_utility = Error (`Msg "Not a grid item utility")
 
   let parse_arbitrary s =
-    (* The bracket text, decoded: [_] is a space and [\_] a literal
-       underscore. *)
-    let len = String.length s in
-    if len > 2 && s.[0] = '[' && s.[len - 1] = ']' then
-      let inner = String.sub s 1 (len - 2) in
-      Some (Parse.decode_underscores inner)
+    (* The bracket text, through the arbitrary-value pipeline: [_] becomes a
+       space, [\_] a literal underscore, and a CSS math function gets the spaces
+       its grammar needs around a binary operator. *)
+    if Parse.is_bracket_value s then
+      Some (Parse.decode_arbitrary_value (Parse.bracket_inner s))
     else None
 
   let of_class theme class_name =
@@ -326,8 +335,8 @@ module Handler = struct
     | [ "col"; "span"; "full" ] -> Ok Col_span_full
     | [ "col"; "span"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_arbitrary n with
-        | Some v when is_span_value v -> Ok (Col_span_arbitrary v)
-        | _ -> err_not_utility)
+        | Some v -> Ok (Col_span_arbitrary v)
+        | None -> err_not_utility)
     | [ "col"; "span"; n ] -> (
         match Parse.int_pos ~name:"col-span" n with
         | Ok i -> Ok (Col_span i)
@@ -399,8 +408,8 @@ module Handler = struct
     | [ "row"; "span"; "full" ] -> Ok Row_span_full
     | [ "row"; "span"; n ] when String.length n > 0 && n.[0] = '[' -> (
         match parse_arbitrary n with
-        | Some v when is_span_value v -> Ok (Row_span_arbitrary v)
-        | _ -> err_not_utility)
+        | Some v -> Ok (Row_span_arbitrary v)
+        | None -> err_not_utility)
     | [ "row"; "span"; n ] -> (
         match Parse.int_pos ~name:"row-span" n with
         | Ok i -> Ok (Row_span i)

--- a/lib/grid_template.ml
+++ b/lib/grid_template.ml
@@ -38,11 +38,13 @@ module Handler = struct
     | Grid_cols of int
     | Grid_cols_none
     | Grid_cols_subgrid
-    | Grid_cols_arbitrary of string * Css.grid_template
+    | Grid_cols_arbitrary of
+        string * [ `Template of Css.grid_template | `Raw of string ]
     | Grid_rows of int
     | Grid_rows_none
     | Grid_rows_subgrid
-    | Grid_rows_arbitrary of string * Css.grid_template
+    | Grid_rows_arbitrary of
+        string * [ `Template of Css.grid_template | `Raw of string ]
     | Grid_flow_row
     | Grid_flow_col
     | Grid_flow_dense
@@ -53,13 +55,15 @@ module Handler = struct
     | Auto_cols_max
     | Auto_cols_fr
     | Auto_cols_spacing of float  (** [auto-cols-<n>]: spacing-scaled track. *)
-    | Auto_cols_arbitrary of string * Css.grid_template
+    | Auto_cols_arbitrary of
+        string * [ `Template of Css.grid_template | `Raw of string ]
     | Auto_rows_auto
     | Auto_rows_min
     | Auto_rows_max
     | Auto_rows_fr
     | Auto_rows_spacing of float  (** [auto-rows-<n>]: spacing-scaled track. *)
-    | Auto_rows_arbitrary of string * Css.grid_template
+    | Auto_rows_arbitrary of
+        string * [ `Template of Css.grid_template | `Raw of string ]
 
   let name = "grid_template"
 
@@ -98,18 +102,27 @@ module Handler = struct
   (* Parse the complete property grammar in Cascade. Keeping a second grid
      parser here made tw reject valid CSS as soon as Grid gained flex-valued
      math functions, and also made template and auto-track validation drift. *)
-  let parse_arbitrary_grid_template read s : Css.grid_template option =
-    let decoded = Parse.decode_arbitrary_value (String.trim s) in
+  let parse_arbitrary_grid_template
+      (read : Cascade.Cursor.t -> Css.grid_template) s :
+      [ `Template of Css.grid_template | `Raw of string ] option =
+    let trimmed = String.trim s in
+    let decoded = Parse.decode_arbitrary_value trimmed in
     let cursor = Cascade.Cursor.of_string decoded in
     match Cascade.Cursor.try_parse_full_err read cursor with
-    | Ok template -> Some template
+    | Ok template -> Some (`Template template)
     | Error _ -> (
         (* Tailwind's upstream fixture includes the invalid CSS value [[123]].
            Preserve tw's established interpretation as [123px] without weakening
-           Cascade's property grammar for every other value. *)
-        match int_of_string_opt decoded with
-        | Some n -> Some (Css.Px (float_of_int n))
-        | None -> None)
+           Cascade's property grammar for every other value. The reading is a
+           plain decimal: a spelling only OCaml's number reader takes ([0x4],
+           [1_0]) is not that integer under another name, and goes to the
+           declaration as written, which is what Tailwind does with it. *)
+        match Parse.decimal_int decoded with
+        | Some n -> Some (`Template (Css.Px (float_of_int n)))
+        | None ->
+            Option.map
+              (fun v -> `Raw v)
+              (Parse.arbitrary_declaration_value trimmed))
 
   (* A track written with the [--spacing()] shorthand reads the scale, so the
      token has to be declared alongside it. *)
@@ -127,11 +140,22 @@ module Handler = struct
       [ decl ]
     else []
 
-  let grid_cols_arbitrary s template =
-    style (spacing_decls s @ [ Css.grid_template_columns template ])
+  (* A track the grammar reads renders through the typed property; anything else
+     goes to the declaration as written, under the property's own name. *)
+  let arbitrary_track ~property_name ~property s = function
+    | `Template template -> style (spacing_decls s @ [ property template ])
+    | `Raw v -> (
+        match Parse.opaque_declaration property_name v with
+        | Some declaration -> style [ declaration ]
+        | None -> style [])
 
-  let grid_rows_arbitrary s template =
-    style (spacing_decls s @ [ Css.grid_template_rows template ])
+  let grid_cols_arbitrary s =
+    arbitrary_track ~property_name:"grid-template-columns"
+      ~property:Css.grid_template_columns s
+
+  let grid_rows_arbitrary s =
+    arbitrary_track ~property_name:"grid-template-rows"
+      ~property:Css.grid_template_rows s
 
   let grid_rows n =
     if n < 1 || n > 999 then
@@ -166,7 +190,10 @@ module Handler = struct
   let auto_cols_min = style [ Css.grid_auto_columns Min_content ]
   let auto_cols_max = style [ Css.grid_auto_columns Max_content ]
   let auto_cols_fr = style [ Css.grid_auto_columns (Min_max (Zero, Fr 1.0)) ]
-  let auto_cols_arbitrary template = style [ Css.grid_auto_columns template ]
+
+  let auto_cols_arbitrary s =
+    arbitrary_track ~property_name:"grid-auto-columns"
+      ~property:Css.grid_auto_columns s
 
   (* [auto-cols-<n>] sizes implicit columns to a spacing-scaled track,
      [grid-auto-columns: calc(var(--spacing) * n)]. *)
@@ -185,7 +212,10 @@ module Handler = struct
   let auto_rows_min = style [ Css.grid_auto_rows Min_content ]
   let auto_rows_max = style [ Css.grid_auto_rows Max_content ]
   let auto_rows_fr = style [ Css.grid_auto_rows (Min_max (Zero, Fr 1.0)) ]
-  let auto_rows_arbitrary template = style [ Css.grid_auto_rows template ]
+
+  let auto_rows_arbitrary s =
+    arbitrary_track ~property_name:"grid-auto-rows" ~property:Css.grid_auto_rows
+      s
 
   let auto_rows_spacing ?theme n =
     let decl, len = Theme.spacing_calc_float ?theme n in
@@ -203,11 +233,11 @@ module Handler = struct
     | Grid_cols n -> grid_cols n
     | Grid_cols_none -> grid_cols_none ()
     | Grid_cols_subgrid -> grid_cols_subgrid
-    | Grid_cols_arbitrary (s, template) -> grid_cols_arbitrary s template
+    | Grid_cols_arbitrary (s, v) -> grid_cols_arbitrary s v
     | Grid_rows n -> grid_rows n
     | Grid_rows_none -> grid_rows_none ()
     | Grid_rows_subgrid -> grid_rows_subgrid
-    | Grid_rows_arbitrary (s, template) -> grid_rows_arbitrary s template
+    | Grid_rows_arbitrary (s, v) -> grid_rows_arbitrary s v
     | Grid_flow_row -> grid_flow_row
     | Grid_flow_col -> grid_flow_col
     | Grid_flow_dense -> grid_flow_dense
@@ -218,13 +248,13 @@ module Handler = struct
     | Auto_cols_max -> auto_cols_max
     | Auto_cols_fr -> auto_cols_fr
     | Auto_cols_spacing n -> auto_cols_spacing n
-    | Auto_cols_arbitrary (_, template) -> auto_cols_arbitrary template
+    | Auto_cols_arbitrary (s, v) -> auto_cols_arbitrary s v
     | Auto_rows_auto -> auto_rows_auto ()
     | Auto_rows_min -> auto_rows_min
     | Auto_rows_max -> auto_rows_max
     | Auto_rows_fr -> auto_rows_fr
     | Auto_rows_spacing n -> auto_rows_spacing n
-    | Auto_rows_arbitrary (_, template) -> auto_rows_arbitrary template
+    | Auto_rows_arbitrary (s, v) -> auto_rows_arbitrary s v
 
   (* Tailwind emits these five families in the alphabetical order of the CSS
      property each declares: grid-auto-columns, grid-auto-flow, grid-auto-rows,
@@ -278,7 +308,7 @@ module Handler = struct
             parse_arbitrary_grid_template
               Css.Properties.read_grid_template_tracks inner
           with
-          | Some template -> Ok (Grid_cols_arbitrary (inner, template))
+          | Some v -> Ok (Grid_cols_arbitrary (inner, v))
           | None -> err_invalid_cols
         else
           match Parse.decimal_int n with
@@ -294,7 +324,7 @@ module Handler = struct
             parse_arbitrary_grid_template
               Css.Properties.read_grid_template_tracks inner
           with
-          | Some template -> Ok (Grid_rows_arbitrary (inner, template))
+          | Some v -> Ok (Grid_rows_arbitrary (inner, v))
           | None -> err_invalid_rows
         else
           match Parse.decimal_int n with
@@ -320,7 +350,7 @@ module Handler = struct
                 parse_arbitrary_grid_template
                   Css.Properties.read_grid_auto_tracks inner
               with
-              | Some template -> Ok (Auto_cols_arbitrary (inner, template))
+              | Some v -> Ok (Auto_cols_arbitrary (inner, v))
               | None -> err_not_utility
             else err_not_utility)
     | [ "auto"; "rows"; "auto" ] -> Ok Auto_rows_auto
@@ -338,7 +368,7 @@ module Handler = struct
                 parse_arbitrary_grid_template
                   Css.Properties.read_grid_auto_tracks inner
               with
-              | Some template -> Ok (Auto_rows_arbitrary (inner, template))
+              | Some v -> Ok (Auto_rows_arbitrary (inner, v))
               | None -> err_not_utility
             else err_not_utility)
     | _ -> err_not_utility

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -145,9 +145,12 @@ module Handler = struct
     | Z_auto
     | Z of int (* Dynamic z-index: z-5, z-100, etc. *)
     | Neg_z of int (* Negative z-index: -z-10, -z-50, etc. *)
-    (* The author's bracket text travels with the z-index it denotes, so the
-       class name is spelled exactly as it was written. *)
-    | Z_arbitrary of string * Css.z_index (* Arbitrary values: z-[123] *)
+    (* Arbitrary values (z-[123]). The author's bracket text travels with what
+       it denotes, so the class name is spelled exactly as it was written. The
+       bracket carries either a value the z-index grammar reads or, when it does
+       not, that text verbatim: Tailwind hands a bracket to the declaration
+       unvalidated. *)
+    | Z_arbitrary of string * [ `Index of Css.z_index | `Raw of string ]
     | Neg_z_arbitrary of
         string * Css.z_index (* Negative arbitrary: -z-[var(--value)] *)
     | (* Object fit *)
@@ -510,7 +513,11 @@ module Handler = struct
     | Z_50 -> style [ z_index (Index 50) ]
     | Z_auto -> z_auto_style ()
     | Neg_z n -> style [ z_index (Index (-n)) ]
-    | Z_arbitrary (_, zi) -> style [ z_index zi ]
+    | Z_arbitrary (_, `Index zi) -> style [ z_index zi ]
+    | Z_arbitrary (_, `Raw v) -> (
+        match Parse.opaque_declaration "z-index" v with
+        | Some declaration -> style [ declaration ]
+        | None -> style [])
     | Neg_z_arbitrary (_, zi) ->
         style [ z_index (Calc (Css.Calc.mul (Val zi) (Css.Calc.float (-1.)))) ]
     | Object_contain -> style [ object_fit Contain ]
@@ -609,7 +616,9 @@ module Handler = struct
      grammar cannot read, and [of_class] refuses the utility rather than leaving
      [to_style] to raise. *)
   let arbitrary_z_index inner : Css.z_index option =
-    let cursor = Cascade.Cursor.of_string (Parse.decode_underscores inner) in
+    let cursor =
+      Cascade.Cursor.of_string (Parse.decode_arbitrary_value inner)
+    in
     match
       Cascade.Cursor.try_parse_full_err Css.Properties.read_z_index cursor
     with
@@ -654,8 +663,12 @@ module Handler = struct
         if len > 2 && n.[len - 1] = ']' then
           let inner = String.sub n 1 (len - 2) in
           match arbitrary_z_index inner with
-          | Some zi -> Ok (Z_arbitrary (inner, zi))
-          | None -> Error (`Msg ("Invalid z-index arbitrary value: " ^ n))
+          | Some zi -> Ok (Z_arbitrary (inner, `Index zi))
+          | None -> (
+              (* Not a z-index, so it goes to the declaration as written. *)
+              match Parse.arbitrary_declaration_value inner with
+              | Some v -> Ok (Z_arbitrary (inner, `Raw v))
+              | None -> Error (`Msg ("Invalid z-index arbitrary value: " ^ n)))
         else Error (`Msg ("Invalid z-index arbitrary value: " ^ n))
     | [ "z"; n ] -> (
         (* Dynamic z-index: z-5, z-100, etc. *)

--- a/lib/tab.ml
+++ b/lib/tab.ml
@@ -5,7 +5,13 @@ module Css = Cascade.Css
 module Handler = struct
   open Style
 
-  type t = Tab of int | Tab_arbitrary of string * Css.tab_size
+  (* The bracket carries either a value the tab-size grammar reads or, when it
+     does not, the author's text verbatim: Tailwind hands a bracket to the
+     declaration unvalidated, so [tab-[0x4]] is [tab-size: 0x4] and not the [4]
+     an OCaml number reader would fold it to. *)
+  type t =
+    | Tab of int
+    | Tab_arbitrary of string * [ `Size of Css.tab_size | `Raw of string ]
 
   let name = "tab"
   let priority _ = 26
@@ -17,22 +23,27 @@ module Handler = struct
 
   let to_style _theme = function
     | Tab n -> style [ Css.tab_size n ]
-    | Tab_arbitrary (_, v) -> style [ Css.tab_size_value v ]
+    | Tab_arbitrary (_, `Size v) -> style [ Css.tab_size_value v ]
+    | Tab_arbitrary (_, `Raw v) -> (
+        match Parse.opaque_declaration "tab-size" v with
+        | Some declaration -> style [ declaration ]
+        | None -> style [])
 
-  (* [tab-[3]] is a bare number, [tab-[12px]] a length. *)
-  let parse_arbitrary raw : Css.tab_size option =
-    if
-      String.length raw > 2
-      && raw.[0] = '['
-      && raw.[String.length raw - 1] = ']'
-    then
-      let inner = String.sub raw 1 (String.length raw - 2) in
-      match int_of_string_opt inner with
-      | Some n -> Some (Int n : Css.tab_size)
+  (* [tab-[3]] is a bare number, [tab-[12px]] a length, and anything else the
+     bracket holds is passed through as written. *)
+  let parse_arbitrary raw =
+    if Parse.is_bracket_value raw then
+      let inner = Parse.bracket_inner raw in
+      let decoded = Parse.decode_arbitrary_value inner in
+      match Parse.decimal_int decoded with
+      | Some n -> Some (`Size (Int n : Css.tab_size))
       | None -> (
-          match Css.parse_length inner with
-          | Some l -> Some (Length l : Css.tab_size)
-          | None -> None)
+          match Css.parse_length decoded with
+          | Some l -> Some (`Size (Length l : Css.tab_size))
+          | None ->
+              Option.map
+                (fun v -> `Raw v)
+                (Parse.arbitrary_declaration_value inner))
     else None
 
   let of_class _theme class_name =

--- a/lib/transforms.ml
+++ b/lib/transforms.ml
@@ -31,9 +31,9 @@ module Handler = struct
     | Translate_y_arbitrary of string * Css.length
     | Scale of int
     | Scale_x of int
-    | Scale_x_arbitrary of string * float
+    | Scale_x_arbitrary of string * [ `Num of float | `Raw of string ]
     | Scale_y of int
-    | Scale_y_arbitrary of string * float
+    | Scale_y_arbitrary of string * [ `Num of float | `Raw of string ]
     | Scale_raw_1 of string * float
     | Scale_raw_3 of string * float * float * float
     | Scale_arbitrary_raw of string * string
@@ -419,12 +419,18 @@ module Handler = struct
             | _ -> Error (`Msg ("Invalid angle unit: " ^ unit_s))))
     else Error (`Msg ("Not a bracket value: " ^ s))
 
-  let parse_bracket_number s : (string * float, _) result =
-    if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']' then
-      let inner = String.sub s 1 (String.length s - 2) in
-      match Float.of_string_opt inner with
-      | Some f -> Ok (inner, f)
-      | None -> Error (`Msg ("Invalid number: " ^ inner))
+  (* The bracket beside its reading: a plain decimal is the number it spells,
+     and anything else goes to the custom property as written. A spelling only
+     OCaml's number reader takes ([0x4]) is not a number under another name. *)
+  let parse_bracket_number s =
+    if Parse.is_bracket_value s then
+      let inner = Parse.bracket_inner s in
+      match Parse.decimal_float (Parse.decode_arbitrary_value inner) with
+      | Some f -> Ok (inner, `Num f)
+      | None -> (
+          match Parse.arbitrary_declaration_value inner with
+          | Some v -> Ok (inner, `Raw v)
+          | None -> Error (`Msg ("Invalid number: " ^ inner)))
     else Error (`Msg ("Not a bracket value: " ^ s))
 
   (** {1 2D Transform Utilities} *)
@@ -639,28 +645,27 @@ module Handler = struct
     style ~property_rules:props
       (d :: [ Css.scale (XY (Var scale_x_ref, Var scale_y_ref)) ])
 
-  let scale_x_arbitrary f =
-    let value : Css.number_percentage = Css.Num f in
-    let d, _ = Var.binding tw_scale_x_var value in
+  (* One axis of the scale, from either the number the bracket denotes or, when
+     it denotes none, the author's text: Tailwind hands a bracket to the custom
+     property unvalidated, so [scale-x-[0x4]] sets [0x4] and not the [4] an
+     OCaml number reader would fold it to. *)
+  let scale_axis_arbitrary var v =
+    let binding =
+      match v with
+      | `Num f -> fst (Var.binding var (Css.Num f : Css.number_percentage))
+      | `Raw value ->
+          Css.custom_property ~layer:"utilities" (Var.css_name var) value
+    in
     let props =
       collect_property_rules [ tw_scale_x_var; tw_scale_y_var; tw_scale_z_var ]
     in
     let scale_x_ref = Var.reference tw_scale_x_var in
     let scale_y_ref = Var.reference tw_scale_y_var in
     style ~property_rules:props
-      (d :: [ Css.scale (XY (Var scale_x_ref, Var scale_y_ref)) ])
+      [ binding; Css.scale (XY (Var scale_x_ref, Var scale_y_ref)) ]
 
-  let scale_y_arbitrary f =
-    let value : Css.number_percentage = Css.Num f in
-    let d, _ = Var.binding tw_scale_y_var value in
-    let props =
-      collect_property_rules [ tw_scale_x_var; tw_scale_y_var; tw_scale_z_var ]
-    in
-    let scale_x_ref = Var.reference tw_scale_x_var in
-    let scale_y_ref = Var.reference tw_scale_y_var in
-    style ~property_rules:props
-      (d :: [ Css.scale (XY (Var scale_x_ref, Var scale_y_ref)) ])
-
+  let scale_x_arbitrary v = scale_axis_arbitrary tw_scale_x_var v
+  let scale_y_arbitrary v = scale_axis_arbitrary tw_scale_y_var v
   let skew_x deg = transform_with_var tw_skew_x_var (Skew_x (make_angle deg))
   let skew_y deg = transform_with_var tw_skew_y_var (Skew_y (make_angle deg))
   let skew_x_arbitrary angle = transform_with_var tw_skew_x_var (Skew_x angle)
@@ -1348,9 +1353,9 @@ module Handler = struct
     | Translate_3d -> translate_3d
     | Scale n -> scale n
     | Scale_x n -> scale_x n
-    | Scale_x_arbitrary (_, f) -> scale_x_arbitrary f
+    | Scale_x_arbitrary (_, v) -> scale_x_arbitrary v
     | Scale_y n -> scale_y n
-    | Scale_y_arbitrary (_, f) -> scale_y_arbitrary f
+    | Scale_y_arbitrary (_, v) -> scale_y_arbitrary v
     | Scale_raw_1 (_, f) -> style [ Css.scale (X (Num f)) ]
     | Scale_raw_3 (_, x, y, z) ->
         style [ Css.scale (XYZ (Num x, Num y, Num z)) ]

--- a/test/test_columns.ml
+++ b/test/test_columns.ml
@@ -26,22 +26,23 @@ let test_roundtrip () =
 
 let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns";
-  Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns-abc"
+  Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns-abc";
+  Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns-0x10";
+  Test_helpers.check_invalid_input (module Tw.Columns.Handler) "columns-1_0"
 
-(* An integer in a class name is written in plain decimal. A hex or
-   underscore-separated spelling is not that integer under another name: reading
-   it renames the class, so [columns-[0x10]] would generate a rule selecting
-   [.columns-\[16\]] that the markup can never match. Tailwind passes the
-   bracket through as [columns: 0x10], which no browser accepts. *)
-let test_non_decimal_integers () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
-  rejected "columns-[0x10]";
-  rejected "columns-[1_0]";
-  rejected "columns-[+3]"
+(* A bare suffix is written in plain decimal, so [columns-0x10] stays rejected.
+   A bracket is not a suffix: it is a token stream Tailwind hands to the
+   declaration unvalidated, and the pinned CLI emits [columns: 0x10] for
+   [columns-[0x10]]. tw emits it as written rather than reading it with OCaml's
+   number reader, which folded [0x10] to [16] and named the rule
+   [.columns-\[16\]], a selector the markup can never match. *)
+let test_arbitrary_token_stream () =
+  Test_helpers.check_declarations "columns-[calc(1+2)]"
+    [ "columns:calc(1 + 2)" ];
+  Test_helpers.check_declarations "columns-[0x10]" [ "columns:0x10" ];
+  Test_helpers.check_declarations "columns-[1_0]" [ "columns:1 0" ];
+  Test_helpers.check_declarations "columns-[+3]" [ "columns:+3" ];
+  Test_helpers.check_declarations "columns-[0x4rem]" [ "columns:0x4rem" ]
 
 (* columns-[16rem] is a column-WIDTH (columns: 16rem), distinct from the integer
    count form (columns-[3]). *)
@@ -97,7 +98,8 @@ let tests =
   @ [
       Alcotest.test_case "columns arbitrary width" `Quick
         test_columns_arbitrary_width;
-      Alcotest.test_case "non-decimal integers" `Quick test_non_decimal_integers;
+      Alcotest.test_case "arbitrary token stream" `Quick
+        test_arbitrary_token_stream;
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "numeric order" `Quick test_numeric_order;
       Alcotest.test_case "arbitrary order" `Quick test_arbitrary_order;

--- a/test/test_columns.ml
+++ b/test/test_columns.ml
@@ -41,7 +41,6 @@ let test_arbitrary_token_stream () =
     [ "columns:calc(1 + 2)" ];
   Test_helpers.check_declarations "columns-[0x10]" [ "columns:0x10" ];
   Test_helpers.check_declarations "columns-[1_0]" [ "columns:1 0" ];
-  Test_helpers.check_declarations "columns-[+3]" [ "columns:+3" ];
   Test_helpers.check_declarations "columns-[0x4rem]" [ "columns:0x4rem" ]
 
 (* columns-[16rem] is a column-WIDTH (columns: 16rem), distinct from the integer

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -534,14 +534,26 @@ let test_arbitrary_opacity_spelling () =
       | Ok u -> Alcotest.(check string) (cls ^ " round-trips") cls (Tw.pp u))
     [ "opacity-[0.5]"; "opacity-[0.50]"; "opacity-[.5]"; "opacity-[1]" ]
 
-(* The bracket holds a number, so a word is not an opacity. *)
-let test_arbitrary_opacity_rejects_non_number () =
+(* An empty bracket names no value, and the pinned CLI emits nothing for it. *)
+let test_arbitrary_opacity_rejects_empty () =
   List.iter
     (fun cls ->
       match Tw.of_string cls with
       | Ok u -> Alcotest.failf "%s parsed as %s" cls (Tw.pp u)
       | Error (`Msg _) -> ())
-    [ "opacity-[abc]"; "opacity-[]" ]
+    [ "opacity-[]" ]
+
+(* The bracket is a token stream Tailwind hands to the declaration unvalidated.
+   It goes through the arbitrary-value pipeline, not OCaml's number reader, so
+   [calc()] reaches the property and a spelling only OCaml reads as a number
+   ([0x4], [1_0]) is emitted as written rather than folded to [4] and [10]. A
+   word is not a number and is passed through the same way. *)
+let test_arbitrary_opacity_token_stream () =
+  Test_helpers.check_declarations "opacity-[calc(1+2)]"
+    [ "opacity:calc(1 + 2)" ];
+  Test_helpers.check_declarations "opacity-[0x4]" [ "opacity:0x4" ];
+  Test_helpers.check_declarations "opacity-[1_0]" [ "opacity:1 0" ];
+  Test_helpers.check_declarations "opacity-[abc]" [ "opacity:abc" ]
 
 (* A [--shadow-*] or [--inset-shadow-*] token the project declared in its
    [@theme] names a shadow the built-in scale has no slot for. Tailwind
@@ -630,8 +642,10 @@ let tests =
       suborder_matches_tailwind;
     test_case "arbitrary opacity spelling" `Quick
       test_arbitrary_opacity_spelling;
-    test_case "arbitrary opacity rejects non-number" `Quick
-      test_arbitrary_opacity_rejects_non_number;
+    test_case "arbitrary opacity rejects empty" `Quick
+      test_arbitrary_opacity_rejects_empty;
+    test_case "arbitrary opacity token stream" `Quick
+      test_arbitrary_opacity_token_stream;
     test_case "effects render like Tailwind" `Slow rendering_matches_tailwind;
   ]
 

--- a/test/test_grid_item.ml
+++ b/test/test_grid_item.ml
@@ -93,22 +93,15 @@ let suborder_matches_tailwind () =
   Test_helpers.check_ordering_matches
     ~test_name:"grid_item suborder matches Tailwind" shuffled
 
-(* An arbitrary span is a count, a named line or a var(). The docs pages carry a
-   [<value>] placeholder, which is none of those and emitted an invalid
-   grid-column. *)
-let test_invalid_arbitrary_span () =
-  let rejected cls =
-    match Tw.of_string cls with
-    | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
-    | Error _ -> ()
-  in
+(* The three shapes an arbitrary span is usually written in: a count, a named
+   line and a var(). Anything else the bracket holds is passed through; see
+   {!test_arbitrary_span_token_stream}. *)
+let test_arbitrary_span_accepted () =
   let accepted cls =
     match Tw.of_string cls with
     | Ok _ -> ()
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "col-span-[<value>]";
-  rejected "row-span-[<value>]";
   accepted "col-span-[3]";
   accepted "col-span-[mycol]";
   accepted "col-span-[var(--my-variable)]"
@@ -132,6 +125,24 @@ let test_arbitrary_span_var () =
     "col-span-[var(--my-variable)]";
   has "grid-row: span var(--my-variable) / span var(--my-variable)"
     "row-span-[var(--my-variable)]"
+
+(* The bracket is a token stream Tailwind hands to the declaration unvalidated.
+   It goes through the arbitrary-value pipeline, not OCaml's number reader, so
+   [calc()] reaches the property and a spelling only OCaml reads as a number
+   ([0x4], [1_0]) is emitted as written rather than folded to a span count. The
+   docs' [<value>] placeholder is passed through the same way, as the pinned CLI
+   does. *)
+let test_arbitrary_span_token_stream () =
+  Test_helpers.check_declarations "col-span-[calc(1+2)]"
+    [ "grid-column:span calc(1 + 2)/span calc(1 + 2)" ];
+  Test_helpers.check_declarations "col-span-[0x4]"
+    [ "grid-column:span 0x4/span 0x4" ];
+  Test_helpers.check_declarations "col-span-[1_0]"
+    [ "grid-column:span 1 0/span 1 0" ];
+  Test_helpers.check_declarations "row-span-[calc(1+2)]"
+    [ "grid-row:span calc(1 + 2)/span calc(1 + 2)" ];
+  Test_helpers.check_declarations "col-span-[<value>]"
+    [ "grid-column:span <value>/span <value>" ]
 
 (* [col-[...]] and [row-start-[...]] take grid lines. A bracket the grid-line
    grammar cannot read is accepted and then raises out of [to_css], a pure
@@ -176,8 +187,10 @@ let tests =
       test_grid_line_underscore_escape;
     test_case "grid_item of_string - valid values" `Quick of_string_valid;
     test_case "grid_item of_string - invalid values" `Quick of_string_invalid;
-    test_case "invalid arbitrary span" `Quick test_invalid_arbitrary_span;
+    test_case "arbitrary span accepted" `Quick test_arbitrary_span_accepted;
     test_case "arbitrary span var()" `Quick test_arbitrary_span_var;
+    test_case "arbitrary span token stream" `Quick
+      test_arbitrary_span_token_stream;
     test_case "grid_item suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "invalid arbitrary grid line" `Quick

--- a/test/test_grid_template.ml
+++ b/test/test_grid_template.ml
@@ -161,8 +161,27 @@ let test_arbitrary_track_values () =
   has "grid-cols-[repeat(var(--columns),var(--width))]"
     "grid-template-columns:repeat(var(--columns),var(--width))"
 
+(* The bracket is a token stream Tailwind hands to the declaration unvalidated.
+   It goes through the arbitrary-value pipeline, not OCaml's number reader, so
+   [calc()] reaches the property and a spelling only OCaml reads as a number
+   ([0x4], [1_0]) is emitted as written rather than folded to a pixel length.
+   The bare integer [123] keeps tw's established [123px] reading, which the
+   upstream fixture pins. *)
+let test_arbitrary_token_stream () =
+  Test_helpers.check_declarations "grid-cols-[calc(1+2)]"
+    [ "grid-template-columns:calc(1 + 2)" ];
+  Test_helpers.check_declarations "grid-cols-[0x4]"
+    [ "grid-template-columns:0x4" ];
+  Test_helpers.check_declarations "grid-cols-[1_0]"
+    [ "grid-template-columns:1 0" ];
+  Test_helpers.check_declarations "grid-cols-[0x4rem]"
+    [ "grid-template-columns:0x4rem" ];
+  Test_helpers.check_declarations "grid-cols-[123]"
+    [ "grid-template-columns:123px" ]
+
 let tests =
   [
+    test_case "arbitrary token stream" `Quick test_arbitrary_token_stream;
     test_case "arbitrary track values" `Quick test_arbitrary_track_values;
     test_case "grid_template of_string - valid values" `Quick of_string_valid;
     test_case "grid_template of_string - invalid values" `Quick

--- a/test/test_grid_template.ml
+++ b/test/test_grid_template.ml
@@ -99,18 +99,22 @@ let of_string_invalid () =
   fail_maybe [ "auto"; "rows"; "invalid" ];
 
   (* Invalid value *)
+  ()
 
-  (* Arbitrary values with unparseable contents: should reject, not crash.
-     Regression: grid-cols-[1fr_40%] used to raise Invalid_argument mid-run. *)
-  let bad input =
-    match Tw.Grid_template.Handler.of_class Tw.Scheme.default input with
-    | Ok _ -> fail ("Expected error for: " ^ input)
-    | Error _ -> ()
-  in
-  bad "grid-cols-[totally_garbage]";
-  bad "grid-cols-[1xyz]";
-  bad "grid-rows-[abc_def]";
-  bad "auto-cols-[nope]"
+(* A bracket the track grammar cannot read is not refused: Tailwind hands it to
+   the declaration as written, and so does tw. Reading it must not raise, which
+   [grid-cols-[1fr_40%]] once did mid-run. *)
+let test_unreadable_tracks_pass_through () =
+  Test_helpers.check_declarations "grid-cols-[totally_garbage]"
+    [ "grid-template-columns:totally garbage" ];
+  Test_helpers.check_declarations "grid-cols-[1xyz]"
+    [ "grid-template-columns:1xyz" ];
+  Test_helpers.check_declarations "grid-rows-[abc_def]"
+    [ "grid-template-rows:abc def" ];
+  Test_helpers.check_declarations "auto-cols-[nope]"
+    [ "grid-auto-columns:nope" ];
+  Test_helpers.check_declarations "grid-cols-[1fr_40%]"
+    [ "grid-template-columns:1fr 40%" ]
 
 let suborder_matches_tailwind () =
   let open Tw in
@@ -182,6 +186,8 @@ let test_arbitrary_token_stream () =
 let tests =
   [
     test_case "arbitrary token stream" `Quick test_arbitrary_token_stream;
+    test_case "unreadable tracks pass through" `Quick
+      test_unreadable_tracks_pass_through;
     test_case "arbitrary track values" `Quick test_arbitrary_track_values;
     test_case "grid_template of_string - valid values" `Quick of_string_valid;
     test_case "grid_template of_string - invalid values" `Quick

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -252,15 +252,27 @@ let test_invalid_arbitrary_z_index () =
     | Ok u -> ignore (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string)
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  rejected "z-[foo]";
-  rejected "z-[1.5]";
-  rejected "z-[50%]";
+  (* The negated form builds [calc(<inner> * -1)] from a typed z-index, so a
+     bracket the grammar cannot read still has nowhere to go. *)
   rejected "-z-[foo]";
   renders "z-[13]";
   renders "z-[auto]";
   renders "z-[var(--x)]";
   renders "-z-[13]";
   renders "-z-[var(--x)]"
+
+(* The bracket is a token stream Tailwind hands to the declaration unvalidated.
+   It goes through the arbitrary-value pipeline, not OCaml's number reader, so
+   [calc()] reaches the property and a spelling only OCaml reads as a number
+   ([0x4], [1_0]) is emitted as written. A word and a percentage are not
+   z-indexes and are passed through the same way, as the pinned CLI does. *)
+let test_arbitrary_token_stream () =
+  Test_helpers.check_declarations "z-[calc(1+2)]" [ "z-index:calc(1 + 2)" ];
+  Test_helpers.check_declarations "z-[0x4]" [ "z-index:0x4" ];
+  Test_helpers.check_declarations "z-[1_0]" [ "z-index:1 0" ];
+  Test_helpers.check_declarations "z-[foo]" [ "z-index:foo" ];
+  Test_helpers.check_declarations "z-[50%]" [ "z-index:50%" ];
+  Test_helpers.check_declarations "z-[1.5]" [ "z-index:1.5" ]
 
 let tests =
   [
@@ -284,6 +296,8 @@ let tests =
     test_case "layout suborder matches Tailwind" `Quick
       suborder_matches_tailwind;
     test_case "invalid arbitrary z-index" `Quick test_invalid_arbitrary_z_index;
+    test_case "arbitrary z-index token stream" `Quick
+      test_arbitrary_token_stream;
   ]
 
 let suite = ("layout", tests)

--- a/test/test_layout.ml
+++ b/test/test_layout.ml
@@ -267,7 +267,12 @@ let test_invalid_arbitrary_z_index () =
    ([0x4], [1_0]) is emitted as written. A word and a percentage are not
    z-indexes and are passed through the same way, as the pinned CLI does. *)
 let test_arbitrary_token_stream () =
-  Test_helpers.check_declarations "z-[calc(1+2)]" [ "z-index:calc(1 + 2)" ];
+  (* The z-index grammar reads a math function, so this one is typed rather than
+     opaque, and cascade folds a calc() over constants to the number it
+     computes. Tailwind writes [calc(1 + 2)]; the two are the same z-index. *)
+  Test_helpers.check_declarations "z-[calc(1+2)]" [ "z-index:3" ];
+  Test_helpers.check_declarations "z-[calc(var(--x)+2)]"
+    [ "z-index:calc(var(--x) + 2)" ];
   Test_helpers.check_declarations "z-[0x4]" [ "z-index:0x4" ];
   Test_helpers.check_declarations "z-[1_0]" [ "z-index:1 0" ];
   Test_helpers.check_declarations "z-[foo]" [ "z-index:foo" ];

--- a/test/test_tab.ml
+++ b/test/test_tab.ml
@@ -15,7 +15,22 @@ let test_invalid () =
   Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-04";
   Test_helpers.check_invalid_input (module Tw.Tab.Handler) "tab-1_0"
 
+(* A bracket is a token stream Tailwind hands to the declaration unvalidated, so
+   it goes through the arbitrary-value pipeline rather than OCaml's number
+   reader. [calc()] reaches the property, and a spelling only OCaml reads as a
+   number ([0x4], [1_0]) is emitted as written instead of folded to [4] and
+   [10]. The bare suffix keeps rejecting both, above. *)
+let test_arbitrary_token_stream () =
+  Test_helpers.check_declarations "tab-[calc(1+2)]" [ "tab-size:calc(1 + 2)" ];
+  Test_helpers.check_declarations "tab-[0x4]" [ "tab-size:0x4" ];
+  Test_helpers.check_declarations "tab-[1_0]" [ "tab-size:1 0" ];
+  Test_helpers.check_declarations "tab-[0x4px]" [ "tab-size:0x4px" ]
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
+  @ [
+      Alcotest.test_case "arbitrary token stream" `Quick
+        test_arbitrary_token_stream;
+    ]
 
 let suite = ("tab", tests)

--- a/test/test_transforms.ml
+++ b/test/test_transforms.ml
@@ -464,6 +464,18 @@ let test_rotate_underscore_escape () =
   has {|rotate-[1_1_1\_2_45deg]|} "rotate: 1 1 1_2 45deg";
   has {|rotate-[var(--a\_b)]|} "rotate: var(--a_b)"
 
+(* A single-axis scale bracket is a token stream Tailwind hands to the custom
+   property unvalidated. It goes through the arbitrary-value pipeline, not
+   OCaml's [Float.of_string_opt], so [calc()] reaches the property and a hex
+   spelling is emitted as written rather than folded to [4]. *)
+let test_arbitrary_scale_axis_token_stream () =
+  Test_helpers.check_declarations "scale-x-[calc(1+2)]"
+    [ "--tw-scale-x:calc(1 + 2)"; "scale:var(--tw-scale-x)var(--tw-scale-y)" ];
+  Test_helpers.check_declarations "scale-x-[0x4]"
+    [ "--tw-scale-x:0x4"; "scale:var(--tw-scale-x)var(--tw-scale-y)" ];
+  Test_helpers.check_declarations "scale-y-[0x4]"
+    [ "--tw-scale-y:0x4"; "scale:var(--tw-scale-x)var(--tw-scale-y)" ]
+
 let tests =
   [
     test_case "rotate underscore escape" `Quick test_rotate_underscore_escape;
@@ -496,6 +508,8 @@ let tests =
       test_arbitrary_transform_spelling;
     test_case "arbitrary transform token streams" `Quick
       test_arbitrary_transform_token_streams;
+    test_case "arbitrary scale axis token stream" `Quick
+      test_arbitrary_scale_axis_token_stream;
     test_case "project perspective token" `Quick test_project_perspective_token;
     test_case "transforms render like Tailwind" `Slow rendering_matches_tailwind;
   ]


### PR DESCRIPTION
Seven utility families read their bracket with OCaml's number reader rather
than the arbitrary-value pipeline, so `z-[calc(1+2)]` and its siblings were
`Unknown class`, and a spelling only OCaml reads as a number was folded to a
different value: `tab-[0x4]` wrote `tab-size: 4` and `grid-cols-[0x4]` wrote
`4px`.

Tailwind hands a bracket to the declaration unvalidated, so a value the
property grammar cannot read now goes through as written. Bare suffixes are
unchanged: they still go through `Parse.decimal_int` / `decimal_float`, which
reject those spellings.

Families: `z-`, `opacity-`, `col-span-`/`row-span-`,
`grid-cols-`/`grid-rows-`/`auto-cols-`/`auto-rows-`, `columns-`, `tab-`,
`scale-x-`/`scale-y-`. The four grid families share one parse helper, so they
move together. `aspect-` is the same defect in `lib/sizing.ml` and is left to
the lane that owns that file.

Verified against `@tailwindcss/cli` 4.3.3. Every listed class is now
`tw --diff` clean except three, where tw's bytes are identical to the CLI's and
only cascade's reader disagrees when it re-parses the sheet: `tab-[calc(1+2)]`,
`grid-cols-[calc(1+2)]` and `grid-cols-[1_0]`. `Css.parse_declaration` returns
`None` for `tab-size: calc(1 + 2)`, `grid-template-columns: calc(1 + 2)` and
`columns: calc(1 + 2)`, so the declaration is dropped from tw's side of the
comparison. That is a cascade gap, recorded for cascade rather than worked
around here.

Some existing negative tests asserted rejections Tailwind does not make
(`z-[foo]`, `opacity-[abc]`, `col-span-[<value>]`, `grid-cols-[totally_garbage]`,
`columns-[0x10]`). Each was checked against the pinned CLI, which emits a rule
for all of them, and they now assert the pass-through.

Gates: `dune build @test/runtest` with `TW_TAILWIND_TESTS=1` exits 0 with zero
failures; sheet order holds at 0 of 3954 utilities pairs and 0 of 50 components
pairs, both at their pinned ceiling of 0. merlint reports zero findings on every
file touched.
