### PR TITLE
test: pin exact output in the borders, rule and html suites

### DIFF
--- a/test/html/test_tw_html.ml
+++ b/test/html/test_tw_html.ml
@@ -8,108 +8,65 @@ let test_txt () =
   let html_str = to_string text in
   check string "text content" "Hello World" html_str
 
+(* The whole rendering is compared rather than searched: a substring says
+   nothing about where the class attribute went or what else came out beside it,
+   and a [check bool] failure prints neither the markup nor the subject. *)
 let test_element_creation () =
-  let div = div ~tw:Tw.[ p 4; bg white ] [ txt "Content" ] in
-  let html_str = to_string div in
-
-  check bool "is div element" true
-    (Astring.String.is_prefix ~affix:"<div" html_str);
-  check bool "contains content" true
-    (Astring.String.is_infix ~affix:"Content" html_str);
-  check bool "has classes" true
-    (Astring.String.is_infix ~affix:"class=" html_str)
+  check string "utilities render into one class attribute"
+    {|<div class="p-4 bg-white">Content</div>|}
+    (to_string (div ~tw:Tw.[ p 4; bg white ] [ txt "Content" ]))
 
 let test_attributes () =
-  let link =
-    a
-      ~at:[ At.href "/about"; At.title "About page" ]
-      ~tw:Tw.[ text ~shade:600 blue; hover [ underline ] ]
-      [ txt "About" ]
-  in
-  let html_str = to_string link in
-
-  check bool "has href" true
-    (Astring.String.is_infix ~affix:"href=\"/about\"" html_str);
-  check bool "has title" true
-    (Astring.String.is_infix ~affix:"title=\"About page\"" html_str);
-  check bool "contains text" true
-    (Astring.String.is_infix ~affix:"About" html_str)
+  check string "the class attribute comes first, then the given ones in order"
+    {|<a class="text-blue-600 hover:underline" href="/about" title="About page">About</a>|}
+    (to_string
+       (a
+          ~at:[ At.href "/about"; At.title "About page" ]
+          ~tw:Tw.[ text ~shade:600 blue; hover [ underline ] ]
+          [ txt "About" ]))
 
 let test_html_escaping () =
-  (* Text content escaping *)
-  let dangerous = txt "<script>if (a && b) alert(\"x\")</script>" in
-  let html_str = to_string dangerous in
-  check bool "escapes < and >" true
-    (Astring.String.is_infix ~affix:"&lt;script&gt;" html_str);
-  check bool "escapes & inside" true
-    (Astring.String.is_infix ~affix:"&amp;&amp;" html_str);
-  check bool "escapes quotes" true
-    (Astring.String.is_infix ~affix:"\"x\"" html_str
-    || Astring.String.is_infix ~affix:"&quot;x&quot;" html_str);
-
-  (* Attribute value escaping *)
-  let elem = div ~at:[ At.title "5 > 3 & \"yes\"" ] [ txt "t" ] in
-  let s = to_string elem in
-  check bool "attribute escapes >" true
-    (Astring.String.is_infix ~affix:"&gt;" s);
-  check bool "attribute escapes & and quotes" true
-    (Astring.String.is_infix ~affix:"&amp;" s
-    && Astring.String.is_infix ~affix:"&quot;yes&quot;" s)
+  check string "text content escapes <, >, & and the quote"
+    "&lt;script&gt;if (a &amp;&amp; b) alert(&quot;x&quot;)&lt;/script&gt;"
+    (to_string (txt "<script>if (a && b) alert(\"x\")</script>"));
+  check string "an attribute value escapes the same four"
+    {|<div title="5 &gt; 3 &amp; &quot;yes&quot;">t</div>|}
+    (to_string (div ~at:[ At.title "5 > 3 & \"yes\"" ] [ txt "t" ]))
 
 let test_boolean_and_data_attrs () =
-  (* Boolean attributes render as presence-only *)
-  let i = input ~at:[ At.disabled; At.checked; At.required ] () in
-  let s = to_string i in
-  check bool "has disabled" true (Astring.String.is_infix ~affix:"disabled" s);
-  check bool "has checked" true (Astring.String.is_infix ~affix:"checked" s);
-  check bool "has required" true (Astring.String.is_infix ~affix:"required" s);
-
-  (* aria and data attributes serialization *)
-  let d =
-    div
-      ~at:
-        [
-          Aria.label "Greeting";
-          Aria.hidden;
-          Aria.expanded true;
-          At.v "data-user" "Tom & Jerry";
-        ]
-      [ txt "x" ]
-  in
-  let sd = to_string d in
-  check bool "aria-label set" true
-    (Astring.String.is_infix ~affix:"aria-label=\"Greeting\"" sd);
-  check bool "aria-hidden set" true
-    (Astring.String.is_infix ~affix:"aria-hidden=\"true\"" sd);
-  check bool "aria-expanded set" true
-    (Astring.String.is_infix ~affix:"aria-expanded=\"true\"" sd);
-  check bool "data-* serialized and escaped" true
-    (Astring.String.is_infix ~affix:"data-user=\"Tom &amp; Jerry\"" sd)
+  (* A boolean attribute is written with an empty value, which HTML reads as the
+     attribute being present. A substring on the name alone could not tell that
+     from any other spelling. *)
+  check string "boolean attributes carry an empty value"
+    {|<input disabled="" checked="" required="" />|}
+    (to_string (input ~at:[ At.disabled; At.checked; At.required ] ()));
+  check string "aria and data attributes serialise in order, values escaped"
+    {|<div aria-label="Greeting" aria-hidden="true" aria-expanded="true" data-user="Tom &amp; Jerry">x</div>|}
+    (to_string
+       (div
+          ~at:
+            [
+              Aria.label "Greeting";
+              Aria.hidden;
+              Aria.expanded true;
+              At.v "data-user" "Tom & Jerry";
+            ]
+          [ txt "x" ]))
 
 let test_nesting () =
-  let nested =
-    div
-      [
-        h1 [ txt "Title" ];
-        p
+  check string "children render in place, in document order"
+    {|<div><h1>Title</h1><p>Paragraph with <span class="font-bold">bold</span> text.</p></div>|}
+    (to_string
+       (div
           [
-            txt "Paragraph with ";
-            span ~tw:Tw.[ font_bold ] [ txt "bold" ];
-            txt " text.";
-          ];
-      ]
-  in
-  let html_str = to_string nested in
-
-  check bool "has h1" true (Astring.String.is_infix ~affix:"<h1>" html_str);
-  check bool "has paragraph" true
-    (Astring.String.is_infix ~affix:"<p>" html_str);
-  check bool "has span with bold" true
-    (Astring.String.is_infix ~affix:"<span" html_str);
-  check bool "correct nesting" true
-    (Astring.String.is_infix ~affix:"Paragraph with" html_str
-    && Astring.String.is_infix ~affix:"bold" html_str
-    && Astring.String.is_infix ~affix:"text." html_str)
+            h1 [ txt "Title" ];
+            p
+              [
+                txt "Paragraph with ";
+                span ~tw:Tw.[ font_bold ] [ txt "bold" ];
+                txt " text.";
+              ];
+          ]))
 
 let test_to_tw () =
   let elem =
@@ -126,13 +83,9 @@ let test_to_tw () =
     (List.exists (fun tw -> Tw.pp tw = "font-bold") tw_classes)
 
 let test_pp () =
-  let elem = div ~tw:Tw.[ p 2 ] [ txt "Test" ] in
-  let pp_output = pp elem in
-
-  check bool "pp contains element tag" true
-    (Astring.String.is_infix ~affix:"<div" pp_output);
-  check bool "pp contains classes" true
-    (Astring.String.is_infix ~affix:"p-2" pp_output)
+  check string "pp names the utilities alongside the rendering"
+    {|<element with classes="p-2"><div class="p-2">Test</div></element>|}
+    (pp (div ~tw:Tw.[ p 2 ] [ txt "Test" ]))
 
 let test_page_cache_busting () =
   (* Test that page function generates cache-busted CSS URLs *)
@@ -146,35 +99,41 @@ let test_page_cache_busting () =
   let html_content = html test_page in
   let css_filename, _css_stylesheet = css test_page in
 
-  (* Check that the HTML contains a cache-busted CSS link *)
-  check bool "HTML contains link tag" true
-    (Astring.String.is_infix ~affix:"<link" html_content);
-  check bool "CSS link has cache buster" true
-    (Astring.String.is_infix ~affix:"styles.css?v=" html_content);
   check
     Alcotest.(option string)
     "CSS filename is correct" (Some "styles.css") css_filename;
 
