### PR TITLE
Consolidate helpers that had drifted or were about to

### DIFF
--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1301,36 +1301,20 @@ let theme_color_order_map =
     ("white", 24);
   ]
 
-(* Utilities layer color ordering map for conflict resolution. *)
+(* Utilities layer color ordering map for conflict resolution. The utilities
+   layer ranks the same names the theme layer does, but by its own rule:
+   [transparent] and [black] lead and the rest are alphabetical. Reading the
+   names off the theme map is what keeps a colour added there from silently
+   taking the unknown-colour slot here. *)
 let utilities_color_order_map =
-  [
-    (* Basic colors come first *)
-    ("transparent", 0);
-    ("black", 1);
-    ("amber", 2);
-    ("blue", 3);
-    ("cyan", 4);
-    ("emerald", 5);
-    ("fuchsia", 6);
-    ("gray", 7);
-    ("green", 8);
-    ("indigo", 9);
-    ("lime", 10);
-    ("neutral", 11);
-    ("orange", 12);
-    ("pink", 13);
-    ("purple", 14);
-    ("red", 15);
-    ("rose", 16);
-    ("sky", 17);
-    ("slate", 18);
-    ("stone", 19);
-    ("teal", 20);
-    ("violet", 21);
-    ("white", 22);
-    ("yellow", 23);
-    ("zinc", 24);
-  ]
+  let leading = [ "transparent"; "black" ] in
+  let alphabetical =
+    List.sort String.compare
+      (List.filter_map
+         (fun (name, _) -> if List.mem name leading then None else Some name)
+         theme_color_order_map)
+  in
+  List.mapi (fun index name -> (name, index)) (leading @ alphabetical)
 
 (* Get theme layer order for a color variable. Returns (priority=2, suborder)
    where 2 indicates these are theme layer variables. *)

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -1917,10 +1917,11 @@ module Handler = struct
             | Some value -> parse_theme_color value
             | None -> to_css ?theme c (if is_base_color c then 500 else shade)))
 
-  (* Aliases for color constructors/functions that will be shadowed by open
-     Css *)
+  (* Aliases for names that open Css shadows: the color constructors below, and
+     [Pp], whose byte formatter cascade's own [Pp] does not carry. *)
   let mk_color_hex s : color = Hex s
   let color_of_string = of_string
+  let hex_byte = Pp.hex_byte
 
   open Style
   open Css
@@ -2462,10 +2463,6 @@ module Handler = struct
         Alpha_byte (min 255 (max 0 (Float.to_int (Float.round (f *. 2.55)))))
     | Var _ | Calc _ -> Alpha_unresolvable
 
-  let to_hex_byte n =
-    let hex = "0123456789abcdef" in
-    String.make 1 hex.[n / 16] ^ String.make 1 hex.[n mod 16]
-
   (** Convert a typed CSS color to a hex string for Tailwind parity *)
   let css_color_to_hex (c : Css.color) : Css.color option =
     let hex_of_bytes bytes = Some (Css.hex ("#" ^ shorten_hex_str bytes)) in
@@ -2473,17 +2470,16 @@ module Handler = struct
     | Rgb (Channels { r; g; b }) -> (
         match (channel_to_int r, channel_to_int g, channel_to_int b) with
         | Some r, Some g, Some b ->
-            hex_of_bytes (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b)
+            hex_of_bytes (hex_byte r ^ hex_byte g ^ hex_byte b)
         | _ -> None)
     | Rgba { rgb = Channels { r; g; b }; a; _ } -> (
         match
           (channel_to_int r, channel_to_int g, channel_to_int b, fold_alpha a)
         with
         | Some r, Some g, Some b, Opaque ->
-            hex_of_bytes (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b)
+            hex_of_bytes (hex_byte r ^ hex_byte g ^ hex_byte b)
         | Some r, Some g, Some b, Alpha_byte a ->
-            hex_of_bytes
-              (to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b ^ to_hex_byte a)
+            hex_of_bytes (hex_byte r ^ hex_byte g ^ hex_byte b ^ hex_byte a)
         | _ -> None)
     | Hsl _ -> (
         (* Fold through cascade's own colour path: it knows every hue unit and
@@ -2494,8 +2490,8 @@ module Handler = struct
           Cascade.Values.nonkeyword_color (Cascade.Values.normalize_color c)
         with
         | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-            let hex = to_hex_byte r ^ to_hex_byte g ^ to_hex_byte b in
-            hex_of_bytes (if a = 255 then hex else hex ^ to_hex_byte a)
+            let hex = hex_byte r ^ hex_byte g ^ hex_byte b in
+            hex_of_bytes (if a = 255 then hex else hex ^ hex_byte a)
         | _ -> None)
     | _ -> None
 
@@ -2507,7 +2503,7 @@ module Handler = struct
     match css_color with
     | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
         let value = hex_string_of_rgb (r, g, b) in
-        let value = if a = 255 then value else value ^ to_hex_byte a in
+        let value = if a = 255 then value else value ^ hex_byte a in
         Css.hex ("#" ^ shorten_hex_str value)
     | _ -> (
         match css_color_to_hex css_color with

--- a/lib/forms.ml
+++ b/lib/forms.ml
@@ -84,6 +84,9 @@ let focus_ring_decls ~offset_width ~ring_width_px =
     box_shadows box_shadow_vars;
   ]
 
+(* The focus ring a text input carries: 1px, no offset. The plugin renders the
+   same ring on [.form-input] and on the bare elements it restyles, so both read
+   it from here. *)
 let input_focus_decls =
   let open Css in
   focus_ring_decls ~offset_width:(Px 0.) ~ring_width_px:1
@@ -98,6 +101,8 @@ let input_focus_decls =
            });
     ]
 
+(* The focus ring a checkbox or radio carries: 2px, offset by 2px. Shared with
+   the bare-element rules for the same reason. *)
 let checkbox_focus_decls =
   let open Css in
   focus_ring_decls ~offset_width:(Px 2.) ~ring_width_px:2
@@ -627,35 +632,6 @@ let text_inputs =
       Css.Selector.element "select";
     ]
 
-(** Focus ring declarations for text inputs (1px ring, no offset) *)
-let text_input_focus_ring_decls =
-  let open Css in
-  focus_ring_decls ~offset_width:(Px 0.) ~ring_width_px:1
-  @ [
-      border_color blue_600;
-      outline
-        (Shorthand
-           {
-             width = Some (Px 2.);
-             style = Some Solid;
-             color = Some (hex "#0000");
-           });
-    ]
-
-(** Focus ring declarations for checkboxes/radios (2px ring, 2px offset) *)
-let checkbox_focus_ring_decls =
-  let open Css in
-  focus_ring_decls ~offset_width:(Px 2.) ~ring_width_px:2
-  @ [
-      outline
-        (Shorthand
-           {
-             width = Some (Px 2.);
-             style = Some Solid;
-             color = Some (hex "#0000");
-           });
-    ]
-
 (** Webkit datetime edit pseudo-element rules for text inputs *)
 let webkit_datetime_rules () =
   let open Css in
