### PR TITLE
position, sizing: fix the inset and spacing scales

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,10 @@
   keep the `calc(var(--spacing) * n)` Tailwind writes for every step, so
   `start-px`, `start-0.5` and `start-1/2` resolve and `start-0` no longer drops
   `--spacing` from the theme layer (#677).
+- Every inset side reads an arbitrary length under either sign, and `start-*`
+  and `end-*` read one at all. `start-[4px]`, `end-[4px]`, `-top-[4px]` and
+  `-inset-bs-[4px]` reach the sheet, as does a name the theme binds on the
+  logical inline sides (#PR).
 - Transforms, backgrounds, grids and typography take the keywords Tailwind
   documents: `translate-none`, `rotate-none`, `scale-none`, `perspective-near`,
   `duration-initial`, `ease-initial`, `via-none`, `grow-3`, `indent-px` and a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -162,6 +162,9 @@
   it, so the selector matches the markup. `min-[0.5ch]:flex` emitted
   `.min-\[\.5ch\]\:flex`, a rule nothing on the page could match, for every
   unit outside a handful (#543).
+- A spacing step is a non-negative multiple of 0.25 on the inset and sizing
+  families, as it already was on padding, margin and gap, so `top-1.7` and
+  `w-1.7` stop being utilities Tailwind never emits (#PR).
 - A class whose arbitrary value has an unbalanced paren is rejected rather than
   compiled. The value was re-parsed inside a `calc()` the code wrapped around
   it, so the added `)` silently closed the author's stray one and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,7 +101,7 @@
 - Every inset side reads an arbitrary length under either sign, and `start-*`
   and `end-*` read one at all. `start-[4px]`, `end-[4px]`, `-top-[4px]` and
   `-inset-bs-[4px]` reach the sheet, as does a name the theme binds on the
-  logical inline sides (#PR).
+  logical inline sides (#691).
 - Transforms, backgrounds, grids and typography take the keywords Tailwind
   documents: `translate-none`, `rotate-none`, `scale-none`, `perspective-near`,
   `duration-initial`, `ease-initial`, `via-none`, `grow-3`, `indent-px` and a
@@ -164,7 +164,7 @@
   unit outside a handful (#543).
 - A spacing step is a non-negative multiple of 0.25 on the inset and sizing
   families, as it already was on padding, margin and gap, so `top-1.7` and
-  `w-1.7` stop being utilities Tailwind never emits (#PR).
+  `w-1.7` stop being utilities Tailwind never emits (#691).
 - A class whose arbitrary value has an unbalanced paren is rejected rather than
   compiled. The value was re-parsed inside a `calc()` the code wrapped around
   it, so the added `)` silently closed the author's stray one and

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -138,13 +138,18 @@ module Side = struct
   let folds_spacing_scale = function Start | End -> false | _ -> true
 end
 
+(* A spacing step is a non-negative multiple of 0.25 ([isValidSpacingMultiplier]
+   upstream), so [top-1.25] is a utility and [top-1.7] is not. *)
+let is_quarter_multiple f = f >= 0. && Float.rem f 0.25 = 0.
+
 (* [top-2.5] / [right-0.5] / [left-px]: a spacing token that is not a plain
    integer (those keep their existing [Top of int] path). *)
 let parse_pos_spacing s : Style.spacing option =
   if s = "px" then Some `Px
   else
     match Parse.decimal_float s with
-    | Some f when f >= 0. && not (Float.is_integer f) -> Some (`Rem (f *. 0.25))
+    | Some f when is_quarter_multiple f && not (Float.is_integer f) ->
+        Some (`Rem (f *. 0.25))
     | _ -> None
 
 (* Resolve a spacing token to (optional --spacing binding, length), mirroring

--- a/lib/position.ml
+++ b/lib/position.ml
@@ -4,46 +4,6 @@ module Css = Cascade.Css
 
 (** {1 Helper Functions} *)
 
-(* Parse a bracket value like [4px] or [var(--x)] and return a Css.length *)
-let parse_bracket_length s : (Css.length, _) result =
-  if String.length s >= 3 && s.[0] = '[' && s.[String.length s - 1] = ']' then (
-    let inner = String.sub s 1 (String.length s - 2) in
-    if Parse.is_var inner then
-      Ok (Css.Var (Var.bracket (Parse.extract_var_name inner)) : Css.length)
-    else
-      let slen = String.length inner in
-      let i = ref 0 in
-      while
-        !i < slen
-        && (inner.[!i] = '-'
-           || inner.[!i] = '.'
-           || (inner.[!i] >= '0' && inner.[!i] <= '9'))
-      do
-        incr i
-      done;
-      let num_s = String.sub inner 0 !i in
-      let unit_s = String.sub inner !i (slen - !i) in
-      (* Fall back to the full length grammar (calc, container-query units, ...)
-         when the value is not a plain <number><unit>. *)
-      let full () =
-        match Css.parse_length (Parse.normalize_css_math_operators inner) with
-        | Some l -> Ok l
-        | None -> Error (`Msg ("Invalid length: " ^ inner))
-      in
-      match Float.of_string_opt num_s with
-      | None -> full ()
-      | Some n -> (
-          let open Css in
-          match unit_s with
-          | "px" -> Ok (Px n)
-          | "rem" -> Ok (Rem n)
-          | "em" -> Ok (Em n)
-          | "%" -> Ok (Pct n)
-          | "vw" -> Ok (Vw n)
-          | "vh" -> Ok (Vh n)
-          | _ -> full ()))
-  else Error (`Msg ("Not a bracket value: " ^ s))
-
 (* Negate an inset length: simple units flip sign directly; var()/calc() and
    parenthesized expressions wrap in [calc(... * -1)] to match Tailwind. *)
 let negate_length (l : Css.length) : Css.length =
@@ -57,37 +17,44 @@ let negate_length (l : Css.length) : Css.length =
   | Vh n -> Vh (-.n)
   | other -> Calc (Calc.mul (Calc.length other) (Calc.float (-1.)))
 
-(* Parse a negative arbitrary inset value like [-left-[(var(--a)+var(--b))]]. A
-   bare parenthesised expression is not a length on its own, so read it as a
-   calc body straight off a cursor and negate the typed calc. *)
-let parse_neg_bracket_length s : Css.length option =
-  if String.length s > 2 && s.[0] = '[' && s.[String.length s - 1] = ']' then
-    let inner =
-      Parse.decode_arbitrary_value (String.sub s 1 (String.length s - 2))
-    in
-    match Css.parse_length inner with
-    | Some l -> Some (negate_length l)
-    | None -> (
-        if
-          String.length inner < 2
-          || inner.[0] <> '('
-          || inner.[String.length inner - 1] <> ')'
-        then None
-        else
-          (* The bracket form is a calc body without the [calc] function. Wrap
-             it before normalising so [+] and [-] are recognised as math
-             operators inside the parenthesised group. *)
-          let calc =
-            Parse.normalize_css_math_operators ("calc(" ^ inner ^ ")")
-          in
-          match
-            Cascade.Cursor.try_parse_full_err
-              (Css.Values.read_calc Css.Values.read_length)
-              (Cascade.Cursor.of_string calc)
-          with
-          | Ok c -> Some (Css.Calc (Css.Calc.mul c (Css.Calc.float (-1.))))
-          | Error _ -> None)
-  else None
+(* A bare parenthesised group is a calc body Tailwind writes without the [calc]
+   function, as in [left-[(var(--a)+var(--b))]]. Wrap it before normalising so
+   [+] and [-] read as math operators inside the group. *)
+let read_paren_calc inner : Css.length Css.calc option =
+  let len = String.length inner in
+  if len < 2 || inner.[0] <> '(' || inner.[len - 1] <> ')' then None
+  else
+    let calc = Parse.normalize_css_math_operators ("calc(" ^ inner ^ ")") in
+    match
+      Cascade.Cursor.try_parse_full_err
+        (Css.Values.read_calc Css.Values.read_length)
+        (Cascade.Cursor.of_string calc)
+    with
+    | Ok c -> Some c
+    | Error _ -> None
+
+(* The inside of an arbitrary inset value, as a length: one reader for every
+   side and both signs.
+
+   A bare parenthesised group is a length only under [negate]. Tailwind writes
+   the negative as [calc((a + b) * -1)], where the group is a calc
+   sub-expression; the positive it writes as [top: (a + b)], which is no
+   declaration a browser accepts, so there is nothing to agree with. *)
+let parse_bracket_length ?(negate = false) s : Css.length option =
+  if not (Parse.is_bracket_value s) then None
+  else
+    let inner = Parse.bracket_inner s in
+    let signed l = if negate then negate_length l else l in
+    if Parse.is_var inner then
+      Some (signed (Css.Var (Var.bracket (Parse.extract_var_name inner))))
+    else
+      match Parse.arbitrary_length inner with
+      | Some l -> Some (signed l)
+      | None when not negate -> None
+      | None -> (
+          match read_paren_calc (Parse.decode_arbitrary_value inner) with
+          | None -> None
+          | Some c -> Some (Css.Calc (Css.Calc.mul c (Css.Calc.float (-1.)))))
 
 (* Memoization cache for inset-named theme variables *)
 let inset_named_cache = Domain_cache.v 16
@@ -127,6 +94,10 @@ module Side = struct
     | Inset
     | Inset_x
     | Inset_y
+    | Inset_s
+    | Inset_e
+    | Inset_bs
+    | Inset_be
     | Start
     | End
 
@@ -138,8 +109,28 @@ module Side = struct
     | Inset -> "inset"
     | Inset_x -> "inset-x"
     | Inset_y -> "inset-y"
+    | Inset_s -> "inset-s"
+    | Inset_e -> "inset-e"
+    | Inset_bs -> "inset-bs"
+    | Inset_be -> "inset-be"
     | Start -> "start"
     | End -> "end"
+
+  (* What the side writes. [start] and [inset-s] name one property under two
+     spellings, as [end] and [inset-e] do. *)
+  let declarations side (len : Css.length) =
+    match side with
+    | Top -> [ Css.top len ]
+    | Right -> [ Css.right len ]
+    | Bottom -> [ Css.bottom len ]
+    | Left -> [ Css.left len ]
+    | Inset -> [ Css.inset [ len ] ]
+    | Inset_x -> [ Css.inset_inline [ len ] ]
+    | Inset_y -> [ Css.inset_block [ len ] ]
+    | Start | Inset_s -> [ Css.inset_inline_start len ]
+    | End | Inset_e -> [ Css.inset_inline_end len ]
+    | Inset_bs -> [ Css.inset_block_start len ]
+    | Inset_be -> [ Css.inset_block_end len ]
 
   (* Tailwind folds the zero and unit multipliers of the spacing scale to [0px]
      and [var(--spacing)], but its [start]/[end] handler resolves the step
@@ -175,20 +166,7 @@ let len_of_pos_spacing ?theme side (s : Style.spacing) :
 
 let pos_spacing_style ?theme side (s : Style.spacing) =
   let decl_opt, len = len_of_pos_spacing ?theme side s in
-  let decls = Option.to_list decl_opt in
-  let body =
-    match side with
-    | Side.Top -> [ Css.top len ]
-    | Side.Right -> [ Css.right len ]
-    | Side.Bottom -> [ Css.bottom len ]
-    | Side.Left -> [ Css.left len ]
-    | Side.Inset -> [ Css.inset [ len ] ]
-    | Side.Inset_x -> [ Css.inset_inline [ len ] ]
-    | Side.Inset_y -> [ Css.inset_block [ len ] ]
-    | Side.Start -> [ Css.inset_inline_start len ]
-    | Side.End -> [ Css.inset_inline_end len ]
-  in
-  Style.style (decls @ body)
+  Style.style (Option.to_list decl_opt @ Side.declarations side len)
 
 (* The same step, negated: [-inset-x-0.5]. The px step flips its sign directly,
    the scale steps through the negated multiplier so the calc reads
@@ -199,20 +177,7 @@ let neg_pos_spacing_style ?theme side (s : Style.spacing) =
   in
   let decl_opt, len = len_of_pos_spacing ?theme side negated in
   let len = match s with `Px -> negate_length len | _ -> len in
-  let decls = Option.to_list decl_opt in
-  let body =
-    match side with
-    | Side.Top -> [ Css.top len ]
-    | Side.Right -> [ Css.right len ]
-    | Side.Bottom -> [ Css.bottom len ]
-    | Side.Left -> [ Css.left len ]
-    | Side.Inset -> [ Css.inset [ len ] ]
-    | Side.Inset_x -> [ Css.inset_inline [ len ] ]
-    | Side.Inset_y -> [ Css.inset_block [ len ] ]
-    | Side.Start -> [ Css.inset_inline_start len ]
-    | Side.End -> [ Css.inset_inline_end len ]
-  in
-  Style.style (decls @ body)
+  Style.style (Option.to_list decl_opt @ Side.declarations side len)
 
 (* A position fraction [n/m] resolves to [n/m * 100%], the same reading the
    sizing families give it: any numerator over any positive denominator, and an
@@ -251,40 +216,31 @@ module Handler = struct
     | Pos_spacing of Side.t * Style.spacing
     | Neg_pos_spacing of Side.t * Style.spacing
       (* fractional or px spacing step on a physical/axis inset side *)
+    | Pos_arbitrary of Side.t * string * Css.length
+      (* raw bracket suffix kept for the class name, value already signed *)
+    | Neg_pos_arbitrary of Side.t * string * Css.length
+    | Pos_named of Side.t * string
+      (* custom property reference like inset-shadowned *)
     | Inset of int
-    | Inset_arbitrary of string * Css.length
-    | Inset_named of string (* Custom property reference like inset-shadowned *)
     | Inset_x of int
-    | Inset_x_arbitrary of string * Css.length
-    | Inset_x_named of string
     | Inset_y of int
-    | Inset_y_arbitrary of string * Css.length
-    | Inset_y_named of string
     (* Logical position utilities: inset-s, inset-e, inset-bs, inset-be *)
     | Inset_s of int
-    | Inset_s_arbitrary of string * Css.length
-    | Inset_s_named of string
     | Inset_s_auto
     | Inset_s_full
     | Neg_inset_s_full
     | Inset_s_3_4
     | Inset_e of int
-    | Inset_e_arbitrary of string * Css.length
-    | Inset_e_named of string
     | Inset_e_auto
     | Inset_e_full
     | Neg_inset_e_full
     | Inset_e_3_4
     | Inset_bs of int
-    | Inset_bs_arbitrary of string * Css.length
-    | Inset_bs_named of string
     | Inset_bs_auto
     | Inset_bs_full
     | Neg_inset_bs_full
     | Inset_bs_3_4
     | Inset_be of int
-    | Inset_be_arbitrary of string * Css.length
-    | Inset_be_named of string
     | Inset_be_auto
     | Inset_be_full
     | Neg_inset_be_full
@@ -295,33 +251,23 @@ module Handler = struct
     | Top_auto
     | Top_full
     | Neg_top_full
-    | Top_arbitrary of string * Css.length
-    | Top_named of string
     | Right of int
     | Right_auto
     | Right_full
     | Neg_right_full
     | Right_fraction of string
     | Neg_right_fraction of string
-    | Right_arbitrary of string * Css.length
-    | Right_named of string
     | Bottom of int
     | Bottom_auto
     | Bottom_full
     | Neg_bottom_full
     | Bottom_3_4
-    | Bottom_arbitrary of string * Css.length
-    | Bottom_named of string
     | Left of int
     | Left_fraction of string
     | Neg_left_fraction of string
     | Left_auto
     | Left_full
     | Neg_left_full
-    | Left_arbitrary of string * Css.length
-    | Neg_left_arbitrary of string * Css.length
-      (* raw bracket suffix kept for the class name; value is negated *)
-    | Left_named of string
     | Start_auto
     | Start_full
     | Neg_start_full
@@ -376,34 +322,23 @@ module Handler = struct
     | Inset_y_3_4 -> style [ Css.inset_block [ Pct 75.0 ] ]
     | Pos_spacing (side, sp) -> pos_spacing_style ~theme side sp
     | Neg_pos_spacing (side, sp) -> neg_pos_spacing_style ~theme side sp
+    | Pos_arbitrary (side, _, len) | Neg_pos_arbitrary (side, _, len) ->
+        style (Side.declarations side len)
+    | Pos_named (side, name) ->
+        let decl, value = named_inset_value name in
+        style (decl :: Side.declarations side value)
     | Inset n ->
         let decl, value = spacing_value n in
-        style (decl :: [ Css.inset [ value ] ])
-    | Inset_arbitrary (_, len) -> style [ Css.inset [ len ] ]
-    | Inset_named name ->
-        let decl, value = named_inset_value name in
         style (decl :: [ Css.inset [ value ] ])
     | Inset_x n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_inline [ value ] ])
-    | Inset_x_arbitrary (_, len) -> style [ Css.inset_inline [ len ] ]
-    | Inset_x_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.inset_inline [ value ] ])
     | Inset_y n ->
         let decl, value = spacing_value n in
-        style (decl :: [ Css.inset_block [ value ] ])
-    | Inset_y_arbitrary (_, len) -> style [ Css.inset_block [ len ] ]
-    | Inset_y_named name ->
-        let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_block [ value ] ])
     (* inset-s = inset-inline-start *)
     | Inset_s n ->
         let decl, value = spacing_value n in
-        style (decl :: [ Css.inset_inline_start value ])
-    | Inset_s_arbitrary (_, len) -> style [ Css.inset_inline_start len ]
-    | Inset_s_named name ->
-        let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_inline_start value ])
     | Inset_s_auto -> style [ Css.inset_inline_start Auto ]
     | Inset_s_full -> style [ Css.inset_inline_start (Pct 100.0) ]
@@ -413,10 +348,6 @@ module Handler = struct
     | Inset_e n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_inline_end value ])
