### PR TITLE
tw: resolve the theme(--x) spelling in an arbitrary value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -168,6 +168,9 @@
   `content-[url('a_b.png')]`, `[background-image:url('a_b.png')]` and
   `mask-[image-set(url('a_b.png')_1x)]` named a file they did not mean; the
   underscore outside the `url()` still becomes a space (#692).
+- `theme(--x)` and `--theme(--x)`, v4's own spelling of a theme lookup, resolve
+  in an arbitrary value. `p-[theme(--spacing)]` and its siblings were rejected
+  as unknown classes; only the v3 dot paths resolved (#701).
 - The first argument of a `var()` or a `theme()` in an arbitrary value keeps its
   underscores, which spell the name of a custom property rather than spaces.
   `[--x:var(--my_var)]` referenced `--my var`, and `shadow-[0_0_0_var(--my_var)]`

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1518,7 +1518,7 @@ let has_pseudo_elements tw_classes =
     | Utility.Modified (modifier, u) -> has_pseudo modifier || check_utility u
     | Utility.Group us -> List.exists check_utility us
     | Utility.Important (_, u) -> check_utility u
-    | Utility.Aliased (_, u) -> check_utility u
+    | Utility.Aliased (_, u) | Utility.Theme_bound (_, u) -> check_utility u
   in
   List.exists check_utility tw_classes
 
@@ -1535,8 +1535,10 @@ let has_transition_utility tw_classes =
         String.length c >= 10
         && String.sub c 0 10 = "transition"
         && not (String.equal c "transition-none")
-    | Utility.Modified (_, u) | Utility.Important (_, u) | Utility.Aliased (_, u)
-      ->
+    | Utility.Modified (_, u)
+    | Utility.Important (_, u)
+    | Utility.Aliased (_, u)
+    | Utility.Theme_bound (_, u) ->
         check u
     | Utility.Group us -> List.exists check us
   in

--- a/lib/modifiers.ml
+++ b/lib/modifiers.ml
@@ -618,7 +618,8 @@ let rec has_responsive_modifier = function
   | Utility.Modified (_, t) -> has_responsive_modifier t
   | Utility.Group styles -> List.exists has_responsive_modifier styles
   | Utility.Important (_, t) -> has_responsive_modifier t
-  | Utility.Aliased (_, t) -> has_responsive_modifier t
+  | Utility.Aliased (_, t) | Utility.Theme_bound (_, t) ->
+      has_responsive_modifier t
 
 (* Validate no nested responsive modifiers *)
 let validate_no_nested_responsive styles =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -2434,8 +2434,10 @@ let extract_style_with_rules ~sel ~class_name ?merge_key ~props rule_list =
 let outputs ?(theme = Scheme.default) ?order_tbl util =
   let rec utility_order = function
     | Utility.Base b -> Some (Utility.order b)
-    | Utility.Modified (_, u) | Utility.Important (_, u) | Utility.Aliased (_, u)
-      ->
+    | Utility.Modified (_, u)
+    | Utility.Important (_, u)
+    | Utility.Aliased (_, u)
+    | Utility.Theme_bound (_, u) ->
         utility_order u
     | Utility.Group _ -> None
   in

--- a/lib/tw.ml
+++ b/lib/tw.ml
@@ -180,16 +180,41 @@ let theme_key_value ~theme path =
       Stdlib.Option.bind (float_of_string_opt n) Theme.spacing_times
   | _ -> None
 
+(* The value the resolved theme binds [--<name>] to, with the [\@layer theme]
+   declaration that keeps the binding in the sheet. A registered default or a
+   project override answers for itself; the palette answers through the same
+   catalogue an arbitrary [var(--color-red-500)] reads, so a shaded entry and a
+   shadeless one both resolve. [None] is a token the resolved theme does not
+   carry. *)
+let theme_token_binding ~theme name =
+  match Scheme.token theme name with
+  | Some css ->
+      Some (css, Cascade.Css.custom_property ~layer:"theme" ("--" ^ name) css)
+  | None ->
+      Stdlib.Option.map
+        (fun decl -> (Cascade.Css.declaration_value decl, decl))
+        (Color.Handler.theme_color_decl ~theme name)
+
+(* The token a [theme(--x)] names, resolved. This is the v4 spelling of the
+   lookup, and it reads the token table itself rather than one of the v3
+   namespaces the dot paths name. *)
+let theme_token_value ~theme path =
+  if String.length path > 2 && String.sub path 0 2 = "--" then
+    theme_token_binding ~theme (String.sub path 2 (String.length path - 2))
+  else None
+
 (* Resolve one theme() argument.
 
    [`Value] is the key resolved, mixed with the [/<alpha>] it carries when it
-   has one. [`Missing] is a key the theme provably does not carry, which
-   Tailwind answers with no rule at all: a bare segment names no namespace, and
-   the palette namespace is one tw resolves in full, so an entry missing from it
-   is missing. [`Verbatim] is everything else - an alpha naming no number, the
-   [--<token>] spelling, and a namespace tw does not resolve - where there is no
-   table saying the key is absent and Tailwind emits a rule for the ones it
-   knows. *)
+   has one. [`Token] is the same for the [--<name>] spelling, and carries the
+   binding that keeps the token in the theme layer: unlike a dot path, that
+   spelling does not consume it. [`Missing] is a key the theme provably does not
+   carry, which Tailwind answers with no rule at all: a bare segment names no
+   namespace, the palette namespace is one tw resolves in full, and the
+   [--<name>] spelling reads the token table itself, so an absence there is an
+   absence. [`Verbatim] is everything else - an alpha naming no number, and a
+   namespace tw does not resolve - where there is no table saying the key is
+   absent and Tailwind emits a rule for the ones it knows. *)
 let theme_resolve_key ~theme key =
   let path, alpha =
     match String.index_opt key '/' with
@@ -198,21 +223,24 @@ let theme_resolve_key ~theme key =
           Some (String.sub key (k + 1) (String.length key - k - 1)) )
     | None -> (key, None)
   in
+  let with_alpha base =
+    match alpha with
+    | None -> Some base
+    | Some a -> theme_color_with_alpha base a
+  in
   match theme_key_value ~theme path with
   | Some base -> (
-      match alpha with
-      | None -> `Value base
-      | Some a -> (
-          match theme_color_with_alpha base a with
-          | Some v -> `Value v
-          | None -> `Verbatim))
+      match with_alpha base with Some v -> `Value v | None -> `Verbatim)
   | None -> (
-      match String.split_on_char '.' path with
-      | "colors" :: _ -> `Missing
-      | [ token ]
-        when not (String.length token > 2 && String.sub token 0 2 = "--") ->
-          `Missing
-      | _ -> `Verbatim)
+      match theme_token_value ~theme path with
+      | Some (base, decl) -> (
+          match with_alpha base with
+          | Some v -> `Token (decl, v)
+          | None -> `Verbatim)
+      | None -> (
+          match String.split_on_char '.' path with
+          | "colors" :: _ | [ _ ] -> `Missing
+          | _ -> `Verbatim))
 
 (* Split a theme() argument into its key and the fallback after the first
    top-level comma, which stands in whenever the key resolves to nothing. *)
