### PR TITLE
test: pin what four suites emit instead of searching it

### DIFF
--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -3,6 +3,12 @@ open Alcotest
 
 let check = Test_helpers.check_handler_roundtrip (module Tw.Effects.Handler)
 
+(* Every box-shadow utility composes the same five channels; only the channel it
+   sets ahead of this differs. Naming it keeps the expectations below readable
+   without weakening them: it is one string, compared whole. *)
+let composes_box_shadow =
+  "box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)"
+
 let of_string_valid () =
   (* Box shadow *)
   check "shadow";
@@ -56,42 +62,59 @@ let test_ring_width_order () =
 (* ring-black / ring-white (shadeless theme colours) parse with an optional
    /opacity; a shaded colour without a shade (ring-red) stays rejected. *)
 let test_ring_shadeless_color () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  Alcotest.check bool "ring-black sets ring color" true
-    (Astring.String.is_infix ~affix:"--tw-ring-color" (css "ring-black"));
-  Alcotest.check bool "ring-white/10 uses color-mix" true
-    (Astring.String.is_infix ~affix:"color-mix" (css "ring-white/10"));
+  Test_helpers.check_declarations "ring-black"
+    [ "--tw-ring-color:var(--color-black)" ];
+  (* The plain declaration carries the folded sRGB colour and the [@supports]
+     copy the [color-mix] enhancement, so both are pinned. *)
+  Test_helpers.check_declarations "ring-white/10"
+    [
+      "--tw-ring-color:#ffffff1a";
+      "--tw-ring-color:color-mix(in oklab,var(--color-white) 10%,transparent)";
+    ];
   (* Palette colours (blue-500) also apply the /opacity modifier on a var-ref
      theme; the ring family resolves it via oklab like bg/text do. *)
-  Alcotest.check bool "ring-blue-500/50 applies opacity" true
-    (Astring.String.is_infix ~affix:"color-mix" (css "ring-blue-500/50"));
-  Alcotest.check bool "inset-ring-gray-950/10 applies opacity" true
-    (Astring.String.is_infix ~affix:"color-mix" (css "inset-ring-gray-950/10"));
+  Test_helpers.check_declarations "ring-blue-500/50"
+    [
+      "--tw-ring-color:#3080ff80";
+      "--tw-ring-color:color-mix(in oklab,var(--color-blue-500) \
+       50%,transparent)";
+    ];
+  Test_helpers.check_declarations "inset-ring-gray-950/10"
+    [
+      "--tw-inset-ring-color:#0307121a";
+      "--tw-inset-ring-color:color-mix(in oklab,var(--color-gray-950) \
+       10%,transparent)";
+    ];
   match Tw.of_string "ring-red" with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "ring-red (no shade) should be rejected"
 
+(* A filter utility sets its own channel and recomposes the whole filter list
+   from every channel, so the composition is the same string whichever one is
+   set. The backdrop families write the [-webkit-] alias first. *)
 let test_filters_css_generation () =
-  (* Spot-check a few filter/backdrop utilities *)
-  let open Tw in
-  let css =
-    Build.to_css
-      [
-        Filters.blur;
-        Filters.backdrop_blur_lg;
-        Filters.backdrop_brightness 125;
-        Filters.backdrop_opacity 50.;
-      ]
-    |> Css.to_string
+  let filter_composition =
+    "filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)"
   in
-  Alcotest.check bool "has filter property" true
-    (Astring.String.is_infix ~affix:"filter:" css);
-  Alcotest.check bool "has backdrop-filter property" true
-    (Astring.String.is_infix ~affix:"backdrop-filter:" css)
+  let backdrop_composition prefix =
+    prefix
+    ^ ":var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,)"
+  in
+  let backdrop channel value =
+    [
+      channel ^ ":" ^ value;
+      backdrop_composition "-webkit-backdrop-filter";
+      backdrop_composition "backdrop-filter";
+    ]
+  in
+  Test_helpers.check_declarations "blur"
+    [ "--tw-blur:blur(8px)"; filter_composition ];
+  Test_helpers.check_declarations "backdrop-blur-lg"
+    (backdrop "--tw-backdrop-blur" "blur(var(--blur-lg))");
+  Test_helpers.check_declarations "backdrop-brightness-125"
+    (backdrop "--tw-backdrop-brightness" "brightness(125%)");
+  Test_helpers.check_declarations "backdrop-opacity-50"
+    (backdrop "--tw-backdrop-opacity" "opacity(50%)")
 
 (* ring-inset registers the ring/shadow @property family, like the other ring
    utilities; it used to emit only the --tw-ring-inset declaration. *)