@@ -726,9 +702,7 @@ let text_inputs_base () =
         font_size (Rem 1.);
         line_height (Rem 1.5);
       ];
-    rule
-      ~selector:Selector.(is_ text_input_items && Focus)
-      text_input_focus_ring_decls;
+    rule ~selector:Selector.(is_ text_input_items && Focus) input_focus_decls;
     rule
       ~selector:
         Selector.(
@@ -908,7 +882,7 @@ let checkbox_radio_base () =
     (* 4. Focus ring for both *)
     rule
       ~selector:Selector.(list [ type_checkbox && Focus; type_radio && Focus ])
-      checkbox_focus_ring_decls;
+      checkbox_focus_decls;
   ]
   @ checkbox_checked_rules ()
   @ checkbox_indeterminate_rules ()

--- a/lib/prose.ml
+++ b/lib/prose.ml
@@ -1645,272 +1645,333 @@ let xl2_size_rules selector =
 let bind_prose_vars bindings =
   List.map (fun (var, value) -> fst (Var.binding var value)) bindings
 
-(* Gray theme: normal bindings *)
-let gray_normal_bindings =
-  [
-    (prose_body_var, Css.oklch 37.3 0.034 259.733);
-    (prose_headings_var, Css.oklch 21.0 0.034 264.665);
-    (prose_lead_var, Css.oklch 44.6 0.030 256.802);
-    (prose_links_var, Css.oklch 21.0 0.034 264.665);
-    (prose_bold_var, Css.oklch 21.0 0.034 264.665);
-    (prose_counters_var, Css.oklch 55.1 0.027 264.364);
-    (prose_bullets_var, Css.oklch 87.2 0.010 258.338);
-    (prose_hr_var, Css.oklch 92.8 0.006 264.531);
-    (prose_quotes_var, Css.oklch 21.0 0.034 264.665);
-    (prose_quote_borders_var, Css.oklch 92.8 0.006 264.531);
-    (prose_captions_var, Css.oklch 55.1 0.027 264.364);
-    (prose_kbd_var, Css.oklch 21.0 0.034 264.665);
-    (prose_kbd_shadows_var, Css.oklaba 21.0 (-0.00316127) (-0.0338527) 0.1);
-    (prose_code_var, Css.oklch 21.0 0.034 264.665);
-    (prose_pre_code_var, Css.oklch 92.8 0.006 264.531);
-    (prose_pre_bg_var, Css.oklch 27.8 0.033 256.848);
-    (prose_th_borders_var, Css.oklch 87.2 0.010 258.338);
-    (prose_td_borders_var, Css.oklch 92.8 0.006 264.531);
-  ]
+(* The eighteen colour slots a prose palette fills. Each theme below is one
+   record, so a slot added here is a compile error in every theme rather than a
+   declaration that silently goes missing from one of them. *)
+type palette = {
+  body : Css.color;
+  headings : Css.color;
+  lead : Css.color;
+  links : Css.color;
+  bold : Css.color;
+  counters : Css.color;
+  bullets : Css.color;
+  hr : Css.color;
+  quotes : Css.color;
+  quote_borders : Css.color;
+  captions : Css.color;
+  kbd : Css.color;
+  kbd_shadows : Css.color;
+  code : Css.color;
+  pre_code : Css.color;
+  pre_bg : Css.color;
+  th_borders : Css.color;
+  td_borders : Css.color;
+}
 
-(* Gray theme: invert bindings *)
-let gray_invert_bindings =
-  [
-    (prose_invert_body_var, Css.oklch 87.2 0.010 258.338);
-    (prose_invert_headings_var, Css.hex "fff");
-    (prose_invert_lead_var, Css.oklch 70.7 0.022 261.325);
-    (prose_invert_links_var, Css.hex "fff");
-    (prose_invert_bold_var, Css.hex "fff");
-    (prose_invert_counters_var, Css.oklch 70.7 0.022 261.325);
-    (prose_invert_bullets_var, Css.oklch 44.6 0.030 256.802);
-    (prose_invert_hr_var, Css.oklch 37.3 0.034 259.733);
-    (prose_invert_quotes_var, Css.oklch 96.7 0.003 264.542);
-    (prose_invert_quote_borders_var, Css.oklch 37.3 0.034 259.733);
-    (prose_invert_captions_var, Css.oklch 70.7 0.022 261.325);
-    (prose_invert_kbd_var, Css.hex "fff");
-    (prose_invert_kbd_shadows_var, Css.hex "#ffffff1a");
-    (prose_invert_code_var, Css.hex "fff");
-    (prose_invert_pre_code_var, Css.oklch 87.2 0.010 258.338);
-    (prose_invert_pre_bg_var, Css.hex "00000080");
-    (prose_invert_th_borders_var, Css.oklch 44.6 0.030 256.802);
-    (prose_invert_td_borders_var, Css.oklch 37.3 0.034 259.733);
-  ]
+(* The two ways a palette reaches the sheet: as the prose colours themselves,
+   and as the inverted set [.prose-invert] swaps in. *)
+let normal_bindings p =
+  bind_prose_vars
+    [
+      (prose_body_var, p.body);
+      (prose_headings_var, p.headings);
+      (prose_lead_var, p.lead);
+      (prose_links_var, p.links);
+      (prose_bold_var, p.bold);
+      (prose_counters_var, p.counters);
+      (prose_bullets_var, p.bullets);
+      (prose_hr_var, p.hr);
+      (prose_quotes_var, p.quotes);
+      (prose_quote_borders_var, p.quote_borders);
+      (prose_captions_var, p.captions);
+      (prose_kbd_var, p.kbd);
+      (prose_kbd_shadows_var, p.kbd_shadows);
+      (prose_code_var, p.code);
+      (prose_pre_code_var, p.pre_code);
+      (prose_pre_bg_var, p.pre_bg);
+      (prose_th_borders_var, p.th_borders);
+      (prose_td_borders_var, p.td_borders);
+    ]
 