-  (* Check that the hash is 8 characters (MD5 hash prefix) *)
-  match Astring.String.find_sub ~sub:"styles.css?v=" html_content with
-  | Some idx ->
-      let hash_start = idx + String.length "styles.css?v=" in
-      let rest =
-        String.sub html_content hash_start
-          (String.length html_content - hash_start)
-      in
-      (* Find the end of the hash (until quote) *)
-      let hash_end = try String.index rest '"' with Not_found -> 8 in
-      let hash = String.sub rest 0 hash_end in
-      check int "hash length is 8 characters" 8 (String.length hash);
-      (* Check that hash is hexadecimal *)
-      let is_hex c =
-        (c >= '0' && c <= '9')
-        || (c >= 'a' && c <= 'f')
-        || (c >= 'A' && c <= 'F')
-      in
-      check bool "hash is hexadecimal" true (String.for_all is_hex hash)
-  | None -> fail "Cache buster not found in HTML"
+  (* The buster is an MD5 prefix over the stylesheet, so it moves with anything
+     that changes the CSS. Read it back and check its shape, then compare the
+     document around it whole: that is what says the link is a [<link>] in the
+     head and that nothing else was emitted beside it. *)
+  let hash =
+    match Astring.String.find_sub ~sub:"styles.css?v=" html_content with
+    | None -> fail "Cache buster not found in HTML"
+    | Some idx ->
+        let start = idx + String.length "styles.css?v=" in
+        let rest =
+          String.sub html_content start (String.length html_content - start)
+        in
+        let stop =
+          match Astring.String.find (Char.equal '"') rest with
+          | Some i -> i
+          | None -> String.length rest
+        in
+        String.sub rest 0 stop
+  in
+  check int "hash length is 8 characters" 8 (String.length hash);
+  let is_hex c =
+    (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+  in
+  check bool "hash is hexadecimal" true (String.for_all is_hex hash);
+  check string "the document links the cache-busted stylesheet"
+    ({|<!DOCTYPE html>|} ^ "\n"
+   ^ {|<html lang="en"><head><meta charset="utf-8" /><meta name="description" content="Test page for cache busting" /><title>Test Page</title><link rel="stylesheet" href="styles.css?v=|}
+   ^ hash
+   ^ {|" /></head><body><div class="p-4 bg-white">Test content</div></body></html>|}
+    )
+    html_content
 
 let test_page_cache_busting_consistency () =
   (* Test that same content produces same hash *)
@@ -225,59 +184,43 @@ let test_inline_css () =
   (* Inline pages have no external CSS file *)
   check Alcotest.(option string) "no external CSS file" None css_filename;
 
-  (* The CSS is embedded in a <style> tag, not referenced via <link> *)
-  check bool "HTML contains style tag" true
-    (Astring.String.is_infix ~affix:"<style>" html_content);
-  check bool "HTML has no link tag" false
-    (Astring.String.is_infix ~affix:"<link" html_content);
-
-  (* The stylesheet is inlined verbatim: <style> is a raw-text element, so the
-     CSS must not be HTML-escaped (e.g. [>] must stay [>], not [&gt;]). *)
-  let expected_css = Tw.Css.to_string ~minify:true css_stylesheet in
-  check bool "stylesheet inlined verbatim (unescaped)" true
-    (Astring.String.is_infix ~affix:expected_css html_content)
+  (* The stylesheet is inlined verbatim inside [<style>], a raw-text element, so
+     the CSS must not be HTML-escaped ([>] stays [>], not [&gt;]). Composing the
+     expected document from the stylesheet keeps this about the embedding rather
+     than about the sheet, and comparing it whole is what says no [<link>] went
+     out beside it. *)
+  check string "stylesheet embedded verbatim, and no link tag"
+    ({|<!DOCTYPE html>|} ^ "\n"
+   ^ {|<html lang="en"><head><meta charset="utf-8" /><title>Inline Style Test</title><style>|}
+    ^ Tw.Css.to_string ~minify:true css_stylesheet
+    ^ {|</style></head><body><div class="p-4 bg-white">Inline content</div></body></html>|}
+    )
+    html_content
 
 let test_class_merging () =
-  (* tw classes and explicit class attribute should merge into one class attr *)
-  let elem =
-    div
-      ~at:[ At.v "class" "custom-class" ]
-      ~tw:Tw.[ p 4; flex ]
-      [ txt "Merged" ]
-  in
-  let html_str = to_string elem in
-  (* Should have exactly one class attribute containing both *)
-  let class_count =
-    let rec count s from n =
-      match Astring.String.find_sub ~start:from ~sub:"class=" s with
-      | Some i -> count s (i + 6) (n + 1)
-      | None -> n
-    in
-    count html_str 0 0
-  in
-  check int "single class attribute" 1 class_count;
-  check bool "has tw classes" true
-    (Astring.String.is_infix ~affix:"p-4" html_str);
-  check bool "has custom class" true
-    (Astring.String.is_infix ~affix:"custom-class" html_str)
+  (* The tw utilities and the explicit class attribute merge into one attribute,
+     utilities first. Comparing the whole rendering is what says there is no
+     second [class=]. *)
+  check string "one class attribute, utilities then the explicit names"
+    {|<div class="p-4 flex custom-class">Merged</div>|}
+    (to_string
+       (div
+          ~at:[ At.v "class" "custom-class" ]
+          ~tw:Tw.[ p 4; flex ]
+          [ txt "Merged" ]))
 
 let test_no_class_without_tw () =
-  (* No class attribute when tw is empty *)
-  let elem = div [ txt "Plain" ] in
-  let html_str = to_string elem in
-  check bool "no class attribute" false
-    (Astring.String.is_infix ~affix:"class=" html_str)
+  check string "no class attribute when there are no utilities"
+    "<div>Plain</div>"
+    (to_string (div [ txt "Plain" ]))
 
 let test_void_elements () =
   (* A void element carries no end tag, whichever constructor built it. *)
-  let s = to_string (picture [ source ~at:[ At.src "a.webp" ] () ]) in
-  check bool "source self-closed" true
-    (Astring.String.is_infix ~affix:"<source src=\"a.webp\" />" s);
-  check bool "no source end tag" false
-    (Astring.String.is_infix ~affix:"</source>" s);
-  let img_str = to_string (img ~at:[ At.src "a.png" ] ()) in
-  check bool "img self-closed" true
-    (Astring.String.is_infix ~affix:"<img src=\"a.png\" />" img_str);
+  check string "source self-closed, with no end tag"
+    {|<picture><source src="a.webp" /></picture>|}
+    (to_string (picture [ source ~at:[ At.src "a.webp" ] () ]));
+  check string "img self-closed" {|<img src="a.png" />|}
+    (to_string (img ~at:[ At.src "a.png" ] ()));
   let br_str = to_string (br ()) in
   check string "br self-closed" "<br />" br_str;
   let hr_str = to_string (hr ()) in

--- a/test/test_borders.ml
+++ b/test/test_borders.ml
@@ -3,6 +3,17 @@ open Test_helpers
 
 let check = check_handler_roundtrip (module Tw.Borders.Handler)
 
+(* A theme token's value and a variant's selector are neither of them a
+   declaration, so the tests that turn on one compare the sheet whole.
+   [check_declarations] reads only the rules whose selector holds a [.], which
+   is what leaves both out. *)
+let sheet cls =
+  match Tw.of_string cls with
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+let check_sheet cls expected = Alcotest.(check string) cls expected (sheet cls)
+
 let of_string_valid () =
   check "border";
   check "border-0";
@@ -167,100 +178,62 @@ let rendering_matches_tailwind () =
 
 (* rounded-sm's default radius is .25rem in v4.3.1, not the old .125rem. *)
 let test_rounded_sm_default () =
-  let css = Tw.to_css ~base:false [ Tw.rounded_sm ] |> Tw.Css.to_string in
-  Alcotest.(check bool)
-    "rounded-sm default is .25rem" true
-    (Astring.String.is_infix ~affix:"--radius-sm: .25rem" css)
+  check_sheet "rounded-sm"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--radius-sm:.25rem}}@layer components;@layer \
+     utilities{.rounded-sm{border-radius:var(--radius-sm)}}"
 
 (* rounded-xs is a v4.3.1 addition: references var(--radius-xs) and emits the
    .125rem default token. *)
 let test_rounded_xs () =
-  let css = Tw.to_css ~base:false [ Tw.rounded_xs ] |> Tw.Css.to_string in
-  Alcotest.(check bool)
-    "rounded-xs default is .125rem" true
-    (Astring.String.is_infix ~affix:"--radius-xs: .125rem" css);
-  Alcotest.(check bool)
-    "rounded-xs references var(--radius-xs)" true
-    (Astring.String.is_infix ~affix:"border-radius: var(--radius-xs)" css)
+  check_sheet "rounded-xs"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--radius-xs:.125rem}}@layer components;@layer \
+     utilities{.rounded-xs{border-radius:var(--radius-xs)}}"
 
 (* rounded-4xl is a v4.3.1 addition: references var(--radius-4xl) and emits the
    2rem default token. *)
 let test_rounded_4xl () =
-  let css = Tw.to_css ~base:false [ Tw.rounded_4xl ] |> Tw.Css.to_string in
-  Alcotest.(check bool)
-    "rounded-4xl default is 2rem" true
-    (Astring.String.is_infix ~affix:"--radius-4xl: 2rem" css);
-  Alcotest.(check bool)
-    "rounded-4xl references var(--radius-4xl)" true
-    (Astring.String.is_infix ~affix:"border-radius: var(--radius-4xl)" css)
+  check_sheet "rounded-4xl"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--radius-4xl:2rem}}@layer components;@layer \
+     utilities{.rounded-4xl{border-radius:var(--radius-4xl)}}"
 
 (* Per-side/corner full radius inlines the infinite value (matching the
    all-corners variant and Tailwind's calc(infinity*1px)), not a --radius-full
-   token that defaulted to the wrong 9999px. *)
+   token that defaulted to the wrong 9999px. The empty theme layer is what says
+   no such token is emitted, which no assertion on the declarations alone
+   reaches. *)
 let test_rounded_side_full_inlined () =