@@ -102,8 +125,9 @@ let test_ring_inset_property_rules () =
     | Ok u -> to_css ~base:false [ u ] |> Css.to_string
     | Error (`Msg m) -> Alcotest.failf "ring-inset: %s" m
   in
-  Alcotest.check bool "ring-inset sets --tw-ring-inset" true
-    (Astring.String.is_infix ~affix:"--tw-ring-inset: inset" css);
+  Test_helpers.check_declarations "ring-inset" [ "--tw-ring-inset:inset" ];
+  (* The [@property] rule is not a declaration on the class, so it is read off
+     the sheet. *)
   Alcotest.check bool "ring-inset registers @property --tw-ring-shadow" true
     (Astring.String.is_infix ~affix:"@property --tw-ring-shadow" css)
 
@@ -173,24 +197,24 @@ let rendering_matches_tailwind () =
 (* shadow-2xl's default shadow alpha is .25 (#00000040) in v4, not the .10
    (#0000001a) the smaller shadows use. *)
 let test_shadow_2xl_alpha () =
-  let css = Tw.to_css ~base:false [ Tw.shadow_2xl ] |> Tw.Css.to_string in
-  Alcotest.(check bool)
-    "shadow-2xl uses #00000040 alpha" true
-    (Astring.String.is_infix ~affix:"#00000040" css)
+  Test_helpers.check_declarations "shadow-2xl"
+    [
+      "--tw-shadow:0 25px 50px -12px var(--tw-shadow-color,#00000040)";
+      composes_box_shadow;
+    ]
 
 (* The two smallest box-shadow sizes (alpha .05 = #0000000d): 2xs is a single 0
    1px shadow with no blur, xs is 0 1px 2px 0. *)
 let test_shadow_small_sizes () =
-  let css u = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true in
-  Alcotest.(check bool)
-    "shadow-2xs uses #0000000d" true
-    (Astring.String.is_infix ~affix:"#0000000d" (css Tw.shadow_2xs));
-  Alcotest.(check bool)
-    "shadow-xs uses #0000000d" true
-    (Astring.String.is_infix ~affix:"#0000000d" (css Tw.shadow_xs));
-  Alcotest.(check bool)
-    "shadow-xs has a 2px blur" true
-    (Astring.String.is_infix ~affix:"1px 2px" (css Tw.shadow_xs))
+  Test_helpers.check_declarations "shadow-2xs"
+    [
+      "--tw-shadow:0 1px var(--tw-shadow-color,#0000000d)"; composes_box_shadow;
+    ];
+  Test_helpers.check_declarations "shadow-xs"
+    [
+      "--tw-shadow:0 1px 2px 0 var(--tw-shadow-color,#0000000d)";
+      composes_box_shadow;
+    ]
 
 (* The v4.3.1 default inset-shadow scale is inset-shadow-{2xs,xs,sm} plus
    inset-shadow-none. Bare inset-shadow and md/lg/xl/2xl do not exist. *)
@@ -212,19 +236,16 @@ let test_inset_shadow_invalid () =
 (* The default scale (alpha .05 = #0000000d): 2xs is a single inset shadow with
    no blur ([inset 0 1px]); sm is [inset 0 2px 4px]. *)
 let test_inset_shadow_default_scale () =
-  let css cls =
-    Tw.to_css ~base:false [ Result.get_ok (Tw.of_string cls) ]
-    |> Tw.Css.to_string ~minify:true
-  in
-  Alcotest.(check bool)
-    "inset-shadow-2xs uses #0000000d" true
-    (Astring.String.is_infix ~affix:"#0000000d" (css "inset-shadow-2xs"));
-  Alcotest.(check bool)
-    "inset-shadow-2xs has no blur ([inset 0 1px])" true
-    (Astring.String.is_infix ~affix:"inset 0 1px var(" (css "inset-shadow-2xs"));
-  Alcotest.(check bool)
-    "inset-shadow-sm is [inset 0 2px 4px]" true
-    (Astring.String.is_infix ~affix:"inset 0 2px 4px" (css "inset-shadow-sm"))
+  Test_helpers.check_declarations "inset-shadow-2xs"
+    [
+      "--tw-inset-shadow:inset 0 1px var(--tw-inset-shadow-color,#0000000d)";
+      composes_box_shadow;
+    ];
+  Test_helpers.check_declarations "inset-shadow-sm"
+    [
+      "--tw-inset-shadow:inset 0 2px 4px var(--tw-inset-shadow-color,#0000000d)";
+      composes_box_shadow;
+    ]
 
 (* A threaded @theme override for an inset-shadow token flows through to the
    inlined value. The default inset-shadow-sm is [inset 0 2px 4px]; with the
@@ -251,107 +272,116 @@ let test_inset_shadow_theme_override () =
    colour parse: the size cases claimed the segment and rejected it. The class
    name drops the shade too, or it comes back as shadow-white-500. *)
 let test_shadeless_shadow_colors () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "shadow-white" ".shadow-white{--tw-shadow-color:#fff}";
-  has "shadow-white/10" ".shadow-white\\/10{--tw-shadow-color:#ffffff1a}";
-  has "inset-shadow-white" ".inset-shadow-white{--tw-inset-shadow-color:#fff}";
-  has "inset-shadow-white/20"
-    ".inset-shadow-white\\/20{--tw-inset-shadow-color:#fff3}"
+  Test_helpers.check_declarations "shadow-white"
+    [
+      "--tw-shadow-color:#fff";
+      "--tw-shadow-color:color-mix(in oklab,var(--color-white) \
+       var(--tw-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "shadow-white/10"
+    [
+      "--tw-shadow-color:#ffffff1a";
+      "--tw-shadow-color:color-mix(in oklab,color-mix(in \
+       oklab,var(--color-white) 10%,transparent) \
+       var(--tw-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "inset-shadow-white"
+    [
+      "--tw-inset-shadow-color:#fff";
+      "--tw-inset-shadow-color:color-mix(in oklab,var(--color-white) \
+       var(--tw-inset-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "inset-shadow-white/20"
+    [
+      "--tw-inset-shadow-color:#fff3";
+      "--tw-inset-shadow-color:color-mix(in oklab,color-mix(in \
+       oklab,var(--color-white) 20%,transparent) \
+       var(--tw-inset-shadow-alpha),transparent)";
+    ]
 
 (* A default palette token is already an OKLCH colour. Tailwind keeps that value
    as the unguarded shadow-colour fallback; converting it to sRGB hex changes
    wide-gamut colours before the [color-mix()] enhancement applies. *)
 let test_palette_shadow_colors_keep_oklch () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "shadow-indigo-500" "--tw-shadow-color:oklch(58.5%.233 277.117)";
-  has "inset-shadow-indigo-500"
-    "--tw-inset-shadow-color:oklch(58.5%.233 277.117)"
+  Test_helpers.check_declarations "shadow-indigo-500"
+    [
+      "--tw-shadow-color:oklch(58.5%.233 277.117)";
+      "--tw-shadow-color:color-mix(in oklab,var(--color-indigo-500) \
+       var(--tw-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "inset-shadow-indigo-500"
+    [
+      "--tw-inset-shadow-color:oklch(58.5%.233 277.117)";
+      "--tw-inset-shadow-color:color-mix(in oklab,var(--color-indigo-500) \
+       var(--tw-inset-shadow-alpha),transparent)";
+    ]
 
 (* shadow-inner is a shadow shape like the others: it sets --tw-shadow and
    composes, rather than writing box-shadow directly. *)
 let test_shadow_inner () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let out = css "shadow-inner" in
-  Alcotest.(check bool)
-    "shadow-inner sets --tw-shadow" true
-    (Astring.String.is_infix ~affix:"--tw-shadow:inset 0 2px 4px 0 " out);
-  Alcotest.(check bool)
-    "shadow-inner composes box-shadow" true
-    (Astring.String.is_infix
-       ~affix:"box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow)"
-       out)
+  Test_helpers.check_declarations "shadow-inner"
+    [
+      "--tw-shadow:inset 0 2px 4px 0 var(--tw-shadow-color,#0000000d)";
+      composes_box_shadow;
+    ]
 
 (* A shadow list is one shadow per layer. The single-shadow reading also drops
    the spread, so anything with a comma goes to the value parser. *)
 let test_arbitrary_shadow_list () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  Alcotest.(check bool)
-    "both layers survive with their spread" true
-    (Astring.String.is_infix
-       ~affix:
-         "--tw-shadow:-5px 10px 15px -3px \
-          var(--tw-shadow-color,var(--shadow-color)),-5px 4px 6px -4px \
-          var(--tw-shadow-color,var(--shadow-color))"
-       (css
-          "shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)]"))
+  Test_helpers.check_declarations
+    "shadow-[-5px_10px_15px_-3px_var(--shadow-color),-5px_4px_6px_-4px_var(--shadow-color)]"
+    [
+      "--tw-shadow:-5px 10px 15px -3px \
+       var(--tw-shadow-color,var(--shadow-color)),-5px 4px 6px -4px \
+       var(--tw-shadow-color,var(--shadow-color))";
+      composes_box_shadow;
+    ]
 
 (* A single arbitrary shadow reads every CSS length, not the px/rem/em subset,
    and keeps its spread. A token that is not a length makes the whole value not
    a shadow rather than dropping out and shifting its neighbours along. *)
 let test_arbitrary_shadow_lengths () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  let shadow cls value =
+    Test_helpers.check_declarations cls
+      [ "--tw-shadow:" ^ value; composes_box_shadow ]
   in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
+  let inset_shadow cls value =
+    Test_helpers.check_declarations cls
+      [ "--tw-inset-shadow:" ^ value; composes_box_shadow ]
   in
-  emits "--tw-shadow: 0 1ch 2px var(--tw-shadow-color, oklab(0% 0 0 / .5))"
-    "shadow-[0_1ch_2px_#000]/50";
-  emits "--tw-shadow: 0 1px 2px 3px var(--tw-shadow-color, oklab(0% 0 0 / .5))"
-    "shadow-[0_1px_2px_3px_#000]/50";
-  emits
-    "--tw-shadow: 0 1ch 2px 3vmin var(--tw-shadow-color, oklab(0% 0 0 / .5))"
-    "shadow-[0_1ch_2px_3vmin_#000]/50";
+  let with_alpha cls alpha value =
+    Test_helpers.check_declarations cls
+      [
+        "--tw-shadow-alpha:" ^ alpha;
+        "--tw-shadow:" ^ value;
+        composes_box_shadow;
+      ]
+  in
+  with_alpha "shadow-[0_1ch_2px_#000]/50" "50%"
+    "0 1ch 2px var(--tw-shadow-color,oklab(0%0 0/.5))";
+  with_alpha "shadow-[0_1px_2px_3px_#000]/50" "50%"
+    "0 1px 2px 3px var(--tw-shadow-color,oklab(0%0 0/.5))";
+  with_alpha "shadow-[0_1ch_2px_3vmin_#000]/50" "50%"
+    "0 1ch 2px 3vmin var(--tw-shadow-color,oklab(0%0 0/.5))";
   (* inset-shadow reads its arbitrary value through the same parser, with no
      [Css.parse_shadow] fallback to hide the dropped tokens. *)
-  emits
-    "--tw-inset-shadow: inset 0 1ch 2px var(--tw-inset-shadow-color, #000000)"
-    "inset-shadow-[0_1ch_2px_#000]";
-  emits
-    "--tw-inset-shadow: inset 0 1px 2px 3px var(--tw-inset-shadow-color, \
-     #000000)"
-    "inset-shadow-[0_1px_2px_3px_#000]";
-  emits "--tw-shadow: 0 var(--tw-shadow-color,bogus) 2px" "shadow-[0_bogus_2px]";
-  emits
-    "--tw-shadow: 0 var(--tw-shadow-color,oklab(from bogus l a b / 50%)) 2px"
-    "shadow-[0_bogus_2px]/50";
-  emits "--tw-inset-shadow: inset 0 var(--tw-inset-shadow-color,bogus) 2px"
-    "inset-shadow-[0_bogus_2px]"
+  inset_shadow "inset-shadow-[0_1ch_2px_#000]"
+    "inset 0 1ch 2px var(--tw-inset-shadow-color,#000)";
+  inset_shadow "inset-shadow-[0_1px_2px_3px_#000]"
+    "inset 0 1px 2px 3px var(--tw-inset-shadow-color,#000)";
+  shadow "shadow-[0_bogus_2px]" "0 var(--tw-shadow-color,bogus) 2px";
+  with_alpha "shadow-[0_bogus_2px]/50" "50%"
+    "0 var(--tw-shadow-color,oklab(from bogus l a b / 50%)) 2px";
+  inset_shadow "inset-shadow-[0_bogus_2px]"
+    "inset 0 var(--tw-inset-shadow-color,bogus) 2px"
 
+(* [shadow-[<colour>]/<alpha>] where the bracket already carries a [%] alpha:
+   the modifier folds into a [color-mix] rather than into a hex byte.
+
+   [shadow-[0_0_8px_#f00]/[var(--x)]] and its inset twin are left on a
+   substring: tw expands the authored [#f00] to [#ff0000] where the pinned CLI
+   passes the six-character spelling through, so their declarations cannot be
+   pinned without encoding that divergence. *)
 let test_arbitrary_shadow_colour_opacity () =
   let css cls =
     match Tw.of_string cls with
@@ -361,10 +391,21 @@ let test_arbitrary_shadow_colour_opacity () =
   let has cls affix =
     Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
   in
-  has "shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
-    "var(--tw-shadow-color,color-mix(";
-  has "inset-shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
-    "var(--tw-inset-shadow-color,color-mix(";
+  Test_helpers.check_declarations "shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
+    [
+      "--tw-shadow-alpha:50%";
+      "--tw-shadow:0 0 8px var(--tw-shadow-color,color-mix(in \
+       oklab,oklch(50%.2 250) 50%,transparent))";
+      composes_box_shadow;
+    ];
+  Test_helpers.check_declarations "inset-shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
+    [
+      "--tw-inset-shadow-alpha:50%";
+      "--tw-inset-shadow:inset 0 0 8px \
+       var(--tw-inset-shadow-color,color-mix(in oklab,oklch(50%.2 250) \
+       50%,transparent))";
+      composes_box_shadow;
+    ];
   has "shadow-[0_0_8px_#f00]/[var(--x)]" "--tw-shadow-alpha:var(--x)";
   has "shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from";
   has "inset-shadow-[0_0_8px_#f00]/[var(--x)]"
@@ -377,27 +418,28 @@ let test_arbitrary_shadow_colour_opacity () =
    in oklab; the colour used to fall through untouched, which painted the shadow
    fully opaque and dropped the modifier. *)
 let test_bracket_colour_opacity_without_hex () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  let lacks cls affix =
-    Alcotest.(check bool) cls false (Astring.String.is_infix ~affix (css cls))
-  in
-  has "shadow-[oklch(0.7_0.1_200)]/50" "--tw-shadow-color:color-mix(in srgb,";
-  lacks "shadow-[oklch(0.7_0.1_200)]/50" "--tw-shadow-color:oklch(";
-  has "inset-shadow-[oklch(0.7_0.1_200)]/50"
-    "--tw-inset-shadow-color:color-mix(in srgb,";
-  lacks "inset-shadow-[oklch(0.7_0.1_200)]/50" "--tw-inset-shadow-color:oklch("
+  Test_helpers.check_declarations "shadow-[oklch(0.7_0.1_200)]/50"
+    [
+      "--tw-shadow-color:color-mix(in srgb,oklch(.7 .1 200) 50%,transparent)";
+      "--tw-shadow-color:color-mix(in oklab,color-mix(in oklab,oklch(.7 .1 \
+       200) 50%,transparent) var(--tw-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "inset-shadow-[oklch(0.7_0.1_200)]/50"
+    [
+      "--tw-inset-shadow-color:color-mix(in srgb,oklch(.7 .1 200) \
+       50%,transparent)";
+      "--tw-inset-shadow-color:color-mix(in oklab,color-mix(in oklab,oklch(.7 \
+       .1 200) 50%,transparent) var(--tw-inset-shadow-alpha),transparent)";
+    ]
 
 (* A hex bracket colour whose modifier reads a custom property keeps that
    property inside the guarded [color-mix]. The hex arm folded the modifier into
    an alpha byte, which a var() has no value for, so the modifier was dropped
-   and the shadow painted fully opaque. *)
+   and the shadow painted fully opaque.
+
+   These two classes stay on a substring: tw expands the authored [#f00] to
+   [#ff0000] where the pinned CLI keeps the three-character spelling, so their
+   declarations cannot be pinned without encoding that divergence. *)
 let test_bracket_hex_opacity_var () =
   let css cls =
     match Tw.of_string cls with
@@ -428,21 +470,40 @@ let test_shadow_bracket_alpha_tracking () =
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
   let lacks cls affix =
     Alcotest.(check bool) cls false (Astring.String.is_infix ~affix (css cls))
   in
-  has "shadow-lg/[25]" "--tw-shadow-alpha:25;";
+  let shadow_lg alpha painted =
+    [
+      "--tw-shadow-alpha:" ^ alpha;
+      "--tw-shadow:0 10px 15px -3px var(--tw-shadow-color," ^ painted
+      ^ "),0 4px 6px -4px var(--tw-shadow-color," ^ painted ^ ")";
+      composes_box_shadow;
+    ]
+  in
+  Test_helpers.check_declarations "shadow-lg/[25]"
+    (shadow_lg "25" "oklab(0%0 0/25)");
   lacks "shadow-lg/[25]" "--tw-shadow-alpha:2500%";
-  has "shadow-[0_1px_2px_#000]/[25]" "--tw-shadow-alpha:25;";
-  has "inset-shadow-sm/[25]" "--tw-inset-shadow-alpha:25;";
+  Test_helpers.check_declarations "shadow-[0_1px_2px_#000]/[25]"
+    [
+      "--tw-shadow-alpha:25";
+      "--tw-shadow:0 1px 2px var(--tw-shadow-color,oklab(0%0 0/25))";
+      composes_box_shadow;
+    ];
+  Test_helpers.check_declarations "inset-shadow-sm/[25]"
+    [
+      "--tw-inset-shadow-alpha:25";
+      "--tw-inset-shadow:inset 0 2px 4px var(--tw-inset-shadow-color,oklab(0%0 \
+       0/25))";
+      composes_box_shadow;
+    ];
   lacks "inset-shadow-sm/[25]" "--tw-inset-shadow-alpha:2500%";
   (* A bracket alpha that does carry a [%] sign, or the plain percent form, both
      keep behaving as a percentage. *)
-  has "shadow-lg/[25%]" "--tw-shadow-alpha:25%";
-  has "shadow-lg/50" "--tw-shadow-alpha:50%"
+  Test_helpers.check_declarations "shadow-lg/[25%]"
+    (shadow_lg "25%" "oklab(0%0 0/.25)");
+  Test_helpers.check_declarations "shadow-lg/50"
+    (shadow_lg "50%" "oklab(0%0 0/.5)")
 
 (* Tailwind forwards a declaration-safe arbitrary shadow token stream even when
    it is not a valid shadow value. *)
@@ -467,9 +528,6 @@ let test_arbitrary_bracket_color_token_stream () =
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  let emits cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
   List.iter
     (fun prefix ->
       ignore (css (prefix ^ "-[#zz]"));
@@ -482,15 +540,30 @@ let test_arbitrary_bracket_color_token_stream () =
   ignore (css "shadow-[0_1px_2px_#12345]");
   ignore (css "shadow-[0_1px_2px_#zz]/50");
   ignore (css "inset-shadow-[0_1px_2px_#zz]");
-  emits "shadow-[#abc]" "--tw-shadow-color:#abc";
-  emits "ring-[#123456]" "--tw-ring-color:#123456";
-  emits "inset-shadow-[#abc]" "--tw-inset-shadow-color:#abc";
-  emits "inset-ring-[#abc]" "--tw-inset-ring-color:#abc";
-  emits "ring-offset-[#abc]" "--tw-ring-offset-color:#abc";
-  emits "shadow-[0_1px_2px_#000]"
-    "--tw-shadow:0 1px 2px var(--tw-shadow-color,#000)";
-  emits "inset-shadow-[0_1px_2px_#000]"
-    "--tw-inset-shadow:inset 0 1px 2px var(--tw-inset-shadow-color,#000)"
+  Test_helpers.check_declarations "shadow-[#abc]"
+    [
+      "--tw-shadow-color:#abc";
+      "--tw-shadow-color:color-mix(in oklab,#abc \
+       var(--tw-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "ring-[#123456]" [ "--tw-ring-color:#123456" ];
+  Test_helpers.check_declarations "inset-shadow-[#abc]"
+    [
+      "--tw-inset-shadow-color:#abc";
+      "--tw-inset-shadow-color:color-mix(in oklab,#abc \
+       var(--tw-inset-shadow-alpha),transparent)";
+    ];
+  Test_helpers.check_declarations "inset-ring-[#abc]"
+    [ "--tw-inset-ring-color:#abc" ];
+  Test_helpers.check_declarations "ring-offset-[#abc]"
+    [ "--tw-ring-offset-color:#abc" ];
+  Test_helpers.check_declarations "shadow-[0_1px_2px_#000]"
+    [ "--tw-shadow:0 1px 2px var(--tw-shadow-color,#000)"; composes_box_shadow ];
+  Test_helpers.check_declarations "inset-shadow-[0_1px_2px_#000]"
+    [
+      "--tw-inset-shadow:inset 0 1px 2px var(--tw-inset-shadow-color,#000)";
+      composes_box_shadow;
+    ]
 
 (* A shade the palette does not define is not a colour. These utilities read the
    shade without checking it, so the class was accepted and then rendered a
@@ -585,16 +658,11 @@ let test_project_shadow_tokens () =
 (* A shadow's parts are separated by the [_] that stands for a space, so a
    variable name carrying an underscore of its own is written [\_]. *)
 let test_shadow_underscore_escape () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  Alcotest.(check bool)
-    "an escaped underscore stays in the variable name" true
-    (Astring.String.is_infix
-       ~affix:"0 0 0 1px var(--tw-shadow-color, var(--a_b))"
-       (css {|shadow-[0_0_0_1px_var(--a\_b)]|}))
+  Test_helpers.check_declarations {|shadow-[0_0_0_1px_var(--a\_b)]|}
+    [
+      "--tw-shadow:0 0 0 1px var(--tw-shadow-color,var(--a_b))";
+      composes_box_shadow;
+    ]
 
 let tests =
   [

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -11,6 +11,26 @@ open Tw.Animations
 open Tw.Transitions
 open Tw.Borders
 
+(* A variant decides the selector and the at-rules wrapped around it, and
+   neither is a declaration, so what these tests have to compare is the sheet
+   itself. Comparing it whole is what a substring cannot do: [:has(:focus)] is
+   an infix of [:has(:focus-visible)], and a [check bool] failure prints neither
+   the class nor the CSS. *)
+let sheet cls =
+  match Tw.of_string cls with
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+let check_sheet cls expected = Alcotest.(check string) cls expected (sheet cls)
+
+(* Most classes here draw on no theme token, so the layers ahead of [utilities]
+   are empty and only the utilities layer is worth spelling out. The comparison
+   is still against the whole sheet. *)
+let check_utilities cls expected =
+  check_sheet cls
+    ("@layer theme,components,utilities;@layer theme;@layer components;@layer \
+      utilities{" ^ expected ^ "}")
+
 (* Test responsive modifier detection *)
 let test_has_responsive_modifier () =
   (* Basic styles should not have responsive modifier *)
@@ -267,24 +287,11 @@ let test_combined_media_modifiers () =
 
 (* Test that motion-reduce:transition-none outputs transition-property: none *)
 let test_motion_reduce_transition_none () =
-  (* Tailwind v4 uses transition-property: none, not transition: none *)
-  let css = Tw.Build.to_css [ motion_reduce [ transition_none ] ] in
-  let css_str = Tw.Css.to_string ~minify:true css in
-
-  (* Should contain transition-property:none *)
-  let has_transition_property =
-    Astring.String.is_infix ~affix:"transition-property" css_str
-  in
-  check bool "has transition-property (not transition shorthand)" true
-    has_transition_property;
-
-  (* Should NOT contain the shorthand 'transition: none' (with zero duration) *)
-  let has_shorthand =
-    Astring.String.is_infix ~affix:"transition:" css_str
-    && Astring.String.is_infix ~affix:"none" css_str
-    && Astring.String.is_infix ~affix:"0s" css_str
-  in
-  check bool "should NOT have shorthand transition: none 0s" false has_shorthand
+  (* Tailwind v4 writes transition-property: none, not the transition shorthand
+     with a zero duration; the whole rule is pinned, so the shorthand cannot
+     come back alongside it. *)
+  check_utilities "motion-reduce:transition-none"
+    {|@media(prefers-reduced-motion:reduce){.motion-reduce\:transition-none{transition-property:none}}|}
 
 (* The class a modifier renders has to be the class it was read from. This is
    the cheap guard on the two spellings staying merged: the class name comes
@@ -608,15 +615,7 @@ let test_variant_inner_order () =
    tokens (--spacing) normal, preserves the class name, and nests under a
    modifier (md:!flex). *)
 let test_important_prefix () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.fail m
-  in
-  let flex = css "!flex" in
-  Alcotest.(check bool)
-    "!flex marks display important" true
-    (Astring.String.is_infix ~affix:"display:flex!important" flex);
+  check_utilities "!flex" {|.\!flex{display:flex!important}|};
   (match Tw.of_string "!flex" with
   | Ok u -> Alcotest.(check string) "!flex class round-trips" "!flex" (Tw.pp u)
   | Error (`Msg m) -> Alcotest.fail m);
