### PR TITLE
parse, masks: stop truncating var() names and mask url() values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,11 @@
   `content-[url('a_b.png')]`, `[background-image:url('a_b.png')]` and
   `mask-[image-set(url('a_b.png')_1x)]` named a file they did not mean; the
   underscore outside the `url()` still becomes a space (#692).
+- The first argument of a `var()` or a `theme()` in an arbitrary value keeps its
+  underscores, which spell the name of a custom property rather than spaces.
+  `[--x:var(--my_var)]` referenced `--my var`, and `shadow-[0_0_0_var(--my_var)]`
+  truncated the reference to `var(--my)` without saying so; a later argument
+  still decodes (#PR).
 - `bg-[url(a\]b)]` names the file the class means. The escaped bracket reached
   the value as a backslash of its own and emitted `url("a\\]b")`; the whole
   `url()` is now read by the CSS tokeniser, which resolves its quotes and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -189,6 +189,10 @@
 - `mask-[url(...)]` keeps the bare underscore a file name carries, the way
   `bg-[url(...)]` already does: it named a different file, with a space in it
   (#688).
+- `mask-[url(...)]` reads the whole `url()` with the CSS tokeniser, so a bracket
+  carrying anything after it is refused rather than sliced.
+  `mask-[url(x.png)_center]` emitted `mask-image: url("x.png)_cente")` under
+  `.mask-\[url\(x\.png\)_cente\)\]`, a selector no markup carries (#PR).
 - An arbitrary value keeps the underscore its `\_` escape spells, so
   `font-['My\_Font']`, `[--my\_var:red]` and `data-[foo=bar\_baz]:flex` reach
   the sheet as written instead of carrying the backslash into the value (#676).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -164,7 +164,7 @@
   underscores, which spell the name of a custom property rather than spaces.
   `[--x:var(--my_var)]` referenced `--my var`, and `shadow-[0_0_0_var(--my_var)]`
   truncated the reference to `var(--my)` without saying so; a later argument
-  still decodes (#PR).
+  still decodes (#695).
 - `bg-[url(a\]b)]` names the file the class means. The escaped bracket reached
   the value as a backslash of its own and emitted `url("a\\]b")`; the whole
   `url()` is now read by the CSS tokeniser, which resolves its quotes and
@@ -192,7 +192,7 @@
 - `mask-[url(...)]` reads the whole `url()` with the CSS tokeniser, so a bracket
   carrying anything after it is refused rather than sliced.
   `mask-[url(x.png)_center]` emitted `mask-image: url("x.png)_cente")` under
-  `.mask-\[url\(x\.png\)_cente\)\]`, a selector no markup carries (#PR).
+  `.mask-\[url\(x\.png\)_cente\)\]`, a selector no markup carries (#695).
 - An arbitrary value keeps the underscore its `\_` escape spells, so
   `font-['My\_Font']`, `[--my\_var:red]` and `data-[foo=bar\_baz]:flex` reach
   the sheet as written instead of carrying the backslash into the value (#676).

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -359,8 +359,15 @@ module Handler = struct
             Css.webkit_mask_image (Var var_ref);
             Css.mask_image (Var var_ref);
           ]
-    | Bracket_url url ->
-        style [ Css.webkit_mask_image (Url url); Css.mask_image (Url url) ]
+    (* The whole [url()] is kept, so cascade reads the token rather than masks
+       slicing the file name out of it: the quotes are the tokeniser's, and an
+       escape in it stands for one character of the URL. [of_class] refuses a
+       value the token reader will not take, so [None] names nothing. *)
+    | Bracket_url v -> (
+        match Parse.url_token (Parse.decode_arbitrary_value v) with
+        | Some url ->
+            style [ Css.webkit_mask_image (Url url); Css.mask_image (Url url) ]
+        | None -> style [])
     | Bracket_url_var v ->
         let bare = Parse.extract_var_name v in
         let var_ref : Css.background_image Css.var = Var.bracket bare in
@@ -551,9 +558,10 @@ module Handler = struct
            between the first [(] and the last [)] and so swallows the comma of a
            layer list. *)
         | _ when is_image_value inner -> Ok (Bracket_image inner)
-        | _ when String.length inner > 4 && String.sub inner 0 4 = "url(" ->
-            let url_content = String.sub inner 4 (String.length inner - 5) in
-            Ok (Bracket_url url_content)
+        | _ when String.starts_with ~prefix:"url(" inner -> (
+            match Parse.url_token (Parse.decode_arbitrary_value inner) with
+            | Some _ -> Ok (Bracket_url inner)
+            | None -> Error (`Msg ("Unknown mask bracket url: " ^ inner)))
         | _ when Parse.is_var inner -> Ok (Bracket_var inner)
         | _ -> (
             match parse_bracket_position inner with
@@ -610,7 +618,7 @@ module Handler = struct
     | Bracket_position (v, _) -> "mask-[" ^ v ^ "]"
     | Bracket_typed_position (v, _) -> "mask-[position:" ^ v ^ "]"
     | Bracket_image_var v -> "mask-[image:" ^ v ^ "]"
-    | Bracket_url url -> "mask-[url(" ^ url ^ ")]"
+    | Bracket_url v -> "mask-[" ^ v ^ "]"
     | Bracket_url_var v -> "mask-[url:" ^ v ^ "]"
     | Bracket_var v -> "mask-[" ^ v ^ "]"
     | Bracket_image v -> "mask-[" ^ v ^ "]"

--- a/lib/masks.ml
+++ b/lib/masks.ml
@@ -283,22 +283,6 @@ module Handler = struct
   let mask_position_style positions =
     style [ Css.webkit_mask_position positions; Css.mask_position positions ]
 
-  (* A whole value that is one [url()]: the first [)] closes it, so no second
-     layer hides behind a comma. *)
-  let is_single_url inner =
-    let n = String.length inner in
-    n > 5
-    && String.sub inner 0 4 = "url("
-    && inner.[n - 1] = ')'
-    && not (String.contains (String.sub inner 4 (n - 5)) ')')
-
-  (* Tailwind keeps a bare [_] inside [url()], where it is part of the file
-     name, and undoes only the [\_] escape; everywhere else in an arbitrary
-     value an underscore is a space. *)
-  let image_source inner =
-    if is_single_url inner then Parse.unescape_underscores inner
-    else Parse.decode_underscores inner
-
   let to_style _theme = function
     | No_mask -> mask_none
     | Add -> mask_add
@@ -387,7 +371,7 @@ module Handler = struct
             Css.mask_image (Var var_ref);
           ]
     | Bracket_image v -> (
-        match Css.parse_background_image (image_source v) with
+        match Css.parse_background_image (Parse.decode_underscores v) with
         | Some (img :: _) ->
             style [ Css.webkit_mask_image img; Css.mask_image img ]
         | _ ->
@@ -455,7 +439,7 @@ module Handler = struct
      whether the value parser accepts it, not which gradient function it
      names. *)
   let is_image_value inner =
-    match Css.parse_background_image (image_source inner) with
+    match Css.parse_background_image (Parse.decode_underscores inner) with
     | Some (_ :: _) -> true
     | _ -> false
 
@@ -554,9 +538,8 @@ module Handler = struct
               (Bracket_image_var (String.sub inner 6 (String.length inner - 6)))
         | _ when String.length inner > 4 && String.sub inner 0 4 = "url:" ->
             Ok (Bracket_url_var (String.sub inner 4 (String.length inner - 4)))
-        (* Before the single-[url(...)] reading below, which takes everything
-           between the first [(] and the last [)] and so swallows the comma of a
-           layer list. *)
+        (* Before the [url(...)] reading below, which takes one whole token and
+           so has no answer for the comma of a layer list. *)
         | _ when is_image_value inner -> Ok (Bracket_image inner)
         | _ when String.starts_with ~prefix:"url(" inner -> (
             match Parse.url_token (Parse.decode_arbitrary_value inner) with

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -160,31 +160,42 @@ let is_bracket_value s = bracket_close s = Some (String.length s - 1)
 let bracket_inner s =
   if is_bracket_value s then String.sub s 1 (String.length s - 2) else s
 
+(* How a span the decoder does not read as ordinary text is copied out.
+   [Verbatim] keeps every character, escape included; [Literal_underscore] reads
+   the text but leaves a bare [_] standing for itself. *)
+type exempt_span = Verbatim | Literal_underscore
+
 (* In an arbitrary value [_] stands for a space, and [\_] for a literal
    underscore — otherwise a value that needs one could not be written. The two
    readings differ only in what a bare [_] stands for, which [plain] carries,
-   and in [verbatim], the spans copied out unread. *)
-let read_underscores ~plain ~verbatim s =
+   and in [exempt], the spans read under one of the rules above. *)
+let read_underscores ~plain ~exempt s =
   let len = String.length s in
   let buf = Buffer.create len in
+  (* One character of text, [under] standing for a bare [_]. *)
+  let text under i =
+    if s.[i] = '\\' && i + 1 < len && s.[i + 1] = '_' then begin
+      Buffer.add_char buf '_';
+      i + 2
+    end
+    else begin
+      Buffer.add_char buf (if s.[i] = '_' then under else s.[i]);
+      i + 1
+    end
+  in
   let rec go i spans =
     if i >= len then ()
     else
       match spans with
-      | (start, stop) :: rest when i = start ->
+      | (start, stop, Verbatim) :: rest when i = start ->
           Buffer.add_substring buf s start (stop - start);
           go stop rest
-      | _ ->
-          if s.[i] = '\\' && i + 1 < len && s.[i + 1] = '_' then begin
-            Buffer.add_char buf '_';
-            go (i + 2) spans
-          end
-          else begin
-            Buffer.add_char buf (if s.[i] = '_' then plain else s.[i]);
-            go (i + 1) spans
-          end
+      | (start, stop, Literal_underscore) :: rest when i = start ->
+          let rec span j = if j >= stop then j else span (text '_' j) in
+          go (span start) rest
+      | _ -> go (text plain i) spans
   in
-  go 0 verbatim;
+  go 0 exempt;
   Buffer.contents buf
 
 (* Tailwind's value parser: a word runs to the next of [/ : , = > < ( )] or
@@ -194,33 +205,68 @@ let breaks_word = function
   | '/' | ':' | ',' | '=' | '>' | '<' | '(' | ')' | ' ' | '\t' | '\n' -> true
   | _ -> false
 
-(* [url_argument_spans s] is the list, in order, of the argument lists a [url()]
-   opens in [s], each as the half-open range between its parentheses.
-
-   Tailwind decodes an arbitrary value node by node and leaves these alone: a
-   [_] inside a [url()] is part of a file name, not a space. The function name
-   is matched the way Tailwind matches it, on [url] or a name ending in [_url],
-   so [myurl(a_b)] and [a-url(a_b)] decode their arguments and [_url(a_b)] does
-   not. *)
-let url_argument_spans s =
+(* The [)] closing the argument list opened before [i] in [s], or the end of [s]
+   when it is left open, as the tokeniser leaves it. *)
+let rec paren_end s i depth =
   let len = String.length s in
-  (* The name before the [(] at [i] started at [word]. *)
-  let names_url i word =
-    i - word >= 3
-    && String.sub s (i - 3) 3 = "url"
-    && (i - word = 3 || s.[i - 4] = '_')
-  in
-  (* The [)] closing the argument list, or the end of [s] when it is left open,
-     as the tokeniser leaves it. *)
-  let rec paren_end i depth =
-    if i >= len then len
-    else
-      match s.[i] with
-      | '\\' -> paren_end (i + 2) depth
-      | '\'' | '"' -> paren_end (string_end s (i + 1) s.[i]) depth
-      | '(' -> paren_end (i + 1) (depth + 1)
-      | ')' -> if depth = 0 then i else paren_end (i + 1) (depth - 1)
-      | _ -> paren_end (i + 1) depth
+  if i >= len then len
+  else
+    match s.[i] with
+    | '\\' -> paren_end s (i + 2) depth
+    | '\'' | '"' -> paren_end s (string_end s (i + 1) s.[i]) depth
+    | '(' -> paren_end s (i + 1) (depth + 1)
+    | ')' -> if depth = 0 then i else paren_end s (i + 1) (depth - 1)
+    | _ -> paren_end s (i + 1) depth
+
+(* Where the word starting at [i] in [s] ends, which is where Tailwind's value
+   parser breaks one. A [\] escape and a quoted string are part of the word. *)
+let rec word_end s i =
+  let len = String.length s in
+  if i >= len then len
+  else
+    match s.[i] with
+    | '\\' -> word_end s (i + 2)
+    | '\'' | '"' -> word_end s (string_end s (i + 1) s.[i])
+    | c when breaks_word c -> i
+    | _ -> word_end s (i + 1)
+
+(* Whether the function name before the [(] at [i] in [s], a name that started
+   at [word], is [key] or ends in [_key]. *)
+let names s i word key =
+  let n = String.length key in
+  i - word >= n
+  && String.sub s (i - n) n = key
+  && (i - word = n || s.[i - n - 1] = '_')
+
+(* [exempt_spans s] is the list, in order, of the spans of [s] that the decoder
+   does not read as ordinary text, each as a half-open range.
+
+   Tailwind decodes an arbitrary value node by node, and two kinds of function
+   node keep text the decoding would otherwise change. A [url()] keeps its whole
+   argument list as written, escape included: a [_] there is part of a file
+   name. A [var()] or [theme()] keeps the bare [_] of its first argument, which
+   names a custom property, while the [\_] escape there still unescapes.
+
+   The names are matched the way Tailwind matches them, on the word itself or on
+   a name ending in [_url], [_var] or [_theme], because a class writes a space
+   as [_] and the parser reads the whole run before the [(] as one name. That is
+   what carries [shadow-[0_0_0_var(--my_var)]], whose function node is named
+   [0_0_0_var]: the name decodes to [0 0 0 var] and the property it references
+   stays whole. So [myurl(a_b)] and [a-url(a_b)] decode their arguments, and
+   [--my-var(a_b)] is not a [var()].
+
+   Only a first argument that is a word takes the rule. One opening a call of
+   its own is a function node, which Tailwind recurses into instead: the
+   arguments of [var(foo(--a_b))] decode. *)
+let exempt_spans s =
+  let len = String.length s in
+  (* The first argument of the call opening at [i], when it is a word: none when
+     the list opens on a separator or on the [(] of a nested call. *)
+  let first_word i =
+    let stop = word_end s (i + 1) in
+    if stop > i + 1 && not (stop < len && s.[stop] = '(') then
+      Some (i + 1, stop, Literal_underscore)
+    else None
   in
   let rec scan i word acc =
     if i >= len then List.rev acc
@@ -228,15 +274,20 @@ let url_argument_spans s =
       match s.[i] with
       | '\\' -> scan (i + 2) word acc
       | '\'' | '"' -> scan (string_end s (i + 1) s.[i]) word acc
-      | '(' when names_url i word ->
-          let stop = paren_end (i + 1) 0 in
-          scan (stop + 1) (stop + 1) ((i + 1, stop) :: acc)
+      | '(' when names s i word "url" ->
+          let stop = paren_end s (i + 1) 0 in
+          scan (stop + 1) (stop + 1) ((i + 1, stop, Verbatim) :: acc)
+      | '(' when names s i word "var" || names s i word "theme" ->
+          let acc =
+            match first_word i with Some span -> span :: acc | None -> acc
+          in
+          scan (i + 1) (i + 1) acc
       | c -> scan (i + 1) (if breaks_word c then i + 1 else word) acc
   in
   scan 0 0 []
 
 let decode_underscores s =
-  read_underscores ~plain:' ' ~verbatim:(url_argument_spans s) s
+  read_underscores ~plain:' ' ~exempt:(exempt_spans s) s
 
 (* A [url()] in an arbitrary value is CSS source, so an escape in it stands for
    one character of the URL and the quotes are the tokeniser's, not the file
@@ -253,7 +304,7 @@ let url_token s =
 (* A property name has no spaces to spell, so its underscores stand for
    themselves and only the escape is undone. A name holds no [url()] either, so
    nothing is copied out unread. *)
-let unescape_underscores s = read_underscores ~plain:'_' ~verbatim:[] s
+let unescape_underscores s = read_underscores ~plain:'_' ~exempt:[] s
 
 (* The inverse: a utility holding a decoded value writes its class name back,
    and the name has to read as the value it came from. *)

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -92,9 +92,16 @@ val decode_underscores : string -> string
 
     The argument list of a [url()] is left as written, because a [_] there is
     part of a file name: [image-set(url('a_b.png')_1x)] keeps the first
-    underscore and gives the second a space. The function name is matched on
-    [url] or a name ending in [_url], so [myurl(a_b)] and [a-url(a_b)] decode
-    their arguments. *)
+    underscore and gives the second a space.
+
+    The first argument of a [var()] or a [theme()] keeps its bare [_] too,
+    because it names a custom property, while [\_] there still unescapes. The
+    rest of the call reads normally, so [var(--a_b,_c_d)] is [var(--a_b, c d)].
+
+    A name is matched on the word itself or on one ending in [_url], [_var] or
+    [_theme], since a class writes a space as [_]: the whole of [0_0_0_var] is
+    one function name, and [shadow-[0_0_0_var(--my_var)]] keeps the property it
+    references. So [myurl(a_b)] and [a-url(a_b)] decode their arguments. *)
 
 val unescape_underscores : string -> string
 (** [unescape_underscores s] turns the [\_] of an arbitrary value into a literal

--- a/test/test_masks.ml
+++ b/test/test_masks.ml
@@ -204,6 +204,29 @@ let test_bracket_url_underscore () =
   has "mask-[image-set(url('a_b.png')_1x)]"
     "mask-image: image-set(url(a_b.png) 1x)"
 
+(* [mask-image] takes an image and no position, so a [url()] carrying one is not
+   a mask utility. The bracket is read as a whole token rather than sliced
+   between its first [(] and its last [)]: that slice cuts the file name at the
+   trailing word, and both halves of the utility carry the cut, so
+   [mask-[url(x.png)_center]] names itself [.mask-\[url\(x\.png\)_cente\)\]] - a
+   selector no markup carries - and holds [url("x.png)_cente")]. The [bg-]
+   family reads its bracket the same way. *)
+let test_bracket_url_needs_a_whole_token () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  rejected "mask-[url(x.png)_center]";
+  rejected "mask-[url(x.png)_no-repeat]";
+  rejected "mask-[url(x.png)_50%_50%]";
+  (* The whole token still reads, and still names itself. *)
+  Test_helpers.check_declarations "mask-[url(x.png)]"
+    [ "-webkit-mask-image:url(x.png)"; "mask-image:url(x.png)" ];
+  match Tw.of_string "mask-[url(x.png)]" with
+  | Ok u -> Alcotest.(check string) "round-trips" "mask-[url(x.png)]" (Tw.pp u)
+  | Error (`Msg m) -> Alcotest.failf "mask-[url(x.png)]: %s" m
+
 let tests =
   Test_helpers.standard ~roundtrip:test_roundtrip ~invalid:test_invalid
   @ [
@@ -213,6 +236,8 @@ let tests =
         test_bracket_url_keeps_underscores;
       Alcotest.test_case "mask image url underscores" `Quick
         test_bracket_url_underscore;
+      Alcotest.test_case "bracket url needs a whole token" `Quick
+        test_bracket_url_needs_a_whole_token;
       Alcotest.test_case "typed constructors" `Quick test_typed;
       Alcotest.test_case "arbitrary mask image" `Quick test_bracket_image;
       Alcotest.test_case "arbitrary mask layer list" `Quick

--- a/test/test_parse.ml
+++ b/test/test_parse.ml
@@ -419,6 +419,52 @@ let test_underscore_inside_url () =
   reads "a quoted string outside a url decodes" "image-set('a_b.png'_1x)"
     "image-set('a b.png' 1x)"
 
+(* The first argument of a [var()] or a [theme()] names a custom property, so a
+   [_] there belongs to the name. Tailwind exempts that one node and reads the
+   rest of the call normally; the name of the node itself decodes, which is what
+   keeps [0_0_0_var(--my_var)] - one function node named [0_0_0_var] - both a
+   shadow and a reference to [--my_var]. Only the bare [_] is exempt, the [\_]
+   escape still unescapes, which is where this differs from a [url()] argument
+   list. Pinned against @tailwindcss/cli 4.3.3. *)
+let test_underscore_inside_var_and_theme () =
+  let reads name input expected =
+    Alcotest.(check string) name expected (Tw.Parse.decode_underscores input)
+  in
+  reads "a var name keeps its underscore" "var(--my_var)" "var(--my_var)";
+  reads "a theme key keeps its underscore" "theme(--my_key)" "theme(--my_key)";
+  reads "the node name decodes around it" "0_0_0_var(--my_var)"
+    "0 0 0 var(--my_var)";
+  reads "a name ending in _var takes the rule" "my_var(--a_b)" "my var(--a_b)";
+  reads "a name ending in _theme takes it too" "my_theme(--a_b)"
+    "my theme(--a_b)";
+  reads "a later argument still decodes" "var(--a_b,_c_d)" "var(--a_b, c d)";
+  reads "a nested call keeps its own name" "var(--a_b,_var(--c_d))"
+    "var(--a_b, var(--c_d))";
+  reads "the escape still unescapes" {|var(--a\_b)|} "var(--a_b)";
+  reads "a first argument that opens a call is no word" "var(foo(--a_b))"
+    "var(foo(--a b))";
+  reads "the word runs to the first break" "var(--a_b/2)" "var(--a_b/2)";
+  reads "a leading underscore is part of the word" "var(_--a_b)" "var(_--a_b)";
+  reads "an empty argument list reads" "my_var()" "my var()";
+  reads "another name decodes its arguments" "foo(--a_b)" "foo(--a b)";
+  reads "var is matched case-sensitively" "VAR(--a_b)" "VAR(--a b)";
+  reads "two calls each keep their name" "var(--a_b)_var(--c_d)"
+    "var(--a_b) var(--c_d)";
+  reads "a url inside a later argument is still verbatim"
+    "var(--a_b,_url(c_d.png))" "var(--a_b, url(c_d.png))";
+  (* What the exemption saves a shadow from: a name decoded to [--my var] splits
+     at the space, so the reference reaching the sheet is the first half of a
+     custom property nothing declares, and nothing says so. *)
+  Test_helpers.check_declarations {|[--x:var(--my_var)]|}
+    [ "--x:var(--my_var)" ];
+  Test_helpers.check_declarations "shadow-[0_0_0_var(--my_var)]"
+    [
+      "--tw-shadow:0 0 0 var(--tw-shadow-color,var(--my_var))";
+      "box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)";
+    ];
+  Test_helpers.check_declarations {|[--x:var(--a_b,_c_d)]|}
+    [ "--x:var(--a_b,c d)" ]
+
 let tests =
   Alcotest.
     [
@@ -426,6 +472,8 @@ let tests =
       test_case "a quoted bracket stays inside the value" `Quick
         test_quoted_bracket_stays_inside_the_value;
       test_case "underscore inside a url" `Quick test_underscore_inside_url;
+      test_case "underscore inside a var or theme call" `Quick
+        test_underscore_inside_var_and_theme;
       test_case "parse backslash escape in selector" `Quick
         test_escape_in_selector;
       test_case "double bracket class rejected" `Quick


### PR DESCRIPTION
Two silent data losses in arbitrary values, both from `TODO.md`.

**`var()` and `theme()` arguments.** An underscore in the custom property a
`var()` names is part of the name, and tw decoded it to a space, so
`[--x:var(--my_var)]` referenced `--my var` and `shadow-[0_0_0_var(--my_var)]`
split at that space and truncated the reference to `var(--my)`. Measured
against the pinned CLI (4.3.3): a function node named `var` or `theme`, or
whose name ends in `_var` or `_theme`, keeps the bare underscore of its first
argument when that argument is a word. Its own name and every later argument
decode as usual, and `\_` inside the exempt argument still unescapes. All three
classes are now `--diff` clean.

**`mask-[url(...)]`.** The reading sliced the text between the first `(` and the
last `)`, so `mask-[url(x.png)_center]` emitted `mask-image: url("x.png)_cente")`
under `.mask-\[url\(x\.png\)_cente\)\]`, a selector no markup carries. The
bracket goes through `Parse.url_token` now, the reading #692 gave `bg-`.

Note the CLI does not refuse `mask-[url(x.png)_center]`: it writes
`mask-image: url(x.png) center` with no validation, which belongs to the
token-stream contract of #667 rather than to this fix. Refusing it matches what
#692 chose for `bg-[url(x.png)_center]`.

The last commit retires `is_single_url`, whose whole-value test the per-span
`decode_underscores` of #692 already covers.