-    | Inset_e_arbitrary (_, len) -> style [ Css.inset_inline_end len ]
-    | Inset_e_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.inset_inline_end value ])
     | Inset_e_auto -> style [ Css.inset_inline_end Auto ]
     | Inset_e_full -> style [ Css.inset_inline_end (Pct 100.0) ]
     | Neg_inset_e_full -> style [ Css.inset_inline_end (Pct (-100.0)) ]
@@ -425,10 +356,6 @@ module Handler = struct
     | Inset_bs n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.inset_block_start value ])
-    | Inset_bs_arbitrary (_, len) -> style [ Css.inset_block_start len ]
-    | Inset_bs_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.inset_block_start value ])
     | Inset_bs_auto -> style [ Css.inset_block_start Auto ]
     | Inset_bs_full -> style [ Css.inset_block_start (Pct 100.0) ]
     | Neg_inset_bs_full -> style [ Css.inset_block_start (Pct (-100.0)) ]
@@ -436,10 +363,6 @@ module Handler = struct
     (* inset-be = inset-block-end *)
     | Inset_be n ->
         let decl, value = spacing_value n in
-        style (decl :: [ Css.inset_block_end value ])
-    | Inset_be_arbitrary (_, len) -> style [ Css.inset_block_end len ]
-    | Inset_be_named name ->
-        let decl, value = named_inset_value name in
         style (decl :: [ Css.inset_block_end value ])
     | Inset_be_auto -> style [ Css.inset_block_end Auto ]
     | Inset_be_full -> style [ Css.inset_block_end (Pct 100.0) ]