-(* Slate theme: normal bindings *)
-let slate_normal_bindings =
-  [
-    (prose_body_var, Css.oklch 37.2 0.044 257.287);
-    (prose_headings_var, Css.oklch 20.8 0.042 265.755);
-    (prose_lead_var, Css.oklch 44.6 0.043 257.281);
-    (prose_links_var, Css.oklch 20.8 0.042 265.755);
-    (prose_bold_var, Css.oklch 20.8 0.042 265.755);
-    (prose_counters_var, Css.oklch 55.4 0.046 257.417);
-    (prose_bullets_var, Css.oklch 86.9 0.022 252.894);
-    (prose_hr_var, Css.oklch 92.9 0.013 255.508);
-    (prose_quotes_var, Css.oklch 20.8 0.042 265.755);
-    (prose_quote_borders_var, Css.oklch 92.9 0.013 255.508);
-    (prose_captions_var, Css.oklch 55.4 0.046 257.417);
-    (prose_kbd_var, Css.oklch 20.8 0.042 265.755);
-    (prose_kbd_shadows_var, Css.oklaba 20.8 (-0.00310889) (-0.0418848) 0.1);
-    (prose_code_var, Css.oklch 20.8 0.042 265.755);
-    (prose_pre_code_var, Css.oklch 92.9 0.013 255.508);
-    (prose_pre_bg_var, Css.oklch 27.9 0.041 260.031);
-    (prose_th_borders_var, Css.oklch 86.9 0.022 252.894);
-    (prose_td_borders_var, Css.oklch 92.9 0.013 255.508);
-  ]
+let invert_bindings p =
+  bind_prose_vars
+    [
+      (prose_invert_body_var, p.body);
+      (prose_invert_headings_var, p.headings);
+      (prose_invert_lead_var, p.lead);
+      (prose_invert_links_var, p.links);
+      (prose_invert_bold_var, p.bold);
+      (prose_invert_counters_var, p.counters);
+      (prose_invert_bullets_var, p.bullets);
+      (prose_invert_hr_var, p.hr);
+      (prose_invert_quotes_var, p.quotes);
+      (prose_invert_quote_borders_var, p.quote_borders);
+      (prose_invert_captions_var, p.captions);
+      (prose_invert_kbd_var, p.kbd);
+      (prose_invert_kbd_shadows_var, p.kbd_shadows);
+      (prose_invert_code_var, p.code);
+      (prose_invert_pre_code_var, p.pre_code);
+      (prose_invert_pre_bg_var, p.pre_bg);
+      (prose_invert_th_borders_var, p.th_borders);
+      (prose_invert_td_borders_var, p.td_borders);
+    ]
 
-(* Slate theme: invert bindings *)
-let slate_invert_bindings =
-  [
-    (prose_invert_body_var, Css.oklch 86.9 0.022 252.894);
-    (prose_invert_headings_var, Css.hex "fff");
-    (prose_invert_lead_var, Css.oklch 70.4 0.040 256.788);
-    (prose_invert_links_var, Css.hex "fff");
-    (prose_invert_bold_var, Css.hex "fff");
-    (prose_invert_counters_var, Css.oklch 70.4 0.040 256.788);
-    (prose_invert_bullets_var, Css.oklch 44.6 0.043 257.281);
-    (prose_invert_hr_var, Css.oklch 37.2 0.044 257.287);
-    (prose_invert_quotes_var, Css.oklch 96.8 0.007 247.896);
-    (prose_invert_quote_borders_var, Css.oklch 37.2 0.044 257.287);
-    (prose_invert_captions_var, Css.oklch 70.4 0.040 256.788);
-    (prose_invert_kbd_var, Css.hex "fff");
-    (prose_invert_kbd_shadows_var, Css.hex "#ffffff1a");
-    (prose_invert_code_var, Css.hex "fff");
-    (prose_invert_pre_code_var, Css.oklch 86.9 0.022 252.894);
-    (prose_invert_pre_bg_var, Css.hex "00000080");
-    (prose_invert_th_borders_var, Css.oklch 44.6 0.043 257.281);
-    (prose_invert_td_borders_var, Css.oklch 37.2 0.044 257.287);
-  ]
+let gray_normal =
+  {
+    body = Css.oklch 37.3 0.034 259.733;
+    headings = Css.oklch 21.0 0.034 264.665;
+    lead = Css.oklch 44.6 0.030 256.802;
+    links = Css.oklch 21.0 0.034 264.665;
+    bold = Css.oklch 21.0 0.034 264.665;
+    counters = Css.oklch 55.1 0.027 264.364;
+    bullets = Css.oklch 87.2 0.010 258.338;
+    hr = Css.oklch 92.8 0.006 264.531;
+    quotes = Css.oklch 21.0 0.034 264.665;
+    quote_borders = Css.oklch 92.8 0.006 264.531;
+    captions = Css.oklch 55.1 0.027 264.364;
+    kbd = Css.oklch 21.0 0.034 264.665;
+    kbd_shadows = Css.oklaba 21.0 (-0.00316127) (-0.0338527) 0.1;
+    code = Css.oklch 21.0 0.034 264.665;
+    pre_code = Css.oklch 92.8 0.006 264.531;
+    pre_bg = Css.oklch 27.8 0.033 256.848;
+    th_borders = Css.oklch 87.2 0.010 258.338;
+    td_borders = Css.oklch 92.8 0.006 264.531;
+  }
 
-(* Zinc theme: normal bindings *)
-let zinc_normal_bindings =
-  [
-    (prose_body_var, Css.oklch 37.0 0.013 285.805);
-    (prose_headings_var, Css.oklch 21.0 0.006 285.885);
-    (prose_lead_var, Css.oklch 44.2 0.017 285.786);
-    (prose_links_var, Css.oklch 21.0 0.006 285.885);
-    (prose_bold_var, Css.oklch 21.0 0.006 285.885);
-    (prose_counters_var, Css.oklch 55.2 0.016 285.938);
-    (prose_bullets_var, Css.oklch 87.1 0.006 286.286);
-    (prose_hr_var, Css.oklch 92.0 0.004 286.32);
-    (prose_quotes_var, Css.oklch 21.0 0.006 285.885);
-    (prose_quote_borders_var, Css.oklch 92.0 0.004 286.32);
-    (prose_captions_var, Css.oklch 55.2 0.016 285.938);
-    (prose_kbd_var, Css.oklch 21.0 0.006 285.885);
-    (prose_kbd_shadows_var, Css.oklaba 21.0 0.00164225 (-0.00577088) 0.1);
-    (prose_code_var, Css.oklch 21.0 0.006 285.885);
-    (prose_pre_code_var, Css.oklch 92.0 0.004 286.32);
-    (prose_pre_bg_var, Css.oklch 27.4 0.006 286.033);
-    (prose_th_borders_var, Css.oklch 87.1 0.006 286.286);
-    (prose_td_borders_var, Css.oklch 92.0 0.004 286.32);
-  ]
+let gray_invert =
+  {
+    body = Css.oklch 87.2 0.010 258.338;
+    headings = Css.hex "fff";
+    lead = Css.oklch 70.7 0.022 261.325;
+    links = Css.hex "fff";
+    bold = Css.hex "fff";
+    counters = Css.oklch 70.7 0.022 261.325;
+    bullets = Css.oklch 44.6 0.030 256.802;
+    hr = Css.oklch 37.3 0.034 259.733;
+    quotes = Css.oklch 96.7 0.003 264.542;
+    quote_borders = Css.oklch 37.3 0.034 259.733;
+    captions = Css.oklch 70.7 0.022 261.325;
+    kbd = Css.hex "fff";
+    kbd_shadows = Css.hex "#ffffff1a";
+    code = Css.hex "fff";
+    pre_code = Css.oklch 87.2 0.010 258.338;
+    pre_bg = Css.hex "00000080";
+    th_borders = Css.oklch 44.6 0.030 256.802;
+    td_borders = Css.oklch 37.3 0.034 259.733;
+  }
 