@@ -625,15 +624,14 @@ let test_important_prefix () =
       Alcotest.(check string) "md:!flex class round-trips" "md:!flex" (Tw.pp u)
   | Error (`Msg m) -> Alcotest.fail m);
   (* v4 trailing form keeps the suffix in the class name *)
-  Alcotest.(check bool)
-    "flex! marks display important" true
-    (Astring.String.is_infix ~affix:"display:flex!important" (css "flex!"));
+  check_utilities "flex!" {|.flex\!{display:flex!important}|};
   (match Tw.of_string "flex!" with
   | Ok u -> Alcotest.(check string) "flex! class round-trips" "flex!" (Tw.pp u)
   | Error (`Msg m) -> Alcotest.fail m);
-  Alcotest.(check bool)
-    "!p-4 leaves the --spacing theme token normal" false
-    (Astring.String.is_infix ~affix:"--spacing:.25rem!important" (css "!p-4"))
+  (* the theme binding !p-4 drags in stays normal: the whole sheet is compared,
+     so an [!important] appearing on it would fail here *)
+  check_sheet "!p-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{.\!p-4{padding:calc(var(--spacing)*4)!important}}|}
 
 (* [not-has-<X>] reads X as a pseudo-class. The shorthand accepted any text and
    left the selector reader to raise out of [to_css], a pure conversion, while
@@ -658,17 +656,16 @@ let test_not_has_shorthand_selector () =
    dt, dd, table, tr, picture - were not recognised at all, so the class was
    rejected and the utility never reached the element. *)
 let test_prose_element_variants () =
-  let selector name =
-    let cls = "prose-" ^ name ^ ":underline" in
-    match Tw.of_string cls with
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-  in
-  let targets name affix =
-    Alcotest.(check bool)
-      ("prose-" ^ name ^ ": targets " ^ affix)
-      true
-      (Astring.String.is_infix ~affix:(":where(" ^ affix ^ ")") (selector name))
+  (* The variant scopes the utility to a descendant of the prose root, and the
+     [:not(:where([class~=not-prose] ...))] guard is what keeps it off an
+     opted-out subtree, so the whole rule is pinned rather than the element name
+     alone. *)
+  let targets name element =
+    check_utilities
+      ("prose-" ^ name ^ ":underline")
+      (".prose-" ^ name ^ {|\:underline :where(|} ^ element
+     ^ {|):not(:where([class~=not-prose],[class~=not-prose] *)){text-decoration-line:underline}|}
+      )
   in
   List.iter
     (fun n -> targets n n)
@@ -794,17 +791,10 @@ let test_pp_modifier_strings () =
    the right threshold, using Tailwind v4's range syntax ([width >= 20rem]); @xs
    and @3xl+ used to be unknown modifiers. *)
 let test_container_query_scale () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  check bool "@xs:flex is a 20rem container query" true
-    (Astring.String.is_infix ~affix:"@container (width >= 20rem)"
-       (css "@xs:flex"));
-  check bool "@3xl:flex is a 48rem container query" true
-    (Astring.String.is_infix ~affix:"@container (width >= 48rem)"
-       (css "@3xl:flex"));
+  check_utilities "@xs:flex"
+    {|@container(width>=20rem){.\@xs\:flex{display:flex}}|};
+  check_utilities "@3xl:flex"
+    {|@container(width>=48rem){.\@3xl\:flex{display:flex}}|};
   check string "@xs round-trips" "@xs:p-4"
     (Tw.Utility.to_class (Option.get (apply [ "@xs" ] (p 4))))
 
@@ -819,13 +809,20 @@ let test_container_query_min_max () =
   let has cls affix =
     check bool cls true (Astring.String.is_infix ~affix (css cls))
   in
-  has "@min-md:flex" "@container (width >= 28rem)";
-  has "@max-md:flex" "@container (not (width >= 28rem))";
-  has "@min-[20rem]:flex" "@container (width >= 20rem)";
-  has "@max-[40rem]:flex" "@container (not (width >= 40rem))";
-  has "@[480px]:flex" "@container (width >= 480px)";
+  check_utilities "@min-md:flex"
+    {|@container(width>=28rem){.\@min-md\:flex{display:flex}}|};
+  check_utilities "@max-md:flex"
+    {|@container not (width>=28rem){.\@max-md\:flex{display:flex}}|};
+  check_utilities "@min-[20rem]:flex"
+    {|@container(width>=20rem){.\@min-\[20rem\]\:flex{display:flex}}|};
+  check_utilities "@max-[40rem]:flex"
+    {|@container not (width>=40rem){.\@max-\[40rem\]\:flex{display:flex}}|};
+  check_utilities "@[480px]:flex"
+    {|@container(width>=480px){.\@\[480px\]\:flex{display:flex}}|};
   (* A theme(--breakpoint-lg) arbitrary value resolves to the breakpoint the
-     [lg:] variant uses (64rem). *)
+     [lg:] variant uses (64rem). These two stay on a substring: the pinned CLI
+     also writes [--breakpoint-lg: 64rem] into the theme layer and tw does not,
+     so the sheets cannot be compared whole without encoding that gap. *)
   has "@min-[theme(--breakpoint-lg)]:flex" "@container (width >= 64rem)";
   has "@max-[theme(--breakpoint-lg)]:flex" "@container (not (width >= 64rem))";
   check string "@max-md round-trips" "@max-md:p-4"
@@ -853,23 +850,19 @@ let test_apply_bracketed_has () =
    checked: the name resolves to the pseudo-class that state matches, and
    has-hover keeps the pointer gate hover itself carries. *)
 let test_has_state_shorthands () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has_infix affix cls =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has_infix ".has-focus\\:flex:has(:focus)" "has-focus:flex";
-  has_infix ".has-focus-visible\\:flex:has(:focus-visible)"
-    "has-focus-visible:flex";
-  has_infix ".has-first\\:flex:has(:first-child)" "has-first:flex";
-  has_infix ".has-odd\\:flex:has(:nth-child(odd))" "has-odd:flex";
-  has_infix ".group-has-focus\\:flex:is(:where(.group):has(:focus) *)"
-    "group-has-focus:flex";
-  check bool "has-hover keeps the pointer gate" true
-    (Astring.String.is_infix ~affix:"@media(hover:hover)" (css "has-hover:flex"));
+  check_utilities "has-focus:flex"
+    {|.has-focus\:flex:has(:focus){display:flex}|};
+  check_utilities "has-focus-visible:flex"
+    {|.has-focus-visible\:flex:has(:focus-visible){display:flex}|};
+  check_utilities "has-first:flex"
+    {|.has-first\:flex:has(:first-child){display:flex}|};
+  check_utilities "has-odd:flex"
+    {|.has-odd\:flex:has(:nth-child(odd)){display:flex}|};
+  check_utilities "group-has-focus:flex"
+    {|.group-has-focus\:flex:is(:where(.group):has(:focus) *){display:flex}|};
+  (* has-hover keeps the pointer gate hover itself carries *)
+  check_utilities "has-hover:flex"
+    {|@media(hover:hover){.has-hover\:flex:has(:hover){display:flex}}|};
   (* the class name round-trips through the shorthand, not the bracket form *)
   check string "has-focus round-trips" "has-focus:flex"
     (Tw.pp (Result.get_ok (Tw.of_string "has-focus:flex")))