@@ -453,10 +376,6 @@ module Handler = struct
     | Top_auto -> style [ Css.top Auto ]
     | Top_full -> style [ Css.top (Pct 100.0) ]
     | Neg_top_full -> style [ Css.top (Pct (-100.0)) ]
-    | Top_arbitrary (_, len) -> style [ Css.top len ]
-    | Top_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.top value ])
     | Right n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.right value ])
@@ -465,10 +384,6 @@ module Handler = struct
     | Neg_right_full -> style [ Css.right (Pct (-100.0)) ]
     | Right_fraction f -> style [ Css.right (Pct (frac_pct f)) ]
     | Neg_right_fraction f -> style [ Css.right (Pct (-.frac_pct f)) ]
-    | Right_arbitrary (_, len) -> style [ Css.right len ]
-    | Right_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.right value ])
     | Bottom n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.bottom value ])
@@ -476,10 +391,6 @@ module Handler = struct
     | Bottom_full -> style [ Css.bottom (Pct 100.0) ]
     | Neg_bottom_full -> style [ Css.bottom (Pct (-100.0)) ]
     | Bottom_3_4 -> style [ Css.bottom (Pct 75.0) ]
-    | Bottom_arbitrary (_, len) -> style [ Css.bottom len ]
-    | Bottom_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.bottom value ])
     | Left n ->
         let decl, value = spacing_value n in
         style (decl :: [ Css.left value ])