-(* Zinc theme: invert bindings *)
-let zinc_invert_bindings =
-  [
-    (prose_invert_body_var, Css.oklch 87.1 0.006 286.286);
-    (prose_invert_headings_var, Css.hex "fff");
-    (prose_invert_lead_var, Css.oklch 70.5 0.015 286.067);
-    (prose_invert_links_var, Css.hex "fff");
-    (prose_invert_bold_var, Css.hex "fff");
-    (prose_invert_counters_var, Css.oklch 70.5 0.015 286.067);
-    (prose_invert_bullets_var, Css.oklch 44.2 0.017 285.786);
-    (prose_invert_hr_var, Css.oklch 37.0 0.013 285.805);
-    (prose_invert_quotes_var, Css.oklch 96.7 0.001 286.375);
-    (prose_invert_quote_borders_var, Css.oklch 37.0 0.013 285.805);
-    (prose_invert_captions_var, Css.oklch 70.5 0.015 286.067);
-    (prose_invert_kbd_var, Css.hex "fff");
-    (prose_invert_kbd_shadows_var, Css.hex "#ffffff1a");
-    (prose_invert_code_var, Css.hex "fff");
-    (prose_invert_pre_code_var, Css.oklch 87.1 0.006 286.286);
-    (prose_invert_pre_bg_var, Css.hex "00000080");
-    (prose_invert_th_borders_var, Css.oklch 44.2 0.017 285.786);
-    (prose_invert_td_borders_var, Css.oklch 37.0 0.013 285.805);
-  ]
+let slate_normal =
+  {
+    body = Css.oklch 37.2 0.044 257.287;
+    headings = Css.oklch 20.8 0.042 265.755;
+    lead = Css.oklch 44.6 0.043 257.281;
+    links = Css.oklch 20.8 0.042 265.755;
+    bold = Css.oklch 20.8 0.042 265.755;
+    counters = Css.oklch 55.4 0.046 257.417;
+    bullets = Css.oklch 86.9 0.022 252.894;
+    hr = Css.oklch 92.9 0.013 255.508;
+    quotes = Css.oklch 20.8 0.042 265.755;
+    quote_borders = Css.oklch 92.9 0.013 255.508;
+    captions = Css.oklch 55.4 0.046 257.417;
+    kbd = Css.oklch 20.8 0.042 265.755;
+    kbd_shadows = Css.oklaba 20.8 (-0.00310889) (-0.0418848) 0.1;
+    code = Css.oklch 20.8 0.042 265.755;
+    pre_code = Css.oklch 92.9 0.013 255.508;
+    pre_bg = Css.oklch 27.9 0.041 260.031;
+    th_borders = Css.oklch 86.9 0.022 252.894;
+    td_borders = Css.oklch 92.9 0.013 255.508;
+  }
 
-(* Neutral theme: normal bindings *)
-let neutral_normal_bindings =
-  [
-    (prose_body_var, Css.oklch_none_hue 37.1 0.0);
-    (prose_headings_var, Css.oklch_none_hue 20.5 0.0);
-    (prose_lead_var, Css.oklch_none_hue 43.9 0.0);
-    (prose_links_var, Css.oklch_none_hue 20.5 0.0);
-    (prose_bold_var, Css.oklch_none_hue 20.5 0.0);
-    (prose_counters_var, Css.oklch_none_hue 55.6 0.0);
-    (prose_bullets_var, Css.oklch_none_hue 87.0 0.0);
-    (prose_hr_var, Css.oklch_none_hue 92.2 0.0);
-    (prose_quotes_var, Css.oklch_none_hue 20.5 0.0);
-    (prose_quote_borders_var, Css.oklch_none_hue 92.2 0.0);
-    (prose_captions_var, Css.oklch_none_hue 55.6 0.0);
-    (prose_kbd_var, Css.oklch_none_hue 20.5 0.0);
-    (prose_kbd_shadows_var, Css.oklaba 20.5 0.0 0.0 0.1);
-    (prose_code_var, Css.oklch_none_hue 20.5 0.0);
-    (prose_pre_code_var, Css.oklch_none_hue 92.2 0.0);
-    (prose_pre_bg_var, Css.oklch_none_hue 26.9 0.0);
-    (prose_th_borders_var, Css.oklch_none_hue 87.0 0.0);
-    (prose_td_borders_var, Css.oklch_none_hue 92.2 0.0);
-  ]
+let slate_invert =
+  {
+    body = Css.oklch 86.9 0.022 252.894;
+    headings = Css.hex "fff";
+    lead = Css.oklch 70.4 0.040 256.788;
+    links = Css.hex "fff";
+    bold = Css.hex "fff";
+    counters = Css.oklch 70.4 0.040 256.788;
+    bullets = Css.oklch 44.6 0.043 257.281;
+    hr = Css.oklch 37.2 0.044 257.287;
+    quotes = Css.oklch 96.8 0.007 247.896;
+    quote_borders = Css.oklch 37.2 0.044 257.287;
+    captions = Css.oklch 70.4 0.040 256.788;
+    kbd = Css.hex "fff";
+    kbd_shadows = Css.hex "#ffffff1a";
+    code = Css.hex "fff";
+    pre_code = Css.oklch 86.9 0.022 252.894;
+    pre_bg = Css.hex "00000080";
+    th_borders = Css.oklch 44.6 0.043 257.281;
+    td_borders = Css.oklch 37.2 0.044 257.287;
+  }
 