-  let css =
-    match Tw.of_string "rounded-l-full" with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.fail "could not parse rounded-l-full"
-  in
-  Alcotest.(check bool)
-    "rounded-l-full inlines the infinite radius" true
-    (Astring.String.is_infix ~affix:"3.40282e38px" css);
-  Alcotest.(check bool)
-    "rounded-l-full emits no --radius-full token" false
-    (Astring.String.is_infix ~affix:"--radius-full" css);
-  Alcotest.(check bool)
-    "rounded-l-full is not the old 9999px" false
-    (Astring.String.is_infix ~affix:"9999px" css)
+  check_sheet "rounded-l-full"
+    "@layer theme,components,utilities;@layer theme;@layer components;@layer \
+     utilities{.rounded-l-full{border-top-left-radius:3.40282e38px;border-bottom-left-radius:3.40282e38px}}"
 
 (* Numeric outline widths (outline-1/2/4/8) emit outline-width: Npx with the
    outline-style var; they used to be unknown classes. *)
 let test_outline_widths () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.failf "could not parse %S" cls
-  in
-  Alcotest.(check bool)
-    "outline-2 emits outline-width: 2px" true
-    (Astring.String.is_infix ~affix:"outline-width: 2px" (css "outline-2"));
-  Alcotest.(check bool)
-    "outline-1 emits outline-width: 1px" true
-    (Astring.String.is_infix ~affix:"outline-width: 1px" (css "outline-1"));
-  Alcotest.(check bool)
-    "outline-3 emits outline-width: 3px (v4 bare integer)" true
-    (Astring.String.is_infix ~affix:"outline-width: 3px" (css "outline-3"))
+  check_declarations "outline-1"
+    [ "outline-style:var(--tw-outline-style)"; "outline-width:1px" ];
+  check_declarations "outline-2"
+    [ "outline-style:var(--tw-outline-style)"; "outline-width:2px" ];
+  (* v4 takes any bare integer, not just the fixed scale *)
+  check_declarations "outline-3"
+    [ "outline-style:var(--tw-outline-style)"; "outline-width:3px" ]
 
 (* Arbitrary outline-offset lengths (outline-offset-[3px]) emit the length,
    alongside the var() form (outline-offset-[var(--x)]). *)
 let test_outline_offset_arbitrary () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.failf "could not parse %S" cls
-  in
-  Alcotest.(check bool)
-    "outline-offset-[3px] emits outline-offset: 3px" true
-    (Astring.String.is_infix ~affix:"outline-offset: 3px"
-       (css "outline-offset-[3px]"))
+  check_declarations "outline-offset-[3px]" [ "outline-offset:3px" ]
 
 (* outline-hidden's forced-colors reset is its own @media block; under a state
    modifier (focus, focus-within) the block must use the modified selector, not
    the bare .outline-hidden, and stay grouped with the regular rule. It used to
    keep the bare selector and reorder before the regular rule. *)
 let test_outline_hidden_modifier_forced_colors () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let out = css "focus:outline-hidden" in