@@ -488,11 +399,6 @@ module Handler = struct
     | Left_auto -> style [ Css.left Auto ]
     | Left_full -> style [ Css.left (Pct 100.0) ]
     | Neg_left_full -> style [ Css.left (Pct (-100.0)) ]
-    | Left_arbitrary (_, len) -> style [ Css.left len ]
-    | Neg_left_arbitrary (_, len) -> style [ Css.left len ]
-    | Left_named name ->
-        let decl, value = named_inset_value name in
-        style (decl :: [ Css.left value ])
     | Start_auto -> style [ Css.inset_inline_start Auto ]
     | Start_full -> style [ Css.inset_inline_start (Pct 100.0) ]
     | Neg_start_full -> style [ Css.inset_inline_start (Pct (-100.0)) ]
@@ -507,83 +413,69 @@ module Handler = struct
 
   let int_of_string_with_sign = Parse.int_any
 
-  let suborder =
-    let inset = 1_000_000 in
-    let inset_x = 2_000_000 in
-    let inset_y = 3_000_000 in
-    let inset_s = 4_000_000 in
-    let inset_e = 5_000_000 in
-    let inset_bs = 6_000_000 in
-    let inset_be = 7_000_000 in
-    let top = 8_000_000 in
-    let right = 9_000_000 in
-    let bottom = 10_000_000 in
-    let left = 11_000_000 in
-    let start = inset_s in
-    let e = inset_e in
-    function
+  (* Tailwind assigns one order slot to every candidate that writes the same
+     position property, so [start] and [inset-s] share theirs. The shared
+     candidate-name tiebreak then handles negatives, arbitrary values,
+     fractions, keywords and scale values. *)
+  let side_slot = function
+    | Side.Inset -> 1_000_000
+    | Side.Inset_x -> 2_000_000
+    | Side.Inset_y -> 3_000_000
+    | Side.Inset_s | Side.Start -> 4_000_000
+    | Side.Inset_e | Side.End -> 5_000_000
+    | Side.Inset_bs -> 6_000_000
+    | Side.Inset_be -> 7_000_000
+    | Side.Top -> 8_000_000
+    | Side.Right -> 9_000_000
+    | Side.Bottom -> 10_000_000
+    | Side.Left -> 11_000_000
+
+  let suborder = function
     | Position_absolute -> 0
     | Position_fixed -> 1
     | Position_relative -> 2
     | Position_static -> 3
     | Position_sticky -> 4
-    (* Tailwind assigns one order slot to every candidate that writes the same
-       position property. The shared candidate-name tiebreak then handles
-       negatives, arbitrary values, fractions, keywords and scale values. *)
-    | Pos_spacing (Side.Inset, _)
-    | Neg_pos_spacing (Side.Inset, _)
+    | Pos_spacing (side, _)
+    | Neg_pos_spacing (side, _)
+    | Pos_arbitrary (side, _, _)
+    | Neg_pos_arbitrary (side, _, _)
+    | Pos_named (side, _) ->
+        side_slot side
     | Inset_0 | Inset_auto | Inset_full | Neg_inset_full | Inset_fraction _
-    | Neg_inset_fraction _ | Inset _ | Inset_arbitrary _ | Inset_named _ ->
-        inset
-    | Pos_spacing (Side.Inset_x, _)
-    | Neg_pos_spacing (Side.Inset_x, _)
+    | Neg_inset_fraction _ | Inset _ ->
+        side_slot Side.Inset
     | Inset_x_0 | Inset_x_auto | Inset_x_full | Neg_inset_x_full
-    | Inset_x_fraction _ | Neg_inset_x_fraction _ | Inset_x _
-    | Inset_x_arbitrary _ | Inset_x_named _ ->
-        inset_x
-    | Pos_spacing (Side.Inset_y, _)
-    | Neg_pos_spacing (Side.Inset_y, _)
+    | Inset_x_fraction _ | Neg_inset_x_fraction _ | Inset_x _ ->
+        side_slot Side.Inset_x
     | Inset_y_0 | Inset_y_auto | Inset_y_full | Neg_inset_y_full | Inset_y_3_4
-    | Inset_y _ | Inset_y_arbitrary _ | Inset_y_named _ ->
-        inset_y
-    | Pos_spacing (Side.Start, _)
-    | Neg_pos_spacing (Side.Start, _)
-    | Inset_s _ | Inset_s_arbitrary _ | Inset_s_named _ | Inset_s_auto
-    | Inset_s_full | Neg_inset_s_full | Inset_s_3_4 | Start_auto | Start_full
-    | Neg_start_full | Start_fraction _ | Neg_start_fraction _ ->
-        start
-    | Pos_spacing (Side.End, _)
-    | Neg_pos_spacing (Side.End, _)
-    | Inset_e _ | Inset_e_arbitrary _ | Inset_e_named _ | Inset_e_auto
-    | Inset_e_full | Neg_inset_e_full | Inset_e_3_4 | End_auto | End_full
-    | Neg_end_full | End_fraction _ | Neg_end_fraction _ ->
-        e
-    | Inset_bs _ | Inset_bs_arbitrary _ | Inset_bs_named _ | Inset_bs_auto
-    | Inset_bs_full | Neg_inset_bs_full | Inset_bs_3_4 ->
-        inset_bs
-    | Inset_be _ | Inset_be_arbitrary _ | Inset_be_named _ | Inset_be_auto
-    | Inset_be_full | Neg_inset_be_full | Inset_be_3_4 ->
-        inset_be
-    | Pos_spacing (Side.Top, _)
-    | Neg_pos_spacing (Side.Top, _)
+    | Inset_y _ ->
+        side_slot Side.Inset_y
+    | Inset_s _ | Inset_s_auto | Inset_s_full | Neg_inset_s_full | Inset_s_3_4
+    | Start_auto | Start_full | Neg_start_full | Start_fraction _
+    | Neg_start_fraction _ ->
+        side_slot Side.Inset_s
+    | Inset_e _ | Inset_e_auto | Inset_e_full | Neg_inset_e_full | Inset_e_3_4
+    | End_auto | End_full | Neg_end_full | End_fraction _ | Neg_end_fraction _
+      ->
+        side_slot Side.Inset_e
+    | Inset_bs _ | Inset_bs_auto | Inset_bs_full | Neg_inset_bs_full
+    | Inset_bs_3_4 ->
+        side_slot Side.Inset_bs
+    | Inset_be _ | Inset_be_auto | Inset_be_full | Neg_inset_be_full
+    | Inset_be_3_4 ->
+        side_slot Side.Inset_be
     | Top _ | Top_fraction _ | Neg_top_fraction _ | Top_auto | Top_full