-(* Neutral theme: invert bindings *)
-let neutral_invert_bindings =
-  [
-    (prose_invert_body_var, Css.oklch_none_hue 87.0 0.0);
-    (prose_invert_headings_var, Css.hex "fff");
-    (prose_invert_lead_var, Css.oklch_none_hue 70.8 0.0);
-    (prose_invert_links_var, Css.hex "fff");
-    (prose_invert_bold_var, Css.hex "fff");
-    (prose_invert_counters_var, Css.oklch_none_hue 70.8 0.0);
-    (prose_invert_bullets_var, Css.oklch_none_hue 43.9 0.0);
-    (prose_invert_hr_var, Css.oklch_none_hue 37.1 0.0);
-    (prose_invert_quotes_var, Css.oklch_none_hue 97.0 0.0);
-    (prose_invert_quote_borders_var, Css.oklch_none_hue 37.1 0.0);
-    (prose_invert_captions_var, Css.oklch_none_hue 70.8 0.0);
-    (prose_invert_kbd_var, Css.hex "fff");
-    (prose_invert_kbd_shadows_var, Css.hex "#ffffff1a");
-    (prose_invert_code_var, Css.hex "fff");
-    (prose_invert_pre_code_var, Css.oklch_none_hue 87.0 0.0);
-    (prose_invert_pre_bg_var, Css.hex "00000080");
-    (prose_invert_th_borders_var, Css.oklch_none_hue 43.9 0.0);
-    (prose_invert_td_borders_var, Css.oklch_none_hue 37.1 0.0);
-  ]
+let zinc_normal =
+  {
+    body = Css.oklch 37.0 0.013 285.805;
+    headings = Css.oklch 21.0 0.006 285.885;
+    lead = Css.oklch 44.2 0.017 285.786;
+    links = Css.oklch 21.0 0.006 285.885;
+    bold = Css.oklch 21.0 0.006 285.885;
+    counters = Css.oklch 55.2 0.016 285.938;
+    bullets = Css.oklch 87.1 0.006 286.286;
+    hr = Css.oklch 92.0 0.004 286.32;
+    quotes = Css.oklch 21.0 0.006 285.885;
+    quote_borders = Css.oklch 92.0 0.004 286.32;
+    captions = Css.oklch 55.2 0.016 285.938;
+    kbd = Css.oklch 21.0 0.006 285.885;
+    kbd_shadows = Css.oklaba 21.0 0.00164225 (-0.00577088) 0.1;
+    code = Css.oklch 21.0 0.006 285.885;
+    pre_code = Css.oklch 92.0 0.004 286.32;
+    pre_bg = Css.oklch 27.4 0.006 286.033;
+    th_borders = Css.oklch 87.1 0.006 286.286;
+    td_borders = Css.oklch 92.0 0.004 286.32;
+  }
 
-(* Stone theme: normal bindings *)
-let stone_normal_bindings =
-  [
-    (prose_body_var, Css.oklch 37.4 0.01 67.558);
-    (prose_headings_var, Css.oklch 21.6 0.006 56.043);
-    (prose_lead_var, Css.oklch 44.4 0.011 73.639);
-    (prose_links_var, Css.oklch 21.6 0.006 56.043);
-    (prose_bold_var, Css.oklch 21.6 0.006 56.043);
-    (prose_counters_var, Css.oklch 55.3 0.013 58.071);
-    (prose_bullets_var, Css.oklch 86.9 0.005 56.366);
-    (prose_hr_var, Css.oklch 92.3 0.003 48.717);
-    (prose_quotes_var, Css.oklch 21.6 0.006 56.043);
-    (prose_quote_borders_var, Css.oklch 92.3 0.003 48.717);
-    (prose_captions_var, Css.oklch 55.3 0.013 58.071);
-    (prose_kbd_var, Css.oklch 21.6 0.006 56.043);
-    (prose_kbd_shadows_var, Css.oklaba 21.6 0.00335142 0.00497674 0.1);
-    (prose_code_var, Css.oklch 21.6 0.006 56.043);
-    (prose_pre_code_var, Css.oklch 92.3 0.003 48.717);
-    (prose_pre_bg_var, Css.oklch 26.8 0.007 34.298);
-    (prose_th_borders_var, Css.oklch 86.9 0.005 56.366);
-    (prose_td_borders_var, Css.oklch 92.3 0.003 48.717);
-  ]
+let zinc_invert =
+  {
+    body = Css.oklch 87.1 0.006 286.286;
+    headings = Css.hex "fff";
+    lead = Css.oklch 70.5 0.015 286.067;
+    links = Css.hex "fff";
+    bold = Css.hex "fff";
+    counters = Css.oklch 70.5 0.015 286.067;
+    bullets = Css.oklch 44.2 0.017 285.786;
+    hr = Css.oklch 37.0 0.013 285.805;
+    quotes = Css.oklch 96.7 0.001 286.375;
+    quote_borders = Css.oklch 37.0 0.013 285.805;
+    captions = Css.oklch 70.5 0.015 286.067;
+    kbd = Css.hex "fff";
+    kbd_shadows = Css.hex "#ffffff1a";
+    code = Css.hex "fff";
+    pre_code = Css.oklch 87.1 0.006 286.286;
+    pre_bg = Css.hex "00000080";
+    th_borders = Css.oklch 44.2 0.017 285.786;
+    td_borders = Css.oklch 37.0 0.013 285.805;
+  }
 