-  Alcotest.(check bool)
-    "forced-colors block uses the focus-modified selector" true
-    (Astring.String.is_infix ~affix:".focus\\:outline-hidden:focus" out);
-  Alcotest.(check bool)
-    "forced-colors block is not the bare .outline-hidden" false
-    (Astring.String.is_infix ~affix:" .outline-hidden " out)
+  check_sheet "focus:outline-hidden"
+    "@layer theme,components,utilities;@layer theme;@layer components;@layer \
+     utilities{.focus\\:outline-hidden:focus{--tw-outline-style:none;outline-style:none}@media(forced-colors:active){.focus\\:outline-hidden:focus{outline-offset:2px;outline:2px \
+     solid #0000}}}"
 
 (* The outline family sorts as one block: outline-hidden, the widths, the
    offsets, the colors, then the styles. Order matters beyond byte parity here:
@@ -296,103 +269,95 @@ let test_outline_ordering () =
 (* Arbitrary per-side border widths (border-t-[1px], ...) emit the side width
    plus the side border-style var; they used to be unknown classes. *)
 let test_border_side_arbitrary_width () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.failf "could not parse %S" cls
-  in
-  Alcotest.(check bool)
-    "border-t-[1px] sets border-top-width" true
-    (Astring.String.is_infix ~affix:"border-top-width: 1px"
-       (css "border-t-[1px]"));
-  Alcotest.(check bool)
-    "border-l-[0.5rem] sets border-left-width" true
-    (Astring.String.is_infix ~affix:"border-left-width: .5rem"
-       (css "border-l-[0.5rem]"))
+  check_declarations "border-t-[1px]"
+    [ "border-top-style:var(--tw-border-style)"; "border-top-width:1px" ];
+  check_declarations "border-l-[0.5rem]"
+    [ "border-left-style:var(--tw-border-style)"; "border-left-width:.5rem" ]
 
 (* Logical single-side borders emit the inline/block start/end style var and
    width, like the physical per-side borders do. *)
 let test_logical_side_borders () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error _ -> Alcotest.failf "could not parse %S" cls
-  in
-  Alcotest.(check bool)
-    "border-s sets border-inline-start-width: 1px" true
-    (Astring.String.is_infix ~affix:"border-inline-start-width: 1px"
-       (css "border-s"));
-  Alcotest.(check bool)
-    "border-be-2 sets border-block-end-width: 2px" true
-    (Astring.String.is_infix ~affix:"border-block-end-width: 2px"
-       (css "border-be-2"));
-  Alcotest.(check bool)
-    "border-e references the border-style var" true
-    (Astring.String.is_infix
-       ~affix:"border-inline-end-style: var(--tw-border-style)" (css "border-e"))
+  check_declarations "border-s"
+    [
+      "border-inline-start-style:var(--tw-border-style)";
+      "border-inline-start-width:1px";
+    ];
+  check_declarations "border-be-2"
+    [
+      "border-block-end-style:var(--tw-border-style)";
+      "border-block-end-width:2px";
+    ];
+  check_declarations "border-e"
+    [
+      "border-inline-end-style:var(--tw-border-style)";
+      "border-inline-end-width:1px";
+    ]
 
 (* Arbitrary outline and border widths take any CSS length unit, not just the
    px/rem/em/% the hand-rolled suffix parsers knew: Tailwind emits
    outline-width: 3rem for outline-[3rem] and border-width: 3vw for
    border-[3vw]. *)
 let test_bracket_width_units () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  let outline cls width =
+    check_declarations cls
+      [ "outline-style:var(--tw-outline-style)"; "outline-width:" ^ width ]
   in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "outline-width: 3rem" "outline-[3rem]";
-  emits "outline-width: 2em" "outline-[2em]";
-  emits "outline-width: 3px" "outline-[3px]";
-  emits "outline-width: 50%" "outline-[50%]";
-  emits "border-width: 3vw" "border-[3vw]";
-  emits "border-width: 2ch" "border-[2ch]";
-  emits "border-width: .5rem" "border-[0.5rem]";
-  emits "border-top-width: 3vw" "border-t-[3vw]"
+  outline "outline-[3rem]" "3rem";
+  outline "outline-[2em]" "2em";
+  outline "outline-[3px]" "3px";
+  outline "outline-[50%]" "50%";
+  check_declarations "border-[3vw]"
+    [ "border-style:var(--tw-border-style)"; "border-width:3vw" ];
+  check_declarations "border-[2ch]"
+    [ "border-style:var(--tw-border-style)"; "border-width:2ch" ];
+  check_declarations "border-[0.5rem]"
+    [ "border-style:var(--tw-border-style)"; "border-width:.5rem" ];
+  check_declarations "border-t-[3vw]"
+    [ "border-top-style:var(--tw-border-style)"; "border-top-width:3vw" ]
 
 (* A math function in a width bracket stands for the width it computes, so it is
    a width and not a colour. The bracket was classified by its first character,
    which put [calc(...)] on the colour side and refused the class Tailwind
    renders. *)
 let test_bracket_math_function_width () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "border-width: calc(1rem + 2px)" "border-[calc(1rem_+_2px)]";
-  emits "border-top-width: calc(1rem + 2px)" "border-t-[calc(1rem_+_2px)]";
-  emits "border-width: min(2px, 1rem)" "border-[min(2px,1rem)]";
-  emits "border-width: clamp(1px, 2vw, 3rem)" "border-[clamp(1px,2vw,3rem)]";
-  emits "outline-width: calc(1rem + 2px)" "outline-[calc(1rem_+_2px)]";
-  (* a bare var() is still a colour on both *)
-  emits "border-color: var(--w)" "border-[var(--w)]";
-  emits "outline-color: var(--w)" "outline-[var(--w)]"
+  check_declarations "border-[calc(1rem_+_2px)]"
+    [ "border-style:var(--tw-border-style)"; "border-width:calc(1rem + 2px)" ];
+  check_declarations "border-t-[calc(1rem_+_2px)]"
+    [
+      "border-top-style:var(--tw-border-style)";
+      "border-top-width:calc(1rem + 2px)";
+    ];
+  check_declarations "border-[min(2px,1rem)]"
+    [ "border-style:var(--tw-border-style)"; "border-width:min(2px,1rem)" ];
+  check_declarations "border-[clamp(1px,2vw,3rem)]"
+    [
+      "border-style:var(--tw-border-style)"; "border-width:clamp(1px,2vw,3rem)";
+    ];
+  check_declarations "outline-[calc(1rem_+_2px)]"
+    [
+      "outline-style:var(--tw-outline-style)"; "outline-width:calc(1rem + 2px)";
+    ];
+  (* a bare var() is still a colour on both, so it writes the colour alone and
+     none of the width's style var *)
+  check_declarations "border-[var(--w)]" [ "border-color:var(--w)" ];
+  check_declarations "outline-[var(--w)]" [ "outline-color:var(--w)" ]
 
 (* The three CSS line-width keywords are border widths in their own right, so a
    bracket naming one is a width and not an unknown class: Tailwind emits
    border-width: thin for border-[thin], and the same for medium and thick on
    every side. *)
 let test_bracket_line_width_keywords () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  let all_sides cls keyword =
+    check_declarations cls
+      [ "border-style:var(--tw-border-style)"; "border-width:" ^ keyword ]
   in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "border-width: thin" "border-[thin]";
-  emits "border-width: medium" "border-[medium]";
-  emits "border-width: thick" "border-[thick]";
-  emits "border-top-width: thin" "border-t-[thin]";
-  emits "border-left-width: thick" "border-l-[thick]"
+  all_sides "border-[thin]" "thin";
+  all_sides "border-[medium]" "medium";
+  all_sides "border-[thick]" "thick";
+  check_declarations "border-t-[thin]"
+    [ "border-top-style:var(--tw-border-style)"; "border-top-width:thin" ];
+  check_declarations "border-l-[thick]"
+    [ "border-left-style:var(--tw-border-style)"; "border-left-width:thick" ]
 
 (* A [--radius-*] token the project declared in its [@theme] names a corner
    radius the built-in scale has no slot for. Tailwind generates the utility
@@ -407,6 +372,9 @@ let test_project_radius_token () =
     | Ok u -> Tw.to_css ~theme ~base:false [ u ] |> Tw.Css.to_string
     | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
   in
+  (* [check_declarations] and [check_sheet] both compile the class against the
+     default theme, which has no [--radius-blob], so these stay on a substring
+     of the sheet this theme renders. *)
   let emits affix cls =
     Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
   in
@@ -442,22 +410,20 @@ let test_side_width_order () =
    sides do. The bracket arm matched the four physical sides only, so an axis or
    logical side fell through to the colour path and failed there. *)
 let test_axis_arbitrary_width () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  let side cls family width =
+    check_declarations cls
+      [
+        "border-" ^ family ^ "-style:var(--tw-border-style)";
+        "border-" ^ family ^ "-width:" ^ width;
+      ]
   in
-  let emits affix cls =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  emits "border-inline-width: 3px" "border-x-[3px]";
-  emits "border-block-width: 3px" "border-y-[3px]";
-  emits "border-inline-start-width: 3px" "border-s-[3px]";
-  emits "border-inline-end-width: 3px" "border-e-[3px]";
-  emits "border-block-start-width: 3px" "border-bs-[3px]";
-  emits "border-block-end-width: 3px" "border-be-[3px]";
-  emits "border-inline-width: .5rem" "border-x-[0.5rem]";
-  emits "border-inline-style: var(--tw-border-style)" "border-x-[3px]";
+  side "border-x-[3px]" "inline" "3px";
+  side "border-y-[3px]" "block" "3px";
+  side "border-s-[3px]" "inline-start" "3px";
+  side "border-e-[3px]" "inline-end" "3px";
+  side "border-bs-[3px]" "block-start" "3px";
+  side "border-be-[3px]" "block-end" "3px";
+  side "border-x-[0.5rem]" "inline" ".5rem";
   (* a bracket that is not a length is still not a width *)
   Alcotest.(check bool)
     "border-x-[1e] is rejected" true

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -8,6 +8,26 @@ open Tw.Modifiers
 
 (* ===== Tests ===== *)
 
+(* A variant decides the selector and the at-rules wrapped around it, and
+   neither is a declaration, so what these tests have to compare is the sheet
+   itself. Comparing it whole is what a substring cannot do: [:has(:focus)] is
+   an infix of [:has(:focus-visible)], and a [check bool] failure prints neither
+   the class nor the CSS. *)
+let sheet cls =
+  match Tw.of_string cls with
+  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+
+let check_sheet cls expected = Alcotest.(check string) cls expected (sheet cls)
+
+(* Most classes here draw on no theme token, so the layers ahead of [utilities]
+   are empty and only the utilities layer is worth spelling out. The comparison
+   is still against the whole sheet. *)
+let check_utilities cls expected =
+  check_sheet cls
+    ("@layer theme,components,utilities;@layer theme;@layer components;@layer \
+      utilities{" ^ expected ^ "}")
+
 let check_extract_selector_props () =
   let rules = Tw.Rule.outputs (p 4) in
   check int "single rule extracted" 1 (List.length rules);
@@ -127,41 +147,34 @@ let test_modifier_to_rule () =
    Parse_error: the code forced a descendant combine and re-parsed ">div", which
    the selector reader rejects. They must flatten to the combinator selector. *)
 let test_arbitrary_selector_combinator () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  check bool "[&>div:first-child] keeps the child combinator" true
-    (Astring.String.is_infix ~affix:"> div:first-child"
-       (css "[&>div:first-child]:ring-2"));
-  check bool "[&+p] keeps the adjacent-sibling combinator" true
-    (Astring.String.is_infix ~affix:"+ p" (css "[&+p]:underline"));
-  check bool "[&_p] still flattens to a descendant" true
-    (Astring.String.is_infix ~affix:"]\\:underline p" (css "[&_p]:underline"))
+  check_sheet "[&>div:first-child]:ring-2"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-shadow:0 0 #0000;--tw-inset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-inset-ring-shadow:0 0 #0000;--tw-ring-offset-shadow:0 0 #0000;--tw-shadow-color:initial;--tw-shadow-alpha:100%;--tw-inset-shadow-color:initial;--tw-inset-shadow-alpha:100%;--tw-ring-color:initial;--tw-inset-ring-color:initial;--tw-ring-inset:initial;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff}}}@layer theme;@layer components;@layer utilities{.\[\&\>div\:first-child\]\:ring-2>div:first-child{--tw-ring-shadow:var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color,currentcolor);box-shadow:var(--tw-inset-shadow),var(--tw-inset-ring-shadow),var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow)}}@property --tw-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-offset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-shadow-color{syntax:"*";inherits:false}@property --tw-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-inset-shadow-color{syntax:"*";inherits:false}@property --tw-inset-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-ring-color{syntax:"*";inherits:false}@property --tw-inset-ring-color{syntax:"*";inherits:false}@property --tw-ring-inset{syntax:"*";inherits:false}@property --tw-ring-offset-width{syntax:"<length>";inherits:false;initial-value:0}@property --tw-ring-offset-color{syntax:"*";inherits:false;initial-value:#fff}|};
+  check_utilities "[&+p]:underline"
+    {|.\[\&\+p\]\:underline+p{text-decoration-line:underline}|};
+  check_utilities "[&_p]:underline"
+    {|.\[\&_p\]\:underline p{text-decoration-line:underline}|}
 
 (* [&] is the CSS nesting anchor and stands for the utility's own class, so it
    is substituted over the parsed selector. Rewriting the [&] bytes of the
    source text and re-parsing the result also rewrote an [&] that was part of a
    quoted attribute value. *)
 let test_arbitrary_anchor_in_quoted_value () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
+  (* This one stays on a substring. tw's library writes the attribute value
+     quoted, exactly as the pinned CLI does, but the optimizer the [tw] binary
+     runs respells it as [data-x=a\&b], so [--diff] reports a difference and the
+     sheet cannot be pinned as agreed output. *)
   let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
+    check bool cls true (Astring.String.is_infix ~affix (sheet cls))
   in
   has {|[&[data-x="a&b"]]:flex|}
     {|.\[\&\[data-x\=\"a\&b\"\]\]\:flex[data-x="a&b"]|};
   (* the spellings that already worked stay byte-identical *)
-  has "[&>*]:flex" {|.\[\&\>\*\]\:flex>*|};
-  has "[&_p]:flex" {|.\[\&_p\]\:flex p|};
-  has "[&:hover]:flex" {|.\[\&\:hover\]\:flex:hover|};
-  has "[input&]:flex" {|input.\[input\&\]\:flex|};
-  has "[p.foo]:flex" {|.\[p\.foo\]\:flex:is(p.foo)|};
-  has "[.line]:block" {|.\[\.line\]\:block.line|}
+  check_utilities "[&>*]:flex" {|.\[\&\>\*\]\:flex>*{display:flex}|};
+  check_utilities "[&_p]:flex" {|.\[\&_p\]\:flex p{display:flex}|};
+  check_utilities "[&:hover]:flex" {|.\[\&\:hover\]\:flex:hover{display:flex}|};
+  check_utilities "[input&]:flex" {|input.\[input\&\]\:flex{display:flex}|};
+  check_utilities "[p.foo]:flex" {|.\[p\.foo\]\:flex:is(p.foo){display:flex}|};
+  check_utilities "[.line]:block" {|.\[\.line\]\:block.line{display:block}|}
 
 (* Regression: an opacity color emits a progressive-enhancement @supports block.
    Under a variant, that block must stay scoped to the variant instead of
@@ -169,106 +182,94 @@ let test_arbitrary_anchor_in_quoted_value () =
    top-level .text-white/80 @supports rule alongside the correct
    .dark:text-white/80. *)
 let test_opacity_color_variant_no_leak () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  (* The base class must never appear as a standalone selector (".text-white");
-     only the variant-decorated ".dark\:text-white" / ".hover\:text-red" is
-     allowed. *)
-  check bool "dark:text-white/80 leaks no bare .text-white" false
-    (Astring.String.is_infix ~affix:".text-white" (css "dark:text-white/80"));
-  check bool "hover:text-red-500/50 leaks no bare .text-red" false
-    (Astring.String.is_infix ~affix:".text-red" (css "hover:text-red-500/50"))
+  (* Every rule the sheet holds is named here, so a leaked [.text-white] rule
+     has nowhere to hide. *)
+  check_sheet "dark:text-white/80"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-white:#fff}}@layer components;@layer utilities{@media(prefers-color-scheme:dark){.dark\:text-white\/80{color:#fffc}@supports(color:color-mix(in lab,red,red)){.dark\:text-white\/80{color:color-mix(in oklab,var(--color-white) 80%,transparent)}}}}|};
+  check_sheet "hover:text-red-500/50"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-red-500:oklch(63.7%.237 25.331)}}@layer components;@layer utilities{@media(hover:hover){.hover\:text-red-500\/50:hover{color:#fb2c3680}@supports(color:color-mix(in lab,red,red)){.hover\:text-red-500\/50:hover{color:color-mix(in oklab,var(--color-red-500) 50%,transparent)}}}}|}
 
 (* Regression: a stacked hover:dark:* variant must keep the @media (hover:hover)
    wrapper (nested inside the dark media), matching Tailwind. tw used to emit a
    bare @media (dark) block, so the hover style also applied on touch
    devices. *)
 let test_hover_dark_media_wrapper () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let s = css "hover:dark:text-white" in
-  check bool "hover:dark keeps @media (hover:hover)" true
-    (Astring.String.is_infix ~affix:"@media (hover:hover)" s
-    || Astring.String.is_infix ~affix:"@media(hover:hover)" s);
-  check bool "hover:dark keeps the dark media" true
-    (Astring.String.is_infix ~affix:"prefers-color-scheme:dark" s
-    || Astring.String.is_infix ~affix:"prefers-color-scheme: dark" s)
+  check_sheet "hover:dark:text-white"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-white:#fff}}@layer components;@layer utilities{@media(hover:hover){@media(prefers-color-scheme:dark){.hover\:dark\:text-white:hover{color:var(--color-white)}}}}|}
 
 (* An at-rule variant outside [group-hover:] must keep the inner variant's
    pointer-capability gate inside its own block. These wrappers used to consume
    the selector and declarations but not [has_hover], so the style matched on
    touch devices. Both named and bracketed spellings take the same route. *)
 let test_at_rule_keeps_inner_hover_gate () =
-  let cases =
-    [
-      ( "supports-grid:group-hover:flex-row",
-        "@supports(grid:var(--tw)){@media(hover:hover){" );
-      ( "supports-[display:grid]:group-hover:flex-row",
-        "@supports(display:grid){@media(hover:hover){" );
-      ( "[@supports(display:grid)]:group-hover:flex-row",
-        "@supports(display:grid){@media(hover:hover){" );
-      ("starting:group-hover:flex-row", "@starting-style{@media(hover:hover){");
-      ( "[@starting-style]:group-hover:flex-row",
-        "@starting-style{@media(hover:hover){" );
-      ( "sm:supports-[display:grid]:group-hover:flex-row",
-        "@supports(display:grid){@media(hover:hover){" );
-      ( "first:supports-[display:grid]:group-hover:flex-row",
-        "@supports(display:grid){@media(hover:hover){" );
-      ( "sm:starting:group-hover:flex-row",
-        "@starting-style{@media(hover:hover){" );
-      ( "first:[@starting-style]:group-hover:flex-row",
-        "@starting-style{@media(hover:hover){" );
-      ( "first:@sm:group-hover:flex-row",
-        "@container(width>=24rem){@media(hover:hover){" );
-      ( "sm:@sm:group-hover:flex-row",
-        "@container(width>=24rem){@media(hover:hover){" );
-      ( "supports-[display:grid]:starting:group-hover:flex-row",
-        "@supports(display:grid){@starting-style{@media(hover:hover){" );
-      ( "starting:supports-[display:grid]:group-hover:flex-row",
-        "@starting-style{@supports(display:grid){@media(hover:hover){" );
-      ( "supports-[display:grid]:@sm:group-hover:flex-row",
-        "@supports(display:grid){@container(width>=24rem){@media(hover:hover){"
-      );
-    ]
-  in
-  List.iter
-    (fun (cls, nesting) ->
-      let css =
-        match Tw.of_string cls with
-        | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-        | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-      in
-      check bool cls true (Astring.String.is_infix ~affix:nesting css))
-    cases
+  check_utilities "supports-grid:group-hover:flex-row"
+    {|@supports(grid:var(--tw)){@media(hover:hover){.supports-grid\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "supports-[display:grid]:group-hover:flex-row"
+    {|@supports(display:grid){@media(hover:hover){.supports-\[display\:grid\]\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "[@supports(display:grid)]:group-hover:flex-row"
+    {|@supports(display:grid){@media(hover:hover){.\[\@supports\(display\:grid\)\]\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "starting:group-hover:flex-row"
+    {|@starting-style{@media(hover:hover){.starting\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "[@starting-style]:group-hover:flex-row"
+    {|@starting-style{@media(hover:hover){.\[\@starting-style\]\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "sm:supports-[display:grid]:group-hover:flex-row"
+    {|@media(min-width:40rem){@supports(display:grid){@media(hover:hover){.sm\:supports-\[display\:grid\]\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}}|};
+  check_utilities "first:supports-[display:grid]:group-hover:flex-row"
+    {|@supports(display:grid){@media(hover:hover){.first\:supports-\[display\:grid\]\:group-hover\:flex-row:first-child:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "sm:starting:group-hover:flex-row"
+    {|@media(min-width:40rem){@starting-style{@media(hover:hover){.sm\:starting\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}}|};
+  check_utilities "first:[@starting-style]:group-hover:flex-row"
+    {|@starting-style{@media(hover:hover){.first\:\[\@starting-style\]\:group-hover\:flex-row:first-child:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "first:@sm:group-hover:flex-row"
+    {|@container(width>=24rem){@media(hover:hover){.first\:\@sm\:group-hover\:flex-row:first-child:is(:where(.group):hover *){flex-direction:row}}}|};
+  check_utilities "sm:@sm:group-hover:flex-row"
+    {|@media(min-width:40rem){@container(width>=24rem){@media(hover:hover){.sm\:\@sm\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}}|};
+  check_utilities "supports-[display:grid]:starting:group-hover:flex-row"
+    {|@supports(display:grid){@starting-style{@media(hover:hover){.supports-\[display\:grid\]\:starting\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}}|};
+  check_utilities "starting:supports-[display:grid]:group-hover:flex-row"
+    {|@starting-style{@supports(display:grid){@media(hover:hover){.starting\:supports-\[display\:grid\]\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}}|};
+  check_utilities "supports-[display:grid]:@sm:group-hover:flex-row"
+    {|@supports(display:grid){@container(width>=24rem){@media(hover:hover){.supports-\[display\:grid\]\:\@sm\:group-hover\:flex-row:is(:where(.group):hover *){flex-direction:row}}}}|}
 
 (* A selector-building outer variant must retain the capability gate carried by
    an inner peer-hover rule. [not-[:hover]] takes a dedicated multi-rule route,
    which used to keep the transformed selector but drop [has_hover]. *)
 let test_selector_variant_keeps_inner_hover_gate () =
+  (* Each of these renders the same sheet but for its selector: touch-pan-x's
+     property defaults, then the rule inside [@media(hover:hover)]. Spelling the
+     parts they share once is what leaves the selector legible. *)
+  let pan_properties =
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-pan-y:initial;--tw-pinch-zoom:initial;--tw-pan-x:initial}}}@layer theme;@layer components;@layer utilities{@media(hover:hover){|}
+  in
+  let pan_rule =
+    {|{--tw-pan-x:pan-x;touch-action:var(--tw-pan-x,) var(--tw-pan-y,) var(--tw-pinch-zoom,)}}}@property --tw-pan-y{syntax:"*";inherits:false}@property --tw-pinch-zoom{syntax:"*";inherits:false}@property --tw-pan-x{syntax:"*";inherits:false}|}
+  in
+  let gated cls selector =
+    check_sheet cls (pan_properties ^ selector ^ pan_rule)
+  in
+  gated "not-[:hover]:peer-hover:touch-pan-x"
+    {|.not-\[\:hover\]\:peer-hover\:touch-pan-x:not(:hover):is(:where(.peer):hover~*)|};
+  gated "not-focus:peer-hover:touch-pan-x"
+    {|.not-focus\:peer-hover\:touch-pan-x:not(:focus):is(:where(.peer):hover~*)|};
+  gated "group-not-focus:peer-hover:touch-pan-x"
+    {|.group-not-focus\:peer-hover\:touch-pan-x:is(:where(.group):not(:focus) *):is(:where(.peer):hover~*)|};
+  gated "peer-not-focus:peer-hover:touch-pan-x"
+    {|.peer-not-focus\:peer-hover\:touch-pan-x:is(:where(.peer):not(:focus)~*):is(:where(.peer):hover~*)|};
+  gated "group-focus/foo:peer-hover:touch-pan-x"
+    {|.group-focus\/foo\:peer-hover\:touch-pan-x:is(:where(.group\/foo):focus *):is(:where(.peer):hover~*)|};
+  gated "peer-focus/foo:peer-hover:touch-pan-x"
+    {|.peer-focus\/foo\:peer-hover\:touch-pan-x:is(:where(.peer\/foo):focus~*):is(:where(.peer):hover~*)|};
+  (* These two stay on a substring. tw anchors the scope inside an [:is()] -
+     [:is(:where(.parent) .in-\[\.parent\]\:peer-hover\:touch-pan-x)] - where
+     the pinned CLI writes the descendant relation bare, so [--diff] reports a
+     changed selector and neither sheet can be pinned as agreed output. *)
   List.iter
     (fun cls ->
-      let css =
-        match Tw.of_string cls with
-        | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-        | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-      in
       check bool cls true
-        (Astring.String.is_infix ~affix:"@media(hover:hover){" css))
+        (Astring.String.is_infix ~affix:"@media(hover:hover){" (sheet cls)))
     [
-      "not-[:hover]:peer-hover:touch-pan-x";
-      "not-focus:peer-hover:touch-pan-x";
       "in-[.parent]:peer-hover:touch-pan-x";
       "in-data-open:peer-hover:touch-pan-x";
-      "group-not-focus:peer-hover:touch-pan-x";
-      "peer-not-focus:peer-hover:touch-pan-x";
-      "group-focus/foo:peer-hover:touch-pan-x";
-      "peer-focus/foo:peer-hover:touch-pan-x";
     ]
 
 (* An outer variant has to find the class the inner one produced. The child
@@ -277,36 +278,26 @@ let test_selector_variant_keeps_inner_hover_gate () =
    invisible: the outer variant dropped out of the class name, and stacking two
    child variants collapsed to one. *)
 let test_outer_variant_over_child_and_pseudo () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "max-sm:after:block" ".max-sm\\:after\\:block:after";
-  has "hover:before:underline" ".hover\\:before\\:underline:hover:before";
-  has "sm:*:rotate-0" ":is(.sm\\:\\*\\:rotate-0>*)";
-  has "hover:*:underline" ":is(.hover\\:\\*\\:underline:hover>*)";
-  has "*:*:grow" ":is(:is(.\\*\\:\\*\\:grow>*)>*)"
+  check_sheet "max-sm:after:block"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-content:""}}}@layer theme;@layer components;@layer utilities{@media not all and (min-width:40rem){.max-sm\:after\:block:after{content:var(--tw-content);display:block}}}@property --tw-content{syntax:"*";inherits:false;initial-value:""}|};
+  check_sheet "hover:before:underline"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-content:""}}}@layer theme;@layer components;@layer utilities{@media(hover:hover){.hover\:before\:underline:hover:before{content:var(--tw-content);text-decoration-line:underline}}}@property --tw-content{syntax:"*";inherits:false;initial-value:""}|};
+  check_utilities "sm:*:rotate-0"
+    {|@media(min-width:40rem){:is(.sm\:\*\:rotate-0>*){rotate:0deg}}|};
+  check_utilities "hover:*:underline"
+    {|@media(hover:hover){:is(.hover\:\*\:underline:hover>*){text-decoration-line:underline}}|};
+  check_utilities "*:*:grow" {|:is(:is(.\*\:\*\:grow>*)>*){flex-grow:1}|}
 
 (* An arbitrary variant with no [&] anchor compounds onto the utility's own
    class: [[.line]] attaches directly, a type selector goes in an [:is()] since
    it cannot follow a class. One that is not a single compound ([[>img]]) is not
    a variant at all. *)
 let test_bare_arbitrary_selector_variant () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "[.line]:block" ".\\[\\.line\\]\\:block.line";
-  has "[code]:pr-4" ".\\[code\\]\\:pr-4:is(code)";
-  has "**:[code]:pr-4" ":is(.\\*\\*\\:\\[code\\]\\:pr-4 *):is(code)";
+  check_utilities "[.line]:block" {|.\[\.line\]\:block.line{display:block}|};
+  check_sheet "[code]:pr-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{.\[code\]\:pr-4:is(code){padding-right:calc(var(--spacing)*4)}}|};
+  check_sheet "**:[code]:pr-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{:is(.\*\*\:\[code\]\:pr-4 *):is(code){padding-right:calc(var(--spacing)*4)}}|};
   check bool "[>img] is not a variant" true
     (Result.is_error (Tw.of_string "[>img]:flex"))
 
@@ -317,19 +308,14 @@ let test_bare_arbitrary_selector_variant () =
    entirely, since the media path rebuilds the selector from a spelling [[svg]]
    has none of. *)
 let test_arbitrary_selector_stacking () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "[svg]:first:size-4" ".\\[svg\\]\\:first\\:size-4:is(svg):first-child";
-  has "[&_p]:first:size-4" ".\\[\\&_p\\]\\:first\\:size-4 p:first-child";
-  has "[svg]:sm:size-4" ".\\[svg\\]\\:sm\\:size-4:is(svg)";
-  has "**:[svg]:first:sm:size-4"
-    ":is(.\\*\\*\\:\\[svg\\]\\:first\\:sm\\:size-4 *):is(svg):first-child"
+  check_sheet "[svg]:first:size-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{.\[svg\]\:first\:size-4:is(svg):first-child{width:calc(var(--spacing)*4);height:calc(var(--spacing)*4)}}|};
+  check_sheet "[&_p]:first:size-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{.\[\&_p\]\:first\:size-4 p:first-child{width:calc(var(--spacing)*4);height:calc(var(--spacing)*4)}}|};
+  check_sheet "[svg]:sm:size-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@media(min-width:40rem){.\[svg\]\:sm\:size-4:is(svg){width:calc(var(--spacing)*4);height:calc(var(--spacing)*4)}}}|};
+  check_sheet "**:[svg]:first:sm:size-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@media(min-width:40rem){:is(.\*\*\:\[svg\]\:first\:sm\:size-4 *):is(svg):first-child{width:calc(var(--spacing)*4);height:calc(var(--spacing)*4)}}}|}
 
 let occurrences sub str =
   let n = String.length sub in
@@ -404,39 +390,26 @@ let test_opacity_supports_inside_at_rule_variant () =
    variant gave a class the HTML would not match. Its condition is emitted as
    written, prefixed property or not. *)
 let test_bracketed_at_rule_variant () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "[@starting-style]:opacity-0"
-    "@starting-style{.\\[\\@starting-style\\]\\:opacity-0";
-  has "[@supports(display:grid)]:grid" "@supports(display:grid)";
-  has "[@supports(display:grid)]:grid"
-    ".\\[\\@supports\\(display\\:grid\\)\\]\\:grid";
-  has "[@supports(backdrop-filter:blur(0))]:backdrop-blur"
-    "@supports(backdrop-filter:blur(0))";
-  has "supports-[display:grid]:flex" "@supports(display:grid)"
+  check_utilities "[@starting-style]:opacity-0"
+    {|@starting-style{.\[\@starting-style\]\:opacity-0{opacity:0}}|};
+  check_utilities "[@supports(display:grid)]:grid"
+    {|@supports(display:grid){.\[\@supports\(display\:grid\)\]\:grid{display:grid}}|};
+  check_sheet "[@supports(backdrop-filter:blur(0))]:backdrop-blur"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-backdrop-blur:initial;--tw-backdrop-brightness:initial;--tw-backdrop-contrast:initial;--tw-backdrop-grayscale:initial;--tw-backdrop-hue-rotate:initial;--tw-backdrop-invert:initial;--tw-backdrop-opacity:initial;--tw-backdrop-saturate:initial;--tw-backdrop-sepia:initial}}}@layer theme;@layer components;@layer utilities{@supports(backdrop-filter:blur(0)){.\[\@supports\(backdrop-filter\:blur\(0\)\)\]\:backdrop-blur{--tw-backdrop-blur:blur(8px);-webkit-backdrop-filter:var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,);backdrop-filter:var(--tw-backdrop-blur,)var(--tw-backdrop-brightness,)var(--tw-backdrop-contrast,)var(--tw-backdrop-grayscale,)var(--tw-backdrop-hue-rotate,)var(--tw-backdrop-invert,)var(--tw-backdrop-opacity,)var(--tw-backdrop-saturate,)var(--tw-backdrop-sepia,)}}}@property --tw-backdrop-blur{syntax:"*";inherits:false}@property --tw-backdrop-brightness{syntax:"*";inherits:false}@property --tw-backdrop-contrast{syntax:"*";inherits:false}@property --tw-backdrop-grayscale{syntax:"*";inherits:false}@property --tw-backdrop-hue-rotate{syntax:"*";inherits:false}@property --tw-backdrop-invert{syntax:"*";inherits:false}@property --tw-backdrop-opacity{syntax:"*";inherits:false}@property --tw-backdrop-saturate{syntax:"*";inherits:false}@property --tw-backdrop-sepia{syntax:"*";inherits:false}|};
+  check_utilities "supports-[display:grid]:flex"
+    {|@supports(display:grid){.supports-\[display\:grid\]\:flex{display:flex}}|}
 
 (* [in-focus] scopes to an ancestor in that state, the same state names the
    group and peer variants take. It used to be an unknown class: only the
    bracket and data spellings were read. *)
 let test_in_state_variant () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "in-focus:opacity-100" ":where(:focus) .in-focus\\:opacity-100";
-  has "in-checked:flex" ":where(:checked) .in-checked\\:flex";
+  check_utilities "in-focus:opacity-100"
+    {|:where(:focus) .in-focus\:opacity-100{opacity:1}|};
+  check_utilities "in-checked:flex"
+    {|:where(:checked) .in-checked\:flex{display:flex}|};
   (* in-hover gates on the pointer, as hover itself does *)
-  has "in-hover:flex" "@media(hover:hover)"
+  check_utilities "in-hover:flex"
+    {|@media(hover:hover){:where(:hover) .in-hover\:flex{display:flex}}|}
 
 (* [before:]/[after:] add the content declaration the pseudo-element needs, but
    a content-* utility already brings its own: adding a second one left it
@@ -466,103 +439,76 @@ let test_pseudo_element_content_once () =
    used to discard whatever an inner variant had already done: the [:hover], the
    child combinator, the second attribute. *)
 let test_attribute_variant_keeps_inner () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "aria-selected:hover:underline" "[aria-selected=true]:hover";
-  has "data-[closed]:data-[enter]:-translate-x-8" "[data-closed][data-enter]";
-  has "has-checked:hover:bg-indigo-500" ":has(:checked):hover";
-  has "aria-selected:*:font-medium" "[aria-selected=true]>*";
+  check_utilities "aria-selected:hover:underline"
+    {|@media(hover:hover){.aria-selected\:hover\:underline[aria-selected=true]:hover{text-decoration-line:underline}}|};
+  check_sheet "data-[closed]:data-[enter]:-translate-x-8"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-translate-x:0;--tw-translate-y:0;--tw-translate-z:0}}}@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{.data-\[closed\]\:data-\[enter\]\:-translate-x-8[data-closed][data-enter]{--tw-translate-x:calc(var(--spacing)*-8);translate:var(--tw-translate-x)var(--tw-translate-y)}}@property --tw-translate-x{syntax:"*";inherits:false;initial-value:0}@property --tw-translate-y{syntax:"*";inherits:false;initial-value:0}@property --tw-translate-z{syntax:"*";inherits:false;initial-value:0}|};
+  check_sheet "has-checked:hover:bg-indigo-500"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-indigo-500:oklch(58.5%.233 277.117)}}@layer components;@layer utilities{@media(hover:hover){.has-checked\:hover\:bg-indigo-500:has(:checked):hover{background-color:var(--color-indigo-500)}}}|};
+  check_sheet "aria-selected:*:font-medium"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-font-weight:initial}}}@layer theme{:root,:host{--font-weight-medium:500}}@layer components;@layer utilities{:is(.aria-selected\:\*\:font-medium[aria-selected=true]>*){--tw-font-weight:var(--font-weight-medium);font-weight:var(--font-weight-medium)}}@property --tw-font-weight{syntax:"*";inherits:false}|};
   (* the inner [hover:] keeps its own @media gate under an outer variant *)