@@ -230,21 +258,34 @@ let theme_call_fallback inner =
   in
   go 0 0
 
-(* Replace each theme(<path>) in a class string with its resolved value, written
-   back in the spelling an arbitrary value is read in: a space becomes [_] and
-   an underscore [\_], so a project that binds a token to [var(--brand_red)]
-   keeps the variable it named. [None] is a call naming a key the theme does not
-   carry and offering no fallback: Tailwind emits no rule for such a class, so
-   it is not a utility. *)
+(* Replace each theme() call in a class string with what it resolves to, and
+   report the theme tokens the calls read.
+
+   [theme(<key>)] writes the resolved value back in the spelling an arbitrary
+   value is read in: a space becomes [_] and an underscore [\_], so a project
+   that binds a token to [var(--brand_red)] keeps the variable it named.
+   [--theme(--<name>)] is the same lookup written as a reference, and writes
+   [var(--<name>)] instead of the value; it admits neither a v3 dot path nor an
+   alpha, both of which Tailwind reads some other way, so those are left for the
+   class to fail on.
+
+   [None] is a call naming a key the theme does not carry and offering no
+   fallback: Tailwind emits no rule for such a class, so it is not a utility. *)
 let resolve_theme_functions ~theme s =
   let buf = Buffer.create (String.length s) in
   let n = String.length s in
   let missing = ref false in