-(* Stone theme: invert bindings *)
-let stone_invert_bindings =
-  [
-    (prose_invert_body_var, Css.oklch 86.9 0.005 56.366);
-    (prose_invert_headings_var, Css.hex "fff");
-    (prose_invert_lead_var, Css.oklch 70.9 0.01 56.259);
-    (prose_invert_links_var, Css.hex "fff");
-    (prose_invert_bold_var, Css.hex "fff");
-    (prose_invert_counters_var, Css.oklch 70.9 0.01 56.259);
-    (prose_invert_bullets_var, Css.oklch 44.4 0.011 73.639);
-    (prose_invert_hr_var, Css.oklch 37.4 0.01 67.558);
-    (prose_invert_quotes_var, Css.oklch 97.0 0.001 106.424);
-    (prose_invert_quote_borders_var, Css.oklch 37.4 0.01 67.558);
-    (prose_invert_captions_var, Css.oklch 70.9 0.01 56.259);
-    (prose_invert_kbd_var, Css.hex "fff");
-    (prose_invert_kbd_shadows_var, Css.hex "#ffffff1a");
-    (prose_invert_code_var, Css.hex "fff");
-    (prose_invert_pre_code_var, Css.oklch 86.9 0.005 56.366);
-    (prose_invert_pre_bg_var, Css.hex "00000080");
-    (prose_invert_th_borders_var, Css.oklch 44.4 0.011 73.639);
-    (prose_invert_td_borders_var, Css.oklch 37.4 0.01 67.558);
-  ]
+let neutral_normal =
+  {
+    body = Css.oklch_none_hue 37.1 0.0;
+    headings = Css.oklch_none_hue 20.5 0.0;
+    lead = Css.oklch_none_hue 43.9 0.0;
+    links = Css.oklch_none_hue 20.5 0.0;
+    bold = Css.oklch_none_hue 20.5 0.0;
+    counters = Css.oklch_none_hue 55.6 0.0;
+    bullets = Css.oklch_none_hue 87.0 0.0;
+    hr = Css.oklch_none_hue 92.2 0.0;
+    quotes = Css.oklch_none_hue 20.5 0.0;
+    quote_borders = Css.oklch_none_hue 92.2 0.0;
+    captions = Css.oklch_none_hue 55.6 0.0;
+    kbd = Css.oklch_none_hue 20.5 0.0;
+    kbd_shadows = Css.oklaba 20.5 0.0 0.0 0.1;
+    code = Css.oklch_none_hue 20.5 0.0;
+    pre_code = Css.oklch_none_hue 92.2 0.0;
+    pre_bg = Css.oklch_none_hue 26.9 0.0;
+    th_borders = Css.oklch_none_hue 87.0 0.0;
+    td_borders = Css.oklch_none_hue 92.2 0.0;
+  }
+
+let neutral_invert =
+  {
+    body = Css.oklch_none_hue 87.0 0.0;
+    headings = Css.hex "fff";
+    lead = Css.oklch_none_hue 70.8 0.0;
+    links = Css.hex "fff";
+    bold = Css.hex "fff";
+    counters = Css.oklch_none_hue 70.8 0.0;
+    bullets = Css.oklch_none_hue 43.9 0.0;
+    hr = Css.oklch_none_hue 37.1 0.0;
+    quotes = Css.oklch_none_hue 97.0 0.0;
+    quote_borders = Css.oklch_none_hue 37.1 0.0;
+    captions = Css.oklch_none_hue 70.8 0.0;
+    kbd = Css.hex "fff";
+    kbd_shadows = Css.hex "#ffffff1a";
+    code = Css.hex "fff";
+    pre_code = Css.oklch_none_hue 87.0 0.0;
+    pre_bg = Css.hex "00000080";
+    th_borders = Css.oklch_none_hue 43.9 0.0;
+    td_borders = Css.oklch_none_hue 37.1 0.0;
+  }
+
+let stone_normal =
+  {
+    body = Css.oklch 37.4 0.01 67.558;
+    headings = Css.oklch 21.6 0.006 56.043;
+    lead = Css.oklch 44.4 0.011 73.639;
+    links = Css.oklch 21.6 0.006 56.043;
+    bold = Css.oklch 21.6 0.006 56.043;
+    counters = Css.oklch 55.3 0.013 58.071;
+    bullets = Css.oklch 86.9 0.005 56.366;
+    hr = Css.oklch 92.3 0.003 48.717;
+    quotes = Css.oklch 21.6 0.006 56.043;
+    quote_borders = Css.oklch 92.3 0.003 48.717;
+    captions = Css.oklch 55.3 0.013 58.071;
+    kbd = Css.oklch 21.6 0.006 56.043;
+    kbd_shadows = Css.oklaba 21.6 0.00335142 0.00497674 0.1;
+    code = Css.oklch 21.6 0.006 56.043;
+    pre_code = Css.oklch 92.3 0.003 48.717;
+    pre_bg = Css.oklch 26.8 0.007 34.298;
+    th_borders = Css.oklch 86.9 0.005 56.366;
+    td_borders = Css.oklch 92.3 0.003 48.717;
+  }
+
+let stone_invert =
+  {
+    body = Css.oklch 86.9 0.005 56.366;
+    headings = Css.hex "fff";
+    lead = Css.oklch 70.9 0.01 56.259;
+    links = Css.hex "fff";
+    bold = Css.hex "fff";
+    counters = Css.oklch 70.9 0.01 56.259;
+    bullets = Css.oklch 44.4 0.011 73.639;
+    hr = Css.oklch 37.4 0.01 67.558;
+    quotes = Css.oklch 97.0 0.001 106.424;
+    quote_borders = Css.oklch 37.4 0.01 67.558;
+    captions = Css.oklch 70.9 0.01 56.259;
+    kbd = Css.hex "fff";
+    kbd_shadows = Css.hex "#ffffff1a";
+    code = Css.hex "fff";
+    pre_code = Css.oklch 86.9 0.005 56.366;
+    pre_bg = Css.hex "00000080";
+    th_borders = Css.oklch 44.4 0.011 73.639;
+    td_borders = Css.oklch 37.4 0.01 67.558;
+  }
 
 (* Helper to create color variable bindings for color themes - returns
    declarations *)
 let color_theme_bindings theme_name =
   match theme_name with