@@ -879,50 +872,31 @@ let test_has_state_shorthands () =
    attribute shorthand under group-/peer- too, keeping a class name distinct
    from the bracket spelling. *)
 let test_named_anchor_and_bare_data () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "group-hover/edit:underline"
-    ".group-hover\\/edit\\:underline:is(:where(.group\\/edit):hover *)";
-  has "group-focus/option:underline"
-    ".group-focus\\/option\\:underline:is(:where(.group\\/option):focus *)";
-  has "peer-checked/draft:block"
-    ".peer-checked\\/draft\\:block:is(:where(.peer\\/draft):checked~*)";
-  has "group-data-modified:italic"
-    ".group-data-modified\\:italic:is(:where(.group)[data-modified] *)";
-  (* the bracket spelling keeps its own class name *)
-  has "group-data-[modified]:italic"
-    ".group-data-\\[modified\\]\\:italic:is(:where(.group)[data-modified] *)";
   (* group-hover gates on the pointer, as a plain hover does *)
-  check bool "group-hover/edit keeps the pointer gate" true
-    (Astring.String.is_infix ~affix:"@media(hover:hover)"
-       (css "group-hover/edit:underline"))
+  check_utilities "group-hover/edit:underline"
+    {|@media(hover:hover){.group-hover\/edit\:underline:is(:where(.group\/edit):hover *){text-decoration-line:underline}}|};
+  check_utilities "group-focus/option:underline"
+    {|.group-focus\/option\:underline:is(:where(.group\/option):focus *){text-decoration-line:underline}|};
+  check_utilities "peer-checked/draft:block"
+    {|.peer-checked\/draft\:block:is(:where(.peer\/draft):checked~*){display:block}|};
+  check_utilities "group-data-modified:italic"
+    {|.group-data-modified\:italic:is(:where(.group)[data-modified] *){font-style:italic}|};
+  (* the bracket spelling keeps its own class name *)
+  check_utilities "group-data-[modified]:italic"
+    {|.group-data-\[modified\]\:italic:is(:where(.group)[data-modified] *){font-style:italic}|}
 
 (* [has-data-lg] matches an attribute rather than a state but spells itself the
    same way, and [not-] composes over any variant, including a scoped
    [group-has-]: the negation wraps the whole relative selector. *)
 let test_has_data_and_not_composition () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "has-data-lg:opacity-40" ".has-data-lg\\:opacity-40:has([data-lg])";
-  has "group-has-data-lg:opacity-40"
-    ".group-has-data-lg\\:opacity-40:is(:where(.group):has([data-lg]) *)";
-  has "not-group-has-data-lg:opacity-40"
-    ".not-group-has-data-lg\\:opacity-40:not(:is(:where(.group):has([data-lg]) \
-     *))";
-  has "not-peer-has-checked:opacity-0"
-    ".not-peer-has-checked\\:opacity-0:not(:is(:where(.peer):has(:checked)~*))"
+  check_utilities "has-data-lg:opacity-40"
+    {|.has-data-lg\:opacity-40:has([data-lg]){opacity:.4}|};
+  check_utilities "group-has-data-lg:opacity-40"
+    {|.group-has-data-lg\:opacity-40:is(:where(.group):has([data-lg]) *){opacity:.4}|};
+  check_utilities "not-group-has-data-lg:opacity-40"
+    {|.not-group-has-data-lg\:opacity-40:not(:is(:where(.group):has([data-lg]) *)){opacity:.4}|};
+  check_utilities "not-peer-has-checked:opacity-0"
+    {|.not-peer-has-checked\:opacity-0:not(:is(:where(.peer):has(:checked)~*)){opacity:0}|}
 
 (* A bracket [has-] argument is one arbitrary relative selector, so Tailwind
    wraps it in [:is()], including a bare type selector. The brackets stay in the
@@ -937,64 +911,61 @@ let test_has_bracket_arguments () =
   let has cls affix =
     check bool cls true (Astring.String.is_infix ~affix (css cls))
   in
-  has "has-[[data-a],[data-b]]:block" ":has(:is([data-a], [data-b]))";
-  has "has-[a]:block" ".has-\\[a\\]\\:block:has(:is(a))";
-  has "has-[:focus]:block" ".has-\\[\\:focus\\]\\:block:has(:focus)";
-  has "has-[.item]:block" ".has-\\[\\.item\\]\\:block:has(.item)";
-  has "has-[a_.item]:block" ".has-\\[a_\\.item\\]\\:block:has(:is(a .item))";
-  has "has-[&>img]:block" ".has-\\[\\&\\>img\\]\\:block:has(*>img)";
-  has "group-has-[a]:block"
-    ".group-has-\\[a\\]\\:block:is(:where(.group):has(:is(a)) *)";
-  has "peer-has-[a]:block"
-    ".peer-has-\\[a\\]\\:block:is(:where(.peer):has(:is(a))~*)";
-  has "group-not-has-[[data-hover],[data-focus]]:block"
-    ":not(:has(:is([data-hover], [data-focus])))";
-  (* the hocus shorthand really is two selectors and stays a list *)
+  check_utilities "has-[[data-a],[data-b]]:block"
+    {|.has-\[\[data-a\]\,\[data-b\]\]\:block:has(:is([data-a], [data-b])){display:block}|};
+  check_utilities "has-[a]:block"
+    {|.has-\[a\]\:block:has(:is(a)){display:block}|};
+  check_utilities "has-[:focus]:block"
+    {|.has-\[\:focus\]\:block:has(:focus){display:block}|};
+  check_utilities "has-[.item]:block"
+    {|.has-\[\.item\]\:block:has(.item){display:block}|};
+  check_utilities "has-[a_.item]:block"
+    {|.has-\[a_\.item\]\:block:has(:is(a .item)){display:block}|};
+  check_utilities "has-[&>img]:block"
+    {|.has-\[\&\>img\]\:block:has(*>img){display:block}|};
+  check_utilities "group-has-[a]:block"
+    {|.group-has-\[a\]\:block:is(:where(.group):has(:is(a)) *){display:block}|};
+  check_utilities "peer-has-[a]:block"
+    {|.peer-has-\[a\]\:block:is(:where(.peer):has(:is(a))~*){display:block}|};
+  check_utilities "group-not-has-[[data-hover],[data-focus]]:block"
+    {|.group-not-has-\[\[data-hover\]\,\[data-focus\]\]\:block:is(:where(.group):not(:has(:is([data-hover], [data-focus]))) *){display:block}|};
+  (* The hocus shorthand really is two selectors and stays a list. It stays on a
+     substring: the pinned CLI emits nothing at all for [has-hocus], so pinning
+     the sheet would pin a rule only tw writes. *)
   has "has-hocus:flex" ":has(:hover,:focus)"
 
 (* A group or peer bracket without an [&] attaches its compound to the anchor:
    group-[.is-published] scopes to a .group that also has that class. It used to
    be an unknown class, since the anchor had to be spelled. *)
 let test_anchor_bracket_without_ampersand () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "group-[.is-published]:block" ":is(:where(.group).is-published *)";
-  has "peer-[.is-dirty]:block" ":is(:where(.peer).is-dirty~*)";
+  check_utilities "group-[.is-published]:block"
+    {|.group-\[\.is-published\]\:block:is(:where(.group).is-published *){display:block}|};
+  check_utilities "peer-[.is-dirty]:block"
+    {|.peer-\[\.is-dirty\]\:block:is(:where(.peer).is-dirty~*){display:block}|};
   (* the spelled anchor still works *)
-  has "group-[&:hover]:block" ":is(:where(.group):hover *)"
+  check_utilities "group-[&:hover]:block"
+    {|.group-\[\&\:hover\]\:block:is(:where(.group):hover *){display:block}|}
 
 (* What follows the [&] anchor in a group or peer bracket is a selector, so it
    is read as one. A pseudo-class outside a short hand-written list came out as
    a class literally named [:defined], and a compound remainder was taken whole
    as an element name, so [&_p.foo] named an element [p.foo]. *)
 let test_anchor_bracket_reads_remainder () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "group-[&:defined]:flex"
-    {|.group-\[\&\:defined\]\:flex:is(:where(.group):defined *)|};
-  has "group-[&:nth-child(2)]:flex"
-    {|.group-\[\&\:nth-child\(2\)\]\:flex:is(:where(.group):nth-child(2) *)|};
-  has "group-[&_p.foo]:flex"
-    {|.group-\[\&_p\.foo\]\:flex:is(:where(.group) p.foo *)|};
+  check_utilities "group-[&:defined]:flex"
+    {|.group-\[\&\:defined\]\:flex:is(:where(.group):defined *){display:flex}|};
+  check_utilities "group-[&:nth-child(2)]:flex"
+    {|.group-\[\&\:nth-child\(2\)\]\:flex:is(:where(.group):nth-child(2) *){display:flex}|};
+  check_utilities "group-[&_p.foo]:flex"
+    {|.group-\[\&_p\.foo\]\:flex:is(:where(.group) p.foo *){display:flex}|};
   (* the spellings that already worked stay byte-identical *)
-  has "group-[&:hover]:flex"
-    {|.group-\[\&\:hover\]\:flex:is(:where(.group):hover *)|};
-  has "group-[&_p]:flex" {|.group-\[\&_p\]\:flex:is(:where(.group) p *)|};
-  has "group-[:nth-of-type(3)_&]:flex" {|:is(:nth-of-type(3) :where(.group) *)|};
-  has "peer-[&:hover]:flex"
-    {|.peer-\[\&\:hover\]\:flex:is(:where(.peer):hover~*)|}
+  check_utilities "group-[&:hover]:flex"
+    {|.group-\[\&\:hover\]\:flex:is(:where(.group):hover *){display:flex}|};
+  check_utilities "group-[&_p]:flex"
+    {|.group-\[\&_p\]\:flex:is(:where(.group) p *){display:flex}|};
+  check_utilities "group-[:nth-of-type(3)_&]:flex"
+    {|.group-\[\:nth-of-type\(3\)_\&\]\:flex:is(:nth-of-type(3) :where(.group) *){display:flex}|};
+  check_utilities "peer-[&:hover]:flex"
+    {|.peer-\[\&\:hover\]\:flex:is(:where(.peer):hover~*){display:flex}|}
 
 (* Test ARIA and data modifiers class names *)
 let test_aria_and_data_modifiers () =
@@ -1074,25 +1045,11 @@ let test_nested_modifier_class_names () =
 
 (* Test CSS generation for nested modifiers *)
 let test_nested_modifier_css_generation () =
-  (* Ensure dark:hover: generates valid CSS with proper media query nesting *)
-  let utilities = [ dark [ hover [ bg blue ] ] ] in
-  let css_str = Tw.Css.to_string ~minify:true (Tw.Build.to_css utilities) in
-
-  (* Should contain the escaped class name *)
-  let has_class =
-    Astring.String.is_infix ~affix:{|dark\:hover\:bg-blue-500|} css_str
-  in
-  check bool "CSS contains dark:hover: class selector" true has_class;
-
-  (* Should contain prefers-color-scheme:dark media query *)
-  let has_dark_media =
-    Astring.String.is_infix ~affix:"prefers-color-scheme" css_str
-    && Astring.String.is_infix ~affix:"dark" css_str
-  in
-  check bool "CSS contains dark mode media query" true has_dark_media;
-
-  (* Should parse correctly *)
-  match Tw.Css.of_string css_str with
+  (* dark:hover: nests one media query inside the other, in the order the class
+     spells them, and keeps the escaped class name. *)
+  check_sheet "dark:hover:bg-blue-500"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-blue-500:oklch(62.3%.214 259.815)}}@layer components;@layer utilities{@media(prefers-color-scheme:dark){@media(hover:hover){.dark\:hover\:bg-blue-500:hover{background-color:var(--color-blue-500)}}}}|};
+  match Tw.Css.of_string (sheet "dark:hover:bg-blue-500") with
   | Ok _ -> ()
   | Error e ->
       Alcotest.failf "Nested modifier CSS parse failed:\n%s"
