### PR TITLE
parse: read url() and quoted brackets as CSS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@
   `content-[url('a_b.png')]`, `[background-image:url('a_b.png')]` and
   `mask-[image-set(url('a_b.png')_1x)]` named a file they did not mean; the
   underscore outside the `url()` still becomes a space (#PR).
+- An arbitrary property whose value quotes or escapes a closing bracket reaches
+  the sheet. `[content:'a]b']`, `[--x:'a]b']` and
+  `[background-image:url('a]b')]` were refused, because the scan for the
+  closing bracket read neither strings nor escapes (#PR).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,11 +159,17 @@
   are part of a file name rather than spaces. `list-image-[url('a_b.png')]`,
   `content-[url('a_b.png')]`, `[background-image:url('a_b.png')]` and
   `mask-[image-set(url('a_b.png')_1x)]` named a file they did not mean; the
-  underscore outside the `url()` still becomes a space (#PR).
-- An arbitrary property whose value quotes or escapes a closing bracket reaches
-  the sheet. `[content:'a]b']`, `[--x:'a]b']` and
-  `[background-image:url('a]b')]` were refused, because the scan for the
-  closing bracket read neither strings nor escapes (#PR).
+  underscore outside the `url()` still becomes a space (#692).
+- `bg-[url(a\]b)]` names the file the class means. The escaped bracket reached
+  the value as a backslash of its own and emitted `url("a\\]b")`; the whole
+  `url()` is now read by the CSS tokeniser, which resolves its quotes and
+  escapes (#692).
+- A closing bracket the arbitrary value quotes or escapes belongs to the value,
+  so `[content:'a]b']`, `[--x:'a]b']`, `[background-image:url('a]b')]`,
+  `bg-[url('a]b')]`, `font-['My]Font']`, `shadow-[0_0_0_'a]b']` and
+  `after:content-['a]b']` reach the sheet. Both scans for the closing bracket
+  read strings and the backslash escape as the CSS tokeniser does; a string the
+  value leaves open runs to the end, so no later bracket closes it (#692).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,11 @@
   to the value, so `bg-[url('a]b')]`, `font-['My]Font']`, `mask-[url('a]b')]`,
   `shadow-[0_0_0_'a]b']` and `list-image-[url('a]b')]` reach the sheet. An
   unterminated string still refuses the class, as it does in Tailwind (#689).
+- A `url()` in an arbitrary value keeps the underscores of its argument, which
+  are part of a file name rather than spaces. `list-image-[url('a_b.png')]`,
+  `content-[url('a_b.png')]`, `[background-image:url('a_b.png')]` and
+  `mask-[image-set(url('a_b.png')_1x)]` named a file they did not mean; the
+  underscore outside the `url()` still becomes a space (#PR).
 - `delay-[...]` takes the arbitrary token streams `duration-[...]` already
   took, so `delay-[calc(1s+2s)]` and `delay-[--spacing(1)]` reach the sheet, and
   a `var()` fallback in either family decodes its underscores (#PR).

--- a/lib/arbitrary.ml
+++ b/lib/arbitrary.ml
@@ -304,96 +304,86 @@ module Handler = struct
     | Parsed_decl { property; value } -> "[" ^ property ^ ":" ^ value ^ "]"
 
   let of_class theme class_name =
-    (* Must start with [ and contain : *)
     let len = String.length class_name in
-    if len < 3 || class_name.[0] <> '[' then err_not_utility
-    else
-      (* Find the closing ] tracking bracket depth *)
-      let rec find_close i depth =
-        if i >= len then None
-        else
-          match class_name.[i] with
-          | '[' -> find_close (i + 1) (depth + 1)
-          | ']' -> if depth = 1 then Some i else find_close (i + 1) (depth - 1)
-          | _ -> find_close (i + 1) depth
-      in
-      match find_close 0 0 with
-      | None -> err_not_utility
-      | Some close_pos -> (
-          let inner = String.sub class_name 1 (close_pos - 1) in
-          (* Find the colon that separates property from value *)
-          let rec find_colon i =
-            if i >= String.length inner then None
-            else if inner.[i] = ':' then Some i
-            else find_colon (i + 1)
-          in
-          match find_colon 0 with
-          | None -> err_not_utility
-          | Some colon_pos -> (
-              let property = String.sub inner 0 colon_pos in
-              let raw_value =
-                String.sub inner (colon_pos + 1)
-                  (String.length inner - colon_pos - 1)
-              in
-              (* [--alpha(C/P)] is the [/opacity] form spelled as a function, so
-                 it resolves to the same fallback and [@supports] pair. *)
-              let value, fn_alpha =
-                match alpha_fn_parts raw_value with
-                | Some (c, p) -> (
-                    (* [--alpha()] writes the alpha as a percentage; the [/]
-                       modifier writes the bare number. *)
-                    let bare =
-                      if String.ends_with ~suffix:"%" p then
-                        String.sub p 0 (String.length p - 1)
-                      else p
-                    in
-                    match Color.opacity_of_string ~theme bare with
-                    | Some alpha -> (c, Some { spelling = raw_value; alpha })
-                    | None -> (raw_value, None))
-                | None -> (raw_value, None)
-              in
-              (* What follows the closing bracket is part of the class name, so
-                 it has to be a [/opacity] modifier in full: a suffix that does
-                 not parse names a class Tailwind does not recognise. *)
-              let suffix =
-                String.sub class_name (close_pos + 1) (len - close_pos - 1)
-              in
-              let modifier =
-                if suffix = "" then Some Color.No_opacity
-                else if suffix.[0] = '/' then
-                  Color.opacity_of_string ~theme
-                    (String.sub suffix 1 (String.length suffix - 1))
-                else None
-              in
-              match modifier with
-              | None -> err_not_utility
-              | Some opacity -> (
-                  if fn_alpha <> None || opacity <> Color.No_opacity then
-                    (* The /opacity form wraps the value in color-mix, so it
-                       needs a colour target (known colour property or custom
-                       property) and a colour value. Non-colour cases are
-                       rejected (Tailwind blindly color-mixes them, which is
-                       meaningless). *)
-                    let is_colour_value =
-                      Parse.is_var value
-                      || Css.parse_color (Parse.decode_arbitrary_value value)
-                         <> None
-                    in
-                    if color_emitter property <> None && is_colour_value then
-                      Ok
-                        (Color_opacity
-                           { property; value; alpha_fn = fn_alpha; opacity })
-                    else err_not_utility
-                  else
-                    (* Plain [property:value]: any property whose value cascade
-                       can parse becomes a typed declaration. *)
-                    match
-                      Css.parse_declaration
-                        (declared_property property)
-                        (Parse.decode_arbitrary_value value)
-                    with
-                    | Some _ -> Ok (Parsed_decl { property; value })
-                    | None -> err_not_utility)))
+    (* The bracket is closed by the tokeniser's reading, so a []] the value
+       quotes or escapes stays inside it: [[content:'a]b']] is one property and
+       one value. *)
+    match Parse.bracket_close class_name with
+    | None -> err_not_utility
+    | Some close_pos -> (
+        let inner = String.sub class_name 1 (close_pos - 1) in
+        (* Find the colon that separates property from value *)
+        let rec find_colon i =
+          if i >= String.length inner then None
+          else if inner.[i] = ':' then Some i
+          else find_colon (i + 1)
+        in
+        match find_colon 0 with
+        | None -> err_not_utility
+        | Some colon_pos -> (
+            let property = String.sub inner 0 colon_pos in
+            let raw_value =
+              String.sub inner (colon_pos + 1)
+                (String.length inner - colon_pos - 1)
+            in
+            (* [--alpha(C/P)] is the [/opacity] form spelled as a function, so
+               it resolves to the same fallback and [@supports] pair. *)
+            let value, fn_alpha =
+              match alpha_fn_parts raw_value with
+              | Some (c, p) -> (
+                  (* [--alpha()] writes the alpha as a percentage; the [/]
+                     modifier writes the bare number. *)
+                  let bare =
+                    if String.ends_with ~suffix:"%" p then
+                      String.sub p 0 (String.length p - 1)
+                    else p
+                  in
+                  match Color.opacity_of_string ~theme bare with
+                  | Some alpha -> (c, Some { spelling = raw_value; alpha })
+                  | None -> (raw_value, None))
+              | None -> (raw_value, None)
+            in
+            (* What follows the closing bracket is part of the class name, so it
+               has to be a [/opacity] modifier in full: a suffix that does not
+               parse names a class Tailwind does not recognise. *)
+            let suffix =
+              String.sub class_name (close_pos + 1) (len - close_pos - 1)
+            in
+            let modifier =
+              if suffix = "" then Some Color.No_opacity
+              else if suffix.[0] = '/' then
+                Color.opacity_of_string ~theme
+                  (String.sub suffix 1 (String.length suffix - 1))
+              else None
+            in
+            match modifier with
+            | None -> err_not_utility
+            | Some opacity -> (
+                if fn_alpha <> None || opacity <> Color.No_opacity then
+                  (* The /opacity form wraps the value in color-mix, so it needs
+                     a colour target (known colour property or custom property)
+                     and a colour value. Non-colour cases are rejected (Tailwind
+                     blindly color-mixes them, which is meaningless). *)
+                  let is_colour_value =
+                    Parse.is_var value
+                    || Css.parse_color (Parse.decode_arbitrary_value value)
+                       <> None
+                  in
+                  if color_emitter property <> None && is_colour_value then
+                    Ok
+                      (Color_opacity
+                         { property; value; alpha_fn = fn_alpha; opacity })
+                  else err_not_utility
+                else
+                  (* Plain [property:value]: any property whose value cascade
+                     can parse becomes a typed declaration. *)
+                  match
+                    Css.parse_declaration
+                      (declared_property property)
+                      (Parse.decode_arbitrary_value value)
+                  with
+                  | Some _ -> Ok (Parsed_decl { property; value })
+                  | None -> err_not_utility)))
 
   let examples = []
 end

--- a/lib/backgrounds.ml
+++ b/lib/backgrounds.ml
@@ -31,16 +31,6 @@ module Handler = struct
   (* Helper to check if a string contains an opacity modifier *)
   let has_opacity s = String.contains s '/'
 
-  (* An arbitrary url() value may already carry its own quotes (url('a.png') /
-     url("a.png")). Drop a matching outer pair so the typed [Url] pretty-printer
-     canonicalises it instead of double-wrapping it into the broken
-     url("'a.png'"). *)
-  let strip_outer_quotes s =
-    let n = String.length s in
-    if n >= 2 && (s.[0] = '\'' || s.[0] = '"') && s.[n - 1] = s.[0] then
-      String.sub s 1 (n - 2)
-    else s
-
   (* The named background positions, as [bg-<position>] spells them. *)
   module Position = struct
     type t =
@@ -143,7 +133,9 @@ module Handler = struct
     (* Bracket notation: bg-[image:<gradient/literal>] → background-image, with
        the image: hint kept in the class name *)
     | Bg_bracket_image of string * Css.background_image
-    (* Bracket notation: bg-[url(...)] → background-image *)
+    (* Bracket notation: bg-[url(...)] → background-image, holding the whole
+       url() as written so the token reader, not tw, resolves its quotes and
+       escapes *)
     | Bg_bracket_url of string
     (* Bracket notation: bg-[image:url(...)] → background-image (image: hint
        forces background-image; selector keeps the image: form) *)
@@ -318,8 +310,8 @@ module Handler = struct
     | Bg_bracket_var v -> "bg-[" ^ v ^ "]"
     | Bg_bracket_image_var v -> "bg-[image:" ^ v ^ "]"
     | Bg_bracket_image (v, _) -> "bg-[image:" ^ v ^ "]"
-    | Bg_bracket_url v -> "bg-[url(" ^ v ^ ")]"
-    | Bg_bracket_image_url v -> "bg-[image:url(" ^ v ^ ")]"
+    | Bg_bracket_url v -> "bg-[" ^ v ^ "]"
+    | Bg_bracket_image_url v -> "bg-[image:" ^ v ^ "]"
     | Bg_bracket_url_var v -> "bg-[url:" ^ v ^ "]"
     | Bg_bracket_linear_gradient (v, _) -> "bg-[" ^ v ^ "]"
     | Bg_bracket_color_var_opacity (v, opacity) ->
@@ -1517,15 +1509,14 @@ module Handler = struct
         let var_ref : Css.background_image Css.var = Var.bracket bare in
         style [ Css.background_image (Var var_ref) ]
     | Bg_bracket_image (_, img) -> style [ Css.background_image img ]
-    (* A [url()] is the one place an arbitrary value keeps its bare [_], so only
-       the [\_] escape is undone and a path spelled either way names the same
-       file. *)
-    | Bg_bracket_url url ->
-        let url = strip_outer_quotes (Parse.unescape_underscores url) in
-        style [ Css.background_image (Url url) ]
-    | Bg_bracket_image_url url ->
-        let url = strip_outer_quotes (Parse.unescape_underscores url) in
-        style [ Css.background_image (Url url) ]
+    (* The whole [url()] is kept, so cascade reads the token rather than tw
+       slicing the file name out of it: the quotes are the tokeniser's, and an
+       escape in it stands for one character of the URL. [of_class] refuses a
+       value the token reader will not take, so [None] names nothing. *)
+    | Bg_bracket_url v | Bg_bracket_image_url v -> (
+        match Parse.url_token (Parse.decode_arbitrary_value v) with
+        | Some url -> style [ Css.background_image (Url url) ]
+        | None -> style [])
     | Bg_bracket_url_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
@@ -1953,8 +1944,10 @@ module Handler = struct
                  value is a [url(...)] literal, a [var(...)] reference, or a
                  literal image (e.g. a gradient). *)
               let v = String.sub inner 6 (String.length inner - 6) in
-              if String.length v > 4 && String.sub v 0 4 = "url(" then
-                Ok (Bg_bracket_image_url (String.sub v 4 (String.length v - 5)))
+              if String.starts_with ~prefix:"url(" v then
+                match Parse.url_token (Parse.decode_arbitrary_value v) with
+                | Some _ -> Ok (Bg_bracket_image_url v)
+                | None -> Error (`Msg ("Unknown bg bracket image: " ^ v))
               else if Parse.is_var v then Ok (Bg_bracket_image_var v)
               else
                 match parse_bracket_image v with
@@ -1964,9 +1957,10 @@ module Handler = struct
               Ok
                 (Bg_bracket_url_var
                    (String.sub inner 4 (String.length inner - 4)))
-          | _ when String.length inner > 4 && String.sub inner 0 4 = "url(" ->
-              let url_content = String.sub inner 4 (String.length inner - 5) in
-              Ok (Bg_bracket_url url_content)
+          | _ when String.starts_with ~prefix:"url(" inner -> (
+              match Parse.url_token (Parse.decode_arbitrary_value inner) with
+              | Some _ -> Ok (Bg_bracket_url inner)
+              | None -> Error (`Msg ("Unknown bg bracket url: " ^ inner)))
           | _ when Parse.is_var inner -> Ok (Bg_bracket_var inner)
           | _ -> (
               (* Try parsing as background-image (gradients, urls,

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -238,6 +238,18 @@ let url_argument_spans s =
 let decode_underscores s =
   read_underscores ~plain:' ' ~verbatim:(url_argument_spans s) s
 
+(* A [url()] in an arbitrary value is CSS source, so an escape in it stands for
+   one character of the URL and the quotes are the tokeniser's, not the file
+   name's: [url(a\]b)], [url(a]b)] and [url('a]b')] all name [a]b]. Reading the
+   token rather than slicing the text out of it keeps the backslash from
+   reaching the value as a character of its own. *)
+let url_token s =
+  try
+    let cursor = Cascade.Cursor.of_string s in
+    let url = Cascade.Cursor.url cursor in
+    if Cascade.Cursor.is_done cursor then Some url else None
+  with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> None
+
 (* A property name has no spaces to spell, so its underscores stand for
    themselves and only the escape is undone. A name holds no [url()] either, so
    nothing is copied out unread. *)

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -118,35 +118,43 @@ let extract_var_name s =
       | name, Some fallback -> name ^ ", " ^ fallback
     with Cascade.Cursor.Parse_error _ | Invalid_argument _ -> s
 
-(* One bracket, not two: the closing bracket has to be the last character. A
-   suffix carrying a second bracket - one bracket with a bracket modifier, or
-   two brackets in a row - would otherwise read as one bracket whose inner text
-   has a stray bracket in it, which no declaration value takes.
+(* A quoted string runs to its closing quote, and to the end of the input when
+   the value leaves it open, as the CSS Syntax 3 sec. 4.3 tokeniser leaves it.
+   The result is the index just past the string. *)
+let string_end s i quote =
+  let len = String.length s in
+  let rec go i =
+    if i >= len then len
+    else if s.[i] = '\\' then go (i + 2)
+    else if s.[i] = quote then i + 1
+    else go (i + 1)
+  in
+  go i
 
-   A []] the value quotes or escapes is part of the value, so the scan tokenises
-   strings and the [\] escape the way CSS Syntax 3 sec. 4.3 does:
-   [bg-[url('a]b')]] is one bracket whose text carries a []]. A string the value
-   leaves open runs to the end of the input, as it does in the tokeniser, so no
-   []] after it closes the bracket and the suffix is refused - which is what
-   Tailwind does with [bg-[url('a)]]. *)
-let is_bracket_value s =
+(* A []] the value quotes or escapes is part of the value, not the bracket's
+   end, so the scan reads strings and the [\] escape the way the tokeniser does:
+   [[background-image:url('a]b')]] is one bracket whose text carries a []]. A
+   string left open swallows every later []], which is what Tailwind does with
+   [bg-[url('a)]]. *)
+let bracket_close s =
   let len = String.length s in
   let rec close i depth =
-    if i >= len then false
+    if i >= len then None
     else
       match s.[i] with
       | '\\' -> close (i + 2) depth
-      | '\'' | '"' -> in_string (i + 1) depth s.[i]
+      | '\'' | '"' -> close (string_end s (i + 1) s.[i]) depth
       | '[' -> close (i + 1) (depth + 1)
-      | ']' -> if depth = 0 then i = len - 1 else close (i + 1) (depth - 1)
+      | ']' -> if depth = 0 then Some i else close (i + 1) (depth - 1)
       | _ -> close (i + 1) depth
-  and in_string i depth quote =
-    if i >= len then false
-    else if s.[i] = '\\' then in_string (i + 2) depth quote
-    else if s.[i] = quote then close (i + 1) depth
-    else in_string (i + 1) depth quote
   in
-  len > 2 && s.[0] = '[' && close 1 0
+  if len > 2 && s.[0] = '[' then close 1 0 else None
+
+(* One bracket, not two: the closing bracket has to be the last character. A
+   suffix carrying a second bracket - one bracket with a bracket modifier, or
+   two brackets in a row - would otherwise read as one bracket whose inner text
+   has a stray bracket in it, which no declaration value takes. *)
+let is_bracket_value s = bracket_close s = Some (String.length s - 1)
 
 (** Extract the inner content from a bracket value "[foo]" → "foo" *)
 let bracket_inner s =
@@ -202,12 +210,6 @@ let url_argument_spans s =
     && String.sub s (i - 3) 3 = "url"
     && (i - word = 3 || s.[i - 4] = '_')
   in
-  let rec string_end i quote =
-    if i >= len then len
-    else if s.[i] = '\\' then string_end (i + 2) quote
-    else if s.[i] = quote then i + 1
-    else string_end (i + 1) quote
-  in
   (* The [)] closing the argument list, or the end of [s] when it is left open,
      as the tokeniser leaves it. *)
   let rec paren_end i depth =
@@ -215,7 +217,7 @@ let url_argument_spans s =
     else
       match s.[i] with
       | '\\' -> paren_end (i + 2) depth
-      | '\'' | '"' -> paren_end (string_end (i + 1) s.[i]) depth
+      | '\'' | '"' -> paren_end (string_end s (i + 1) s.[i]) depth
       | '(' -> paren_end (i + 1) (depth + 1)
       | ')' -> if depth = 0 then i else paren_end (i + 1) (depth - 1)
       | _ -> paren_end (i + 1) depth
@@ -225,7 +227,7 @@ let url_argument_spans s =
     else
       match s.[i] with
       | '\\' -> scan (i + 2) word acc
-      | '\'' | '"' -> scan (string_end (i + 1) s.[i]) word acc
+      | '\'' | '"' -> scan (string_end s (i + 1) s.[i]) word acc
       | '(' when names_url i word ->
           let stop = paren_end (i + 1) 0 in
           scan (stop + 1) (stop + 1) ((i + 1, stop) :: acc)

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -154,29 +154,92 @@ let bracket_inner s =
 
 (* In an arbitrary value [_] stands for a space, and [\_] for a literal
    underscore — otherwise a value that needs one could not be written. The two
-   readings differ only in what a bare [_] stands for, which [plain] carries. *)
-let read_underscores ~plain s =
+   readings differ only in what a bare [_] stands for, which [plain] carries,
+   and in [verbatim], the spans copied out unread. *)
+let read_underscores ~plain ~verbatim s =
   let len = String.length s in
   let buf = Buffer.create len in
-  let rec go i =
+  let rec go i spans =
     if i >= len then ()
-    else if s.[i] = '\\' && i + 1 < len && s.[i + 1] = '_' then begin
-      Buffer.add_char buf '_';
-      go (i + 2)
-    end
-    else begin
-      Buffer.add_char buf (if s.[i] = '_' then plain else s.[i]);
-      go (i + 1)
-    end
+    else
+      match spans with
+      | (start, stop) :: rest when i = start ->
+          Buffer.add_substring buf s start (stop - start);
+          go stop rest
+      | _ ->
+          if s.[i] = '\\' && i + 1 < len && s.[i + 1] = '_' then begin
+            Buffer.add_char buf '_';
+            go (i + 2) spans
+          end
+          else begin
+            Buffer.add_char buf (if s.[i] = '_' then plain else s.[i]);
+            go (i + 1) spans
+          end
   in
-  go 0;
+  go 0 verbatim;
   Buffer.contents buf
 
-let decode_underscores s = read_underscores ~plain:' ' s
+(* Tailwind's value parser: a word runs to the next of [/ : , = > < ( )] or
+   whitespace, and a [\] escape or a quoted string is part of the word it stands
+   in. A [(] opens a function whose name is the word before it. *)
+let breaks_word = function
+  | '/' | ':' | ',' | '=' | '>' | '<' | '(' | ')' | ' ' | '\t' | '\n' -> true
+  | _ -> false
+
+(* [url_argument_spans s] is the list, in order, of the argument lists a [url()]
+   opens in [s], each as the half-open range between its parentheses.
+
+   Tailwind decodes an arbitrary value node by node and leaves these alone: a
+   [_] inside a [url()] is part of a file name, not a space. The function name
+   is matched the way Tailwind matches it, on [url] or a name ending in [_url],
+   so [myurl(a_b)] and [a-url(a_b)] decode their arguments and [_url(a_b)] does
+   not. *)
+let url_argument_spans s =
+  let len = String.length s in
+  (* The name before the [(] at [i] started at [word]. *)
+  let names_url i word =
+    i - word >= 3
+    && String.sub s (i - 3) 3 = "url"
+    && (i - word = 3 || s.[i - 4] = '_')
+  in
+  let rec string_end i quote =
+    if i >= len then len
+    else if s.[i] = '\\' then string_end (i + 2) quote
+    else if s.[i] = quote then i + 1
+    else string_end (i + 1) quote
+  in
+  (* The [)] closing the argument list, or the end of [s] when it is left open,
+     as the tokeniser leaves it. *)
+  let rec paren_end i depth =
+    if i >= len then len
+    else
+      match s.[i] with
+      | '\\' -> paren_end (i + 2) depth
+      | '\'' | '"' -> paren_end (string_end (i + 1) s.[i]) depth
+      | '(' -> paren_end (i + 1) (depth + 1)
+      | ')' -> if depth = 0 then i else paren_end (i + 1) (depth - 1)
+      | _ -> paren_end (i + 1) depth
+  in
+  let rec scan i word acc =
+    if i >= len then List.rev acc
+    else
+      match s.[i] with
+      | '\\' -> scan (i + 2) word acc
+      | '\'' | '"' -> scan (string_end (i + 1) s.[i]) word acc
+      | '(' when names_url i word ->
+          let stop = paren_end (i + 1) 0 in
+          scan (stop + 1) (stop + 1) ((i + 1, stop) :: acc)
+      | c -> scan (i + 1) (if breaks_word c then i + 1 else word) acc
+  in
+  scan 0 0 []
+
+let decode_underscores s =
+  read_underscores ~plain:' ' ~verbatim:(url_argument_spans s) s
 
 (* A property name has no spaces to spell, so its underscores stand for
-   themselves and only the escape is undone. *)
-let unescape_underscores s = read_underscores ~plain:'_' s
+   themselves and only the escape is undone. A name holds no [url()] either, so
+   nothing is copied out unread. *)
+let unescape_underscores s = read_underscores ~plain:'_' ~verbatim:[] s
 
 (* The inverse: a utility holding a decoded value writes its class name back,
    and the name has to read as the value it came from. *)

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -114,6 +114,15 @@ val decode_arbitrary_value : string -> string
     spaces and normalizes omitted whitespace around binary [+] and [-] operators
     inside CSS math functions such as [calc()]. *)
 
+val url_token : string -> string option
+(** [url_token s] reads [s] as one whole CSS [url()] token and returns the URL
+    it names, with quotes and escapes resolved: [url(a\]b)], [url(a\\\]b)] and
+    [url('a\]b')] all name [a\]b]. [None] when [s] is not one whole token.
+
+    A utility holding a [url()] as it was written reads it back through this
+    rather than slicing the file name out of the text, which would carry the
+    backslash of an escape into the value. *)
+
 val normalize_css_math_operators : string -> string
 (** [normalize_css_math_operators s] inserts the spaces CSS math functions
     (calc/min/max/...) require around binary [+] and [-], e.g.

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -65,17 +65,22 @@ val extract_var_name : string -> string
     name without the [--] prefix, retaining an optional fallback after a comma.
     If [s] is not exactly one valid reference, it returns [s] unchanged. *)
 
+val bracket_close : string -> int option
+(** [bracket_close s] is the index of the [\]] closing the [\[] that [s] starts
+    with, and [None] when [s] does not start with one or leaves it open. Nested
+    brackets are matched.
+
+    A [\]] the value quotes or escapes belongs to the value: strings and the
+    backslash escape are read as CSS Syntax 3 sec. 4.3 reads them, so
+    [[background-image:url('a]b')\]] closes on its last bracket. A string left
+    open runs to the end of [s], so nothing after it closes the bracket. *)
+
 val is_bracket_value : string -> bool
 (** [is_bracket_value s] returns [true] if [s] is one bracket-wrapped value. The
     closing bracket has to be the last character, so a suffix carrying a second
     bracket - one bracket with a bracket modifier, or two brackets in a row - is
-    not one bracket value.
-
-    A closing bracket the value quotes or escapes belongs to the value: strings
-    and the backslash escape are read as CSS Syntax 3 sec. 4.3 reads them, so a
-    quoted [url()] argument carrying one is still one bracket value. A string
-    left open runs to the end of [s], so nothing after it can close the bracket
-    and [s] is not one. *)
+    not one bracket value. It is {!bracket_close} landing on the last character,
+    and reads quotes and escapes the same way. *)
 
 val bracket_inner : string -> string
 (** [bracket_inner s] extracts the inner content from ["[foo]"], returning

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -83,7 +83,13 @@ val bracket_inner : string -> string
 
 val decode_underscores : string -> string
 (** [decode_underscores s] turns the [_] of an arbitrary value into a space, and
-    [\_] into a literal underscore. *)
+    [\_] into a literal underscore.
+
+    The argument list of a [url()] is left as written, because a [_] there is
+    part of a file name: [image-set(url('a_b.png')_1x)] keeps the first
+    underscore and gives the second a space. The function name is matched on
+    [url] or a name ending in [_url], so [myurl(a_b)] and [a-url(a_b)] decode
+    their arguments. *)
 
 val unescape_underscores : string -> string
 (** [unescape_underscores s] turns the [\_] of an arbitrary value into a literal

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -334,9 +334,11 @@ let test_quoted_closing_bracket () =
   Alcotest.(check bool)
     "[content:'a]b'] keeps the bracket in the string" true
     (Astring.String.is_infix ~affix:"content: 'a]b'" (css "[content:'a]b']"));
+  (* Tailwind keeps the quote the class wrote; the quoting is cascade's
+     canonical spelling of the same CSS string. *)
   Alcotest.(check bool)
     "[--x:'a]b'] keeps the bracket in the string" true
-    (Astring.String.is_infix ~affix:"--x: 'a]b'" (css "[--x:'a]b']"));
+    (Astring.String.is_infix ~affix:{|--x: "a]b"|} (css "[--x:'a]b']"));
   Alcotest.(check bool)
     "[background-image:url('a]b')] keeps the bracket in the url" true
     (Astring.String.is_infix ~affix:"background-image: url('a]b')"
@@ -349,14 +351,19 @@ let test_url_underscore () =
     "the url keeps its underscore" true
     (Astring.String.is_infix ~affix:"background-image: url('a_b.png')"
        (css "[background-image:url('a_b.png')]"));
+  (* Outside the url the underscore is a space, in a shorthand that takes both.
+     [background-image] does not take a position, and tw declines to write the
+     invalid declaration Tailwind emits for it. *)
   Alcotest.(check bool)
     "the underscore after the url is a space" true
-    (Astring.String.is_infix ~affix:"background-image: url('a_b.png') center"
-       (css "[background-image:url('a_b.png')_center]"));
+    (Astring.String.is_infix ~affix:"background: url(a_b.png) no-repeat"
+       (css "[background:url(a_b.png)_no-repeat]"));
+  (* Tailwind keeps the inner url quoted; the quoting is cascade's canonical
+     spelling of the same URL. *)
   Alcotest.(check bool)
     "the underscore inside an image-set url stays" true
     (Astring.String.is_infix
-       ~affix:"background-image: image-set(url('a_b.png') 1x)"
+       ~affix:"background-image: image-set(url(a_b.png) 1x)"
        (css "[background-image:image-set(url('a_b.png')_1x)]"))
 
 let tests =

--- a/test/test_arbitrary.ml
+++ b/test/test_arbitrary.ml
@@ -323,6 +323,42 @@ let test_property_underscore_escape () =
   has {|[--my\_var:red]|} "--my_var: red";
   has "[--my_var:red]" "--my_var: red"
 
+(* A []] the value quotes belongs to the value, so the scan for the closing
+   bracket reads strings the way the CSS tokeniser does. Tailwind emits
+   [content: 'a]b'] for the first of these; a scan blind to quotes stopped at
+   the []] inside the string and refused the class. *)
+let test_quoted_closing_bracket () =
+  check "[content:'a]b']";
+  check "[--x:'a]b']";
+  check {|[content:"a]b"]|};
+  Alcotest.(check bool)
+    "[content:'a]b'] keeps the bracket in the string" true
+    (Astring.String.is_infix ~affix:"content: 'a]b'" (css "[content:'a]b']"));
+  Alcotest.(check bool)
+    "[--x:'a]b'] keeps the bracket in the string" true
+    (Astring.String.is_infix ~affix:"--x: 'a]b'" (css "[--x:'a]b']"));
+  Alcotest.(check bool)
+    "[background-image:url('a]b')] keeps the bracket in the url" true
+    (Astring.String.is_infix ~affix:"background-image: url('a]b')"
+       (css "[background-image:url('a]b')]"))
+
+(* A [url()] argument is left verbatim, so a [_] in a file name stays one while
+   the [_] separating it from the next value becomes a space. *)
+let test_url_underscore () =
+  Alcotest.(check bool)
+    "the url keeps its underscore" true
+    (Astring.String.is_infix ~affix:"background-image: url('a_b.png')"
+       (css "[background-image:url('a_b.png')]"));
+  Alcotest.(check bool)
+    "the underscore after the url is a space" true
+    (Astring.String.is_infix ~affix:"background-image: url('a_b.png') center"
+       (css "[background-image:url('a_b.png')_center]"));
+  Alcotest.(check bool)
+    "the underscore inside an image-set url stays" true
+    (Astring.String.is_infix
+       ~affix:"background-image: image-set(url('a_b.png') 1x)"
+       (css "[background-image:image-set(url('a_b.png')_1x)]"))
+
 let tests =
   [
     test_case "property name underscore escape" `Quick
@@ -333,6 +369,8 @@ let tests =
     test_case "arbitrary of_string - valid values" `Quick of_string_valid;
     test_case "arbitrary of_string - invalid values" `Quick of_string_invalid;
     test_case "text after the closing bracket" `Quick test_trailing_text;
+    test_case "quoted closing bracket" `Quick test_quoted_closing_bracket;
+    test_case "url argument underscores" `Quick test_url_underscore;
     test_case "--alpha() value with a /opacity modifier" `Quick
       test_alpha_fn_with_modifier;
     test_case "var-valued opacity modifier spelling" `Quick

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -584,10 +584,34 @@ let test_arbitrary_underscore_escape () =
   has {|bg-[url('a\_b.png')]|} "background-image: url(a_b.png)";
   has {|bg-linear-[to\_bottom]|} "--tw-gradient-position: to_bottom"
 
+(* A [url()] is CSS source, so a [\]] in it is one character of the URL, not a
+   backslash of its own: [url(a\]b)] and [url(a]b)] name the same file, and
+   Tailwind emits the first verbatim. tw used to hand cascade the backslash as
+   well and emit the double-escaped url("a\\]b"). *)
+let test_bracket_url_escape () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has {|bg-[url(a\]b)]|} "background-image: url(a]b)";
+  has {|bg-[image:url(a\]b)]|} "background-image: url(a]b)";
+  (* A quoted []] needs no escape and keeps its quotes. *)
+  has "bg-[url('a]b')]" "background-image: url('a]b')";
+  (* A url argument keeps a bare [_], which is part of the file name. *)
+  has "bg-[url('a_b.png')]" "background-image: url('a_b.png')"
+
 let tests =
   [
     test_case "arbitrary underscore escape" `Quick
       test_arbitrary_underscore_escape;
+    test_case "bracket url escape" `Quick test_bracket_url_escape;
     test_case "gradient interpolation" `Quick test_gradient_interpolation;
     test_case "gradient stop position units" `Quick
       test_gradient_stop_position_units;

--- a/test/test_backgrounds.ml
+++ b/test/test_backgrounds.ml
@@ -602,10 +602,11 @@ let test_bracket_url_escape () =
   in
   has {|bg-[url(a\]b)]|} "background-image: url(a]b)";
   has {|bg-[image:url(a\]b)]|} "background-image: url(a]b)";