-  | "gray" -> bind_prose_vars (gray_normal_bindings @ gray_invert_bindings)
-  | "slate" -> bind_prose_vars (slate_normal_bindings @ slate_invert_bindings)
-  | "zinc" -> bind_prose_vars (zinc_normal_bindings @ zinc_invert_bindings)
-  | "neutral" ->
-      bind_prose_vars (neutral_normal_bindings @ neutral_invert_bindings)
-  | "stone" -> bind_prose_vars (stone_normal_bindings @ stone_invert_bindings)
+  | "gray" -> normal_bindings gray_normal @ invert_bindings gray_invert
+  | "slate" -> normal_bindings slate_normal @ invert_bindings slate_invert
+  | "zinc" -> normal_bindings zinc_normal @ invert_bindings zinc_invert
+  | "neutral" -> normal_bindings neutral_normal @ invert_bindings neutral_invert
+  | "stone" -> normal_bindings stone_normal @ invert_bindings stone_invert
   | _ -> []
 
 (* prose-invert remaps every --tw-prose-* to its --tw-prose-invert-*
    counterpart, the way Tailwind's [.prose-invert] does. *)
 let invert_remap_bindings =
-  bind_prose_vars
-    [
-      (prose_body_var, Css.Var (snd theme.invert_body));
-      (prose_headings_var, Css.Var (snd theme.invert_headings));
-      (prose_lead_var, Css.Var (snd theme.invert_lead));
-      (prose_links_var, Css.Var (snd theme.invert_links));
-      (prose_bold_var, Css.Var (snd theme.invert_bold));
-      (prose_counters_var, Css.Var (snd theme.invert_counters));
-      (prose_bullets_var, Css.Var (snd theme.invert_bullets));
-      (prose_hr_var, Css.Var (snd theme.invert_hr));
-      (prose_quotes_var, Css.Var (snd theme.invert_quotes));
-      (prose_quote_borders_var, Css.Var (snd theme.invert_quote_borders));
-      (prose_captions_var, Css.Var (snd theme.invert_captions));
-      (prose_kbd_var, Css.Var (snd theme.invert_kbd));
-      (prose_kbd_shadows_var, Css.Var (snd theme.invert_kbd_shadows));
-      (prose_code_var, Css.Var (snd theme.invert_code));
-      (prose_pre_code_var, Css.Var (snd theme.invert_pre_code));
-      (prose_pre_bg_var, Css.Var (snd theme.invert_pre_bg));
-      (prose_th_borders_var, Css.Var (snd theme.invert_th_borders));
-      (prose_td_borders_var, Css.Var (snd theme.invert_td_borders));
-    ]
+  normal_bindings
+    {
+      body = Css.Var (snd theme.invert_body);
+      headings = Css.Var (snd theme.invert_headings);
+      lead = Css.Var (snd theme.invert_lead);
+      links = Css.Var (snd theme.invert_links);
+      bold = Css.Var (snd theme.invert_bold);
+      counters = Css.Var (snd theme.invert_counters);
+      bullets = Css.Var (snd theme.invert_bullets);
+      hr = Css.Var (snd theme.invert_hr);
+      quotes = Css.Var (snd theme.invert_quotes);
+      quote_borders = Css.Var (snd theme.invert_quote_borders);
+      captions = Css.Var (snd theme.invert_captions);
+      kbd = Css.Var (snd theme.invert_kbd);
+      kbd_shadows = Css.Var (snd theme.invert_kbd_shadows);
+      code = Css.Var (snd theme.invert_code);
+      pre_code = Css.Var (snd theme.invert_pre_code);
+      pre_bg = Css.Var (snd theme.invert_pre_bg);
+      th_borders = Css.Var (snd theme.invert_th_borders);
+      td_borders = Css.Var (snd theme.invert_td_borders);
+    }
 
 (* Accent colour themes (prose-orange, ...) only override the link colours,
    normal and inverted. Values taken from the Tailwind typography plugin. *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -961,14 +961,6 @@ let media_condition_of_modifier = function
     not-* rules sort by variant position, not alphabetically. The offset is
     multiplied by 100 to leave room for the base suborder. *)
 
-(** Check if string [s] contains substring [pat]. *)
-let has_substring s pat =
-  let slen = String.length s and plen = String.length pat in
-  let rec check i =
-    i + plen <= slen && (String.sub s i plen = pat || check (i + 1))
-  in
-  check 0
-
 (** Compute variant_order from base_class and selector. A stacked candidate is
     placed by its highest-order modifier, matching the descending key list used
     by the comparator. For before/after, the base_class is the raw utility name
@@ -990,9 +982,9 @@ let compute_variant_order ~selector_str base_class =
      to avoid matching utility-generated pseudo-elements like prose's
      ::before. *)
   if vo > 0 then vo
-  else if has_substring selector_str "before\\:" then
+  else if Strings.contains ~sub:"before\\:" selector_str then
     Modifiers.variant_order_of_prefix "before"
-  else if has_substring selector_str "after\\:" then
+  else if Strings.contains ~sub:"after\\:" selector_str then
     Modifiers.variant_order_of_prefix "after"
   else 0
 

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -639,14 +639,12 @@ let compare_by_priority_index r1 r2 =
         if idx_cmp <> 0 then idx_cmp
         else String.compare r1.selector_str r2.selector_str
 
-let is_digit c = c >= '0' && c <= '9'
-
 (* Natural sort comparison: treats consecutive digit sequences as integers.
    E.g., "2.5" < "2.25" because 5 < 25 when compared as numbers. This matches
    Tailwind v4's selector ordering for opacity modifiers like /2.5 vs /2.25. *)
 let natural_extract_number s i =
   let rec go j acc =
-    if j >= String.length s || not (is_digit s.[j]) then (acc, j)
+    if j >= String.length s || not (Strings.is_digit s.[j]) then (acc, j)
     else go (j + 1) ((acc * 10) + Char.code s.[j] - Char.code '0')
   in
   go i 0
@@ -681,7 +679,7 @@ let natural_compare s1 s2 =
     | `Greater -> 1
     | `Continue ->
         let c1 = s1.[i1] and c2 = s2.[i2] in
-        if is_digit c1 && is_digit c2 then
+        if Strings.is_digit c1 && Strings.is_digit c2 then
           let n1, end1 = natural_extract_number s1 i1 in
           let n2, end2 = natural_extract_number s2 i2 in
           let num_cmp = Int.compare n1 n2 in

--- a/lib/strings.ml
+++ b/lib/strings.ml
@@ -1,0 +1,6 @@
+let contains ~sub s =
+  let n = String.length s and m = String.length sub in
+  let rec loop i = i + m <= n && (String.sub s i m = sub || loop (i + 1)) in
+  loop 0
+
+let is_digit c = c >= '0' && c <= '9'

--- a/lib/strings.mli
+++ b/lib/strings.mli
@@ -1,0 +1,12 @@
+(** String scanning predicates shared across the library and the dev tools.
+
+    Both were hand-rolled in several modules before landing here, and the
+    substring test had already drifted on the empty pattern. [tw_tools] depends
+    on [tw], so this module is the single answer for both. *)
+
+val contains : sub:string -> string -> bool
+(** [contains ~sub s] is [true] when [sub] occurs in [s]. The empty string
+    occurs in every string, so [contains ~sub:"" s] is [true] for any [s]. *)
+
+val is_digit : char -> bool
+(** [is_digit c] is [true] for the ASCII digits ['0'] to ['9']. *)

--- a/lib/tools/cascade_provenance.ml
+++ b/lib/tools/cascade_provenance.ml
@@ -28,13 +28,6 @@ let repo_root () =
   in
   match Sys.getcwd () with exception Sys_error _ -> None | cwd -> climb cwd 4
 
-let contains haystack word =
-  let n = String.length haystack and m = String.length word in
-  let rec loop i =
-    i + m <= n && (String.sub haystack i m = word || loop (i + 1))
-  in
-  m > 0 && loop 0
-
 (* The [dune-project] depends line is [(cascade (and (>= X) (< Y)))]; grabbed
    verbatim rather than sexp-parsed since it is only ever displayed, never
    compared against. *)
@@ -49,8 +42,10 @@ let cascade_constraint root =
         | exception End_of_file -> None
         | line ->
             let trimmed = String.trim line in
-            if contains trimmed "cascade" && contains trimmed "(and" then
-              Some trimmed
+            if
+              Tw.Strings.contains ~sub:"cascade" trimmed
+              && Tw.Strings.contains ~sub:"(and" trimmed
+            then Some trimmed
             else loop ()
       in
       loop ()

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -422,6 +422,7 @@ module Touch = Touch
 module Parse = Parse
 module Mask_gradient = Mask_gradient
 module Property = Property
+module Strings = Strings
 
 (* Include flex utilities *)
 include Flex

--- a/lib/tw.mli
+++ b/lib/tw.mli
@@ -4563,3 +4563,4 @@ module Touch = Touch
 module Arbitrary = Arbitrary
 module Property = Property
 module Parse = Parse
+module Strings = Strings

--- a/lib/var.ml
+++ b/lib/var.ml
@@ -401,16 +401,12 @@ let needs_property_rule v =
       | None -> assert false)
 
 let order_of_declaration decl =
-  match Css.meta_of_declaration decl with
-  | None -> None
-  | Some meta -> (
-      match info_of_meta meta with Some (Info t) -> t.order | None -> None)
+  Option.bind (metadata_of_declaration decl) metadata_order
 
 let is_runtime_declaration decl =
-  match Css.meta_of_declaration decl with
+  match metadata_of_declaration decl with
+  | Some (Info t) -> t.runtime
   | None -> false
-  | Some meta -> (
-      match info_of_meta meta with Some (Info t) -> t.runtime | None -> false)
 
 let property_initial_declaration = declaration_of_property_info
 let pp v = Pp.str [ "Var(--"; v.name; ")" ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -71,6 +71,7 @@ let () =
       Test_var.suite;
       Test_modifiers.suite;
       Test_pp.suite;
+      Test_strings.suite;
       Test_prose.suite;
       Test_theme.suite;
       Test_utility.suite;

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -1013,6 +1013,68 @@ let test_bracket_colour_underscore_escape () =
     (Astring.String.is_infix ~affix:"color: light-dark(var(--a_b), red)"
        (css {|text-[light-dark(var(--a\_b),red)]|}))
 
+(* The theme layer and the utilities layer rank the same colour names in
+   different orders, and a name missing from either map silently takes that
+   map's unknown-colour slot. Both are derived from one list, so the pairing
+   holds by construction; this is what fails if that stops being true. *)
+let ranked_color_names =
+  [
+    "transparent";
+    "black";
+    "white";
+    "red";
+    "orange";
+    "amber";
+    "yellow";
+    "lime";
+    "green";
+    "emerald";
+    "teal";
+    "cyan";
+    "sky";
+    "blue";
+    "indigo";
+    "violet";
+    "purple";
+    "fuchsia";
+    "pink";
+    "rose";
+    "slate";
+    "gray";
+    "zinc";
+    "neutral";
+    "stone";
+  ]
+
+let test_color_orders_cover_the_same_names () =
+  let unknown_theme = Tw.Color.theme_order "definitely-not-a-colour" in
+  let unknown_utilities = Tw.Color.utilities_order "definitely-not-a-colour" in
+  Alcotest.(check (pair int int))
+    "unknown theme colour falls back" (2, 100000) unknown_theme;
+  Alcotest.(check (pair int int))
+    "unknown utility colour falls back" (2, 100) unknown_utilities;
+  List.iter
+    (fun name ->
+      Alcotest.(check bool)
+        (name ^ " has a theme slot")
+        false
+        (Tw.Color.theme_order name = unknown_theme);
+      Alcotest.(check bool)
+        (name ^ " has a utilities slot")
+        false
+        (Tw.Color.utilities_order name = unknown_utilities))
+    ranked_color_names
+
+(* The utilities layer leads with transparent and black and is alphabetical from
+   there. *)
+let test_utilities_color_order_is_alphabetical () =
+  let order name = snd (Tw.Color.utilities_order name) in
+  Alcotest.(check int) "transparent leads" 0 (order "transparent");
+  Alcotest.(check int) "black follows" 1 (order "black");
+  Alcotest.(check int) "amber opens the alphabetical run" 2 (order "amber");
+  Alcotest.(check int) "white sits between violet and yellow" 22 (order "white");
+  Alcotest.(check int) "zinc closes it" 24 (order "zinc")
+
 let tests =
   [
     ( "Bracket colour underscore escape",
@@ -1083,6 +1145,12 @@ let tests =
       test_removed_mix_token_stays_runtime );
     ("Shorthand hex with alpha", `Quick, test_shorthand_hex_alpha);
     ("Out-of-gamut OKLCH", `Quick, test_out_of_gamut_oklch);
+    ( "Colour orders cover the same names",
+      `Quick,
+      test_color_orders_cover_the_same_names );
+    ( "Utilities colour order is alphabetical",
+      `Quick,
+      test_utilities_color_order_is_alphabetical );
   ]
 
 let suite = ("color", tests)

--- a/test/test_strings.ml
+++ b/test/test_strings.ml
@@ -1,0 +1,46 @@
+(* Tests for the shared string predicates. *)
+module Strings = Tw.Strings
+
+let check_contains msg expected ~sub s =
+  Alcotest.(check bool) msg expected (Strings.contains ~sub s)
+
+let test_contains_found () =
+  check_contains "at the start" true ~sub:"ab" "abc";
+  check_contains "in the middle" true ~sub:"b" "abc";
+  check_contains "at the end" true ~sub:"bc" "abc";
+  check_contains "the whole string" true ~sub:"abc" "abc";
+  check_contains "an escaped modifier prefix" true ~sub:"before\\:"
+    ".before\\:absolute::before"
+
+let test_contains_absent () =
+  check_contains "a missing pattern" false ~sub:"d" "abc";
+  check_contains "a pattern longer than the string" false ~sub:"abcd" "abc";
+  check_contains "a pattern whose characters are scattered" false ~sub:"ac"
+    "abc";
+  check_contains "any pattern in the empty string" false ~sub:"a" ""
+
+(* The empty string occurs in every string, at every position. Answering [false]
+   would break the rule that every prefix of an occurring pattern also
+   occurs. *)
+let test_contains_empty_pattern () =
+  check_contains "the empty pattern in a string" true ~sub:"" "abc";
+  check_contains "the empty pattern in the empty string" true ~sub:"" ""
+
+let test_is_digit () =
+  Alcotest.(check bool) "zero" true (Strings.is_digit '0');
+  Alcotest.(check bool) "nine" true (Strings.is_digit '9');
+  Alcotest.(check bool) "five" true (Strings.is_digit '5');
+  Alcotest.(check bool) "a letter" false (Strings.is_digit 'a');
+  Alcotest.(check bool) "the slash below zero" false (Strings.is_digit '/');
+  Alcotest.(check bool) "the colon above nine" false (Strings.is_digit ':')
+
+let suite =
+  ( "strings",
+    [
+      Alcotest.test_case "contains finds a pattern" `Quick test_contains_found;
+      Alcotest.test_case "contains rejects an absent pattern" `Quick
+        test_contains_absent;
+      Alcotest.test_case "contains accepts the empty pattern" `Quick
+        test_contains_empty_pattern;
+      Alcotest.test_case "is_digit" `Quick test_is_digit;
+    ] )

--- a/test/test_strings.mli
+++ b/test/test_strings.mli
@@ -1,0 +1,4 @@
+(** Test suite for the Strings module *)
+
+val suite : string * unit Alcotest.test_case list
+(** [suite] test suite. *)


### PR DESCRIPTION
Seven consolidations of helpers that had drifted or were about to, one commit
each so any of them can be reverted alone.

- `Tw.Strings` is a new home for the substring and digit predicates that
  `rule.ml`, `sort.ml` and `lib/tools/cascade_provenance.ml` each hand-rolled.
  The two substring copies disagreed on the empty pattern; the shared one
  answers `true`, because the empty string occurs in every string and the other
  answer breaks the rule that a prefix of an occurring pattern also occurs.
  Neither call site passes an empty pattern, so no output moves. That change
  sits in its own commit.
- `forms.ml` rendered the focus ring twice, once for the `.form-*` component
  rules and once for the base-layer element rules. The plugin exists to make
  those match, so they now read the same declarations.
- The utilities colour order is derived from the theme colour order instead of
  being a second hand-written list of the same 25 names.
- `color.ml` formats hex bytes through `Pp.hex_byte` instead of its own copy.
- `var.ml` reads declaration metadata through `metadata_of_declaration`.
- The eleven prose palette binding lists become one record with eighteen
  fields, so adding a prose colour is a compile error in every theme that has
  not been updated rather than a declaration missing from one of them.

No behaviour changes. The sheet built from `test/parity/classlist.txt` with the
committed entrypoint is byte-identical before and after, and the prose colour
themes, which that class list does not reach, were compared separately through
the OCaml API and are byte-identical too.