+  let bindings = ref [] in
   let i = ref 0 in
   let resolved v = Buffer.add_string buf (Parse.encode_underscores v) in
+  let opens j lit =
+    j + String.length lit <= n && String.sub s j (String.length lit) = lit
+  in
   while !i < n do
-    if !i + 6 <= n && String.sub s !i 6 = "theme(" then begin
-      let j = ref (!i + 6) and depth = ref 1 in
+    let reference = opens !i "--theme(" in
+    if reference || opens !i "theme(" then begin
+      let open_len = if reference then 8 else 6 in
+      let j = ref (!i + open_len) and depth = ref 1 in
       while !j < n && !depth > 0 do
         if s.[!j] = '(' then incr depth else if s.[!j] = ')' then decr depth;
         if !depth > 0 then incr j
@@ -254,7 +295,7 @@ let resolve_theme_functions ~theme s =
          unterminated call has no key to read, so the rest of the string is
          copied through and the class stays unresolved. *)
       let closed = !depth = 0 in
-      let inner = String.sub s (!i + 6) (!j - (!i + 6)) in
+      let inner = String.sub s (!i + open_len) (!j - (!i + open_len)) in
       let verbatim () =
         let stop = if closed then !j + 1 else n in
         Buffer.add_string buf (String.sub s !i (stop - !i))
@@ -262,13 +303,22 @@ let resolve_theme_functions ~theme s =
       (if not closed then verbatim ()
        else
          let key, fallback = theme_call_fallback inner in
-         match theme_resolve_key ~theme key with
-         | `Value v -> resolved v
-         | `Verbatim -> verbatim ()
-         | `Missing -> (
-             match fallback with
-             | Some f -> Buffer.add_string buf f
-             | None -> missing := true));
+         if reference && String.contains key '/' then verbatim ()
+         else
+           match theme_resolve_key ~theme key with
+           | `Value v -> if reference then verbatim () else resolved v
+           | `Token (decl, v) ->
+               bindings := decl :: !bindings;
+               (* [key] is the [--<name>] the call spelled: the reference form
+                  bailed above on anything carrying an alpha, so the whole key
+                  is the property name. *)
+               if reference then Buffer.add_string buf ("var(" ^ key ^ ")")
+               else resolved v
+           | `Verbatim -> verbatim ()
+           | `Missing -> (
+               match fallback with
+               | Some f -> Buffer.add_string buf f
+               | None -> missing := true));
       i := if closed then !j + 1 else n
     end
     else begin
@@ -276,7 +326,7 @@ let resolve_theme_functions ~theme s =
       incr i
     end
   done;
-  if !missing then None else Some (Buffer.contents buf)
+  if !missing then None else Some (Buffer.contents buf, List.rev !bindings)
 
 (* The rejection a class gets once no handler has claimed it. A bracket class
    that looks like an arbitrary property but that nothing accepted is malformed
@@ -302,7 +352,7 @@ let of_string ?(theme = Scheme.default) class_str =
   (* Wrap [important] around the base before applying modifiers, so a
      responsive/state prefix stays outermost: md:!flex -> md:(!flex). An
      optional [alias] sits inside importance so [w-(--w)!] keeps both forms. *)
-  let finish ?alias base_utility =
+  let finish ?alias ?(bindings = []) base_utility =
     let base_util = Utility.base base_utility in
     let base_util =
       match alias with
@@ -315,6 +365,9 @@ let of_string ?(theme = Scheme.default) class_str =
       | `Suffix -> Utility.important ~suffix:true base_util
       | `None -> base_util
     in
+    (* Outside [important]: the binding is a theme declaration the utility drags
+       in, not one of the declarations the [!] marks. *)
+    let base_util = Utility.theme_bound bindings base_util in
     match Modifiers.apply ~theme modifiers base_util with
     | Some u -> Ok u
     | None -> Error (`Msg ("Unknown modifier in: " ^ class_str))
@@ -324,12 +377,12 @@ let of_string ?(theme = Scheme.default) class_str =
      leaves nothing to dispatch on. *)
   match resolve_theme_functions ~theme base_class with
   | None -> unknown_class_error ~base_class class_str