@@ -1104,16 +1061,10 @@ let test_nested_modifier_css_generation () =
    .os-macos descendants). It used to escape the bracket content as one class
    name instead. *)
 let test_not_bracket_arbitrary_selector () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  check bool "not-[.os-macos_&]:block negates the descendant context" true
-    (Astring.String.is_infix ~affix:":not(.os-macos *)"
-       (css "not-[.os-macos_&]:block"));
-  check bool "not-[.foo]:block negates a plain class" true
-    (Astring.String.is_infix ~affix:":not(.foo)" (css "not-[.foo]:block"))
+  check_utilities "not-[.os-macos_&]:block"
+    {|.not-\[\.os-macos_\&\]\:block:not(.os-macos *){display:block}|};
+  check_utilities "not-[.foo]:block"
+    {|.not-\[\.foo\]\:block:not(.foo){display:block}|}
 
 (* The bracket is negated as a selector, so content the selector grammar cannot
    read is not a negation and the class is refused at parse time. The reader
@@ -1153,17 +1104,10 @@ let test_not_bracket_unreadable_selector_rejected () =
    (e.g. group-[:nth-of-type(3)_&]) keeps that prefix ahead of the anchor,
    rather than dropping it down to just :where(.group). *)
 let test_group_arbitrary_prefix () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  check bool "group-[:nth-of-type(3)_&] keeps the prefix" true