-  has "disabled:hover:bg-indigo-500" "(hover:hover)";
-  has "has-checked:hover:bg-indigo-500" "(hover:hover)"
+  check_sheet "disabled:hover:bg-indigo-500"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-indigo-500:oklch(58.5%.233 277.117)}}@layer components;@layer utilities{@media(hover:hover){.disabled\:hover\:bg-indigo-500:disabled:hover{background-color:var(--color-indigo-500)}}}|}
 
 (* [not-] over a variant that anchors the class under an ancestor negates the
    ancestor relation, and over an inner variant it keeps that variant's own
    selector work. *)
 let test_not_variant_keeps_inner () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "not-in-data-open:hidden" ":not(:where([data-open]) *)";
-  has "not-checked:before:hidden" ":not(:checked):before";
-  has "not-data-focus:not-has-checked:ring-inset"
-    ":not([data-focus]):not(:has(:checked))"
+  check_utilities "not-in-data-open:hidden"
+    {|.not-in-data-open\:hidden:not(:where([data-open]) *){display:none}|};
+  check_sheet "not-checked:before:hidden"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-content:""}}}@layer theme;@layer components;@layer utilities{.not-checked\:before\:hidden:not(:checked):before{content:var(--tw-content);display:none}}@property --tw-content{syntax:"*";inherits:false;initial-value:""}|};
+  check_sheet "not-data-focus:not-has-checked:ring-inset"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-shadow:0 0 #0000;--tw-shadow-color:initial;--tw-shadow-alpha:100%;--tw-inset-shadow:0 0 #0000;--tw-inset-shadow-color:initial;--tw-inset-shadow-alpha:100%;--tw-ring-color:initial;--tw-ring-shadow:0 0 #0000;--tw-inset-ring-color:initial;--tw-inset-ring-shadow:0 0 #0000;--tw-ring-inset:initial;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-offset-shadow:0 0 #0000}}}@layer theme;@layer components;@layer utilities{.not-data-focus\:not-has-checked\:ring-inset:not([data-focus]):not(:has(:checked)){--tw-ring-inset:inset}}@property --tw-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-shadow-color{syntax:"*";inherits:false}@property --tw-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-inset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-shadow-color{syntax:"*";inherits:false}@property --tw-inset-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-ring-color{syntax:"*";inherits:false}@property --tw-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-inset-ring-color{syntax:"*";inherits:false}@property --tw-inset-ring-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}@property --tw-ring-inset{syntax:"*";inherits:false}@property --tw-ring-offset-width{syntax:"<length>";inherits:false;initial-value:0}@property --tw-ring-offset-color{syntax:"*";inherits:false;initial-value:#fff}@property --tw-ring-offset-shadow{syntax:"*";inherits:false;initial-value:0 0 #0000}|}
 
 (* The in-/named-group/peer routes build their selector from the bare class too,
    so an outer one used to drop the anchor an inner arbitrary selector had put
    in place. *)
 let test_in_variant_keeps_inner () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "in-data-stack:[:first-child>&]:underline"