-    | Neg_top_full | Top_arbitrary _ | Top_named _ ->
-        top
-    | Pos_spacing (Side.Right, _)
-    | Neg_pos_spacing (Side.Right, _)
+    | Neg_top_full ->
+        side_slot Side.Top
     | Right _ | Right_auto | Right_full | Neg_right_full | Right_fraction _
-    | Neg_right_fraction _ | Right_arbitrary _ | Right_named _ ->
-        right
-    | Pos_spacing (Side.Bottom, _)
-    | Neg_pos_spacing (Side.Bottom, _)
-    | Bottom _ | Bottom_auto | Bottom_full | Neg_bottom_full | Bottom_3_4
-    | Bottom_arbitrary _ | Bottom_named _ ->
-        bottom
-    | Pos_spacing (Side.Left, _)
-    | Neg_pos_spacing (Side.Left, _)
+    | Neg_right_fraction _ ->
+        side_slot Side.Right
+    | Bottom _ | Bottom_auto | Bottom_full | Neg_bottom_full | Bottom_3_4 ->
+        side_slot Side.Bottom
     | Left _ | Left_fraction _ | Neg_left_fraction _ | Left_auto | Left_full
-    | Neg_left_full | Left_arbitrary _ | Neg_left_arbitrary _ | Left_named _ ->
-        left
+    | Neg_left_full ->
+        side_slot Side.Left
 
   (* A named inset (top-header) is valid only when the theme defines the token.
      Tailwind resolves the name against the [--inset-*] namespace, then falls
@@ -617,6 +509,32 @@ module Handler = struct
       | Ok _ -> None
       | Error _ -> parse_pos_spacing n
     in
+    (* The tail every inset side shares once its own scale reader has declined:
+       an arbitrary bracket, then a name the theme binds. Tailwind defines no
+       negative named inset, so the negative tail reads the bracket alone. *)
+    let arbitrary_or_named side n =
+      match parse_bracket_length n with
+      | Some len -> Ok (Pos_arbitrary (side, n, len))
+      | None when Parse.is_valid_theme_name n && is_named_inset theme n ->
+          Ok (Pos_named (side, n))
+      | None -> Error (`Msg "invalid")
+    in
+    let neg_arbitrary side n =
+      match parse_bracket_length ~negate:true n with
+      | Some len -> Ok (Neg_pos_arbitrary (side, n, len))
+      | None -> Error (`Msg "invalid")
+    in
+    (* The scale, then the shared tail, on a side that has both. *)
+    let scale_or_arbitrary side n =
+      match parse_pos_spacing n with
+      | Some sp -> Ok (Pos_spacing (side, sp))
+      | None -> arbitrary_or_named side n
+    in
+    let neg_scale_or_arbitrary side n =
+      match parse_pos_spacing n with
+      | Some sp -> Ok (Neg_pos_spacing (side, sp))
+      | None -> neg_arbitrary side n
+    in
     let parts = Parse.split_class class_name in
     match parts with
     | [ "static" ] -> Ok Position_static
@@ -642,45 +560,21 @@ module Handler = struct
     | [ "inset"; "x"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_x x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Inset_x, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Inset_x_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Inset_x_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Inset_x n)
     | [ ""; "inset"; "x"; frac ] when frac_valid frac ->
         Ok (Neg_inset_x_fraction frac)
     | [ ""; "inset"; "x"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_x (-x))
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (Side.Inset_x, sp))
-            | None -> Error (`Msg "invalid")))
+        | Error _ -> neg_scale_or_arbitrary Side.Inset_x n)
     | [ "inset"; "y"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_y x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Inset_y, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Inset_y_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Inset_y_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Inset_y n)
     | [ ""; "inset"; "y"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_y (-x))
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (Side.Inset_y, sp))
-            | None -> Error (`Msg "invalid")))
+        | Error _ -> neg_scale_or_arbitrary Side.Inset_y n)
     (* inset-s = inset-inline-start *)
     | [ "inset"; "s"; "auto" ] -> Ok Inset_s_auto
     | [ "inset"; "s"; "full" ] -> Ok Inset_s_full
@@ -689,15 +583,11 @@ module Handler = struct
     | [ "inset"; "s"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_s x)
-        | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_s_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_s_named n)
-            | Error _ -> Error (`Msg "invalid")))
-    | [ ""; "inset"; "s"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset_s (-x))
+        | Error _ -> arbitrary_or_named Side.Inset_s n)
+    | [ ""; "inset"; "s"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset_s (-x))
+        | Error _ -> neg_arbitrary Side.Inset_s n)
     (* inset-e = inset-inline-end *)
     | [ "inset"; "e"; "auto" ] -> Ok Inset_e_auto
     | [ "inset"; "e"; "full" ] -> Ok Inset_e_full
@@ -706,15 +596,11 @@ module Handler = struct
     | [ "inset"; "e"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_e x)
-        | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_e_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_e_named n)
-            | Error _ -> Error (`Msg "invalid")))
-    | [ ""; "inset"; "e"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset_e (-x))
+        | Error _ -> arbitrary_or_named Side.Inset_e n)
+    | [ ""; "inset"; "e"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset_e (-x))
+        | Error _ -> neg_arbitrary Side.Inset_e n)
     (* inset-bs = inset-block-start *)
     | [ "inset"; "bs"; "auto" ] -> Ok Inset_bs_auto
     | [ "inset"; "bs"; "full" ] -> Ok Inset_bs_full
@@ -723,15 +609,11 @@ module Handler = struct
     | [ "inset"; "bs"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_bs x)