-  | Some resolved_base -> (
+  | Some (resolved_base, bindings) -> (
       let theme_alias =
         if resolved_base = base_class then None else Some base_class
       in
       match Utility.base_of_class theme resolved_base with
-      | Ok base_utility -> finish ?alias:theme_alias base_utility
+      | Ok base_utility -> finish ?alias:theme_alias ~bindings base_utility
       | Error _ -> (
           (* Fallback: the v4 [prop-(--x)] shorthand for handlers that accept
              the [prop-[var(--x)]] form but not the paren spelling directly.

--- a/lib/utility.ml
+++ b/lib/utility.ml
@@ -12,10 +12,18 @@ type t =
           {!to_class}, so the emitted selector matches the source spelling. Used
           for the [prop-(--x)] shorthand, which is [prop-[var(--x)]] in value
           but keeps its own class name. *)
+  | Theme_bound of Cascade.Css.declaration list * t
+      (** [Theme_bound (decls, u)] renders as [u] with [decls] alongside its own
+          declarations. Carries the [\@layer theme] binding of a token a
+          [theme(--x)] read: resolving the reference does not consume the token,
+          so Tailwind writes the binding as well. *)
 
 let base x = Base x
 let important ?(suffix = false) x = Important (suffix, x)
 let alias class_name u = Aliased (class_name, u)
+
+let theme_bound decls u =
+  match decls with [] -> u | _ -> Theme_bound (decls, u)
 
 (* See the .mli. *)
 module Property_order = struct
@@ -275,12 +283,21 @@ let base_to_style theme u =
   in
   try_handlers handlers
 
+(* A theme binding rides on the rule's own declarations, where the theme layer
+   collects it and the utilities layer filters it out - the same carriage a
+   container query's binding uses. *)
+let rec bind_props decls = function
+  | Style.Style s -> Style.Style { s with props = decls @ s.props }
+  | Style.Modified (m, t) -> Style.Modified (m, bind_props decls t)
+  | Style.Group ts -> Style.Group (List.map (bind_props decls) ts)
+
 let rec to_style theme = function
   | Base u -> base_to_style theme u
   | Modified (m, u) -> Style.Modified (m, to_style theme u)
   | Group us -> Style.Group (List.map (to_style theme) us)
   | Important (_, u) -> Style.map_important (to_style theme u)
   | Aliased (_, u) -> to_style theme u
+  | Theme_bound (decls, u) -> bind_props decls (to_style theme u)
 
 let rec to_class = function
   | Base u -> class_of_base u
@@ -296,6 +313,7 @@ let rec to_class = function
   | Important (suffix, u) ->
       if suffix then to_class u ^ "!" else "!" ^ to_class u
   | Aliased (class_name, _) -> class_name
+  | Theme_bound (_, u) -> to_class u
 
 let rec pp = function
   | Base u -> "Base " ^ class_of_base u
@@ -303,6 +321,7 @@ let rec pp = function
   | Group us -> "Group [" ^ String.concat "; " (List.map pp us) ^ "]"
   | Important (_, u) -> "Important (" ^ pp u ^ ")"
   | Aliased (class_name, u) -> "Aliased (" ^ class_name ^ ", " ^ pp u ^ ")"
+  | Theme_bound (_, u) -> "Theme_bound (" ^ pp u ^ ")"
 
 let order (u : base) : int * int =
   let rec try_handlers = function

--- a/lib/utility.mli
+++ b/lib/utility.mli
@@ -75,6 +75,11 @@ type t =
           {!to_class}, so the emitted selector matches the source spelling. Used
           for the [prop-(--x)] shorthand, which is [prop-[var(--x)]] in value
           but keeps its own class name. *)
+  | Theme_bound of Cascade.Css.declaration list * t
+      (** [Theme_bound (decls, u)] renders as [u] with [decls] alongside its own
+          declarations. Carries the [\@layer theme] binding of a token a
+          [theme(--x)] read: resolving the reference does not consume the token,
+          so Tailwind writes the binding as well. *)
 
 val base : base -> t
 (** [base u] wraps a base utility into a Utility.t. *)
@@ -82,6 +87,10 @@ val base : base -> t
 val alias : string -> t -> t
 (** [alias class_name u] is [u] with its class name overridden to [class_name]
     (see {!constructor-Aliased}). *)
+
+val theme_bound : Cascade.Css.declaration list -> t -> t
+(** [theme_bound decls u] is [u] carrying [decls] alongside its own declarations
+    (see {!constructor-Theme_bound}). [u] itself for an empty list. *)
 
 val important : ?suffix:bool -> t -> t
 (** [important ?suffix u] marks every declaration [u] emits as [!important]: the

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -542,6 +542,108 @@ let theme_function_keeps_an_underscore () =
         "the class is the one the source spells" "[color:theme(colors.red.500)]"
         (Tw.to_classes [ u ])
 
+(* [theme(--x)] is v4's own spelling of a theme lookup and reads the same token
+   table the dot paths do, across every namespace: [--spacing], [--color-*],
+   [--breakpoint-*], [--container-*], [--radius-*], [--text-*]. Unlike a dot
+   path it does not consume the token: @tailwindcss/cli 4.3.3 inlines the value
+   into the utility and still writes the binding into [@layer theme], so a
+   consumer reading [--spacing] off the sheet finds it. tw answered "Unknown
+   class" for all of them. *)
+let theme_function_custom_property_spelling () =
+  let sheet cls =
+    match Tw.of_string cls with
+    | Ok u -> Tw.to_css ~base:false [ u ] |> Tw.Css.to_string ~minify:true
+    | Error (`Msg m) -> Alcotest.failf "%s: %s" cls m
+  in
+  let check_sheet cls theme utilities =
+    Alcotest.(check string)
+      cls
+      ("@layer theme,components,utilities;@layer theme{:root,:host{" ^ theme
+     ^ "}}@layer components;@layer utilities{" ^ utilities ^ "}")
+      (sheet cls)
+  in
+  check_sheet "p-[theme(--spacing)]" "--spacing:.25rem"
+    {|.p-\[theme\(--spacing\)\]{padding:.25rem}|};
+  check_sheet "text-[theme(--color-red-500)]"
+    "--color-red-500:oklch(63.7%.237 25.331)"
+    {|.text-\[theme\(--color-red-500\)\]{color:oklch(63.7%.237 25.331)}|};
+  check_sheet "max-w-[theme(--breakpoint-sm)]" "--breakpoint-sm:40rem"
+    {|.max-w-\[theme\(--breakpoint-sm\)\]{max-width:40rem}|};
+  check_sheet "max-w-[theme(--container-md)]" "--container-md:28rem"
+    {|.max-w-\[theme\(--container-md\)\]{max-width:28rem}|};
+  check_sheet "rounded-[theme(--radius-lg)]" "--radius-lg:.5rem"
+    {|.rounded-\[theme\(--radius-lg\)\]{border-radius:.5rem}|};
+  check_sheet "text-[length:theme(--text-xl)]" "--text-xl:1.25rem"
+    {|.text-\[length\:theme\(--text-xl\)\]{font-size:1.25rem}|}
+
+(* The token a [theme(--x)] names is bound once however many classes read it,
+   the variants a class carries do not move the binding out of [@layer theme],
+   and a [\@theme] override reaches both the binding and the inlined value. *)
+let theme_function_custom_property_binding () =
+  let sheet ?theme classes =
+    let utilities, unknown = Tw.of_classes ?theme (String.concat " " classes) in
+    match unknown with
+    | cls :: _ -> Alcotest.failf "%s did not parse" cls
+    | [] ->
+        Tw.to_css ?theme ~base:false utilities |> Tw.Css.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "one binding for two readers of the same token"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--spacing:.25rem}}@layer components;@layer \
+     utilities{.m-\\[theme\\(--spacing\\)\\]{margin:.25rem}.p-\\[theme\\(--spacing\\)\\]{padding:.25rem}}"
+    (sheet [ "p-[theme(--spacing)]"; "m-[theme(--spacing)]" ]);
+  Alcotest.(check string)
+    "a variant leaves the binding in the theme layer"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--spacing:.25rem}}@layer components;@layer \
+     utilities{@media \
+     (width>=48rem){.md\\:p-\\[theme\\(--spacing\\)\\]{padding:.25rem}}}"
+    (sheet [ "md:p-[theme(--spacing)]" ]);
+  let theme =
+    Tw.Scheme.with_overrides Tw.Scheme.default [ ("spacing", "0.5rem") ]
+  in
+  Alcotest.(check string)
+    "an override reaches the binding and the inlined value"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--spacing:.5rem}}@layer components;@layer \
+     utilities{.p-\\[theme\\(--spacing\\)\\]{padding:.5rem}}"
+    (sheet ~theme [ "p-[theme(--spacing)]" ])
+
+(* A [theme(--x)] naming a token the theme does not carry has no rule at all,
+   the way a missing dot path has none, and a fallback argument stands in for it
+   and binds nothing. The call composes inside a longer value, where only the
+   call itself is replaced. *)
+let theme_function_custom_property_fallback () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  rejected "p-[theme(--nope)]";
+  rejected "p-[theme(--Spacing)]";
+  Test_helpers.check_declarations "p-[theme(--nope,1rem)]" [ "padding:1rem" ];
+  Test_helpers.check_declarations "p-[calc(theme(--spacing)_*_2)]"
+    [ "padding:calc(.25rem*2)" ]
+
+(* Tailwind spells the same lookup [--theme(--x)] as well, and that spelling
+   references the token instead of inlining it: the CLI writes [padding:
+   var(--spacing)] and the binding beside it. A dot path is not admitted in this
+   spelling. *)
+let theme_function_custom_property_reference () =
+  let rejected cls =
+    match Tw.of_string cls with
+    | Ok u -> Alcotest.failf "expected %s to be rejected, got %s" cls (Tw.pp u)
+    | Error _ -> ()
+  in
+  Test_helpers.check_declarations "p-[--theme(--spacing)]"
+    [ "padding:var(--spacing)" ];
+  Test_helpers.check_declarations "max-w-[--theme(--breakpoint-sm)]"
+    [ "max-width:var(--breakpoint-sm)" ];
+  Test_helpers.check_declarations "p-[--theme(--nope,1rem)]" [ "padding:1rem" ];
+  rejected "p-[--theme(spacing.4)]";
+  rejected "p-[--theme(--nope)]"
+
 (* Tailwind emits no rule at all for a [theme()] naming a key its resolved theme
    does not carry, so a class carrying one is not a utility. A bare segment
    names no namespace and the palette namespace is known in full, so both are
@@ -1506,6 +1608,14 @@ let core_tests =
       theme_function_alpha_reads_any_palette_value;
     test_case "theme() keeps an underscore" `Quick
       theme_function_keeps_an_underscore;
+    test_case "theme(--x) resolves every namespace" `Quick
+      theme_function_custom_property_spelling;
+    test_case "theme(--x) binds the token once" `Quick
+      theme_function_custom_property_binding;
+    test_case "theme(--x) falls back and composes" `Quick
+      theme_function_custom_property_fallback;
+    test_case "--theme(--x) references the token" `Quick
+      theme_function_custom_property_reference;
     test_case "layout" `Slow layout;
     test_case "opacity" `Slow opacity_effects;
     test_case "extended colors" `Slow extended_colors;

--- a/test/test_tw.ml
+++ b/test/test_tw.ml
@@ -542,13 +542,12 @@ let theme_function_keeps_an_underscore () =
         "the class is the one the source spells" "[color:theme(colors.red.500)]"
         (Tw.to_classes [ u ])
 
-(* [theme(--x)] is v4's own spelling of a theme lookup and reads the same token
-   table the dot paths do, across every namespace: [--spacing], [--color-*],
-   [--breakpoint-*], [--container-*], [--radius-*], [--text-*]. Unlike a dot
+(* [theme(--x)] is v4's own spelling of a theme lookup, and it reads the token
+   table rather than one of the v3 namespaces a dot path names. Unlike a dot
    path it does not consume the token: @tailwindcss/cli 4.3.3 inlines the value
    into the utility and still writes the binding into [@layer theme], so a
    consumer reading [--spacing] off the sheet finds it. tw answered "Unknown
-   class" for all of them. *)
+   class" for every one of these. *)
 let theme_function_custom_property_spelling () =
   let sheet cls =
     match Tw.of_string cls with
@@ -564,17 +563,20 @@ let theme_function_custom_property_spelling () =
   in
   check_sheet "p-[theme(--spacing)]" "--spacing:.25rem"
     {|.p-\[theme\(--spacing\)\]{padding:.25rem}|};
+  check_sheet "max-w-[theme(--breakpoint-sm)]" "--breakpoint-sm:40rem"
+    {|.max-w-\[theme\(--breakpoint-sm\)\]{max-width:40rem}|};
+  (* The palette answers through the catalogue an arbitrary
+     [var(--color-red-500)] already reads, so a shaded entry and a shadeless one
+     both resolve and the two spellings of one entry cannot drift apart. *)
   check_sheet "text-[theme(--color-red-500)]"
     "--color-red-500:oklch(63.7%.237 25.331)"
     {|.text-\[theme\(--color-red-500\)\]{color:oklch(63.7%.237 25.331)}|};
-  check_sheet "max-w-[theme(--breakpoint-sm)]" "--breakpoint-sm:40rem"
-    {|.max-w-\[theme\(--breakpoint-sm\)\]{max-width:40rem}|};
-  check_sheet "max-w-[theme(--container-md)]" "--container-md:28rem"
-    {|.max-w-\[theme\(--container-md\)\]{max-width:28rem}|};
-  check_sheet "rounded-[theme(--radius-lg)]" "--radius-lg:.5rem"
-    {|.rounded-\[theme\(--radius-lg\)\]{border-radius:.5rem}|};
-  check_sheet "text-[length:theme(--text-xl)]" "--text-xl:1.25rem"
-    {|.text-\[length\:theme\(--text-xl\)\]{font-size:1.25rem}|}
+  check_sheet "text-[theme(--color-black)]" "--color-black:#000"
+    {|.text-\[theme\(--color-black\)\]{color:#000}|};
+  (* An alpha reads the token the same way a dot path's does. *)
+  check_sheet "bg-[theme(--color-red-500/25%)]"
+    "--color-red-500:oklch(63.7%.237 25.331)"
+    {|.bg-\[theme\(--color-red-500\/25\%\)\]{background-color:color-mix(in oklab,oklch(63.7%.237 25.331) 25%,transparent)}|}
 
 (* The token a [theme(--x)] names is bound once however many classes read it,
    the variants a class carries do not move the binding out of [@layer theme],
@@ -597,9 +599,15 @@ let theme_function_custom_property_binding () =
     "a variant leaves the binding in the theme layer"
     "@layer theme,components,utilities;@layer \
      theme{:root,:host{--spacing:.25rem}}@layer components;@layer \
-     utilities{@media \
-     (width>=48rem){.md\\:p-\\[theme\\(--spacing\\)\\]{padding:.25rem}}}"
+     utilities{@media(min-width:48rem){.md\\:p-\\[theme\\(--spacing\\)\\]{padding:.25rem}}}"
     (sheet [ "md:p-[theme(--spacing)]" ]);
+  (* The binding is not one of the declarations a [!] marks. *)
+  Alcotest.(check string)
+    "important marks the utility and not the binding"
+    "@layer theme,components,utilities;@layer \
+     theme{:root,:host{--spacing:.25rem}}@layer components;@layer \
+     utilities{.p-\\[theme\\(--spacing\\)\\]\\!{padding:.25rem!important}}"
+    (sheet [ "p-[theme(--spacing)]!" ]);
   let theme =
     Tw.Scheme.with_overrides Tw.Scheme.default [ ("spacing", "0.5rem") ]
   in
@@ -610,10 +618,10 @@ let theme_function_custom_property_binding () =
      utilities{.p-\\[theme\\(--spacing\\)\\]{padding:.5rem}}"
     (sheet ~theme [ "p-[theme(--spacing)]" ])
 
-(* A [theme(--x)] naming a token the theme does not carry has no rule at all,
-   the way a missing dot path has none, and a fallback argument stands in for it
-   and binds nothing. The call composes inside a longer value, where only the
-   call itself is replaced. *)
+(* A [theme(--x)] naming a token the resolved theme does not carry has no rule
+   at all, the way a missing dot path has none, and a fallback argument stands
+   in for it and binds nothing. The call composes inside a longer value, where
+   only the call itself is replaced. *)
 let theme_function_custom_property_fallback () =
   let rejected cls =
     match Tw.of_string cls with
@@ -628,8 +636,8 @@ let theme_function_custom_property_fallback () =
 
 (* Tailwind spells the same lookup [--theme(--x)] as well, and that spelling
    references the token instead of inlining it: the CLI writes [padding:
-   var(--spacing)] and the binding beside it. A dot path is not admitted in this
-   spelling. *)
+   var(--spacing)] and the binding beside it. It admits neither a v3 dot path
+   nor an alpha, both of which Tailwind reads some other way. *)
 let theme_function_custom_property_reference () =
   let rejected cls =
     match Tw.of_string cls with
@@ -638,11 +646,12 @@ let theme_function_custom_property_reference () =
   in
   Test_helpers.check_declarations "p-[--theme(--spacing)]"
     [ "padding:var(--spacing)" ];
-  Test_helpers.check_declarations "max-w-[--theme(--breakpoint-sm)]"
-    [ "max-width:var(--breakpoint-sm)" ];
+  Test_helpers.check_declarations "text-[--theme(--color-red-500)]"
+    [ "color:var(--color-red-500)" ];
   Test_helpers.check_declarations "p-[--theme(--nope,1rem)]" [ "padding:1rem" ];
   rejected "p-[--theme(spacing.4)]";
-  rejected "p-[--theme(--nope)]"
+  rejected "p-[--theme(--nope)]";
+  rejected "bg-[--theme(--color-red-500/25%)]"
 
 (* Tailwind emits no rule at all for a [theme()] naming a key its resolved theme
    does not carry, so a class carrying one is not a utility. A bare segment
@@ -1608,7 +1617,7 @@ let core_tests =
       theme_function_alpha_reads_any_palette_value;
     test_case "theme() keeps an underscore" `Quick
       theme_function_keeps_an_underscore;
-    test_case "theme(--x) resolves every namespace" `Quick
+    test_case "theme(--x) resolves the token table" `Quick
       theme_function_custom_property_spelling;
     test_case "theme(--x) binds the token once" `Quick
       theme_function_custom_property_binding;

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -17,6 +17,28 @@ let test_base_of_class_invalid () =
   | Error (`Msg msg) ->
       check bool "error message not empty" true (String.length msg > 0)
 
+(* A theme binding rides on the utility's own declarations, where the theme
+   layer collects it and the utilities layer filters it out. It is not part of
+   the class the utility reports, and an empty list adds no carrier at all. *)
+let test_theme_bound () =
+  let open Tw.Utility in
+  let decl = Cascade.Css.custom_property ~layer:"theme" "--spacing" "0.25rem" in
+  match base_of_class Tw.Scheme.default "p-4" with
+  | Error (`Msg msg) -> fail msg
+  | Ok b -> (
+      let u = theme_bound [ decl ] (Base b) in
+      check string "the class is unchanged" "p-4" (to_class u);
+      check string "an empty list adds no carrier" "Base p-4"
+        (pp (theme_bound [] (Base b)));
+      match to_style Tw.Scheme.default u with
+      | Tw.Style.Style { props; _ } ->
+          check bool "the binding is one of the declarations" true
+            (List.exists
+               (fun d ->
+                 Cascade.Css.custom_declaration_name d = Some "--spacing")
+               props)
+      | _ -> fail "expected p-4 to be a single style")
+
 (* Test deduplication preserves order and keeps last occurrence *)
 let test_deduplicate () =
   let open Tw.Utility in
@@ -377,6 +399,7 @@ let tests =
     test_case "base_of_class valid input" `Quick test_base_of_class_valid;
     test_case "no class claimed twice" `Quick test_no_class_claimed_twice;
     test_case "base_of_class invalid input" `Quick test_base_of_class_invalid;
+    test_case "theme_bound carries a binding" `Quick test_theme_bound;
     test_case "deduplicate preserves order" `Quick test_deduplicate;
     test_case "deduplicate handles empty list" `Quick test_deduplicate_empty;
     (* test_case "css_of_string valid input" `Quick test_css_of_string_valid; *)


### PR DESCRIPTION
`theme(--x)` is v4's own spelling of a theme lookup, and tw rejected it as an unknown class outside a container query where `@tailwindcss/cli` emits the utility and the token's binding. Only the tokens tw's theme table already holds resolve, so a namespace with no entry there still has no rule.