-    (Astring.String.is_infix ~affix:":is(:nth-of-type(3) :where(.group) *)"
-       (css "group-[:nth-of-type(3)_&]:block"));
-  check bool "group-[&_p] anchor-first still works" true
-    (Astring.String.is_infix ~affix:":is(:where(.group) p *)"
-       (css "group-[&_p]:block"))
+  check_utilities "group-[:nth-of-type(3)_&]:block"
+    {|.group-\[\:nth-of-type\(3\)_\&\]\:block:is(:nth-of-type(3) :where(.group) *){display:block}|};
+  check_utilities "group-[&_p]:block"
+    {|.group-\[\&_p\]\:block:is(:where(.group) p *){display:block}|}
 
 (* An nth-* bracket holds an An+B expression and a supports- bracket holds an
    @supports condition; both are taken verbatim, so content the CSS grammar has
@@ -1216,21 +1160,20 @@ let test_padded_attribute_brackets () =
 (* The attribute spellings that do name something keep working, including the
    empty-name-with-value form Tailwind also accepts. *)
 let test_attribute_brackets_still_parse () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits affix cls =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "[aria-modal]" "aria-[modal]:flex";
-  emits "[aria-sort=ascending]" "aria-[sort=ascending]:flex";
-  emits "[aria-=true]" "aria-[=true]:flex";
-  emits "[data-state=open]" "data-[state=open]:flex";
-  emits "[data-dragging]" "group-data-[dragging]:flex";
-  emits "[data-dragging]" "peer-data-[dragging]:flex";
-  emits "[data-modified]" "group-data-modified:flex"
+  check_utilities "aria-[modal]:flex"
+    {|.aria-\[modal\]\:flex[aria-modal]{display:flex}|};
+  check_utilities "aria-[sort=ascending]:flex"
+    {|.aria-\[sort\=ascending\]\:flex[aria-sort=ascending]{display:flex}|};
+  check_utilities "aria-[=true]:flex"
+    {|.aria-\[\=true\]\:flex[aria-=true]{display:flex}|};
+  check_utilities "data-[state=open]:flex"
+    {|.data-\[state\=open\]\:flex[data-state=open]{display:flex}|};
+  check_utilities "group-data-[dragging]:flex"
+    {|.group-data-\[dragging\]\:flex:is(:where(.group)[data-dragging] *){display:flex}|};
+  check_utilities "peer-data-[dragging]:flex"
+    {|.peer-data-\[dragging\]\:flex:is(:where(.peer)[data-dragging]~*){display:flex}|};
+  check_utilities "group-data-modified:flex"
+    {|.group-data-modified\:flex:is(:where(.group)[data-modified] *){display:flex}|}
 
 (* [parse_data_expr] reads the [data-[...]] bracket body into an attribute
    match: every operator ([$=], [^=], [*=], [~=], [|=], bare [=]), the
@@ -1246,18 +1189,31 @@ let test_data_bracket_operators () =
   let emits affix cls =
     check bool cls true (Astring.String.is_infix ~affix (css cls))
   in
-  emits "[data-size~=large]" "data-[size~=large]:flex";
-  emits "[data-foo=bar]" "data-[foo=bar]:flex";
-  emits "[data-foo^=bar]" "data-[foo^=bar]:flex";
-  emits "[data-foo$=bar]" "data-[foo$=bar]:flex";
-  emits "[data-foo*=bar]" "data-[foo*=bar]:flex";
-  emits "[data-foo|=bar]" "data-[foo|=bar]:flex";
-  emits "[data-open]" "data-[open]:flex";
+  check_utilities "data-[size~=large]:flex"
+    {|.data-\[size\~\=large\]\:flex[data-size~=large]{display:flex}|};
+  check_utilities "data-[foo=bar]:flex"
+    {|.data-\[foo\=bar\]\:flex[data-foo=bar]{display:flex}|};
+  check_utilities "data-[foo^=bar]:flex"
+    {|.data-\[foo\^\=bar\]\:flex[data-foo^=bar]{display:flex}|};
+  check_utilities "data-[foo$=bar]:flex"
+    {|.data-\[foo\$\=bar\]\:flex[data-foo$=bar]{display:flex}|};
+  check_utilities "data-[foo*=bar]:flex"
+    {|.data-\[foo\*\=bar\]\:flex[data-foo*=bar]{display:flex}|};
+  check_utilities "data-[foo|=bar]:flex"
+    {|.data-\[foo\|\=bar\]\:flex[data-foo|=bar]{display:flex}|};
+  check_utilities "data-[open]:flex"
+    {|.data-\[open\]\:flex[data-open]{display:flex}|};
+  (* A decoded space in the value stays on a substring: tw quotes the attribute
+     value where the pinned CLI escapes the space instead ([data-foo=a\ b]). *)
   emits {|[data-foo="a b"]|} "data-[foo='a_b']:flex";
-  emits "[data-foo=bar i]" "data-[foo=bar_i]:flex";
-  emits "[data-foo=bar s]" "data-[foo=bar_s]:flex";
-  emits "[data-size~=large]" "group-data-[size~=large]:flex";
-  emits "[data-size~=large]" "peer-data-[size~=large]:flex"
+  check_utilities "data-[foo=bar_i]:flex"
+    {|.data-\[foo\=bar_i\]\:flex[data-foo=bar i]{display:flex}|};
+  check_utilities "data-[foo=bar_s]:flex"
+    {|.data-\[foo\=bar_s\]\:flex[data-foo=bar s]{display:flex}|};
+  check_utilities "group-data-[size~=large]:flex"
+    {|.group-data-\[size\~\=large\]\:flex:is(:where(.group)[data-size~=large] *){display:flex}|};
+  check_utilities "peer-data-[size~=large]:flex"
+    {|.peer-data-\[size\~\=large\]\:flex:is(:where(.peer)[data-size~=large]~*){display:flex}|}
 
 (* A bare [[...]] variant compounds its selector onto the utility's own class,
    so what the brackets hold has to be a compound selector. [~] is both the
@@ -1265,25 +1221,22 @@ let test_data_bracket_operators () =
    reading the bracket as a selector tells them apart: a character scan that
    rejects every [~] rejects [[data-size~=large]] along with [p_~_span]. *)
 let test_bare_selector_variant_attribute_operators () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits affix cls =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
   let rejected cls =
     match Tw.of_string cls with
     | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
     | Error _ -> ()
   in
-  emits "[data-size~=large]" "[[data-size~=large]]:underline";
-  emits "[data-size~=large]" "group-[[data-size~=large]]:underline";
-  emits "[data-size~=large]" "peer-[[data-size~=large]]:underline";
+  check_utilities "[[data-size~=large]]:underline"
+    {|.\[\[data-size\~\=large\]\]\:underline[data-size~=large]{text-decoration-line:underline}|};
+  check_utilities "group-[[data-size~=large]]:underline"
+    {|.group-\[\[data-size\~\=large\]\]\:underline:is(:where(.group)[data-size~=large] *){text-decoration-line:underline}|};
+  check_utilities "peer-[[data-size~=large]]:underline"
+    {|.peer-\[\[data-size\~\=large\]\]\:underline:is(:where(.peer)[data-size~=large]~*){text-decoration-line:underline}|};
   (* the attribute operators that never collided with a combinator stay put *)
-  emits "[lang|=en]" "[[lang|=en]]:underline";
-  emits "[href^=https]" "[[href^=https]]:underline";
+  check_utilities "[[lang|=en]]:underline"
+    {|.\[\[lang\|\=en\]\]\:underline[lang|=en]{text-decoration-line:underline}|};
+  check_utilities "[[href^=https]]:underline"
+    {|.\[\[href\^\=https\]\]\:underline[href^=https]{text-decoration-line:underline}|};
   (* a combinator really is one, and none of these is a compound *)
   rejected "[p_~_span]:underline";
   rejected "[>img]:underline";
@@ -1292,19 +1245,15 @@ let test_bare_selector_variant_attribute_operators () =
 
 (* The valid spellings the validation must keep accepting. *)
 let test_valid_bracket_modifiers () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits affix cls =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits ":nth-child(2n+1)" "nth-[2n+1]:flex";
-  emits ":nth-child(3)" "nth-[3]:flex";
-  emits ":nth-last-child(2n)" "nth-last-[2n]:flex";
-  emits ":nth-of-type(odd)" "nth-of-type-[odd]:flex";
-  emits "@supports (display: grid)" "supports-[display:grid]:flex"
+  check_utilities "nth-[2n+1]:flex"
+    {|.nth-\[2n\+1\]\:flex:nth-child(odd){display:flex}|};
+  check_utilities "nth-[3]:flex" {|.nth-\[3\]\:flex:nth-child(3){display:flex}|};
+  check_utilities "nth-last-[2n]:flex"
+    {|.nth-last-\[2n\]\:flex:nth-last-child(2n){display:flex}|};
+  check_utilities "nth-of-type-[odd]:flex"
+    {|.nth-of-type-\[odd\]\:flex:nth-of-type(odd){display:flex}|};
+  check_utilities "supports-[display:grid]:flex"
+    {|@supports(display:grid){.supports-\[display\:grid\]\:flex{display:flex}}|}
 
 (* A [supports-<property>] test names the property the author wrote, even for a
    property browsers once shipped behind a vendor prefix: Tailwind emits
@@ -1324,12 +1273,19 @@ let test_supports_property_is_unprefixed () =
     check bool cls false (Astring.String.is_infix ~affix:"-webkit-" css);
     check bool cls false (Astring.String.is_infix ~affix:"-moz-" css)
   in
-  emits "@supports (hyphens: var(--tw))" "supports-hyphens:flex";
-  emits "@supports (user-select: var(--tw))" "supports-user-select:flex";
-  emits "@supports (user-select: var(--tw))" "supports-[user-select]:flex";
+  check_utilities "supports-hyphens:flex"
+    {|@supports(hyphens:var(--tw)){.supports-hyphens\:flex{display:flex}}|};
+  check_utilities "supports-user-select:flex"
+    {|@supports(user-select:var(--tw)){.supports-user-select\:flex{display:flex}}|};
+  check_utilities "supports-[user-select]:flex"
+    {|@supports(user-select:var(--tw)){.supports-\[user-select\]\:flex{display:flex}}|};
+  (* text-size-adjust stays on a substring: the pinned CLI's own prefixing turns
+     the condition into three alternatives ([-webkit-], [-moz-], plain) where
+     tw's leaves one, so the sheets cannot be compared whole. *)
   emits "@supports (text-size-adjust: var(--tw))"
     "supports-text-size-adjust:flex";
-  emits "@supports (backdrop-filter: var(--tw))" "supports-backdrop-filter:flex";
+  check_utilities "supports-backdrop-filter:flex"
+    {|@supports(backdrop-filter:var(--tw)){.supports-backdrop-filter\:flex{display:flex}}|};
   unprefixed "supports-hyphens:flex";
   unprefixed "supports-user-select:flex";
   unprefixed "supports-text-size-adjust:flex";
@@ -1342,31 +1298,14 @@ let test_supports_property_is_unprefixed () =
    applied unconditionally and matched a class the author never wrote. Tailwind
    nests the two in the order the class spells them. *)
 let test_at_rule_variant_over_media () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits cls affixes =
-    let out = css cls in
-    List.iter
-      (fun affix ->
-        check bool
-          (cls ^ " emits " ^ affix)
-          true
-          (Astring.String.is_infix ~affix out))
-      affixes
-  in
-  emits "supports-grid:sm:flex"
-    [
-      "@supports (grid: var(--tw))";
-      "min-width: 40rem";
-      ".supports-grid\\:sm\\:flex";
-    ];
-  emits "not-supports-grid:sm:flex"
-    [ "@supports not (grid: var(--tw))"; "min-width: 40rem" ];
-  emits "starting:sm:flex" [ "@starting-style"; "min-width: 40rem" ];
-  emits "@md:sm:flex" [ "@container"; "min-width: 40rem" ]
+  check_utilities "supports-grid:sm:flex"
+    {|@supports(grid:var(--tw)){@media(min-width:40rem){.supports-grid\:sm\:flex{display:flex}}}|};
+  check_utilities "not-supports-grid:sm:flex"
+    {|@supports not (grid:var(--tw)){@media(min-width:40rem){.not-supports-grid\:sm\:flex{display:flex}}}|};
+  check_utilities "starting:sm:flex"
+    {|@starting-style{@media(min-width:40rem){.starting\:sm\:flex{display:flex}}}|};
+  check_utilities "@md:sm:flex"
+    {|@container(width>=28rem){@media(min-width:40rem){.\@md\:sm\:flex{display:flex}}}|}
 
 (* A container query is not a [not-*] inner. Tailwind rejects the class
    outright; tw built a rule whose selector negates the utility's own class
@@ -1422,12 +1361,17 @@ let test_variant_underscore_escape () =
       true
       (Astring.String.is_infix ~affix (css cls))
   in
-  has {|data-[foo=bar\_baz]:flex|} {|[data-foo="bar_baz"]|};
-  has {|supports-[--a\_b]:flex|} "@supports (--a_b: var(--tw))";
-  has {|[.a\_b]:flex|} ".a_b";
-  has {|group-[.a\_b_&]:flex|} ":is(.a_b :where(.group) *)";
-  has {|nth-[2n+1_of_.a\_b]:flex|} ":nth-child(2n+1 of .a_b)";
-  (* A bare [_] still stands for a space. *)
+  check_utilities {|data-[foo=bar\_baz]:flex|}
+    {|.data-\[foo\=bar\\_baz\]\:flex[data-foo=bar_baz]{display:flex}|};
+  check_utilities {|supports-[--a\_b]:flex|}
+    {|@supports(--a_b:var(--tw)){.supports-\[--a\\_b\]\:flex{display:flex}}|};
+  check_utilities {|[.a\_b]:flex|} {|.\[\.a\\_b\]\:flex.a_b{display:flex}|};
+  check_utilities {|group-[.a\_b_&]:flex|}
+    {|.group-\[\.a\\_b_\&\]\:flex:is(.a_b :where(.group) *){display:flex}|};
+  check_utilities {|nth-[2n+1_of_.a\_b]:flex|}
+    {|.nth-\[2n\+1_of_\.a\\_b\]\:flex:nth-child(odd of.a_b){display:flex}|};
+  (* A bare [_] still stands for a space. This one stays on a substring: tw
+     quotes the attribute value where the pinned CLI escapes the space. *)
   has "data-[foo=bar_baz]:flex" {|[data-foo="bar baz"]|}
 
 (* Extend the suite with new tests *)

--- a/test/test_sizing.ml
+++ b/test/test_sizing.ml
@@ -169,24 +169,12 @@ let test_aspect_classes () =
   Alcotest.check string "ratio class" "aspect-16/9" (Tw.pp (aspect_ratio 16 9))
 
 let test_aspect_css () =
-  let open Tw in
-  let css = to_css [ aspect_ratio 16 9 ] |> Css.to_string ~minify:true in
-  Alcotest.check bool "has aspect-ratio" true
-    (Astring.String.is_infix ~affix:"aspect-ratio" css);
-  Alcotest.check bool "has 16/9" true
-    (Astring.String.is_infix ~affix:"16/9" css)
+  check_declarations "aspect-16/9" [ "aspect-ratio:16/9" ]
 
 (* A bare-number arbitrary ratio (aspect-[1.333]) is a single-value
    aspect-ratio; it minifies to just the number, and round-trips. *)
 let test_aspect_bracket_number () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  Alcotest.(check bool)
-    "aspect-[1.333] is aspect-ratio:1.333" true
-    (Astring.String.is_infix ~affix:"aspect-ratio:1.333" (css "aspect-[1.333]"));
+  check_declarations "aspect-[1.333]" [ "aspect-ratio:1.333" ];
   Alcotest.(check string)
     "aspect-[1.333] round-trips" "aspect-[1.333]"
     (Tw.pp (Result.get_ok (Tw.of_string "aspect-[1.333]")))
@@ -194,29 +182,17 @@ let test_aspect_bracket_number () =
 (* A fraction on a logical min/max inline or block axis resolves to a
    percentage, like the physical max-w/max-h families do. *)
 let test_logical_size_fractions () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " is " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css cls))
-  in
-  has "max-block-1/2" "max-block-size:50%";
-  has "min-block-1/3" "min-block-size:33.3333%";
-  has "max-inline-3/4" "max-inline-size:75%";
-  has "min-inline-2/3" "min-inline-size:66.6667%"
+  check_declarations "max-block-1/2" [ "max-block-size:50%" ];
+  check_declarations "min-block-1/3" [ "min-block-size:33.3333%" ];
+  check_declarations "max-inline-3/4" [ "max-inline-size:75%" ];
+  check_declarations "min-inline-2/3" [ "min-inline-size:66.6667%" ]
 
 (* aspect-square inlines the 1/1 ratio in v4; it used to emit aspect-ratio:
    var(--aspect-square) with a stray --aspect-square theme token that bare
    Tailwind does not define. *)
 let test_aspect_square_inlined () =
   let css = Tw.(to_css [ aspect_square ]) |> Tw.Css.to_string ~minify:true in
-  Alcotest.check bool "aspect-square inlines the ratio" true
-    (Astring.String.is_infix ~affix:"aspect-ratio:1" css);
+  check_declarations "aspect-square" [ "aspect-ratio:1" ];
   Alcotest.check bool "aspect-square references no var" false
     (Astring.String.is_infix ~affix:"var(--aspect-square)" css);
   Alcotest.check bool "aspect-square emits no --aspect-square token" false
@@ -238,31 +214,17 @@ let test_class_generation () =
   Alcotest.check string "h 10 -> h-10" "h-10" (Tw.pp (h 10));
   Alcotest.check string "h 64 -> h-64" "h-64" (Tw.pp (h 64));
 
-  (* Verify CSS values are correct. These use calc(var(--spacing)*N) format
-     where N is the class number (NOT the rem value). Tailwind v4: w-64 =>
-     calc(var(--spacing)*64), h-10 => calc(var(--spacing)*10) *)
-  let css_for cls = Tw.to_css [ cls ] |> Tw.Css.to_string ~minify:true in
-  (* w-64 => calc(var(--spacing)*64) *)
-  Alcotest.check bool "w-64 uses spacing*64" true
-    (Astring.String.is_infix ~affix:"*64)" (css_for (w 64)));
-  (* h-10 => calc(var(--spacing)*10) *)
-  Alcotest.check bool "h-10 uses spacing*10" true
-    (Astring.String.is_infix ~affix:"*10)" (css_for (h 10)));
-  (* w-4 => calc(var(--spacing)*4) *)
-  Alcotest.check bool "w-4 uses spacing*4" true
-    (Astring.String.is_infix ~affix:"*4)" (css_for (w 4)));
-  (* min-w-64 => calc(var(--spacing)*64) *)
-  Alcotest.check bool "min_w 64 uses spacing*64" true
-    (Astring.String.is_infix ~affix:"*64)" (css_for (min_w 64)));
-  (* max-h-32 => calc(var(--spacing)*32) *)
-  Alcotest.check bool "max_h 32 uses spacing*32" true
-    (Astring.String.is_infix ~affix:"*32)" (css_for (max_h 32)));
-  (* size-64 => calc(var(--spacing)*64) for both width and height *)
-  Alcotest.check bool "size 64 uses spacing*64" true
-    (Astring.String.is_infix ~affix:"*64)" (css_for (size 64)));
-  (* size-4 => calc(var(--spacing)*4) *)
-  Alcotest.check bool "size 4 uses spacing*4" true
-    (Astring.String.is_infix ~affix:"*4)" (css_for (size 4)))
+  (* The value is calc(var(--spacing)*N) with N the class number, not the rem it
+     works out to. [size-*] writes both axes, in that order. *)
+  check_declarations "w-64" [ "width:calc(var(--spacing)*64)" ];
+  check_declarations "h-10" [ "height:calc(var(--spacing)*10)" ];
+  check_declarations "w-4" [ "width:calc(var(--spacing)*4)" ];
+  check_declarations "min-w-64" [ "min-width:calc(var(--spacing)*64)" ];
+  check_declarations "max-h-32" [ "max-height:calc(var(--spacing)*32)" ];
+  check_declarations "size-64"
+    [ "width:calc(var(--spacing)*64)"; "height:calc(var(--spacing)*64)" ];
+  check_declarations "size-4"
+    [ "width:calc(var(--spacing)*4)"; "height:calc(var(--spacing)*4)" ]
 
 (* The logical sizing utilities are registered after every other utility in
    Tailwind, so they sort last rather than beside w-* and h-*, and among
@@ -400,111 +362,82 @@ let fraction_interleave_matches_tailwind () =
     ~test_name:"sizing fraction interleave matches Tailwind"
     (Test_helpers.shuffle utilities)
 
-let css_of cls =
+(* The whole sheet, theme bindings included, for the one claim that reaches past
+   what the class writes on its own element. *)
+let sheet_of cls =
   match Tw.of_string cls with
-  | Ok s -> Tw.to_css ~base:false [ s ] |> Css.to_string
+  | Ok s -> Tw.to_css ~base:false [ s ] |> Css.to_string ~minify:true
   | Error _ -> Alcotest.failf "could not parse %S" cls
 
 (* Fractional spacing steps must scale --spacing, not truncate to 0. *)
 let test_fractional_spacing () =
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " contains " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css_of cls))
-  in
-  has "h-0.5" "height: calc(var(--spacing) * .5)";
-  has "w-0.5" "width: calc(var(--spacing) * .5)";
-  has "size-0.5" "calc(var(--spacing) * .5)";
-  has "h-2.5" "height: calc(var(--spacing) * 2.5)"
+  check_declarations "h-0.5" [ "height:calc(var(--spacing)*.5)" ];
+  check_declarations "w-0.5" [ "width:calc(var(--spacing)*.5)" ];
+  check_declarations "size-0.5"
+    [ "width:calc(var(--spacing)*.5)"; "height:calc(var(--spacing)*.5)" ];
+  check_declarations "h-2.5" [ "height:calc(var(--spacing)*2.5)" ]
 
 (* Fractional sizing accepts any n/m with a Tailwind denominator (2,3,4,5,6,12),
    not just the originally hardcoded handful; the percentage matches the CLI's
    folded calc(n/m*100%) at 6 significant figures. *)
 let test_general_fractions () =
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " contains " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css_of cls))
-  in
-  has "w-4/12" "width: 33.3333%";
-  has "w-8/12" "width: 66.6667%";
-  has "w-1/12" "width: 8.33333%";
-  has "h-2/6" "height: 33.3333%"
+  check_declarations "w-4/12" [ "width:33.3333%" ];
+  check_declarations "w-8/12" [ "width:66.6667%" ];
+  check_declarations "w-1/12" [ "width:8.33333%" ];
+  check_declarations "h-2/6" [ "height:33.3333%" ]
 
 (* Tailwind treats every integer numerator over a positive denominator as a
    sizing fraction. Zero, equal and improper fractions share the same parser and
    percentage rendering across all thirteen sizing families. *)
 let test_zero_equal_and_improper_fractions () =
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " contains " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css_of cls))
-  in
-  has "w-0/3" "width: 0%";
-  has "w-1/1" "width: 100%";
-  has "h-9/9" "height: 100%";
-  has "w-5/4" "width: 125%";
-  has "w-100/3" "width: 3333.33%";
-  has "size-5/4" "height: 125%";
-  has "min-w-0/3" "min-width: 0%";
-  has "max-h-100/3" "max-height: 3333.33%";
-  has "min-inline-1/1" "min-inline-size: 100%";
+  check_declarations "w-0/3" [ "width:0%" ];
+  check_declarations "w-1/1" [ "width:100%" ];
+  check_declarations "h-9/9" [ "height:100%" ];
+  check_declarations "w-5/4" [ "width:125%" ];
+  check_declarations "w-100/3" [ "width:3333.33%" ];
+  check_declarations "size-5/4" [ "width:125%"; "height:125%" ];
+  check_declarations "min-w-0/3" [ "min-width:0%" ];
+  check_declarations "max-h-100/3" [ "max-height:3333.33%" ];
+  check_declarations "min-inline-1/1" [ "min-inline-size:100%" ];
   Alcotest.(check bool)
     "a zero denominator is still rejected" true
     (Result.is_error (Tw.of_string "w-1/0"))
 
 (* max-w-screen-* references the breakpoint theme var (like the v4 CLI), not an
-   inlined px. *)
+   inlined px. The whole sheet is pinned rather than the declaration alone: the
+   theme binding the class drags in is the other half of the claim, and it sits
+   on [:root, :host], which carries no class. *)
 let test_max_w_screen () =