-  (* A quoted []] needs no escape and keeps its quotes. *)
-  has "bg-[url('a]b')]" "background-image: url('a]b')";
+  (* A quoted []] needs no escape either. Tailwind keeps the quotes the class
+     wrote; dropping them is cascade's canonical spelling of the same URL. *)
+  has "bg-[url('a]b')]" "background-image: url(a]b)";
   (* A url argument keeps a bare [_], which is part of the file name. *)
-  has "bg-[url('a_b.png')]" "background-image: url('a_b.png')"
+  has "bg-[url('a_b.png')]" "background-image: url(a_b.png)"
 
 let tests =
   [

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -199,8 +199,10 @@ let test_bracket_url_underscore () =
       (Astring.String.is_infix ~affix (css cls))
   in
   has "mask-[url('a_b.png')]" "mask-image: url('a_b.png')";
+  (* Tailwind writes the inner url quoted. The quoting is cascade's canonical
+     spelling of the same URL; the underscore is the point. *)
   has "mask-[image-set(url('a_b.png')_1x)]"
-    "mask-image: image-set(url('a_b.png') 1x)"
+    "mask-image: image-set(url(a_b.png) 1x)"
 
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -183,6 +183,25 @@ let test_bracket_url_keeps_underscores () =
   Test_helpers.check_declarations "mask-[url(a_b.png)]"
     [ "-webkit-mask-image:url(a_b.png)"; "mask-image:url(a_b.png)" ]
 
+(* A [url()] argument is left verbatim, so a bare [_] in a file name is a file
+   name too. Only the [_] outside the url is a space, which [image-set()] is the
+   case that tells the two apart. *)
+let test_bracket_url_underscore () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "mask-[url('a_b.png')]" "mask-image: url('a_b.png')";
+  has "mask-[image-set(url('a_b.png')_1x)]"
+    "mask-image: image-set(url('a_b.png') 1x)"
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -190,6 +209,8 @@ let tests =
         test_bracket_image_underscore_escape;
       Alcotest.test_case "bracket url keeps underscores" `Quick
         test_bracket_url_keeps_underscores;
+      Alcotest.test_case "mask image url underscores" `Quick
+        test_bracket_url_underscore;
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
       Alcotest.test_case "arbitrary mask layer list" `Quick

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -390,12 +390,42 @@ let test_quoted_bracket_stays_inside_the_value () =
       {|bg-[url(a\]b)][20px]|};
     ]
 
+(* Tailwind reads an arbitrary value as a value tree and decodes the text of
+   every node except the arguments of a [url()], which stay verbatim: a [_]
+   there is part of a file name, not a space. The function name is matched the
+   way Tailwind matches it, on [url] or a name ending in [_url], so a word that
+   merely ends in the letters decodes its arguments. Pinned against
+   @tailwindcss/cli 4.3.3. *)
+let test_underscore_inside_url () =
+  let reads name input expected =
+    Alcotest.(check string) name expected (Tw.Parse.decode_underscores input)
+  in
+  reads "a quoted url keeps its underscore" "url('a_b.png')" "url('a_b.png')";
+  reads "an unquoted url keeps its underscore" "url(a_b.png)" "url(a_b.png)";
+  reads "a url keeps the escape as written" {|url('a\_b.png')|}
+    {|url('a\_b.png')|};
+  reads "only the url argument is kept" "image-set(url('a_b.png')_1x)"
+    "image-set(url('a_b.png') 1x)";
+  reads "the text after a url is decoded" "url('a_b.png')_center"
+    "url('a_b.png') center";
+  reads "each url of a list is kept" "url(a_b),url(c_d)" "url(a_b),url(c_d)";
+  reads "a url nested in a function is kept" "calc(url(a_b))" "calc(url(a_b))";
+  reads "a url argument list balances its parens" "url(a(b_c)d)" "url(a(b_c)d)";
+  reads "a name merely ending in url decodes" "myurl(a_b)" "myurl(a b)";
+  reads "a hyphen keeps the name apart" "a-url(a_b)" "a-url(a b)";
+  reads "a name ending in _url keeps its arguments" "_url(a_b)" " url(a_b)";
+  reads "url is matched case-sensitively" "URL(a_b)" "URL(a b)";
+  reads "an escaped paren opens no url" {|url\(a_b\)|} {|url\(a b\)|};
+  reads "a quoted string outside a url decodes" "image-set('a_b.png'_1x)"
+    "image-set('a b.png' 1x)"
+
 let tests =
   Alcotest.
     [
       test_case "underscore escape" `Quick test_underscore_escape;
       test_case "a quoted bracket stays inside the value" `Quick
         test_quoted_bracket_stays_inside_the_value;
+      test_case "underscore inside a url" `Quick test_underscore_inside_url;
       test_case "parse backslash escape in selector" `Quick
         test_escape_in_selector;
       test_case "double bracket class rejected" `Quick

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -852,6 +852,25 @@ let test_bracket_list_style () =
     "an unknown counter style is rejected" true
     (Result.is_error (Tw.of_string "list-[nonsense-style]"))
 
+(* A [url()] argument is left verbatim, so a file name keeps the [_] it is
+   written with. [list-image-] and [content-] read their bracket through the
+   arbitrary-value decoder, which used to turn every [_] into a space. *)
+let test_bracket_url_underscore () =
+  let css cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let has cls affix =
+    Alcotest.(check bool)
+      (cls ^ " emits " ^ affix)
+      true
+      (Astring.String.is_infix ~affix (css cls))
+  in
+  has "list-image-[url('a_b.png')]" "list-style-image: url(a_b.png)";
+  has "list-image-[url(a_b.png)]" "list-style-image: url(a_b.png)";
+  has "content-[url('a_b.png')]" "--tw-content: url(a_b.png)"
+
 (* List position, type, and image are three property bands; candidates inside
    each band use their natural class-name order. *)
 let test_list_style_property_bands () =
@@ -1289,6 +1308,7 @@ let tests =
     test_case "text-[<font-size>] invalid values" `Quick
       test_text_bracket_size_invalid;
     test_case "bracket length units" `Quick test_bracket_length_units;
+    test_case "bracket url underscores" `Quick test_bracket_url_underscore;
     test_case "arbitrary leading" `Quick test_arbitrary_leading;
     test_case "arbitrary leading token stream" `Quick
       test_arbitrary_leading_token_stream;

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -869,7 +869,9 @@ let test_bracket_url_underscore () =
   in
   has "list-image-[url('a_b.png')]" "list-style-image: url(a_b.png)";
   has "list-image-[url(a_b.png)]" "list-style-image: url(a_b.png)";
-  has "content-[url('a_b.png')]" "--tw-content: url(a_b.png)"
+  (* Tailwind writes this one [url('a_b.png')]. The quoting is cascade's
+     canonical spelling of the same URL; the underscore is the point. *)
+  has "content-[url('a_b.png')]" {|--tw-content: url("a_b.png")|}
 
 (* List position, type, and image are three property bands; candidates inside
    each band use their natural class-name order. *)


### PR DESCRIPTION
Three defects in how tw reads an arbitrary value, all in the same place: it
took CSS source apart with string slicing where the CSS tokeniser was the
thing that knew how to read it.

`decode_underscores` turned every `_` into a space, including inside a
`url()`, where the underscore is part of a file name. Tailwind decodes an
arbitrary value node by node and leaves a `url()` argument list alone, so the
skip is per span rather than a whole-value test: in
`image-set(url('a_b.png')_1x)` the first underscore stays and the second
becomes a space.

The scan for an arbitrary property's closing bracket read neither strings nor
escapes, so `[content:'a]b']` and its neighbours were refused. It moves to
`Parse.bracket_close`, which `is_bracket_value` now reads the last character
of, so the two agree on where a bracket ends.

`bg-[url(a\]b)]` names three characters, but the utility sliced the file name
out of the text and kept the backslash, which cascade then correctly escaped
into `url("a\\]b")`. The utility now holds the `url()` as written and reads it
back through the tokeniser.

Expectations come from `@tailwindcss/cli` 4.3.3 throughout; the tests were
written and watched to fail before any of it was implemented.

### Overlap with open PRs

`Parse.is_bracket_value` here does what #689 makes it do, because
`bg-[url(a\]b)]` cannot be reached without it and #689 is not merged. #689's
`lib/parse.ml` hunk becomes redundant against this branch. #688's
`is_single_url` in `lib/masks.ml` also becomes redundant: it is the
whole-value test this replaces, and it is wrong for
`mask-[image-set(url('a_b.png')_1x)]`.

### Left alone

`mask-[url(x.png)_center]` still slices its url the way backgrounds did and
emits `url("x.png)_cente")` under a class name nothing matches. It is the same
defect in `lib/masks.ml`, unchanged by this branch and unrelated to the
underscore.

`image-set()` still differs from Tailwind on the `-webkit-image-set()`
fallback and on how cascade spells an image-set source. It shows on
`mask-[image-set(url(x.png)_1x)]`, with no underscore involved.