-    ":first-child>:is(:where([data-stack]) .in-data-stack";
-  (* prose's own [:where(.prose > :last-child)] still only gets renamed *)
-  has "hover:prose" ":where(.hover\\:prose>:last-child)"
+  check_utilities "in-data-stack:[:first-child>&]:underline"
+    {|:first-child>:is(:where([data-stack]) .in-data-stack\:\[\:first-child\>\&\]\:underline){text-decoration-line:underline}|};
+  (* prose's own [:where(.prose > :last-child)] still only gets renamed. This
+     one stays on a substring: [prose] renders the whole typography component
+     sheet, some fourteen thousand bytes of it, and the assertion is about one
+     selector inside it. *)
+  check bool "hover:prose" true
+    (Astring.String.is_infix ~affix:{|:where(.hover\:prose>:last-child)|}
+       (sheet "hover:prose"))
 
 (* An arbitrary-selector variant anchors the utility's class, so when an inner
    variant has already moved the subject the anchor belongs at the class's own
    position - not wrapped around everything the inner variant built. *)
 let test_arbitrary_anchor_over_child () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  check bool "the child variant's tail stays outermost" true
-    (Astring.String.is_infix
-       ~affix:":is(:last-child>:is(:where([data-stack]) .in-data-stack"
-       (css "in-data-stack:[:last-child>&]:*:rounded-b-xl"))
+  check_sheet "in-data-stack:[:last-child>&]:*:rounded-b-xl"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--radius-xl:.75rem}}@layer components;@layer utilities{:is(:last-child>:is(:where([data-stack]) .in-data-stack\:\[\:last-child\>\&\]\:\*\:rounded-b-xl)>*){border-bottom-right-radius:var(--radius-xl);border-bottom-left-radius:var(--radius-xl)}}|}
 
 (* [has-<variant>] takes any variant, not only a state name or a bracket: its
    own selector is what goes inside [:has()]. A scoped variant contributes its
    whole relative selector, so it composes both ways. *)
 let test_has_variant () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