-        | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_bs_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_bs_named n)
-            | Error _ -> Error (`Msg "invalid")))
-    | [ ""; "inset"; "bs"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset_bs (-x))
+        | Error _ -> arbitrary_or_named Side.Inset_bs n)
+    | [ ""; "inset"; "bs"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset_bs (-x))
+        | Error _ -> neg_arbitrary Side.Inset_bs n)
     (* inset-be = inset-block-end *)
     | [ "inset"; "be"; "auto" ] -> Ok Inset_be_auto
     | [ "inset"; "be"; "full" ] -> Ok Inset_be_full
@@ -740,38 +622,22 @@ module Handler = struct
     | [ "inset"; "be"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset_be x)
-        | Error _ -> (
-            match parse_bracket_length n with
-            | Ok len -> Ok (Inset_be_arbitrary (n, len))
-            | Error _ when Parse.is_valid_theme_name n && is_named_inset theme n
-              ->
-                Ok (Inset_be_named n)
-            | Error _ -> Error (`Msg "invalid")))
-    | [ ""; "inset"; "be"; n ] ->
-        int_of_string_with_sign n |> Result.map (fun x -> Inset_be (-x))
+        | Error _ -> arbitrary_or_named Side.Inset_be n)
+    | [ ""; "inset"; "be"; n ] -> (
+        match int_of_string_with_sign n with
+        | Ok x -> Ok (Inset_be (-x))
+        | Error _ -> neg_arbitrary Side.Inset_be n)
     | [ "inset"; n ]
       when n <> "shadow" && n <> "ring" && n <> "x" && n <> "y" && n <> "s"
            && n <> "e" && n <> "bs" && n <> "be" -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Inset, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Inset_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Inset_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Inset n)
     | [ ""; "inset"; frac ] when frac_valid frac -> Ok (Neg_inset_fraction frac)
     | [ ""; "inset"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Inset (-x))
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (Side.Inset, sp))
-            | None -> Error (`Msg "invalid")))
+        | Error _ -> neg_scale_or_arbitrary Side.Inset n)
     | [ "top"; frac ] when frac_valid frac -> Ok (Top_fraction frac)
     | [ "top"; "auto" ] -> Ok Top_auto
     | [ "top"; "full" ] -> Ok Top_full
@@ -779,24 +645,12 @@ module Handler = struct
     | [ "top"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Top x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Top, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Top_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Top_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Top n)
     | [ ""; "top"; frac ] when frac_valid frac -> Ok (Neg_top_fraction frac)
     | [ ""; "top"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Top (-x))
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (Side.Top, sp))
-            | None -> Error (`Msg "invalid")))
+        | Error _ -> neg_scale_or_arbitrary Side.Top n)
     | [ "right"; frac ] when frac_valid frac -> Ok (Right_fraction frac)
     | [ "right"; "auto" ] -> Ok Right_auto
     | [ "right"; "full" ] -> Ok Right_full
@@ -804,24 +658,12 @@ module Handler = struct
     | [ "right"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Right x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Right, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Right_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Right_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Right n)
     | [ ""; "right"; frac ] when frac_valid frac -> Ok (Neg_right_fraction frac)
     | [ ""; "right"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Right (-x))
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (Side.Right, sp))
-            | None -> Error (`Msg "invalid")))
+        | Error _ -> neg_scale_or_arbitrary Side.Right n)
     | [ "bottom"; "3/4" ] -> Ok Bottom_3_4
     | [ "bottom"; "auto" ] -> Ok Bottom_auto
     | [ "bottom"; "full" ] -> Ok Bottom_full
@@ -829,23 +671,11 @@ module Handler = struct
     | [ "bottom"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Bottom x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Bottom, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Bottom_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Bottom_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Bottom n)
     | [ ""; "bottom"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Bottom (-x))
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Neg_pos_spacing (Side.Bottom, sp))
-            | None -> Error (`Msg "invalid")))
+        | Error _ -> neg_scale_or_arbitrary Side.Bottom n)
     | [ "left"; frac ] when frac_valid frac -> Ok (Left_fraction frac)
     | [ "left"; "auto" ] -> Ok Left_auto
     | [ "left"; "full" ] -> Ok Left_full
@@ -853,27 +683,12 @@ module Handler = struct
     | [ "left"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Left x)
-        | Error _ -> (
-            match parse_pos_spacing n with
-            | Some sp -> Ok (Pos_spacing (Side.Left, sp))
-            | None -> (
-                match parse_bracket_length n with
-                | Ok len -> Ok (Left_arbitrary (n, len))
-                | Error _
-                  when Parse.is_valid_theme_name n && is_named_inset theme n ->
-                    Ok (Left_named n)
-                | Error _ -> Error (`Msg "invalid"))))
+        | Error _ -> scale_or_arbitrary Side.Left n)
     | [ ""; "left"; frac ] when frac_valid frac -> Ok (Neg_left_fraction frac)
     | [ ""; "left"; n ] -> (
         match int_of_string_with_sign n with
         | Ok x -> Ok (Left (-x))
-        | Error _ -> (
-            match parse_neg_bracket_length n with
-            | Some len -> Ok (Neg_left_arbitrary (n, len))
-            | None -> (
-                match parse_pos_spacing n with
-                | Some sp -> Ok (Neg_pos_spacing (Side.Left, sp))
-                | None -> Error (`Msg "invalid"))))
+        | Error _ -> neg_scale_or_arbitrary Side.Left n)
     | [ "start"; "auto" ] -> Ok Start_auto
     | [ "start"; "full" ] -> Ok Start_full
     | [ ""; "start"; "full" ] -> Ok Neg_start_full
@@ -882,11 +697,11 @@ module Handler = struct
     | [ "start"; n ] -> (
         match parse_scale_step n with
         | Some sp -> Ok (Pos_spacing (Side.Start, sp))
-        | None -> Error (`Msg "invalid"))
+        | None -> arbitrary_or_named Side.Start n)
     | [ ""; "start"; n ] -> (
         match parse_scale_step n with
         | Some sp -> Ok (Neg_pos_spacing (Side.Start, sp))
-        | None -> Error (`Msg "invalid"))
+        | None -> neg_arbitrary Side.Start n)
     | [ "end"; "auto" ] -> Ok End_auto
     | [ "end"; "full" ] -> Ok End_full
     | [ ""; "end"; "full" ] -> Ok Neg_end_full