-  let xl = css_of "max-w-screen-xl" in
-  Alcotest.(check bool)
-    "max-w-screen-xl references --breakpoint-xl" true
-    (Astring.String.is_infix ~affix:"max-width: var(--breakpoint-xl)" xl);
-  Alcotest.(check bool)
-    "max-w-screen-xl defines --breakpoint-xl: 80rem" true
-    (Astring.String.is_infix ~affix:"--breakpoint-xl: 80rem" xl)
+  check_declarations "max-w-screen-xl" [ "max-width:var(--breakpoint-xl)" ];
+  Alcotest.(check string)
+    "max-w-screen-xl defines --breakpoint-xl"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--breakpoint-xl:80rem}}@layer components;@layer \
+     utilities{.max-w-screen-xl{max-width:var(--breakpoint-xl)}}"
+    (sheet_of "max-w-screen-xl")
 
 (* Arbitrary sizes accept compact calc() (the bracket value is normalized before
    going through the length grammar). *)
 let test_arbitrary_calc () =
-  Alcotest.(check bool)
-    "w-[calc(100vh-4rem)] spaces the operator" true
-    (Astring.String.is_infix ~affix:"width: calc(100vh - 4rem)"
-       (css_of "w-[calc(100vh-4rem)]"))
+  check_declarations "w-[calc(100vh-4rem)]" [ "width:calc(100vh - 4rem)" ]
 
 (* A width fraction is read as a percentage, from any denominator: Tailwind has
    no fixed scale here, and w-3/8 used to be an unknown class. *)
 let test_any_fraction_denominator () =
-  Alcotest.(check bool)
-    "w-3/8 is 37.5%" true
-    (Astring.String.is_infix ~affix:"width: 37.5%" (css_of "w-3/8"));
-  Alcotest.(check bool)
-    "w-7/9 rounds like Tailwind" true
-    (Astring.String.is_infix ~affix:"width: 77.7778%" (css_of "w-7/9"))
+  check_declarations "w-3/8" [ "width:37.5%" ];
+  check_declarations "w-7/9" [ "width:77.7778%" ]
 
 (* A [/] inside a bracket belongs to the value, not to a fraction: the fraction
    branch used to claim w-[calc(2px/2)] and reject it. *)
 let test_bracket_keeps_its_slash () =
-  Alcotest.(check bool)
-    "w-[calc(2px/2)] divides" true
-    (Astring.String.is_infix ~affix:"width: calc(2px / 2)"
-       (css_of "w-[calc(2px/2)]"));
-  Alcotest.(check bool)
-    "w-1/2 is still a fraction" true
-    (Astring.String.is_infix ~affix:"width: 50%" (css_of "w-1/2"))
+  check_declarations "w-[calc(2px/2)]" [ "width:calc(2px/2)" ];
+  check_declarations "w-1/2" [ "width:50%" ]
 
 (* The px step exists on the logical sizes too: block-px and inline-px used to
    be unknown classes. *)
 let test_logical_px_step () =