-  has "has-peer-checked:underline" ":has(:is(:where(.peer):checked~*))";
-  has "group-not-has-peer-not-data-active:underline"
-    ":is(:where(.group):not(:has(:is(:where(.peer):not([data-active])~*))) *)";
+  check_utilities "has-peer-checked:underline"
+    {|.has-peer-checked\:underline:has(:is(:where(.peer):checked~*)){text-decoration-line:underline}|};
+  check_utilities "group-not-has-peer-not-data-active:underline"
+    {|.group-not-has-peer-not-data-active\:underline:is(:where(.group):not(:has(:is(:where(.peer):not([data-active])~*))) *){text-decoration-line:underline}|};
   (* a named group scopes on the marker class, and the whole relative selector
      is what [:has()] sees *)
-  has "has-group-focus/name:underline"
-    ":has(:is(:where(.group\\/name):focus *))"
-
-let variant_css cls =
-  match Tw.of_string cls with
-  | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-  | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  check_utilities "has-group-focus/name:underline"
+    {|.has-group-focus\/name\:underline:has(:is(:where(.group\/name):focus *)){text-decoration-line:underline}|}
 
 let variant_has cls affix =
-  check bool cls true (Astring.String.is_infix ~affix (variant_css cls))
+  check bool cls true (Astring.String.is_infix ~affix (sheet cls))
 
 (* An inner media query's nested blocks hold the utility's class too, so an
    outer responsive variant has to rename it there as well: [sm:] used to drop
    out of the class name whenever [hover:] had wrapped the rule in its own media
    block. *)
 let test_outer_media_renames_nested () =
+  (* Both stay on a substring. Beside the rule under test tw also writes an
+     empty [.sm\:dark\:hover\:underline:hover{}] into the dark media block,
+     which the pinned CLI does not; the canonical [--diff] prunes an empty rule
+     off both sides and so reports no difference. Pinning the sheet would fix
+     that surplus rule in place as if it were agreed output. *)
   variant_has "sm:motion-reduce:hover:translate-y-0"
     ".sm\\:motion-reduce\\:hover\\:translate-y-0:hover";
   variant_has "sm:dark:hover:underline" ".sm\\:dark\\:hover\\:underline:hover"