@@ -895,11 +710,11 @@ module Handler = struct
     | [ "end"; n ] -> (
         match parse_scale_step n with
         | Some sp -> Ok (Pos_spacing (Side.End, sp))
-        | None -> Error (`Msg "invalid"))
+        | None -> arbitrary_or_named Side.End n)
     | [ ""; "end"; n ] -> (
         match parse_scale_step n with
         | Some sp -> Ok (Neg_pos_spacing (Side.End, sp))
-        | None -> Error (`Msg "invalid"))
+        | None -> neg_arbitrary Side.End n)
     | _ -> Error (`Msg "Not a position utility")
 
   let to_class = function
@@ -929,27 +744,22 @@ module Handler = struct
         Side.name side ^ "-" ^ Spacing.pp_spacing_suffix sp
     | Neg_pos_spacing (side, sp) ->
         "-" ^ Side.name side ^ "-" ^ Spacing.pp_spacing_suffix sp
+    | Pos_arbitrary (side, raw, _) -> Side.name side ^ "-" ^ raw
+    | Neg_pos_arbitrary (side, raw, _) -> "-" ^ Side.name side ^ "-" ^ raw
+    | Pos_named (side, name) -> Side.name side ^ "-" ^ name
     | Inset n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-" ^ string_of_int (abs n)
-    | Inset_arbitrary (raw, _) -> "inset-" ^ raw
-    | Inset_named name -> "inset-" ^ name
     | Inset_x n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-x-" ^ string_of_int (abs n)
-    | Inset_x_arbitrary (raw, _) -> "inset-x-" ^ raw
-    | Inset_x_named name -> "inset-x-" ^ name
     | Inset_y n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-y-" ^ string_of_int (abs n)
-    | Inset_y_arbitrary (raw, _) -> "inset-y-" ^ raw
-    | Inset_y_named name -> "inset-y-" ^ name
     (* inset-s = inset-inline-start *)
     | Inset_s n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-s-" ^ string_of_int (abs n)
-    | Inset_s_arbitrary (raw, _) -> "inset-s-" ^ raw
-    | Inset_s_named name -> "inset-s-" ^ name
     | Inset_s_auto -> "inset-s-auto"
     | Inset_s_full -> "inset-s-full"
     | Neg_inset_s_full -> "-inset-s-full"
@@ -958,8 +768,6 @@ module Handler = struct
     | Inset_e n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-e-" ^ string_of_int (abs n)
-    | Inset_e_arbitrary (raw, _) -> "inset-e-" ^ raw
-    | Inset_e_named name -> "inset-e-" ^ name
     | Inset_e_auto -> "inset-e-auto"
     | Inset_e_full -> "inset-e-full"
     | Neg_inset_e_full -> "-inset-e-full"
@@ -968,8 +776,6 @@ module Handler = struct
     | Inset_bs n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-bs-" ^ string_of_int (abs n)
-    | Inset_bs_arbitrary (raw, _) -> "inset-bs-" ^ raw
-    | Inset_bs_named name -> "inset-bs-" ^ name
     | Inset_bs_auto -> "inset-bs-auto"
     | Inset_bs_full -> "inset-bs-full"
     | Neg_inset_bs_full -> "-inset-bs-full"
@@ -978,8 +784,6 @@ module Handler = struct
     | Inset_be n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "inset-be-" ^ string_of_int (abs n)
-    | Inset_be_arbitrary (raw, _) -> "inset-be-" ^ raw
-    | Inset_be_named name -> "inset-be-" ^ name
     | Inset_be_auto -> "inset-be-auto"
     | Inset_be_full -> "inset-be-full"
     | Neg_inset_be_full -> "-inset-be-full"
@@ -992,8 +796,6 @@ module Handler = struct
     | Top n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "top-" ^ string_of_int (abs n)
-    | Top_arbitrary (raw, _) -> "top-" ^ raw
-    | Top_named name -> "top-" ^ name
     | Right_fraction f -> "right-" ^ f
     | Neg_right_fraction f -> "-right-" ^ f
     | Right_auto -> "right-auto"
@@ -1002,8 +804,6 @@ module Handler = struct
     | Right n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "right-" ^ string_of_int (abs n)
-    | Right_arbitrary (raw, _) -> "right-" ^ raw
-    | Right_named name -> "right-" ^ name
     | Bottom_3_4 -> "bottom-3/4"
     | Bottom_auto -> "bottom-auto"
     | Bottom_full -> "bottom-full"
@@ -1011,8 +811,6 @@ module Handler = struct
     | Bottom n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "bottom-" ^ string_of_int (abs n)
-    | Bottom_arbitrary (raw, _) -> "bottom-" ^ raw
-    | Bottom_named name -> "bottom-" ^ name
     | Left_fraction f -> "left-" ^ f
     | Neg_left_fraction f -> "-left-" ^ f
     | Left_auto -> "left-auto"
@@ -1021,9 +819,6 @@ module Handler = struct
     | Left n ->
         let prefix = if n < 0 then "-" else "" in
         prefix ^ "left-" ^ string_of_int (abs n)
-    | Left_arbitrary (raw, _) -> "left-" ^ raw
-    | Neg_left_arbitrary (raw, _) -> "-left-" ^ raw
-    | Left_named name -> "left-" ^ name
     | Start_auto -> "start-auto"
     | Start_full -> "start-full"
     | Neg_start_full -> "-start-full"

--- a/lib/sizing.ml
+++ b/lib/sizing.ml
@@ -749,6 +749,11 @@ module Handler = struct
       | None -> None
     else None
 
+  (* A spacing step, and a ratio part, is a non-negative multiple of 0.25
+     ([isValidSpacingMultiplier]), so [w-1.75] and [8.5/11] are utilities while
+     [w-1.7] and [1.23/4.56] are not. *)
+  let is_quarter_multiple f = f >= 0. && Float.rem f 0.25 = 0.
+
   (* One parser for all thirteen sizing families: the family's own keyword
      table, then the fraction, bracket and spacing tails they share. *)
   let parse_sized ~theme prop v =
@@ -765,7 +770,8 @@ module Handler = struct
           | None -> err_invalid_value f.css_name v
         else
           match Parse.decimal_float v with
-          | Some n when n >= 0. && Theme.has_spacing_step ~theme n ->
+          | Some n when is_quarter_multiple n && Theme.has_spacing_step ~theme n
+            ->
               Ok (Sized (prop, Spacing (n *. 0.25)))
           | _ ->
               (* A size the project named in its own [@theme], under one of the
@@ -778,11 +784,6 @@ module Handler = struct
     match lookup max_width_family ("screen-" ^ s) with
     | Some value -> Ok (Sized (Max_width, value))
     | None -> err_invalid_value "max-width screen size" s
-
-  (* Tailwind accepts a ratio part only when it is a non-negative multiple of
-     0.25 ([isValidSpacingMultiplier]), so [8.5/11] is valid but [1.23/4.56] is
-     not. *)
-  let is_quarter_multiple f = f >= 0. && Float.rem f 0.25 = 0.
 
   (* [read] is how the two spellings of a ratio differ. A bare [aspect-4/3] is a
      class suffix, so each part is a plain decimal; inside a bracket the author

--- a/test/test_position.ml
+++ b/test/test_position.ml
@@ -347,6 +347,118 @@ let logical_inline_rejects_non_utilities () =
   reject "start-1/0";
   reject "start-"
 
+(* Every inset side reads an arbitrary length, and reads it under either sign.
+   The pinned CLI emits [inset-inline-start: 4px] for [start-[4px]] and [top:
+   calc(4px * -1)] for [-top-[4px]]; tw folds the negation into the literal,
+   which [arbitrary_insets_match_tailwind] holds to the CLI. *)
+let arbitrary_length_on_every_inset_side () =
+  let open Test_helpers in
+  check_declarations "start-[4px]" [ "inset-inline-start:4px" ];
+  check_declarations "end-[4px]" [ "inset-inline-end:4px" ];
+  check_declarations "start-[var(--x)]" [ "inset-inline-start:var(--x)" ];
+  check_declarations "end-[calc(5%-2px)]" [ "inset-inline-end:calc(5% - 2px)" ];
+  check_declarations "-start-[4px]" [ "inset-inline-start:-4px" ];
+  check_declarations "-end-[4px]" [ "inset-inline-end:-4px" ];
+  check_declarations "-top-[4px]" [ "top:-4px" ];
+  check_declarations "-right-[4px]" [ "right:-4px" ];
+  check_declarations "-bottom-[4px]" [ "bottom:-4px" ];
+  check_declarations "-left-[4px]" [ "left:-4px" ];
+  check_declarations "-inset-[4px]" [ "inset:-4px" ];
+  check_declarations "-inset-x-[4px]" [ "inset-inline:-4px" ];
+  check_declarations "-inset-y-[4px]" [ "inset-block:-4px" ];
+  check_declarations "-inset-s-[4px]" [ "inset-inline-start:-4px" ];
+  check_declarations "-inset-e-[4px]" [ "inset-inline-end:-4px" ];
+  check_declarations "-inset-bs-[4px]" [ "inset-block-start:-4px" ];
+  check_declarations "-inset-be-[4px]" [ "inset-block-end:-4px" ];
+  check_declarations "-top-[var(--t)]" [ "top:calc(var(--t)*-1)" ];
+  (* the bracket text is the class name, so it has to survive the round trip *)
+  check "start-[4px]";
+  check "end-[4px]";
+  check "-top-[4px]";
+  check "-inset-bs-[4px]";
+  check "-start-[var(--x)]"
+
+(* The logical inline sides resolve a name the theme binds, the way every other
+   inset side does: the CLI reads [--inset-header] for [start-header]. *)
+let named_inset_on_logical_inline_sides () =
+  let themed =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("inset-header", "2rem") ]
+  in
+  let accepts cls =
+    match Tw.Position.Handler.of_class themed cls with
+    | Ok util ->
+        Alcotest.(check string)
+          "round-trips" cls
+          (Tw.Position.Handler.to_class util)
+    | Error (`Msg m) -> Alcotest.failf "%s with theme rejected: %s" cls m
+  in
+  accepts "start-header";
+  accepts "end-header";
+  (* and stays a non-utility when the theme binds no such name *)
+  let reject c =
+    match Tw.Position.Handler.of_class Tw.Scheme.default c with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s should be rejected without a theme token" c
+  in
+  reject "start-header";
+  reject "end-header"
+
+(* The values above against the pinned CLI, sheet for sheet. *)
+let arbitrary_insets_match_tailwind () =
+  let mk s =
+    match Tw.of_string s with
+    | Ok u -> u
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" s m
+  in
+  Test_helpers.check_ordering_matches ~test_name:"arbitrary insets"
+    (List.map mk
+       [
+         "start-[4px]";
+         "end-[4px]";
+         "-start-[4px]";
+         "-end-[4px]";
+         "-top-[4px]";
+         "-right-[4px]";
+         "-bottom-[4px]";
+         "-left-[4px]";
+         "-inset-[4px]";
+         "-inset-x-[4px]";
+         "-inset-y-[4px]";
+         "-inset-s-[4px]";
+         "-inset-e-[4px]";
+         "-inset-bs-[4px]";
+         "-inset-be-[4px]";
+       ])
+
+(* A spacing step is a non-negative multiple of 0.25
+   ([isValidSpacingMultiplier]), so the CLI emits for [top-1.25] and for nothing
+   between the quarters. The bare suffix is read as a plain decimal too, which
+   is what keeps the OCaml literal spellings out. *)
+let spacing_step_is_a_quarter_multiple () =
+  let open Test_helpers in
+  check_declarations "top-1.5" [ "top:calc(var(--spacing)*1.5)" ];
+  check_declarations "top-1.25" [ "top:calc(var(--spacing)*1.25)" ];
+  check_declarations "top-0.75" [ "top:calc(var(--spacing)*.75)" ];
+  check_declarations "start-1.5"
+    [ "inset-inline-start:calc(var(--spacing)*1.5)" ];
+  let reject c = check_invalid_input (module Tw.Position.Handler) c in
+  reject "top-1.7";
+  reject "top-0.3";
+  reject "top-1.1";
+  reject "top-0.125";
+  reject "-top-1.7";
+  reject "inset-1.7";
+  reject "inset-x-1.7";
+  reject "left-1.7";
+  reject "start-1.7";
+  reject "end-1.7";
+  reject "-start-1.7";
+  (* the plain-decimal reading of a bare suffix, which brackets do not share *)
+  reject "top-0x4";
+  reject "top-1_0";
+  reject "start-0x4";
+  reject "start-1_0"
+
 let tests =
   [
     test_case "inset and z" `Quick test_inset_and_z;
@@ -376,6 +488,14 @@ let tests =
     test_case "logical inline scale steps" `Quick logical_inline_scale_steps;
     test_case "logical inline rejects non-utilities" `Quick
       logical_inline_rejects_non_utilities;
+    test_case "arbitrary length on every inset side" `Quick
+      arbitrary_length_on_every_inset_side;
+    test_case "named inset on logical inline sides" `Quick
+      named_inset_on_logical_inline_sides;
+    test_case "arbitrary insets match Tailwind" `Quick
+      arbitrary_insets_match_tailwind;
+    test_case "spacing step is a quarter multiple" `Quick
+      spacing_step_is_a_quarter_multiple;
   ]
 
 let suite = ("position", tests)

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -591,6 +591,24 @@ let typed_prime () =
   check_typed_class "w-4" (w 4);
   check_typed_class "size-4" (size 4)
 
+(* A spacing step is a non-negative multiple of 0.25
+   ([isValidSpacingMultiplier]), so the CLI emits for [w-1.75] and for nothing
+   between the quarters. The sizing families read the same scale the inset ones
+   do. *)
+let spacing_step_is_a_quarter_multiple () =
+  check_declarations "w-1.5" [ "width:calc(var(--spacing)*1.5)" ];
+  check_declarations "w-1.75" [ "width:calc(var(--spacing)*1.75)" ];
+  check_declarations "h-0.25" [ "height:calc(var(--spacing)*.25)" ];
+  let reject c = check_invalid_input (module Tw.Sizing.Handler) c in
+  reject "w-1.7";
+  reject "h-1.7";
+  reject "size-1.7";
+  reject "min-w-1.7";
+  reject "max-h-1.7";
+  reject "inline-1.7";
+  reject "w-0.3";
+  reject "w-0.125"
+
 let tests =
   [
     test_case "typed constructors: half-step" `Quick typed_prime;
@@ -629,6 +647,8 @@ let tests =
     test_case "aspect precedes dimensions" `Quick aspect_precedes_dimensions;
     test_case "aspect candidate order" `Slow
       aspect_candidate_order_matches_tailwind;
+    test_case "spacing step is a quarter multiple" `Quick
+      spacing_step_is_a_quarter_multiple;
   ]
 
 let suite = ("sizing", tests)


### PR DESCRIPTION
Two defects in the inset and spacing scales, both measured against the
pinned tailwindcss CLI.

`start-*` and `end-*` took no arbitrary bracket at all, and only `-left-*`
took a negated one, so classes the CLI emits were unknown. One reader now
serves every inset side under either sign, and the logical inline sides
gain the named inset the other sides already had.

A spacing step is a non-negative multiple of 0.25 upstream, but the inset
and sizing families accepted any decimal, so `top-1.7` and `w-1.7`
resolved to a rule Tailwind never writes.

The fraction half of the second entry needed no work: the merged
`Parse.fraction` already takes any denominator, and `top-1/7` and
`start-1/7` match the CLI as they stand.
