### PR TITLE
color, modifiers: keep the authored hex and the theme binding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -315,6 +315,10 @@
   wrapped in a supports, container or starting-style variant. The modern
   `color-mix()` declaration was previously left unguarded inside that wrapper
   (#666).
+- A container query reading a theme token still writes the token's binding.
+  `@min-[theme(--breakpoint-lg)]:flex` resolved the reference into the query and
+  left `--breakpoint-lg` out of the theme layer, so a consumer reading it off
+  the sheet found nothing (#700).
 - `[attr~=value]` attribute selectors work in arbitrary variants. The gate
   rejected any bracket containing `~`, reading the whitespace-list operator as
   a sibling combinator (#509).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -284,6 +284,9 @@
   `decoration-`, `divide-` and `stroke-` accept the modifier at all now, and a
   colour the browser resolves at use time keeps the `@supports` fallback
   Tailwind writes (#508, #517).
+- An arbitrary colour reaches CSS in the spelling the class wrote. `bg-[#f00]`
+  gave `#ff0000`, `bg-[#ffffffff]` gave `#ffffff` and `bg-[#FF0000]` lost its
+  case, where Tailwind writes back what the bracket held (#700).
 - A `theme()` alpha survives a hex-bound palette entry. It was applied by
   chopping the colour's closing paren, so it vanished whenever the entry was a
   hex rather than an `oklch()` (#508).

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -733,6 +733,19 @@ let shorten_hex_str hex_str =
     else hex_no_hash
   else hex_no_hash
 
+(* An arbitrary colour reaches CSS in the spelling the class wrote it in, which
+   is what Tailwind emits: [bg-[#f00]] gives [#f00] and [bg-[#ffffffff]] all
+   eight digits, whatever the shortest equivalent would be. Cascade's reader is
+   what carries that spelling alongside the decoded bytes; [Css.hex] keeps the
+   bytes alone and the printer then spells them in full. *)
+let authored_hex hex_str =
+  let spelled =
+    if String.starts_with ~prefix:"#" hex_str then hex_str else "#" ^ hex_str
+  in
+  match Css.parse_color spelled with
+  | Some (Css.Authored_hex _ as c) -> c
+  | Some _ | None -> Css.hex spelled
+
 let is_rgb_call s =
   String.starts_with ~prefix:"rgb(" s && String.ends_with ~suffix:")" s
 
@@ -1077,16 +1090,8 @@ let to_css ?theme color shade =
   match color with
   | Black -> Css.hex "#000"
   | White -> Css.hex "#fff"
-  | Hex hex ->
-      (* For arbitrary hex colors, always output valid CSS with # prefix. Per
-         MDN spec, hex colors MUST have # prefix. Shorten hex for CSS output
-         (e.g., 0088cc -> 08c) while class names preserve original. *)
-      let hex_value =
-        if String.starts_with ~prefix:"#" hex then
-          String.sub hex 1 (String.length hex - 1)
-        else hex
-      in
-      Css.hex ("#" ^ shorten_hex_str hex_value)
+  (* The class named the spelling, so that is the one CSS gets, [#] and all. *)
+  | Hex hex -> authored_hex hex
   | Oklch oklch -> css_color_of_oklch oklch
   | Css c -> c
   | Theme_named name -> (
@@ -1998,10 +2003,14 @@ module Handler = struct
           | _ -> None)
       | None -> (
           (* A [#] prefix only names a colour when what follows is a hex
-             spelling; [Css.hex] raises on anything else, and this runs inside
-             [of_class]. *)
+             spelling, so this reads the digits rather than raising on them
+             inside [of_class]. Reading them through the parser is what keeps
+             the spelling the bracket wrote, which is the one Tailwind emits. *)
           let starts_with_hash = String.length inner > 0 && inner.[0] = '#' in
-          if starts_with_hash then Css.hex_opt inner
+          if starts_with_hash then
+            match Css.hex_opt inner with
+            | Some _ -> Some (authored_hex inner)
+            | None -> None
           else
             let normalized = Parse.decode_underscores inner in
             (* Any colour CSS knows wins over the palette, keywords and system
@@ -2472,13 +2481,14 @@ module Handler = struct
         | _ -> None)
     | _ -> None
 
-  (** Resolve a typed [Css.color] to its emission form. Hex colors are
-      shortened, color functions are converted to hex where possible. This
-      mirrors the logic that was previously inlined in each [to_style] branch.
+  (** Resolve a typed [Css.color] to its emission form. A hex keeps the spelling
+      the bracket wrote, a colour function is converted to hex where possible.
   *)
   let resolve_bracket_css_color (css_color : Css.color) : Css.color =
     match css_color with
-    | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
+    (* The bracket's own spelling is the one Tailwind writes back. *)
+    | Authored_hex _ -> css_color
+    | Hex { r; g; b; a } ->
         let value = hex_string_of_rgb (r, g, b) in
         let value = if a = 255 then value else value ^ hex_byte a in
         Css.hex ("#" ^ shorten_hex_str value)
@@ -2858,6 +2868,12 @@ module Handler = struct
     let c = Cascade.Values.nonkeyword_color css_color in
     let c = match css_color_to_hex c with Some hex -> hex | None -> c in
     match c with
+    (* The bracket's own spelling, where it is the three or six digits the alpha
+       arithmetic below reads. A spelling carrying an alpha byte folds to its
+       six digits first, since that is the form [hex_to_rgb] decodes. *)
+    | Authored_hex { value; _ }
+      when String.length value = 3 || String.length value = 6 ->
+        Some (mk_color_hex value)
     | Hex { r; g; b; _ } | Authored_hex { r; g; b; _ } ->
         Some (mk_color_hex (hex_string_of_rgb (r, g, b)))
     | _ -> None
@@ -3426,6 +3442,7 @@ let opacity_to_percent = Handler.opacity_to_percent
 let opacity_var_bare = Handler.opacity_var_bare
 let opacity_var_bare_of = Handler.opacity_var_name
 let shorten_hex_str = shorten_hex_str
+let authored_hex = authored_hex
 let bracket_color_opacity_style = Handler.bracket_color_opacity_style
 
 type bracket_opacity = Handler.bracket_opacity =

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -546,6 +546,13 @@ val rgb_to_oklab : rgb -> float * float * float
 val shorten_hex_str : string -> string
 (** [shorten_hex_str hex] shortens a hex color string if possible. *)
 
+val authored_hex : string -> Css.color
+(** [authored_hex hex] is the colour [hex] spells, keeping that spelling for
+    output: [#f00] stays three digits and [#F00] keeps its case, which is what
+    Tailwind writes back for an arbitrary colour. Leading [#] optional. Raises
+    [Invalid_argument] on a string that is not a hex colour, as {!Css.hex} does.
+*)
+
 val bracket_color_opacity_style :
   ?theme:Scheme.t ->
   ?merge_key:string ->

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -333,8 +333,6 @@ module Handler = struct
       Var.metadata ring_offset_shadow_var;
     ]
 
-  let shorten_hex = Color.shorten_hex_str
-
   (* A bracket alpha with no [%] records the author's own number, unscaled and
      without a unit, which is what Tailwind writes: [shadow-lg/[25]] gives
      [--tw-shadow-alpha: 25]. Every other spelling stays a percentage. The alpha
@@ -1303,7 +1301,7 @@ module Handler = struct
             (fun { h_offset; v_offset; blur; spread; color } ->
               let fallback_color : Css.color =
                 match color with
-                | Hex c -> Css.hex (shorten_hex c)
+                | Hex c -> Color.authored_hex c
                 | Var v -> make_full_color_var v
                 | Css_color c -> (
                     match Color.css_color_to_hex c with
@@ -1381,7 +1379,7 @@ module Handler = struct
               let base_fallback : Css.color =
                 match color with
                 | Hex c ->
-                    if needs_supports then Css.hex (shorten_hex c)
+                    if needs_supports then Color.authored_hex c
                     else Color.hex_to_oklab_alpha c alpha
                 | Var v -> make_full_color_var v
                 | Css_color c ->

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -1953,6 +1953,25 @@ let container_size_of_string = function
   | "7xl" -> Some Container_7xl
   | _ -> None
 
+(* The theme token a container-query arbitrary value reads through [theme()],
+   e.g. [breakpoint-lg] for [@min-[theme(--breakpoint-lg)]]. Tailwind spells the
+   lookup [theme(--x)] and [--theme(--x)]. *)
+let container_theme_token content =
+  let s = String.trim content in
+  let s =
+    if String.length s > 2 && String.sub s 0 2 = "--" then
+      String.sub s 2 (String.length s - 2)
+    else s
+  in
+  let n = String.length s in
+  if n > 7 && String.sub s 0 6 = "theme(" && s.[n - 1] = ')' then
+    let inner = String.trim (String.sub s 6 (n - 7)) in
+    Some
+      (if String.length inner >= 2 && String.sub inner 0 2 = "--" then
+         String.sub inner 2 (String.length inner - 2)
+       else inner)
+  else None
+
 (* A container-query arbitrary value may reference a theme token, e.g.
    [@min-[theme(--breakpoint-lg)]]. [theme(--breakpoint-lg)] resolves to the
    [--breakpoint-lg] default (64rem) via the same token table the [lg:] variant
@@ -1961,23 +1980,33 @@ let parse_container_length content =
   match Css.parse_length content with
   | Some _ as len -> len
   | None ->
-      let s = String.trim content in
-      (* Tailwind spells the theme lookup [theme(--x)] and [--theme(--x)]. *)
-      let s =
-        if String.length s > 2 && String.sub s 0 2 = "--" then
-          String.sub s 2 (String.length s - 2)
-        else s
-      in
-      let n = String.length s in
-      if n > 7 && String.sub s 0 6 = "theme(" && s.[n - 1] = ')' then
-        let inner = String.trim (String.sub s 6 (n - 7)) in
-        let name =
-          if String.length inner >= 2 && String.sub inner 0 2 = "--" then
-            String.sub inner 2 (String.length inner - 2)
-          else inner
-        in
-        Option.bind (Scheme.token_default name) Css.parse_length
-      else None
+      Option.bind
+        (Option.bind (container_theme_token content) Scheme.token_default)
+        Css.parse_length
+
+(* Resolving a [theme()] reference into the query does not consume the token:
+   Tailwind writes its binding into [@layer theme] as well, so a consumer
+   reading [--breakpoint-lg] off the sheet still finds it. The value is the
+   registered default's own text, the way the theme layer emits every other
+   token it holds; the declaration rides on the utility's properties, where the
+   theme extractor collects it and the utilities layer filters it out. *)
+let rec container_query_theme_decls (q : container_query) =
+  let of_bracket raw =
+    match container_theme_token raw with
+    | None -> []
+    | Some name -> (
+        match Scheme.token_default name with
+        | None -> []
+        | Some css -> [ Css.custom_property ~layer:"theme" ("--" ^ name) css ])
+  in
+  match q with
+  | Container_len (raw, _) | Container_len_cmp (_, raw, _) -> of_bracket raw
+  | Container_size (_, inner) | Container_scoped (_, inner) ->
+      container_query_theme_decls inner
+  | Container_3xs | Container_2xs | Container_xs | Container_sm | Container_md
+  | Container_lg | Container_xl | Container_2xl | Container_3xl | Container_4xl
+  | Container_5xl | Container_6xl | Container_7xl | Container_named _ ->
+      []
 
 (* [@sm/main] aims a size query at the container named [main]. The name is the
    tail after the last [/]; the head is any other container-query spelling. *)

--- a/lib/modifiers.mli
+++ b/lib/modifiers.mli
@@ -706,6 +706,16 @@ val apply : ?theme:Scheme.t -> string list -> t -> t option
     [apply ["hover"; "sm"] (bg blue 500)] creates a hover:sm:bg-blue-500 style.
 *)
 
+(** {1 Container Query Helpers} *)
+
+val container_query_theme_decls : Style.container_query -> Css.declaration list
+(** [container_query_theme_decls q] is the theme-layer bindings [q] read through
+    [theme()], e.g. [--breakpoint-lg: 64rem] for
+    [\@min-[theme(--breakpoint-lg)]]. Resolving the reference into the query
+    does not consume the token: Tailwind writes its binding into [\@layer theme]
+    as well, so a consumer reading the token off the sheet still finds it. Empty
+    for a query naming no token. *)
+
 (** {1 ARIA Helpers} *)
 
 val is_aria_shorthand : string -> bool
@@ -748,9 +758,9 @@ val variant_order_of_prefix : ?theme:Scheme.t -> string -> int
     of a class name, the part between two ":" (e.g. ["hover"],
     ["group-has-checked"], ["@min-[64rem]"]). When [theme] is supplied, its
     exact custom-variant names take precedence over the built-in prefix grammar;
-    re-registering [dark] retains its pre-existing built-in position. Returns 0
-    for a token that names no variant, which {!Sort.compare_indexed_rules} reads
-    as "this rule carries no variant". *)
+    re-registering ["dark"] retains its pre-existing built-in position. Returns
+    0 for a token that names no variant, which {!Sort.compare_indexed_rules}
+    reads as "this rule carries no variant". *)
 
 val variant_inner_order : string -> int
 (** [variant_inner_order token] returns what separates [token] from another

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -447,14 +447,17 @@ let container_rule ?(inner_has_hover = false) query base_class selector props =
       ~new_class:modified_class selector
   in
   let condition = Containers.container_query_to_condition query in
+  (* A [theme()] the query read still owes the sheet its binding; carried on the
+     rule's own properties, where the theme layer collects it. *)
+  let theme_decls = Modifiers.container_query_theme_decls query in
   if inner_has_hover then
-    container_query ~condition ~selector:new_selector ~props:[]
+    container_query ~condition ~selector:new_selector ~props:theme_decls
       ~base_class:modified_class
       ~nested:(nested_hover ~selector:new_selector ~props)
       ()
   else
-    container_query ~condition ~selector:new_selector ~props
-      ~base_class:modified_class ()
+    container_query ~condition ~selector:new_selector
+      ~props:(props @ theme_decls) ~base_class:modified_class ()
 
 (** Parse a has-[...] selector string as a relative CSS selector ([:has()]
     accepts a bare leading combinator, e.g. [>div] or [~img]), with [&] (the

--- a/lib/text_shadow.ml
+++ b/lib/text_shadow.ml
@@ -74,8 +74,6 @@ module Handler = struct
   let text_shadow_property_metadata =
     [ Var.metadata text_shadow_color_var; Var.metadata text_shadow_alpha_var ]
 
-  let shorten_hex = Color.shorten_hex_str
-
   (* A [#] value only names a colour when what follows is a hex spelling;
      [Css.hex] raises on anything else, here once the sheet is rendered. *)
   let is_hex_value s =
@@ -496,11 +494,11 @@ module Handler = struct
       ~property_rules:text_shadow_property_rules [ base_decl ]
 
   let set_bracket_hex hex =
-    let short = shorten_hex ("#" ^ hex) in
-    let base_decl, _ = Var.binding text_shadow_color_var (Css.hex short) in
+    let color = Color.authored_hex hex in
+    let base_decl, _ = Var.binding text_shadow_color_var color in
     let enhanced_color =
       Css.color_mix_var_percent ~in_space:Oklab ~var_name:text_shadow_alpha_name
-        (Css.hex short) Css.Transparent
+        color Css.Transparent
     in
     let enhanced_decl, _ = Var.binding text_shadow_color_var enhanced_color in
     let supports_block = color_mix_supports [ enhanced_decl ] in
@@ -612,7 +610,7 @@ module Handler = struct
     | Some (h_offset, v_offset, blur, color) ->
         let fallback_color : Css.color =
           match color with
-          | Hex c -> Css.hex (shorten_hex c)
+          | Hex c -> Color.authored_hex c
           | Var_ref v -> make_full_color_var v
           | Css_color c -> (
               match Color.css_color_to_hex c with Some h -> h | None -> c)

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -122,7 +122,7 @@ let properties_of_class cls =
    [Alcotest.check bool ... true] then prints neither the class nor the CSS when
    it fails, so a red test reports only that something is wrong. The helpers
    below compare whole declarations and name the subject in the failure. *)
-let declarations_of_class cls =
+let declarations_of_class ?(minify = true) cls =
   match compiled cls with
   | None -> Alcotest.failf "%s does not parse" cls
   | Some sheet ->
@@ -131,12 +131,14 @@ let declarations_of_class cls =
           match Css.as_rule stmt with
           | Some (sel, decls, _)
             when String.contains (Css.Selector.to_string sel) '.' ->
-              acc @ List.map (Css.Declaration.to_string ~minify:true) decls
+              acc @ List.map (Css.Declaration.to_string ~minify) decls
           | _ -> acc)
         [] sheet
 
-let check_declarations cls expected =
-  Alcotest.(check (list string)) cls expected (declarations_of_class cls)
+let check_declarations ?minify cls expected =
+  Alcotest.(check (list string))
+    cls expected
+    (declarations_of_class ?minify cls)
 
 (* For a value a test cannot spell exactly, a generated hash or a number the
    suite deliberately leaves open. Anchor the pattern: an unanchored one

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -32,19 +32,22 @@ val properties_of_class : string -> Css.Declaration.prop_key list
 (** [properties_of_class cls] is every property [cls] declares, custom
     properties included: two utilities can conflict on a [--tw-*] alone. *)
 
-val declarations_of_class : string -> string list
+val declarations_of_class : ?minify:bool -> string -> string list
 (** [declarations_of_class cls] is what [cls] writes on an element carrying it,
-    minified, in source order. Only selectors holding a [.] count, so the theme
-    bindings the class drags in and the [*, ::before] property defaults are left
-    out, the way {!class_rule} reads them. Fails the test if [cls] does not
-    parse. *)
+    in source order. Only selectors holding a [.] count, so the theme bindings
+    the class drags in and the [*, ::before] property defaults are left out, the
+    way {!class_rule} reads them. Fails the test if [cls] does not parse.
 
-val check_declarations : string -> string list -> unit
+    [minify] defaults to [true]. Pass [false] where the spelling a value keeps
+    is what is under test: minified printing folds a colour to its shortest hex,
+    so [#f00] and an expanded [#ff0000] read the same there. *)
+
+val check_declarations : ?minify:bool -> string -> string list -> unit
 (** [check_declarations cls expected] checks [cls] writes exactly [expected].
     Prefer it to a substring search: an affix that is a prefix of a longer
     generated class matches it, so [.bg-blue-500] is satisfied by
     [.bg-blue-500\/50] alone, and a [check bool] failure prints neither the
-    class nor the CSS. *)
+    class nor the CSS. [minify] is {!declarations_of_class}'s. *)
 
 val check_declarations_match : string -> string list -> unit
 (** [check_declarations_match cls patterns] checks each PCRE in [patterns]

--- a/test/test_color.ml
+++ b/test/test_color.ml
@@ -801,6 +801,25 @@ let test_shorthand_hex_alpha () =
     "a six-digit hex is unchanged" "#0307121a"
     (Tw.Color.hex_with_alpha "#030712" 10.)
 
+(* Tailwind writes an arbitrary colour back in the spelling the class used: the
+   pinned CLI answers [bg-[#f00]] with [background-color: #f00] and
+   [bg-[#ffffffff]] with all eight digits, whatever the shortest equivalent
+   would be. The digits were decoded to bytes and re-spelled, which turned every
+   short or upper-case hex into its six-digit lower-case form. Minified printing
+   folds a colour to its shortest hex, so the spelling only shows unminified. *)
+let test_bracket_hex_keeps_authored_spelling () =
+  let pin cls decl =
+    Test_helpers.check_declarations ~minify:false cls [ decl ]
+  in
+  pin "bg-[#f00]" "background-color: #f00";
+  pin "bg-[#ff0000]" "background-color: #ff0000";
+  pin "bg-[#FF0000]" "background-color: #FF0000";
+  pin "bg-[#abc]" "background-color: #abc";
+  pin "bg-[#ffffffff]" "background-color: #ffffffff";
+  pin "bg-[#f008]" "background-color: #f008";
+  pin "text-[#0088cc]" "color: #0088cc";
+  pin "border-[#f00]" "border-color: #f00"
+
 (* A [#] bracket only names a colour when what follows is a hex spelling. The
    colour handler handed everything after the [#] to the raising constructor
    from inside [of_class], so a malformed hex escaped the parser as an exception
@@ -1105,6 +1124,9 @@ let tests =
       `Quick,
       test_bracket_colour_underscore_escape );
     ("Invalid bracket hex", `Quick, test_invalid_bracket_hex);
+    ( "Bracket hex keeps its authored spelling",
+      `Quick,
+      test_bracket_hex_keeps_authored_spelling );
     ( "Colour variable name is one ident",
       `Quick,
       test_color_var_name_is_one_ident );

--- a/test/test_effects.ml
+++ b/test/test_effects.ml
@@ -378,19 +378,12 @@ let test_arbitrary_shadow_lengths () =
 (* [shadow-[<colour>]/<alpha>] where the bracket already carries a [%] alpha:
    the modifier folds into a [color-mix] rather than into a hex byte.
 
-   [shadow-[0_0_8px_#f00]/[var(--x)]] and its inset twin are left on a
-   substring: tw expands the authored [#f00] to [#ff0000] where the pinned CLI
-   passes the six-character spelling through, so their declarations cannot be
-   pinned without encoding that divergence. *)
+   The unguarded fallback of [shadow-[0_0_8px_#f00]/[var(--x)]] is pinned as tw
+   writes it, which is not what the CLI writes: the CLI leaves the authored
+   colour alone there and tw folds it to the oklab of the same colour. The inset
+   twin already leaves it alone, so the two spellings below are tw's, not a
+   shared rule. *)
 let test_arbitrary_shadow_colour_opacity () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
   Test_helpers.check_declarations "shadow-[0_0_8px_oklch(50%_0.2_250)]/50"
     [
       "--tw-shadow-alpha:50%";
@@ -406,11 +399,35 @@ let test_arbitrary_shadow_colour_opacity () =
        50%,transparent))";
       composes_box_shadow;
     ];
-  has "shadow-[0_0_8px_#f00]/[var(--x)]" "--tw-shadow-alpha:var(--x)";
-  has "shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from";
-  has "inset-shadow-[0_0_8px_#f00]/[var(--x)]"
-    "--tw-inset-shadow-alpha:var(--x)";
-  has "inset-shadow-[0_0_8px_#f00]/[var(--x)]" "oklab(from"
+  Test_helpers.check_declarations "shadow-[0_0_8px_#f00]/[var(--x)]"
+    [
+      "--tw-shadow-alpha:var(--x)";
+      "--tw-shadow:0 0 8px var(--tw-shadow-color,oklab(62.79553606%.22486306 \
+       .1258463))";
+      "--tw-shadow:0 0 8px var(--tw-shadow-color,oklab(from #f00 l a \
+       b/var(--x)))";
+      composes_box_shadow;
+    ];
+  Test_helpers.check_declarations "inset-shadow-[0_0_8px_#f00]/[var(--x)]"
+    [
+      "--tw-inset-shadow-alpha:var(--x)";
+      "--tw-inset-shadow:inset 0 0 8px var(--tw-inset-shadow-color,#f00)";
+      "--tw-inset-shadow:inset 0 0 8px var(--tw-inset-shadow-color,oklab(from \
+       #f00 l a b/var(--x)))";
+      composes_box_shadow;
+    ];
+  (* Minified printing folds a colour to its shortest hex, so the authored
+     three-digit spelling the CLI keeps only shows unminified. *)
+  Test_helpers.check_declarations ~minify:false
+    "inset-shadow-[0_0_8px_#f00]/[var(--x)]"
+    [
+      "--tw-inset-shadow-alpha: var(--x)";
+      "--tw-inset-shadow: inset 0 0 8px var(--tw-inset-shadow-color, #f00)";
+      "--tw-inset-shadow: inset 0 0 8px var(--tw-inset-shadow-color, \
+       oklab(from #f00 l a b/var(--x)))";
+      "box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), \
+       var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow)";
+    ]
 
 (* A bracket colour with no sRGB hex - [oklch()] and the other wide-gamut
    spellings - has no hex to fold the modifier's alpha into, so the alpha has to
@@ -437,27 +454,23 @@ let test_bracket_colour_opacity_without_hex () =
    an alpha byte, which a var() has no value for, so the modifier was dropped
    and the shadow painted fully opaque.
 
-   These two classes stay on a substring: tw expands the authored [#f00] to
-   [#ff0000] where the pinned CLI keeps the three-character spelling, so their
-   declarations cannot be pinned without encoding that divergence. *)
+   Read unminified: the CLI keeps the [#f00] the class wrote, and minified
+   printing folds a colour to its shortest hex, so an expanded [#ff0000] reads
+   the same as [#f00] there. *)
 let test_bracket_hex_opacity_var () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
-  in
   (* the plain fallback has no percentage to hold, so it keeps the hex *)
-  has "shadow-[#f00]/[var(--x)]" "--tw-shadow-color:#f00";
-  has "shadow-[#f00]/[var(--x)]"
-    "color-mix(in oklab,color-mix(in oklab,#f00 var(--x),transparent) \
-     var(--tw-shadow-alpha),transparent)";
-  has "inset-shadow-[#f00]/[var(--x)]" "--tw-inset-shadow-color:#f00";
-  has "inset-shadow-[#f00]/[var(--x)]"
-    "color-mix(in oklab,color-mix(in oklab,#f00 var(--x),transparent) \
-     var(--tw-inset-shadow-alpha),transparent)"
+  Test_helpers.check_declarations ~minify:false "shadow-[#f00]/[var(--x)]"
+    [
+      "--tw-shadow-color: #f00";
+      "--tw-shadow-color: color-mix(in oklab, color-mix(in oklab, #f00 \
+       var(--x), transparent) var(--tw-shadow-alpha), transparent)";
+    ];
+  Test_helpers.check_declarations ~minify:false "inset-shadow-[#f00]/[var(--x)]"
+    [
+      "--tw-inset-shadow-color: #f00";
+      "--tw-inset-shadow-color: color-mix(in oklab, color-mix(in oklab, #f00 \
+       var(--x), transparent) var(--tw-inset-shadow-alpha), transparent)";
+    ]
 
 (* A bracket alpha modifier with no [%] sign (shadow-lg/[25]) tracks the
    modifier's own written text in --tw-shadow-alpha, the way Tailwind does,

--- a/test/test_modifiers.ml
+++ b/test/test_modifiers.ml
@@ -801,14 +801,6 @@ let test_container_query_scale () =
 (* @max-<size> negates the min query, and @min-/@max-[<len>] and bare @[<len>]
    accept arbitrary lengths. All used to be unknown modifiers. *)
 let test_container_query_min_max () =
-  let css cls =
-    match Tw.of_string cls with
-    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string
-    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
-  in
-  let has cls affix =
-    check bool cls true (Astring.String.is_infix ~affix (css cls))
-  in
   check_utilities "@min-md:flex"
     {|@container(width>=28rem){.\@min-md\:flex{display:flex}}|};
   check_utilities "@max-md:flex"
@@ -820,11 +812,13 @@ let test_container_query_min_max () =
   check_utilities "@[480px]:flex"
     {|@container(width>=480px){.\@\[480px\]\:flex{display:flex}}|};
   (* A theme(--breakpoint-lg) arbitrary value resolves to the breakpoint the
-     [lg:] variant uses (64rem). These two stay on a substring: the pinned CLI
-     also writes [--breakpoint-lg: 64rem] into the theme layer and tw does not,
-     so the sheets cannot be compared whole without encoding that gap. *)
-  has "@min-[theme(--breakpoint-lg)]:flex" "@container (width >= 64rem)";
-  has "@max-[theme(--breakpoint-lg)]:flex" "@container (not (width >= 64rem))";
+     [lg:] variant uses (64rem). Resolving the reference does not consume it:
+     the CLI writes [--breakpoint-lg: 64rem] into the theme layer as well, so a
+     consumer reading the token off the sheet still finds it. *)
+  check_sheet "@min-[theme(--breakpoint-lg)]:flex"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--breakpoint-lg:64rem}}@layer components;@layer utilities{@container(width>=64rem){.\@min-\[theme\(--breakpoint-lg\)\]\:flex{display:flex}}}|};
+  check_sheet "@max-[theme(--breakpoint-lg)]:flex"
+    {|@layer theme,components,utilities;@layer theme{:root,:host{--breakpoint-lg:64rem}}@layer components;@layer utilities{@container not (width>=64rem){.\@max-\[theme\(--breakpoint-lg\)\]\:flex{display:flex}}}|};
   check string "@max-md round-trips" "@max-md:p-4"
     (Tw.Utility.to_class (Option.get (apply [ "@max-md" ] (p 4))));
   check string "@min-[20rem] round-trips" "@min-[20rem]:p-4"

--- a/test/test_text_shadow.ml
+++ b/test/test_text_shadow.ml
@@ -69,7 +69,7 @@ let test_arbitrary_lengths () =
   let emits affix cls =
     Alcotest.(check bool) cls true (Astring.String.is_infix ~affix (css cls))
   in
-  emits "text-shadow: 0 1ch 2px var(--tw-text-shadow-color, #000000)"
+  emits "text-shadow: 0 1ch 2px var(--tw-text-shadow-color, #000)"
     "text-shadow-[0_1ch_2px_#000]";
   emits "text-shadow: 0 1ch 2px var(--tw-text-shadow-color, oklab(0% 0 0 / .5))"
     "text-shadow-[0_1ch_2px_#000]/50";


### PR DESCRIPTION
`@tailwindcss/cli` 4.3.3 writes an arbitrary colour back in the spelling the
class wrote, and it keeps a theme token's binding in `@layer theme` after
resolving a `theme()` reference through it. tw did neither, so a sheet said
`#ff0000` where the markup says `#f00`, and carried no `--breakpoint-lg` at
all. Both were left on substring assertions in #698 for exactly that reason.

The spelling now survives from the bracket to the printer. `bg-[#f00]`,
`text-`, `border-`, `ring-`, `inset-ring-`, `shadow-`, `inset-shadow-`,
`drop-shadow-`, `text-shadow-` and the arbitrary shadow values all emit what
the class held, case and an eight-digit alpha included. Minified printing
folds a colour to its shortest hex either way, so the pins read the sheet
unminified.

`@min-[theme(--breakpoint-lg)]:flex`, its `@max-` and bare `@[...]` forms and
the `/name` scoped spelling now carry the token's binding on the rule, where
the theme layer collects it and the utilities layer filters it out.

Measured against the pinned CLI, not against tw's own output. Four residuals
found while checking the neighbours, none of them touched here:

- A static opacity over a bracket colour folds to `oklab()`; the CLI writes
  `color-mix(in oklab, #f00 50%, transparent)`.
- `bg-[#f00]/[var(--x)]` writes only the guarded mix; the CLI writes an
  unguarded fallback beside it.
- The unguarded fallback of `shadow-[0_0_8px_#f00]/[var(--x)]` is the computed
  oklab of the colour; the CLI keeps the colour. The inset twin already keeps
  it.
- `--color-black` prints `#000000` where the CLI prints `#000`, since the
  palette hexes reach the printer as bytes rather than as a spelling.

Cascade's minifier still never folds a hex to a shorter colour name, so `#f00`
stays `#f00` where Lightning CSS writes `red`. That fold lives in
`normalize_color`, which only the optimiser runs.