@@ -571,78 +517,69 @@ let test_outer_media_renames_nested () =
    and rebuilding the selector from the bare class dropped whatever an inner
    variant had put on it. *)
 let test_at_rule_keeps_inner () =
-  variant_has "starting:open:opacity-0" ":is([open],:popover-open,:open)";
-  variant_has "[@starting-style]:open:opacity-0"
-    ":is([open],:popover-open,:open)"
+  check_utilities "starting:open:opacity-0"
+    {|@starting-style{.starting\:open\:opacity-0:is([open],:popover-open,:open){opacity:0}}|};
+  check_utilities "[@starting-style]:open:opacity-0"
+    {|@starting-style{.\[\@starting-style\]\:open\:opacity-0:is([open],:popover-open,:open){opacity:0}}|}
 
 (* A prose element variant rebuilt its selector from the bare class, which threw
    away whatever an inner variant had put on it: [prose-a:hover:text-red-500]
    lost its [:hover] and coloured every link, [prose-li:marker:text-green-500]
    lost its [::marker] and coloured the item's own text. *)
 let test_prose_element_keeps_inner () =
-  variant_has "prose-a:hover:text-red-500" "[class~=not-prose] *)):hover";
-  variant_has "prose-li:marker:text-green-500" "[class~=not-prose] *))::marker";
-  variant_has "prose-p:first-line:uppercase" "[class~=not-prose] *)):first-line";
-  variant_has "prose-code:after:content-['y']" "[class~=not-prose] *)):after"
+  check_sheet "prose-a:hover:text-red-500"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-red-500:oklch(63.7%.237 25.331)}}@layer components;@layer utilities{@media(hover:hover){.prose-a\:hover\:text-red-500 :where(a):not(:where([class~=not-prose],[class~=not-prose] *)):hover{color:var(--color-red-500)}}}|};
+  check_sheet "prose-li:marker:text-green-500"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-green-500:oklch(72.3%.219 149.579)}}@layer components;@layer utilities{.prose-li\:marker\:text-green-500 :where(li):not(:where([class~=not-prose],[class~=not-prose] *)) ::marker{color:var(--color-green-500)}.prose-li\:marker\:text-green-500 :where(li):not(:where([class~=not-prose],[class~=not-prose] *))::marker{color:var(--color-green-500)}.prose-li\:marker\:text-green-500 :where(li):not(:where([class~=not-prose],[class~=not-prose] *)) ::-webkit-details-marker{color:var(--color-green-500)}.prose-li\:marker\:text-green-500 :where(li):not(:where([class~=not-prose],[class~=not-prose] *))::-webkit-details-marker{color:var(--color-green-500)}}|};
+  check_utilities "prose-p:first-line:uppercase"
+    {|.prose-p\:first-line\:uppercase :where(p):not(:where([class~=not-prose],[class~=not-prose] *)):first-line{text-transform:uppercase}|};
+  check_sheet "prose-code:after:content-['y']"
+    {|@layer properties,theme,components,utilities;@layer properties{@supports(((-webkit-hyphens:none)) and (not (margin-trim:inline)))or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-content:""}}}@layer theme;@layer components;@layer utilities{.prose-code\:after\:content-\[\'y\'\] :where(code):not(:where([class~=not-prose],[class~=not-prose] *)):after{--tw-content:"y";content:var(--tw-content)}}@property --tw-content{syntax:"*";inherits:false;initial-value:""}|}
 
 (* The reverse direction: a prose element variant over a rule that is already a
    media query built its selector from [Modifiers.to_selector], which returned
    the class alone, so the elements it targets went missing and the utility
    landed on the container. *)
 let test_prose_element_over_media () =
-  variant_has "prose-p:md:text-lg" ".prose-p\\:md\\:text-lg :where(p)";
-  variant_has "prose-a:dark:text-white" ".prose-a\\:dark\\:text-white :where(a)"
+  check_sheet "prose-p:md:text-lg"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--text-lg:1.125rem;--text-lg--line-height:calc(1.75/1.125)}}@layer components;@layer utilities{@media(min-width:48rem){.prose-p\:md\:text-lg :where(p):not(:where([class~=not-prose],[class~=not-prose] *)){font-size:var(--text-lg);line-height:var(--tw-leading,var(--text-lg--line-height))}}}|};
+  check_sheet "prose-a:dark:text-white"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--color-white:#fff}}@layer components;@layer utilities{@media(prefers-color-scheme:dark){.prose-a\:dark\:text-white :where(a):not(:where([class~=not-prose],[class~=not-prose] *)){color:var(--color-white)}}}|}
 
 (* [apply_modifier_to_rule] had no arm for a [@starting-style] rule, so an outer
    variant fell through the catch-all and went with it: [hover:starting:p-4]
    named its rule [.starting\\:p-4], a class the source never carries, and the
    rule matched nothing. Every other at-rule wrapper had an arm already. *)
 let test_variant_outside_starting_style () =
-  List.iter
-    (fun cls ->
-      match Tw.of_string cls with
-      | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-      | Ok u ->
-          let css = Tw.to_css ~base:false [ u ] |> Tw.Css.to_string in
-          Alcotest.(check bool)
-            (cls ^ " keeps its own class")
-            true
-            (Astring.String.is_infix
-               ~affix:(Tw.Css.Selector.to_string (Tw.Css.Selector.class_ cls))
-               css);
-          Alcotest.(check bool)
-            (cls ^ " stays inside @starting-style")
-            true
-            (Astring.String.is_infix ~affix:"@starting-style" css))
-    [
-      "starting:p-4";
-      "hover:starting:p-4";
-      "md:starting:p-4";
-      "first:starting:p-4";
-      "nth-3:starting:p-4";
-      "dark:starting:opacity-50";
-    ]
+  check_sheet "starting:p-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@starting-style{.starting\:p-4{padding:calc(var(--spacing)*4)}}}|};
+  check_sheet "hover:starting:p-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@media(hover:hover){@starting-style{.hover\:starting\:p-4:hover{padding:calc(var(--spacing)*4)}}}}|};
+  check_sheet "md:starting:p-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@media(min-width:48rem){@starting-style{.md\:starting\:p-4{padding:calc(var(--spacing)*4)}}}}|};
+  check_sheet "first:starting:p-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@starting-style{.first\:starting\:p-4:first-child{padding:calc(var(--spacing)*4)}}}|};
+  check_sheet "nth-3:starting:p-4"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--spacing:.25rem}}@layer components;@layer utilities{@starting-style{.nth-3\:starting\:p-4:nth-child(3){padding:calc(var(--spacing)*4)}}}|};
+  check_utilities "dark:starting:opacity-50"
+    {|@media(prefers-color-scheme:dark){@starting-style{.dark\:starting\:opacity-50{opacity:.5}}}|}
 
 (* The selector a variant's bracket spells reads [_] as a space and [\_] as a
    literal underscore, so a class or an attribute value carrying one is written
    with the escape. *)
 let test_selector_underscore_escape () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool)
-      (cls ^ " emits " ^ affix)
-      true
-      (Astring.String.is_infix ~affix (css cls))
-  in
-  has {|aria-[label=a\_b]:flex|} {|[aria-label="a_b"]|};
-  has {|not-[.a\_b]:flex|} ":not(.a_b)";
-  has {|[.a\_b_&]:flex|} ".a_b .";
-  (* A bare [_] still stands for a space. *)
-  has "aria-[label=a_b]:flex" {|[aria-label="a b"]|}
+  check_utilities {|aria-[label=a\_b]:flex|}
+    {|.aria-\[label\=a\\_b\]\:flex[aria-label=a_b]{display:flex}|};
+  check_utilities {|not-[.a\_b]:flex|}
+    {|.not-\[\.a\\_b\]\:flex:not(.a_b){display:flex}|};
+  check_utilities {|[.a\_b_&]:flex|}
+    {|.a_b .\[\.a\\_b_\&\]\:flex{display:flex}|};
+  (* A bare [_] still stands for a space. This one stays on a substring: tw
+     quotes the attribute value where the pinned CLI escapes the space
+     ([aria-label=a\ b]), so [--diff] reports a changed selector. *)
+  check bool "aria-[label=a_b]:flex" true
+    (Astring.String.is_infix ~affix:{|[aria-label="a b"]|}
+       (sheet "aria-[label=a_b]:flex"))
 
 let tests =
   [


### PR DESCRIPTION
Converts the substring assertions left in `test_borders.ml`, `test_rule.ml` and `test/html/test_tw_html.ml`. A substring check passes on a longer class name or a longer selector, and a failing `check bool` prints neither the subject nor the output.

Borders compares declarations exactly; the rule and html suites compare the whole rendered sheet or markup, since what they test is a selector, an at-rule or an attribute, none of which is a declaration. Six sites stay on a substring, each with a comment saying why: a project theme the default-theme helper cannot resolve, four classes where tw and the pinned CLI disagree, and `hover:prose`, whose sheet is fourteen thousand bytes.

Two divergences surfaced while pinning. `sm:dark:hover:underline` and `sm:motion-reduce:hover:translate-y-0` make tw write an empty rule beside the real one, which the canonical differ prunes off both sides and so reports as agreement. `aria-[label=a_b]:flex` quotes the attribute value where the CLI escapes the space. Both are recorded in the comments rather than encoded as expected output.