-  Alcotest.(check bool)
-    "block-px is 1px" true
-    (Astring.String.is_infix ~affix:"block-size: 1px" (css_of "block-px"));
-  Alcotest.(check bool)
-    "inline-px is 1px" true
-    (Astring.String.is_infix ~affix:"inline-size: 1px" (css_of "inline-px"))
+  check_declarations "block-px" [ "block-size:1px" ];
+  check_declarations "inline-px" [ "inline-size:1px" ]
 
 (* v4 resolves a named size through the namespaces the family lists ahead of the
    container scale, so a theme that sets both --spacing-sm and --container-sm

--- a/test/test_typography.ml
+++ b/test/test_typography.ml
@@ -272,15 +272,9 @@ let test_content () =
   (* unquoted function values *)
   check "content-[attr(before)]";
   check "content-[counter(x)]";
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  Alcotest.(check bool)
-    "content-[attr(before)] binds attr() to --tw-content" true
-    (Astring.String.is_infix ~affix:"--tw-content:attr(before)"
-       (css "content-[attr(before)]"))
+  (* the bracket binds the channel and [content] reads it back *)
+  check_declarations "content-[attr(before)]"
+    [ "--tw-content:attr(before)"; "content:var(--tw-content)" ]
 
 (* content-<token> parses only when the @theme defines --content-<token>; a bare
    word like content-wrapper with no token is rejected (it used to parse as a
@@ -449,39 +443,26 @@ let test_text_bracket_size_invalid () =
 (* A bracket font-size is any CSS length, not the px/rem/em/% subset the
    hand-rolled suffix parser knew. Same for an arbitrary text-indent. *)
 let test_bracket_length_units () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "font-size: 3ch" "text-[3ch]";
-  emits "font-size: 2vh" "text-[2vh]";
-  emits "font-size: calc(1rem + 2px)" "text-[calc(1rem+2px)]";
-  emits "text-indent: 3ch" "indent-[3ch]";
-  emits "text-indent: -3ch" "-indent-[3ch]"
+  check_declarations "text-[3ch]" [ "font-size:3ch" ];
+  check_declarations "text-[2vh]" [ "font-size:2vh" ];
+  check_declarations "text-[calc(1rem+2px)]" [ "font-size:calc(1rem + 2px)" ];
+  check_declarations "indent-[3ch]" [ "text-indent:3ch" ];
+  check_declarations "-indent-[3ch]" [ "text-indent:-3ch" ]
 
 (* The [/leading] modifier on a text size and the standalone [leading-[...]]
    utility read an arbitrary line-height with one reader, so they agree on every
    spelling. The modifier used to render anything but px, rem or a bare number
    as a zero, collapsing the line box under a selector that matched. *)
 let test_arbitrary_leading () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits cls value =
-    Alcotest.(check bool)
-      (cls ^ " emits line-height: " ^ value)
-      true
-      (Astring.String.is_infix ~affix:("line-height: " ^ value) (css cls))
-  in
+  (* The standalone utility sets the channel and reads it back; the modifier
+     writes the line height beside the size it decorates. *)
   let agree spelling value =
-    emits ("leading-[" ^ spelling ^ "]") value;
-    emits ("text-lg/[" ^ spelling ^ "]") value
+    check_declarations
+      ("leading-[" ^ spelling ^ "]")
+      [ "--tw-leading:" ^ value; "line-height:" ^ value ];
+    check_declarations
+      ("text-lg/[" ^ spelling ^ "]")
+      [ "font-size:var(--text-lg)"; "line-height:" ^ value ]
   in
   agree "2em" "2em";
   agree "150%" "150%";
@@ -670,13 +651,7 @@ let test_underline_offset_bracket_keeps_its_class () =
       ("-underline-offset-[3px]", {|.-underline-offset-\[3px\]|});
     ];
   (* the bare step keeps its own class and the [px] the scale gives it *)
-  match Tw.of_string "underline-offset-3" with
-  | Error (`Msg m) -> Alcotest.failf "underline-offset-3: %s" m
-  | Ok u ->
-      Alcotest.(check bool)
-        "bare step stays on the spacing scale" true
-        (Astring.String.is_infix ~affix:"text-underline-offset: 3px"
-           (Tw.to_css ~base:false [ u ] |> Tw.Css.to_string))
+  check_declarations "underline-offset-3" [ "text-underline-offset:3px" ]
 
 let suborder_matches_tailwind () =
   let open Tw in
@@ -768,10 +743,15 @@ let test_numeric_leading_spacing () =
       (Astring.String.is_infix ~affix (css cls))
   in
   (* Any non-negative N is accepted; N>=2 scales spacing, 1 is bare, 0 is 0. *)
-  has "leading-6" "calc(var(--spacing)*6)";
-  has "leading-2" "calc(var(--spacing)*2)";
-  has "leading-11" "calc(var(--spacing)*11)";
-  has "leading-1" "line-height:var(--spacing)";
+  let scaled cls value =
+    check_declarations cls [ "--tw-leading:" ^ value; "line-height:" ^ value ]
+  in
+  scaled "leading-6" "calc(var(--spacing)*6)";
+  scaled "leading-2" "calc(var(--spacing)*2)";
+  scaled "leading-11" "calc(var(--spacing)*11)";
+  scaled "leading-1" "var(--spacing)";
+  (* leading-0 stays on a substring: the pinned CLI writes [--tw-leading: 0px]
+     where tw writes [0]. *)
   has "leading-0" "line-height:0"
 
 (* [leading'] takes a half-step float, same convention as [p]/[p']; the int base
@@ -779,10 +759,11 @@ let test_numeric_leading_spacing () =
 let test_leading_prime () =
   check_typed_class "leading-1.5" (Tw.leading' 1.5);
   check_typed_class "leading-6" (Tw.leading 6);
-  let css = Tw.to_css [ Tw.leading' 1.5 ] |> Tw.Css.to_string ~minify:true in
-  Alcotest.(check bool)
-    "leading-1.5 -> calc(var(--spacing)*1.5)" true
-    (Astring.String.is_infix ~affix:"calc(var(--spacing)*1.5)" css)
+  check_declarations "leading-1.5"
+    [
+      "--tw-leading:calc(var(--spacing)*1.5)";
+      "line-height:calc(var(--spacing)*1.5)";
+    ]
 
 (* leading-none has no v4.3 theme token, so it inlines line-height: 1 rather
    than minting a --leading-none var. *)
@@ -792,9 +773,7 @@ let test_leading_none_inline () =
     | Ok u -> Tw.to_css [ u ] |> Tw.Css.to_string ~minify:true
     | Error _ -> Alcotest.fail "could not parse leading-none"
   in
-  Alcotest.(check bool)
-    "leading-none inlines line-height:1" true
-    (Astring.String.is_infix ~affix:"line-height:1" css);
+  check_declarations "leading-none" [ "--tw-leading:1"; "line-height:1" ];
   Alcotest.(check bool)
     "leading-none mints no --leading-none token" false
     (Astring.String.is_infix ~affix:"--leading-none" css)
@@ -820,34 +799,20 @@ let test_text_line_height_override () =
    [calc(var(--spacing) * 2)] and [color-mix(in oklab, red 20%,
    transparent)]. *)
 let test_text_bracket_functions () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  Alcotest.(check bool)
-    "text-[--spacing(2)] is a spacing calc" true
-    (Astring.String.is_infix ~affix:"calc(var(--spacing)*2)"
-       (css "text-[--spacing(2)]"));
-  Alcotest.(check bool)
-    "text-[--alpha(red/20%)] is a color-mix" true
-    (Astring.String.is_infix ~affix:"color-mix(in oklab,red 20%,transparent)"
-       (css "text-[--alpha(red/20%)]"))
+  check_declarations "text-[--spacing(2)]"
+    [ "font-size:calc(var(--spacing)*2)" ];
+  (* an alpha bracket names a colour, so it is a text colour rather than a
+     size *)
+  check_declarations "text-[--alpha(red/20%)]"
+    [ "color:color-mix(in oklab,red 20%,transparent)" ]
 
 (* A bracket list-style value is read with the CSS parser rather than a
    hand-rolled keyword table: list-[square] and list-image-[url(...)] used to be
    unknown classes. *)
 let test_bracket_list_style () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "list-[square]" "list-style-type:square";
-  has "list-image-[url(/carrot.png)]" "list-style-image:url(/carrot.png)";
+  check_declarations "list-[square]" [ "list-style-type:square" ];
+  check_declarations "list-image-[url(/carrot.png)]"
+    [ "list-style-image:url(/carrot.png)" ];
   Alcotest.(check bool)
     "an unknown counter style is rejected" true
     (Result.is_error (Tw.of_string "list-[nonsense-style]"))
@@ -856,22 +821,14 @@ let test_bracket_list_style () =
    written with. [list-image-] and [content-] read their bracket through the
    arbitrary-value decoder, which used to turn every [_] into a space. *)
 let test_bracket_url_underscore () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " emits " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css cls))
-  in
-  has "list-image-[url('a_b.png')]" "list-style-image: url(a_b.png)";
-  has "list-image-[url(a_b.png)]" "list-style-image: url(a_b.png)";
+  check_declarations "list-image-[url('a_b.png')]"
+    [ "list-style-image:url(a_b.png)" ];
+  check_declarations "list-image-[url(a_b.png)]"
+    [ "list-style-image:url(a_b.png)" ];
   (* Tailwind writes this one [url('a_b.png')]. The quoting is cascade's
      canonical spelling of the same URL; the underscore is the point. *)
-  has "content-[url('a_b.png')]" {|--tw-content: url("a_b.png")|}
+  check_declarations "content-[url('a_b.png')]"
+    [ "--tw-content:url(a_b.png)"; "content:var(--tw-content)" ]
 
 (* List position, type, and image are three property bands; candidates inside
    each band use their natural class-name order. *)
@@ -897,16 +854,10 @@ let test_font_features_value () =
     | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
     | Error _ -> ()
   in
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
   rejected "font-features-[<value>]";
-  Alcotest.(check bool)
-    "the underscore is a space" true
-    (Astring.String.is_infix ~affix:"font-feature-settings:\"liga\" 0"
-       (css "font-features-[\"liga\"_0]"))
+  (* the underscore is a space *)
+  check_declarations "font-features-[\"liga\"_0]"
+    [ "font-feature-settings:\"liga\" 0" ]
 
 (* font-feature-settings follows font-family and precedes font-size in
    Tailwind's property table. Keeping it after the weight band displaces both
@@ -962,10 +913,8 @@ let test_font_bracket_family_quoted () =
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
     | Ok u -> Tw.Css.to_string (Tw.to_css ~base:false [ u ])
   in
-  Alcotest.(check bool)
-    "a single quoted name keeps exactly one layer of quotes" true
-    (Astring.String.is_infix ~affix:{|font-family: "arial rounded"|}
-       (css {|font-["arial_rounded"]|}));
+  (* one layer of quotes, which minified prints as a bare two-word family *)
+  check_declarations {|font-["arial_rounded"]|} [ "font-family:arial rounded" ];
   Alcotest.(check bool)
     "a quoted string mixed with a bare token is never double-quoted" false
     (Astring.String.is_infix ~affix:{|font-family: "\"liga\"|}
@@ -976,39 +925,24 @@ let test_font_bracket_family_quoted () =
    [<family-name>], so a bare generic keyword among them (here [fantasy]) stays
    an unquoted keyword rather than folding into one quoted string. *)
 let test_font_bracket_family_comma_list () =
-  let css cls =
-    match Tw.of_string cls with
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-  in
-  Alcotest.(check bool)
-    "unquoted comma list, generic keyword kept bare" true
-    (Astring.String.is_infix ~affix:"font-family:Papyrus,fantasy"
-       (css "font-[Papyrus,fantasy]"))
+  check_declarations "font-[Papyrus,fantasy]" [ "font-family:Papyrus,fantasy" ]
 
 (* An arbitrary decoration thickness takes any CSS length unit, not just the px
    the hand-rolled suffix parser knew; the percentage form keeps its em
    conversion. A bracket that is not a length is rejected by the parser rather
    than raising once the sheet is rendered. *)
 let test_decoration_bracket_thickness () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  let thickness cls value =
+    check_declarations cls [ "text-decoration-thickness:" ^ value ]
   in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "text-decoration-thickness: 3rem" "decoration-[3rem]";
-  emits "text-decoration-thickness: 2px" "decoration-[2px]";
-  emits "text-decoration-thickness: 2ch" "decoration-[2ch]";
-  emits "text-decoration-thickness: .5em" "decoration-[50%]";
+  thickness "decoration-[3rem]" "3rem";
+  thickness "decoration-[2px]" "2px";
+  thickness "decoration-[2ch]" "2ch";
+  thickness "decoration-[50%]" ".5em";
   (* The bracket goes through the arbitrary-value decoder, so an escaped space
      and a [--spacing()] call both read as lengths. *)
-  emits "text-decoration-thickness: calc(1rem + 2px)"
-    "decoration-[calc(1rem_+_2px)]";
-  emits "text-decoration-thickness: calc(var(--spacing) * 2)"
-    "decoration-[--spacing(2)]";
+  thickness "decoration-[calc(1rem_+_2px)]" "calc(1rem + 2px)";
+  thickness "decoration-[--spacing(2)]" "calc(var(--spacing)*2)";
   let rejected cls =
     match Tw.of_string cls with
     | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
@@ -1041,21 +975,23 @@ let test_decoration_bracket_unitless_is_color () =
 (* A shadeless decoration colour takes an opacity modifier the same way every
    other colour family does, and keeps its shadeless class name. *)
 let test_decoration_shadeless_opacity () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
   check_late "decoration-white/50";
   check_late "decoration-black/50";
   check_late "decoration-white/[0.5]";
-  emits "color-mix(in oklab,var(--color-white) 50%,transparent)"
-    "decoration-white/50";
-  emits "color-mix(in oklab,var(--color-black) 50%,transparent)"
-    "decoration-black/50";
+  (* the folded sRGB fallback, then the [color-mix] enhancement under its
+     [@supports] guard, aliased for WebKit *)
+  let mixed cls hex token =
+    check_declarations cls
+      [
+        "text-decoration-color:" ^ hex;
+        "-webkit-text-decoration-color:color-mix(in oklab,var(" ^ token
+        ^ ") 50%,transparent)";
+        "text-decoration-color:color-mix(in oklab,var(" ^ token
+        ^ ") 50%,transparent)";
+      ]
+  in
+  mixed "decoration-white/50" "#ffffff80" "--color-white";
+  mixed "decoration-black/50" "#00000080" "--color-black";
   let rejected cls =
     match Tw.of_string cls with
     | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
@@ -1104,9 +1040,6 @@ let test_decoration_bracket_named_color () =
     | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
   (* the value a class sets for [text-decoration-color], so two spellings of one
      colour compare without their class names *)
   let value cls =
@@ -1119,8 +1052,10 @@ let test_decoration_bracket_named_color () =
         Astring.String.with_range ~first sheet
         |> Astring.String.take ~sat:(fun c -> c <> ';' && c <> '}')
   in
-  emits "text-decoration-color:rebeccapurple" "decoration-[rebeccapurple]";
-  emits "text-decoration-color:currentColor" "decoration-[currentColor]";
+  check_declarations "decoration-[rebeccapurple]"
+    [ "text-decoration-color:rebeccapurple" ];
+  check_declarations "decoration-[currentColor]"
+    [ "text-decoration-color:currentColor" ];
   (* the modifier folds into the colour the bracket named, not into black *)
   Alcotest.(check string)
     "decoration-[rebeccapurple]/50 is decoration-[#663399]/50"
@@ -1136,11 +1071,6 @@ let test_decoration_bracket_named_color () =
    raising constructor from inside [of_class], so a malformed hex escaped the
    parser as an exception instead of failing the match. *)
 let test_invalid_decoration_bracket_hex () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
   let rejected cls =
     match Tw.of_string cls with
     | Ok _ -> Alcotest.failf "expected %s to be rejected" cls
@@ -1150,10 +1080,7 @@ let test_invalid_decoration_bracket_hex () =
   rejected "decoration-[#]";
   rejected "decoration-[#12345]";
   rejected "decoration-[#zz]/50";
-  Alcotest.(check bool)
-    "decoration-[#ff0000] still emits the colour" true
-    (Astring.String.is_infix ~affix:"text-decoration-color:#f00"
-       (css "decoration-[#ff0000]"))
+  check_declarations "decoration-[#ff0000]" [ "text-decoration-color:#f00" ]
 
 (* Integers in a class name are plain decimal here too: the leading modifier
    [text-lg/0x10] was read as /16 and the font-weight bracket [font-[0x10]] as
@@ -1227,24 +1154,17 @@ let test_project_tracking_token () =
    Both readings have to reach the value: a family name and a content string are
    written by hand, so either character can be the one meant. *)
 let test_arbitrary_underscore_escape () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  let content cls value =
+    check_declarations cls
+      [ "--tw-content:" ^ value; "content:var(--tw-content)" ]
   in
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " emits " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css cls))
-  in
-  has {|font-['My\_Font']|} "font-family: My_Font";
-  has "font-[Arial_Black]" {|font-family: "Arial Black"|};
-  has {|content-["hello\_world"]|} {|--tw-content: "hello_world"|};
-  has {|content-[attr(a\_b)]|} "--tw-content: attr(a_b)";
+  check_declarations {|font-['My\_Font']|} [ "font-family:My_Font" ];
+  check_declarations "font-[Arial_Black]" [ "font-family:Arial Black" ];
+  content {|content-["hello\_world"]|} {|"hello_world"|};
+  content {|content-[attr(a\_b)]|} "attr(a_b)";
   (* The single-quoted spelling already reads both, and stays that way. *)
-  has {|content-['hello\_world']|} {|--tw-content: 'hello_world'|};
-  has {|content-['hello_world']|} {|--tw-content: 'hello world'|}
+  content {|content-['hello\_world']|} {|"hello_world"|};
+  content {|content-['hello_world']|} {|"hello world"|}
 
 let tests =
   [


### PR DESCRIPTION
`Astring.String.is_infix` accepts more than a test names: the affix
`.bg-blue-500` matches the selector `.bg-blue-500\/50`, so a test naming a
utility passes when only an opacity variant reached the sheet, and a
`check bool` failure prints neither the class nor the CSS.

`test_sizing`, `test_effects` and `test_typography` now compare the exact
declaration list a class writes. `test_modifiers` compares the whole sheet,
since a variant decides the selector and the at-rules around it rather than a
declaration.

Every class went through `tw --single=... --diff` before its output was pinned.
Nine where tw and the pinned CLI disagree keep their substring, each with a
comment saying why:

- `shadow-[#f00]/[var(--x)]`, `inset-shadow-[#f00]/[var(--x)]` and the same pair
  inside `shadow-[0_0_8px_#f00]/[var(--x)]`: tw expands the authored `#f00` to
  `#ff0000` where the CLI passes the three-character spelling through.
- `@min-[theme(--breakpoint-lg)]:flex` and its `@max-` twin: the CLI also writes
  `--breakpoint-lg: 64rem` into the theme layer, tw writes nothing there.
- `has-hocus:flex`: the CLI emits nothing at all, so that rule is tw's alone.
- `data-[foo='a_b']:flex` and `data-[foo=bar_baz]:flex`: tw quotes the attribute
  value where the CLI escapes the space.
- `supports-text-size-adjust:flex`: the CLI's prefixing turns the condition into
  three alternatives where tw's leaves one.
- `leading-0`: the CLI writes `--tw-leading: 0px`, tw writes `0`.

44 substring uses remain across the four files: negations, predicates inside a
`List.exists`, and the sites whose subject a custom `~theme` puts out of reach
of the default-theme helpers.
